### PR TITLE
Add extensible Paint and gradient system

### DIFF
--- a/ModernFormsNext.CodeGeneration/Utilities/CSharpLiteralWriter.cs
+++ b/ModernFormsNext.CodeGeneration/Utilities/CSharpLiteralWriter.cs
@@ -89,6 +89,17 @@ public static class CSharpLiteralWriter
         if (IsType(typeName, "System.Drawing.Point"))
             return $"new System.Drawing.Point({ReadInt(properties, "X")}, {ReadInt(properties, "Y")})";
 
+        if (IsType(typeName, "System.Drawing.PointF"))
+            return $"new System.Drawing.PointF({ReadFloat(properties, "X")}, {ReadFloat(properties, "Y")})";
+
+        if (IsType(typeName, "System.Numerics.Matrix3x2"))
+        {
+            return "new System.Numerics.Matrix3x2("
+                + $"{ReadFloat(properties, "M11", 1)}, {ReadFloat(properties, "M12")}, "
+                + $"{ReadFloat(properties, "M21")}, {ReadFloat(properties, "M22", 1)}, "
+                + $"{ReadFloat(properties, "M31")}, {ReadFloat(properties, "M32")})";
+        }
+
         if (IsType(typeName, "System.Drawing.Rectangle"))
         {
             return $"new System.Drawing.Rectangle({ReadInt(properties, "X")}, {ReadInt(properties, "Y")}, {ReadInt(properties, "Width")}, {ReadInt(properties, "Height")})";
@@ -132,7 +143,7 @@ public static class CSharpLiteralWriter
             var color = properties.TryGetValue("Color", out var colorValue)
                 ? WriteValue(colorValue)
                 : "new SkiaSharp.SKColor(255, 255, 255, 255)";
-            return $"new ModernFormsNext.Drawing.SolidColorBrush({color})";
+            return $"new ModernFormsNext.Drawing.SolidColorBrush({color}) {{ {WriteBrushProperties(properties)} }}";
         }
 
         if (IsType(typeName, "ModernFormsNext.Drawing.GlassBrush"))
@@ -144,7 +155,8 @@ public static class CSharpLiteralWriter
                 + $"HighlightColor = {ReadValue(properties, "HighlightColor", "new SkiaSharp.SKColor(255, 255, 255, 38)")}, "
                 + $"BorderColor = {ReadValue(properties, "BorderColor", "new SkiaSharp.SKColor(255, 255, 255, 65)")}, "
                 + $"ShowHighlight = {ReadBoolLiteral(properties, "ShowHighlight", fallback: true)}, "
-                + $"ShowInnerBorder = {ReadBoolLiteral(properties, "ShowInnerBorder", fallback: true)}"
+                + $"ShowInnerBorder = {ReadBoolLiteral(properties, "ShowInnerBorder", fallback: true)}, "
+                + WriteBrushProperties(properties)
                 + " }";
         }
 
@@ -154,6 +166,7 @@ public static class CSharpLiteralWriter
                 + " { "
                 + $"StartPoint = {ReadValue(properties, "StartPoint", "new SkiaSharp.SKPoint(0f, 0f)")}, "
                 + $"EndPoint = {ReadValue(properties, "EndPoint", "new SkiaSharp.SKPoint(1f, 1f)")}"
+                + WriteGradientBrushProperties(properties)
                 + WriteGradientStopsInitializer(properties)
                 + " }";
         }
@@ -164,6 +177,8 @@ public static class CSharpLiteralWriter
                 + " { "
                 + $"Center = {ReadValue(properties, "Center", "new SkiaSharp.SKPoint(0.5f, 0.5f)")}, "
                 + $"Radius = {ReadFloat(properties, "Radius", 0.5)}"
+                + WriteOptionalProperty(properties, "GradientOrigin")
+                + WriteGradientBrushProperties(properties)
                 + WriteGradientStopsInitializer(properties)
                 + " }";
         }
@@ -175,6 +190,7 @@ public static class CSharpLiteralWriter
                 + $"Center = {ReadValue(properties, "Center", "new SkiaSharp.SKPoint(0.5f, 0.5f)")}, "
                 + $"StartAngle = {ReadFloat(properties, "StartAngle")}, "
                 + $"EndAngle = {ReadFloat(properties, "EndAngle", 360)}"
+                + WriteGradientBrushProperties(properties)
                 + WriteGradientStopsInitializer(properties)
                 + " }";
         }
@@ -200,7 +216,7 @@ public static class CSharpLiteralWriter
             : fallback;
 
     private static string ReadFloat(IReadOnlyDictionary<string, DesignPropertyValue> properties, string name, double fallback = 0)
-        => ReadDouble(properties, name, fallback).ToString("R", CultureInfo.InvariantCulture) + "f";
+        => ((float)ReadDouble(properties, name, fallback)).ToString("R", CultureInfo.InvariantCulture) + "f";
 
     private static string ReadString(IReadOnlyDictionary<string, DesignPropertyValue> properties, string name, string fallback = "")
         => properties.TryGetValue(name, out var value) && value is not null
@@ -222,6 +238,21 @@ public static class CSharpLiteralWriter
         => properties.TryGetValue(name, out var value) && value is not null
             ? WriteValue(value)
             : fallback ? "true" : "false";
+
+    private static string WriteBrushProperties(IReadOnlyDictionary<string, DesignPropertyValue> properties)
+        => $"Opacity = {ReadFloat(properties, "Opacity", 1)}, "
+            + $"Transform = {ReadValue(properties, "Transform", "System.Numerics.Matrix3x2.Identity")}";
+
+    private static string WriteGradientBrushProperties(IReadOnlyDictionary<string, DesignPropertyValue> properties)
+        => $", {WriteBrushProperties(properties)}, SpreadMode = "
+            + ReadValue(properties, "SpreadMode", "ModernFormsNext.Drawing.GradientSpreadMode.Pad");
+
+    private static string WriteOptionalProperty(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name)
+        => properties.TryGetValue(name, out DesignPropertyValue? value) && value is not null
+            ? $", {name} = {WriteValue(value)}"
+            : string.Empty;
 
     private static string WriteGradientStopsInitializer(IReadOnlyDictionary<string, DesignPropertyValue> properties)
     {

--- a/ModernFormsNext.Designer.Tests/BrushDesignerSerializationTests.cs
+++ b/ModernFormsNext.Designer.Tests/BrushDesignerSerializationTests.cs
@@ -1,0 +1,95 @@
+using System.Drawing;
+using System.Numerics;
+using ModernFormsNext.CodeGeneration.Utilities;
+using ModernFormsNext.Designer.Properties;
+using ModernFormsNext.Designing;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+using Xunit;
+using MfnBrush = ModernFormsNext.Drawing.Brush;
+
+namespace ModernFormsNext.Designer.Tests;
+
+public sealed class BrushDesignerSerializationTests
+{
+    [Fact]
+    public void LinearGradientRoundTripPreservesExtendedBrushValues()
+    {
+        var source = new LinearGradientBrush
+        {
+            Start = new PointF(0.1f, 0.2f),
+            End = new PointF(0.8f, 0.9f),
+            Opacity = 0.65f,
+            Transform = Matrix3x2.CreateTranslation(3f, 4f),
+            SpreadMode = GradientSpreadMode.Reflect
+        };
+        source.GradientStops.AddRange([
+            new GradientStop(Color.FromArgb(100, 10, 20, 30), 0.75f),
+            new GradientStop(Color.Red, 0.25f)
+        ]);
+
+        DesignPropertyValue value = DesignerPropertyValueEditor.ToDesignPropertyValue(source, typeof(MfnBrush));
+        var restored = Assert.IsType<LinearGradientBrush>(
+            DesignerPropertyValueEditor.FromDesignPropertyValue(value, typeof(MfnBrush)));
+        string generated = CSharpLiteralWriter.WriteValue(value);
+
+        Assert.Equal(source.Start, restored.Start);
+        Assert.Equal(source.End, restored.End);
+        Assert.Equal(source.Opacity, restored.Opacity);
+        Assert.Equal(source.Transform, restored.Transform);
+        Assert.Equal(source.SpreadMode, restored.SpreadMode);
+        Assert.Equal(2, restored.GradientStops.Count);
+        Assert.Equal(source.GradientStops[0].Color, restored.GradientStops[0].Color);
+        Assert.Contains("Opacity = 0.65f", generated, StringComparison.Ordinal);
+        Assert.Contains("GradientSpreadMode.Reflect", generated, StringComparison.Ordinal);
+        Assert.Contains("System.Numerics.Matrix3x2", generated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RadialGradientRoundTripPreservesFocalOrigin()
+    {
+        var source = new RadialGradientBrush
+        {
+            CenterPoint = new PointF(0.6f, 0.4f),
+            GradientOrigin = new PointF(0.2f, 0.3f),
+            Radius = 0.75f,
+            SpreadMode = GradientSpreadMode.Repeat
+        };
+        source.GradientStops.AddRange([
+            new GradientStop(Color.White, 0f),
+            new GradientStop(Color.Black, 1f)
+        ]);
+
+        DesignPropertyValue value = DesignerPropertyValueEditor.ToDesignPropertyValue(source, typeof(MfnBrush));
+        var restored = Assert.IsType<RadialGradientBrush>(
+            DesignerPropertyValueEditor.FromDesignPropertyValue(value, typeof(MfnBrush)));
+        string generated = CSharpLiteralWriter.WriteValue(value);
+
+        Assert.Equal(source.CenterPoint, restored.CenterPoint);
+        Assert.Equal(source.GradientOrigin, restored.GradientOrigin);
+        Assert.Equal(source.Radius, restored.Radius);
+        Assert.Equal(source.SpreadMode, restored.SpreadMode);
+        Assert.Contains("GradientOrigin = new System.Drawing.PointF(0.2f, 0.3f)", generated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LegacyGradientDocumentUsesBackwardCompatibleDefaults()
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["StartPoint"] = DesignerPropertyValueEditor.ToDesignPropertyValue(new SKPoint(0f, 0f), typeof(SKPoint)),
+            ["EndPoint"] = DesignerPropertyValueEditor.ToDesignPropertyValue(new SKPoint(1f, 1f), typeof(SKPoint)),
+            ["GradientStopCount"] = DesignPropertyValue.FromInt32(0)
+        };
+        DesignPropertyValue legacy = DesignPropertyValue.FromStructuredObject(
+            typeof(LinearGradientBrush).FullName!,
+            properties);
+
+        var restored = Assert.IsType<LinearGradientBrush>(
+            DesignerPropertyValueEditor.FromDesignPropertyValue(legacy, typeof(MfnBrush)));
+
+        Assert.Equal(1f, restored.Opacity);
+        Assert.Equal(Matrix3x2.Identity, restored.Transform);
+        Assert.Equal(GradientSpreadMode.Pad, restored.SpreadMode);
+    }
+}

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyDescriptorFactory.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyDescriptorFactory.cs
@@ -643,7 +643,13 @@ internal static class DesignerPropertyDescriptorFactory
                     if (color is null)
                         node.Properties[path] = DesignPropertyValue.FromNull();
                     else
-                        SetStoredValue(node, path, new ModernFormsNext.Drawing.SolidColorBrush(color.Value), valueType);
+                        SetStoredValue(
+                            node,
+                            path,
+                            CreateSolidBrushPreservingCommonProperties(
+                                GetStoredBrush(node, path, valueType, fallbackBrush),
+                                color.Value),
+                            valueType);
 
                     return (true, null);
                 },
@@ -1806,6 +1812,15 @@ internal static class DesignerPropertyDescriptorFactory
     private static SKColor? GetBrushColor(object? brush)
         => brush is ModernFormsNext.Drawing.SolidColorBrush solidBrush ? solidBrush.Color : null;
 
+    private static ModernFormsNext.Drawing.SolidColorBrush CreateSolidBrushPreservingCommonProperties(
+        ModernFormsNext.Drawing.Brush? source,
+        SKColor color)
+        => new(color)
+        {
+            Opacity = source?.Opacity ?? 1f,
+            Transform = source?.Transform ?? System.Numerics.Matrix3x2.Identity
+        };
+
     private static ModernFormsNext.Drawing.GlassBrush CloneGlassBrush(ModernFormsNext.Drawing.Brush? brush)
     {
         var source = brush as ModernFormsNext.Drawing.GlassBrush ?? new ModernFormsNext.Drawing.GlassBrush();
@@ -1816,7 +1831,9 @@ internal static class DesignerPropertyDescriptorFactory
             HighlightColor = source.HighlightColor,
             BorderColor = source.BorderColor,
             ShowHighlight = source.ShowHighlight,
-            ShowInnerBorder = source.ShowInnerBorder
+            ShowInnerBorder = source.ShowInnerBorder,
+            Opacity = source.Opacity,
+            Transform = source.Transform
         };
     }
 
@@ -1826,7 +1843,10 @@ internal static class DesignerPropertyDescriptorFactory
         var clone = new ModernFormsNext.Drawing.LinearGradientBrush
         {
             StartPoint = source.StartPoint,
-            EndPoint = source.EndPoint
+            EndPoint = source.EndPoint,
+            SpreadMode = source.SpreadMode,
+            Opacity = source.Opacity,
+            Transform = source.Transform
         };
 
         CopyGradientStops(source, clone);
@@ -1839,7 +1859,11 @@ internal static class DesignerPropertyDescriptorFactory
         var clone = new ModernFormsNext.Drawing.RadialGradientBrush
         {
             Center = source.Center,
-            Radius = source.Radius
+            GradientOrigin = source.GradientOrigin,
+            Radius = source.Radius,
+            SpreadMode = source.SpreadMode,
+            Opacity = source.Opacity,
+            Transform = source.Transform
         };
 
         CopyGradientStops(source, clone);
@@ -1853,7 +1877,10 @@ internal static class DesignerPropertyDescriptorFactory
         {
             Center = source.Center,
             StartAngle = source.StartAngle,
-            EndAngle = source.EndAngle
+            EndAngle = source.EndAngle,
+            SpreadMode = source.SpreadMode,
+            Opacity = source.Opacity,
+            Transform = source.Transform
         };
 
         CopyGradientStops(source, clone);

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyValueEditor.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyValueEditor.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Numerics;
 using ModernFormsNext.Designing;
 using SkiaSharp;
 
@@ -26,6 +27,7 @@ internal static class DesignerPropertyValueEditor
             DesignPoint point => $"{point.X}, {point.Y}",
             System.Drawing.Size size => $"{size.Width}, {size.Height}",
             System.Drawing.Point point => $"{point.X}, {point.Y}",
+            System.Drawing.PointF point => $"{point.X.ToString("R", CultureInfo.InvariantCulture)}, {point.Y.ToString("R", CultureInfo.InvariantCulture)}",
             System.Drawing.Rectangle rectangle => $"{rectangle.X}, {rectangle.Y}, {rectangle.Width}, {rectangle.Height}",
             SKPoint point => $"{point.X.ToString("R", CultureInfo.InvariantCulture)}, {point.Y.ToString("R", CultureInfo.InvariantCulture)}",
             SKSize size => $"{size.Width.ToString("R", CultureInfo.InvariantCulture)}, {size.Height.ToString("R", CultureInfo.InvariantCulture)}",
@@ -219,6 +221,24 @@ internal static class DesignerPropertyValueEditor
                 ["Y"] = DesignPropertyValue.FromInt32(point.Y)
             });
 
+        if (value is System.Drawing.PointF pointF)
+            return DesignPropertyValue.FromStructuredObject(typeof(System.Drawing.PointF).FullName!, new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            {
+                ["X"] = DesignPropertyValue.FromDouble(pointF.X),
+                ["Y"] = DesignPropertyValue.FromDouble(pointF.Y)
+            });
+
+        if (value is Matrix3x2 matrix)
+            return DesignPropertyValue.FromStructuredObject(typeof(Matrix3x2).FullName!, new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            {
+                ["M11"] = DesignPropertyValue.FromDouble(matrix.M11),
+                ["M12"] = DesignPropertyValue.FromDouble(matrix.M12),
+                ["M21"] = DesignPropertyValue.FromDouble(matrix.M21),
+                ["M22"] = DesignPropertyValue.FromDouble(matrix.M22),
+                ["M31"] = DesignPropertyValue.FromDouble(matrix.M31),
+                ["M32"] = DesignPropertyValue.FromDouble(matrix.M32)
+            });
+
         if (value is DesignPoint designPoint)
             return DesignPropertyValue.FromStructuredObject(typeof(DesignPoint).FullName!, new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
             {
@@ -281,10 +301,12 @@ internal static class DesignerPropertyValueEditor
 
         if (value is ModernFormsNext.Drawing.SolidColorBrush solidBrush)
         {
-            return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.SolidColorBrush).FullName!, new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
             {
                 ["Color"] = ToColorPropertyValue(solidBrush.Color)
-            });
+            };
+            AddBrushProperties(properties, solidBrush);
+            return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.SolidColorBrush).FullName!, properties);
         }
 
         if (value is ModernFormsNext.Drawing.GlassBrush glassBrush)
@@ -349,7 +371,8 @@ internal static class DesignerPropertyValueEditor
         });
 
     private static DesignPropertyValue ToGlassBrushPropertyValue(ModernFormsNext.Drawing.GlassBrush brush)
-        => DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.GlassBrush).FullName!, new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
         {
             ["TintColor"] = ToColorPropertyValue(brush.TintColor),
             ["SecondaryTintColor"] = ToColorPropertyValue(brush.SecondaryTintColor),
@@ -357,7 +380,10 @@ internal static class DesignerPropertyValueEditor
             ["BorderColor"] = ToColorPropertyValue(brush.BorderColor),
             ["ShowHighlight"] = DesignPropertyValue.FromBoolean(brush.ShowHighlight),
             ["ShowInnerBorder"] = DesignPropertyValue.FromBoolean(brush.ShowInnerBorder)
-        });
+        };
+        AddBrushProperties(properties, brush);
+        return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.GlassBrush).FullName!, properties);
+    }
 
     private static DesignPropertyValue ToLinearGradientBrushPropertyValue(ModernFormsNext.Drawing.LinearGradientBrush brush)
     {
@@ -367,7 +393,7 @@ internal static class DesignerPropertyValueEditor
             ["EndPoint"] = ToDesignPropertyValue(brush.EndPoint, typeof(SKPoint))
         };
 
-        AddGradientStops(properties, brush);
+        AddGradientProperties(properties, brush);
         return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.LinearGradientBrush).FullName!, properties);
     }
 
@@ -376,10 +402,11 @@ internal static class DesignerPropertyValueEditor
         var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
         {
             ["Center"] = ToDesignPropertyValue(brush.Center, typeof(SKPoint)),
+            ["GradientOrigin"] = ToDesignPropertyValue(brush.GradientOrigin, typeof(System.Drawing.PointF)),
             ["Radius"] = DesignPropertyValue.FromDouble(brush.Radius)
         };
 
-        AddGradientStops(properties, brush);
+        AddGradientProperties(properties, brush);
         return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.RadialGradientBrush).FullName!, properties);
     }
 
@@ -392,8 +419,27 @@ internal static class DesignerPropertyValueEditor
             ["EndAngle"] = DesignPropertyValue.FromDouble(brush.EndAngle)
         };
 
-        AddGradientStops(properties, brush);
+        AddGradientProperties(properties, brush);
         return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.SweepGradientBrush).FullName!, properties);
+    }
+
+    private static void AddBrushProperties(
+        SortedDictionary<string, DesignPropertyValue> properties,
+        ModernFormsNext.Drawing.Brush brush)
+    {
+        properties["Opacity"] = DesignPropertyValue.FromDouble(brush.Opacity);
+        properties["Transform"] = ToDesignPropertyValue(brush.Transform, typeof(Matrix3x2));
+    }
+
+    private static void AddGradientProperties(
+        SortedDictionary<string, DesignPropertyValue> properties,
+        ModernFormsNext.Drawing.GradientBrush brush)
+    {
+        AddBrushProperties(properties, brush);
+        properties["SpreadMode"] = DesignPropertyValue.FromEnum(
+            typeof(ModernFormsNext.Drawing.GradientSpreadMode).FullName!,
+            brush.SpreadMode.ToString());
+        AddGradientStops(properties, brush);
     }
 
     private static void AddGradientStops(
@@ -431,6 +477,18 @@ internal static class DesignerPropertyValueEditor
         if (targetType == typeof(System.Drawing.Point))
             return new System.Drawing.Point(ReadInt(properties, "X"), ReadInt(properties, "Y"));
 
+        if (targetType == typeof(System.Drawing.PointF))
+            return new System.Drawing.PointF((float)ReadDouble(properties, "X"), (float)ReadDouble(properties, "Y"));
+
+        if (targetType == typeof(Matrix3x2))
+            return new Matrix3x2(
+                (float)ReadDouble(properties, "M11", 1),
+                (float)ReadDouble(properties, "M12"),
+                (float)ReadDouble(properties, "M21"),
+                (float)ReadDouble(properties, "M22", 1),
+                (float)ReadDouble(properties, "M31"),
+                (float)ReadDouble(properties, "M32"));
+
         if (targetType == typeof(DesignPoint))
             return new DesignPoint(ReadInt(properties, "X"), ReadInt(properties, "Y"));
 
@@ -462,12 +520,14 @@ internal static class DesignerPropertyValueEditor
                 ? FromDesignPropertyValue(colorValue, typeof(SKColor))
                 : new SKColor(255, 255, 255);
 
-            return new ModernFormsNext.Drawing.SolidColorBrush(color is SKColor skColor ? skColor : new SKColor(255, 255, 255));
+            var brush = new ModernFormsNext.Drawing.SolidColorBrush(color is SKColor skColor ? skColor : new SKColor(255, 255, 255));
+            ApplyBrushProperties(properties, brush);
+            return brush;
         }
 
         if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.GlassBrush)))
         {
-            return new ModernFormsNext.Drawing.GlassBrush
+            var brush = new ModernFormsNext.Drawing.GlassBrush
             {
                 TintColor = ReadColor(properties, "TintColor", new SKColor(255, 255, 255, 28)),
                 SecondaryTintColor = ReadColor(properties, "SecondaryTintColor", new SKColor(255, 255, 255, 12)),
@@ -476,6 +536,8 @@ internal static class DesignerPropertyValueEditor
                 ShowHighlight = ReadBool(properties, "ShowHighlight", fallback: true),
                 ShowInnerBorder = ReadBool(properties, "ShowInnerBorder", fallback: true)
             };
+            ApplyBrushProperties(properties, brush);
+            return brush;
         }
 
         if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.LinearGradientBrush)))
@@ -486,18 +548,23 @@ internal static class DesignerPropertyValueEditor
                 EndPoint = ReadSkPoint(properties, "EndPoint", new SKPoint(1f, 1f))
             };
 
+            ApplyGradientProperties(properties, brush);
             ReadGradientStops(properties, brush);
             return brush;
         }
 
         if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.RadialGradientBrush)))
         {
-            var brush = new ModernFormsNext.Drawing.RadialGradientBrush
+            var brush = new ModernFormsNext.Drawing.RadialGradientBrush();
+            brush.Center = ReadSkPoint(properties, "Center", new SKPoint(0.5f, 0.5f));
+            if (properties.TryGetValue("GradientOrigin", out DesignPropertyValue? originValue) &&
+                FromDesignPropertyValue(originValue, typeof(System.Drawing.PointF)) is System.Drawing.PointF origin)
             {
-                Center = ReadSkPoint(properties, "Center", new SKPoint(0.5f, 0.5f)),
-                Radius = (float)ReadDouble(properties, "Radius", 0.5)
-            };
+                brush.GradientOrigin = origin;
+            }
+            brush.Radius = (float)ReadDouble(properties, "Radius", 0.5);
 
+            ApplyGradientProperties(properties, brush);
             ReadGradientStops(properties, brush);
             return brush;
         }
@@ -511,6 +578,7 @@ internal static class DesignerPropertyValueEditor
                 EndAngle = (float)ReadDouble(properties, "EndAngle", 360)
             };
 
+            ApplyGradientProperties(properties, brush);
             ReadGradientStops(properties, brush);
             return brush;
         }
@@ -872,6 +940,30 @@ internal static class DesignerPropertyValueEditor
             var color = ReadColor(value.ObjectProperties, "Color", SKColors.Transparent);
             var offset = (float)ReadDouble(value.ObjectProperties, "Offset");
             brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(color, offset));
+        }
+    }
+
+    private static void ApplyBrushProperties(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        ModernFormsNext.Drawing.Brush brush)
+    {
+        brush.Opacity = (float)ReadDouble(properties, "Opacity", 1);
+        if (properties.TryGetValue("Transform", out DesignPropertyValue? transformValue) &&
+            FromDesignPropertyValue(transformValue, typeof(Matrix3x2)) is Matrix3x2 transform)
+        {
+            brush.Transform = transform;
+        }
+    }
+
+    private static void ApplyGradientProperties(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        ModernFormsNext.Drawing.GradientBrush brush)
+    {
+        ApplyBrushProperties(properties, brush);
+        if (properties.TryGetValue("SpreadMode", out DesignPropertyValue? spreadValue) &&
+            FromDesignPropertyValue(spreadValue, typeof(ModernFormsNext.Drawing.GradientSpreadMode)) is ModernFormsNext.Drawing.GradientSpreadMode spreadMode)
+        {
+            brush.SpreadMode = spreadMode;
         }
     }
 

--- a/ModernFormsNext.Tests/BrushModelTests.cs
+++ b/ModernFormsNext.Tests/BrushModelTests.cs
@@ -1,0 +1,172 @@
+using System.Drawing;
+using System.Numerics;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class BrushModelTests
+{
+    [Fact]
+    public void SolidBrushUsesOneColorValueAcrossNeutralAndCompatibilityApis()
+    {
+        var brush = new SolidColorBrush(Color.FromArgb(128, 12, 34, 56));
+        var changes = 0;
+        brush.Changed += (_, _) => changes++;
+
+        Assert.Equal(Color.FromArgb(128, 12, 34, 56).ToArgb(), brush.PaintColor.ToArgb());
+        Assert.Equal(new SKColor(12, 34, 56, 128), brush.Color);
+
+        brush.Color = new SKColor(90, 80, 70, 60);
+        brush.Color = new SKColor(90, 80, 70, 60);
+
+        Assert.Equal(Color.FromArgb(60, 90, 80, 70).ToArgb(), brush.PaintColor.ToArgb());
+        Assert.Equal(1, changes);
+    }
+
+    [Fact]
+    public void OpacityAndTransformValidateAndNotifyOnlyForEffectiveChanges()
+    {
+        var brush = new SolidColorBrush(Color.Red);
+        var changes = 0;
+        brush.Changed += (_, _) => changes++;
+
+        brush.Opacity = 0.5f;
+        brush.Opacity = 0.5f;
+        brush.Transform = Matrix3x2.CreateTranslation(4f, 7f);
+
+        Assert.Equal(2, changes);
+        Assert.Throws<ArgumentOutOfRangeException>(() => brush.Opacity = -0.01f);
+        Assert.Throws<ArgumentOutOfRangeException>(() => brush.Opacity = float.NaN);
+        Assert.Throws<ArgumentOutOfRangeException>(() => brush.Opacity = 1.01f);
+        Assert.Throws<ArgumentException>(() => brush.Transform = new Matrix3x2(float.NaN, 0, 0, 1, 0, 0));
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(0.37f)]
+    [InlineData(1f)]
+    public void GradientStopAcceptsInclusiveNormalizedOffsets(float offset)
+    {
+        var stop = new GradientStop(Color.FromArgb(80, 10, 20, 30), offset);
+
+        Assert.Equal(offset, stop.Offset);
+        Assert.Equal(new SKColor(10, 20, 30, 80), stop.Color);
+    }
+
+    [Theory]
+    [InlineData(-0.001f)]
+    [InlineData(1.001f)]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    public void GradientStopRejectsInvalidOffsets(float offset)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new GradientStop(Color.Red, offset));
+
+    [Fact]
+    public void GradientStopColorAndOffsetChangesPropagateThroughBrush()
+    {
+        var stop = new GradientStop(Color.Red, 0.25f);
+        var brush = new LinearGradientBrush();
+        brush.GradientStops.Add(stop);
+        var changes = 0;
+        brush.Changed += (_, _) => changes++;
+
+        stop.PaintColor = Color.Blue;
+        stop.Offset = 0.75f;
+
+        Assert.Equal(2, changes);
+        Assert.Equal(Color.Blue.ToArgb(), stop.PaintColor.ToArgb());
+        Assert.Equal(0.75f, stop.Offset);
+    }
+
+    [Fact]
+    public void StopCollectionObservesMembershipOrderAndItemsWithoutDuplicateInstances()
+    {
+        var first = new GradientStop(Color.Red, 0.5f);
+        var second = new GradientStop(Color.Blue, 0.5f);
+        var third = new GradientStop(Color.Green, 1f);
+        var stops = new GradientStopCollection();
+        var changes = 0;
+        stops.Changed += (_, _) => changes++;
+
+        stops.AddRange([first, second]);
+        stops.Insert(1, third);
+        stops.Move(2, 0);
+        stops[1] = new GradientStop(Color.Yellow, 0.75f);
+        stops.Remove(second);
+        stops.Clear();
+
+        Assert.Equal(6, changes);
+        Assert.Empty(stops);
+        Assert.Throws<ArgumentException>(() => stops.AddRange([third, third]));
+    }
+
+    [Fact]
+    public void EqualOffsetsKeepCollectionOrderInStableRenderSnapshot()
+    {
+        var first = new GradientStop(Color.Red, 0.5f);
+        var second = new GradientStop(Color.Blue, 0.5f);
+        var start = new GradientStop(Color.Black, 0f);
+        var brush = new LinearGradientBrush();
+        brush.GradientStops.AddRange([first, second, start]);
+
+        Assert.Equal([start, first, second], brush.GetOrderedStops());
+
+        brush.GradientStops.Move(1, 0);
+
+        Assert.Equal([start, second, first], brush.GetOrderedStops());
+    }
+
+    [Fact]
+    public void LinearCoordinatesAreNeutralRelativeValuesWithSkiaCompatibilityViews()
+    {
+        var brush = new LinearGradientBrush();
+        var changes = 0;
+        brush.Changed += (_, _) => changes++;
+
+        brush.Start = new PointF(-0.25f, 0.5f);
+        brush.EndPoint = new SKPoint(1.25f, 0.75f);
+
+        Assert.Equal(new SKPoint(-0.25f, 0.5f), brush.StartPoint);
+        Assert.Equal(new PointF(1.25f, 0.75f), brush.End);
+        Assert.Equal(2, changes);
+        Assert.Throws<ArgumentException>(() => brush.Start = new PointF(float.NaN, 0f));
+    }
+
+    [Fact]
+    public void RadialOriginFollowsCenterUntilExplicitlyAssigned()
+    {
+        var brush = new RadialGradientBrush();
+
+        brush.CenterPoint = new PointF(0.25f, 0.4f);
+        Assert.Equal(brush.CenterPoint, brush.GradientOrigin);
+
+        brush.GradientOrigin = new PointF(0.1f, 0.2f);
+        brush.Center = new SKPoint(0.8f, 0.7f);
+
+        Assert.Equal(new PointF(0.1f, 0.2f), brush.GradientOrigin);
+        Assert.Equal(new PointF(0.8f, 0.7f), brush.CenterPoint);
+        brush.Radius = 0f;
+        Assert.Equal(0f, brush.Radius);
+        Assert.Throws<ArgumentOutOfRangeException>(() => brush.Radius = -1f);
+        Assert.Throws<ArgumentOutOfRangeException>(() => brush.Radius = float.PositiveInfinity);
+    }
+
+    [Fact]
+    public void SpreadAndSweepValuesValidateAndNotify()
+    {
+        var brush = new SweepGradientBrush();
+        var changes = 0;
+        brush.Changed += (_, _) => changes++;
+
+        brush.SpreadMode = GradientSpreadMode.Reflect;
+        brush.CenterPoint = new PointF(0.25f, 0.75f);
+        brush.StartAngle = -90f;
+        brush.EndAngle = 270f;
+
+        Assert.Equal(4, changes);
+        Assert.Throws<ArgumentOutOfRangeException>(() => brush.SpreadMode = (GradientSpreadMode)99);
+        Assert.Throws<ArgumentOutOfRangeException>(() => brush.StartAngle = float.NaN);
+    }
+}

--- a/ModernFormsNext.Tests/BrushRenderingTests.cs
+++ b/ModernFormsNext.Tests/BrushRenderingTests.cs
@@ -1,0 +1,142 @@
+using System.Drawing;
+using System.Numerics;
+using ModernFormsNext.Drawing;
+using ModernFormsNext.Rendering.Skia;
+using SkiaSharp;
+using Xunit;
+using MfnBrush = ModernFormsNext.Drawing.Brush;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class BrushRenderingTests
+{
+    [Fact]
+    public void SolidOpacityMultipliesColorAlpha()
+    {
+        var brush = new SolidColorBrush(Color.FromArgb(128, 20, 40, 60)) { Opacity = 0.5f };
+
+        SKColor pixel = RenderPixel(brush, 4, 4, 2, 2);
+
+        Assert.InRange(pixel.Alpha, (byte)63, (byte)65);
+        Assert.Equal((byte)20, pixel.Red);
+        Assert.Equal((byte)40, pixel.Green);
+        Assert.Equal((byte)60, pixel.Blue);
+    }
+
+    [Fact]
+    public void NoBrushAndEmptyGradientLeaveTheDestinationUntouched()
+    {
+        Assert.Equal(0, RenderPixel(new NoBrush(), 4, 4, 2, 2).Alpha);
+        Assert.Equal(0, RenderPixel(new LinearGradientBrush(), 4, 4, 2, 2).Alpha);
+    }
+
+    [Fact]
+    public void OneStopAndZeroRadiusGradientsHaveDeterministicSolidResults()
+    {
+        var oneStop = new LinearGradientBrush();
+        oneStop.GradientStops.Add(new GradientStop(Color.CornflowerBlue, 0.4f));
+
+        var zeroRadius = new RadialGradientBrush { Radius = 0f };
+        zeroRadius.GradientStops.AddRange([
+            new GradientStop(Color.Red, 0f),
+            new GradientStop(Color.Lime, 1f)
+        ]);
+
+        Assert.Equal(new SKColor(100, 149, 237), RenderPixel(oneStop, 6, 6, 3, 3));
+        Assert.Equal(SKColors.Lime, RenderPixel(zeroRadius, 6, 6, 0, 0));
+    }
+
+    [Theory]
+    [InlineData(GradientSpreadMode.Pad, SKShaderTileMode.Clamp)]
+    [InlineData(GradientSpreadMode.Repeat, SKShaderTileMode.Repeat)]
+    [InlineData(GradientSpreadMode.Reflect, SKShaderTileMode.Mirror)]
+    public void SpreadModesMapToSkiaTileModes(GradientSpreadMode source, SKShaderTileMode expected)
+        => Assert.Equal(expected, SkiaBrushFactory.MapSpreadMode(source));
+
+    [Fact]
+    public void RelativeCoordinatesResolveAgainstEachCurrentBoundsWithoutDpiRescaling()
+    {
+        var point = new PointF(0.25f, 0.75f);
+
+        Assert.Equal(new SKPoint(35f, 35f), SkiaBrushFactory.ResolveRelativePoint(point, new SKRect(10, 20, 110, 40)));
+        Assert.Equal(new SKPoint(60f, 80f), SkiaBrushFactory.ResolveRelativePoint(point, new SKRect(10, 20, 210, 100)));
+    }
+
+    [Fact]
+    public void LinearRadialFocalAndSweepBrushesCreateBoundsSpecificShaders()
+    {
+        GradientBrush[] brushes =
+        [
+            Gradient(new LinearGradientBrush { Start = new PointF(0, 0), End = new PointF(1, 0) }),
+            Gradient(new RadialGradientBrush { CenterPoint = new PointF(0.5f, 0.5f), Radius = 0.5f }),
+            Gradient(new RadialGradientBrush { CenterPoint = new PointF(0.5f, 0.5f), GradientOrigin = new PointF(0.25f, 0.5f), Radius = 0.5f }),
+            Gradient(new SweepGradientBrush { CenterPoint = new PointF(0.5f, 0.5f), StartAngle = 0, EndAngle = 360 })
+        ];
+
+        foreach (GradientBrush brush in brushes)
+        {
+            using SKShader? first = SkiaBrushFactory.CreateGradientShader(brush, new SKRect(0, 0, 100, 40));
+            using SKShader? resized = SkiaBrushFactory.CreateGradientShader(brush, new SKRect(0, 0, 220, 80));
+            Assert.NotNull(first);
+            Assert.NotNull(resized);
+            Assert.NotSame(first, resized);
+        }
+    }
+
+    [Fact]
+    public void TransformCreatesAnOwnedShaderAndRepeatedScopesDisposeCleanly()
+    {
+        var brush = Gradient(new LinearGradientBrush
+        {
+            Start = new PointF(0, 0),
+            End = new PointF(1, 0),
+            Transform = Matrix3x2.CreateTranslation(5f, 0f)
+        });
+
+        for (var index = 0; index < 250; index++)
+        {
+            using SKShader? shader = SkiaBrushFactory.CreateGradientShader(brush, new SKRect(0, 0, 100 + index, 40));
+            Assert.NotNull(shader);
+        }
+    }
+
+    [Fact]
+    public void RepeatAndReflectProduceDifferentAlternateIntervals()
+    {
+        var repeat = CreateShortLinearGradient(GradientSpreadMode.Repeat);
+        var reflect = CreateShortLinearGradient(GradientSpreadMode.Reflect);
+
+        SKColor repeatSecondInterval = RenderPixel(repeat, 100, 4, 31, 2);
+        SKColor reflectSecondInterval = RenderPixel(reflect, 100, 4, 31, 2);
+
+        Assert.True(repeatSecondInterval.Red < 150, $"Expected repeated interval near dark; actual {repeatSecondInterval}.");
+        Assert.True(reflectSecondInterval.Red > 150, $"Expected reflected interval near light; actual {reflectSecondInterval}.");
+    }
+
+    private static T Gradient<T>(T brush) where T : GradientBrush
+    {
+        brush.GradientStops.AddRange([
+            new GradientStop(Color.Black, 0f),
+            new GradientStop(Color.White, 1f)
+        ]);
+        return brush;
+    }
+
+    private static LinearGradientBrush CreateShortLinearGradient(GradientSpreadMode mode)
+        => Gradient(new LinearGradientBrush
+        {
+            Start = new PointF(0f, 0f),
+            End = new PointF(0.25f, 0f),
+            SpreadMode = mode
+        });
+
+    private static SKColor RenderPixel(MfnBrush brush, int width, int height, int x, int y)
+    {
+        using var bitmap = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+        SkiaExtensions.RenderBrushBackground(canvas, new SKRect(0, 0, width, height), brush, SKColors.Magenta);
+        canvas.Flush();
+        return bitmap.GetPixel(x, y);
+    }
+}

--- a/ModernFormsNext.Tests/BrushRenderingTests.cs
+++ b/ModernFormsNext.Tests/BrushRenderingTests.cs
@@ -31,6 +31,25 @@ public sealed class BrushRenderingTests
     }
 
     [Fact]
+    public void BackgroundBrushOverridesLegacyBackColorAndNullRestoresIt()
+    {
+        using var control = new Control
+        {
+            BackColor = SKColors.Red,
+            BackgroundBrush = new SolidColorBrush(Color.Blue)
+        };
+        using var adapter = new SkiaControlSurface(control);
+        using var bitmap = new SKBitmap(12, 12, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        adapter.Resize(12, 12);
+
+        Assert.Equal(SKColors.Blue, RenderControlPixel(adapter, canvas, bitmap));
+
+        control.BackgroundBrush = null;
+        Assert.Equal(SKColors.Red, RenderControlPixel(adapter, canvas, bitmap));
+    }
+
+    [Fact]
     public void OneStopAndZeroRadiusGradientsHaveDeterministicSolidResults()
     {
         var oneStop = new LinearGradientBrush();
@@ -138,5 +157,13 @@ public sealed class BrushRenderingTests
         SkiaExtensions.RenderBrushBackground(canvas, new SKRect(0, 0, width, height), brush, SKColors.Magenta);
         canvas.Flush();
         return bitmap.GetPixel(x, y);
+    }
+
+    private static SKColor RenderControlPixel(SkiaControlSurface adapter, SKCanvas canvas, SKBitmap bitmap)
+    {
+        canvas.Clear(SKColors.Transparent);
+        adapter.Render(canvas);
+        canvas.Flush();
+        return bitmap.GetPixel(6, 6);
     }
 }

--- a/ModernFormsNext.Tests/BrushResourceTests.cs
+++ b/ModernFormsNext.Tests/BrushResourceTests.cs
@@ -1,0 +1,202 @@
+using System.Drawing;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using ModernFormsNext.Drawing;
+using ModernFormsNext.WindowKit.Platform;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class BrushResourceTests
+{
+    [Fact]
+    public void ApplicationWindowAndControlScopesResolveNearestBrush()
+    {
+        object key = NewKey();
+        var applicationBrush = new SolidColorBrush(Color.Red);
+        var windowBrush = Gradient(Color.Blue, Color.Green);
+        var controlBrush = new SolidColorBrush(Color.Yellow);
+        Application.Resources[key] = applicationBrush;
+
+        try
+        {
+            using var window = new TestWindow();
+            using var control = new Control();
+            window.Controls.Add(control);
+            control.SetResourceReference(nameof(Control.BackgroundBrush), key);
+            Assert.Same(applicationBrush, control.BackgroundBrush);
+
+            window.Resources[key] = windowBrush;
+            Assert.Same(windowBrush, control.BackgroundBrush);
+
+            control.Resources[key] = controlBrush;
+            Assert.Same(controlBrush, control.BackgroundBrush);
+        }
+        finally
+        {
+            Application.Resources.Remove(key);
+        }
+    }
+
+    [Fact]
+    public void ResourceReplacementDetachesOldBrushAndNestedMutationInvalidatesNewBrush()
+    {
+        object key = NewKey();
+        var solid = new SolidColorBrush(Color.Red);
+        var gradient = Gradient(Color.Black, Color.White);
+        using var control = new InvalidationProbeControl();
+        using var surface = new SkiaControlSurface(control);
+        control.Resources[key] = solid;
+        control.SetResourceReference(nameof(Control.BackgroundBrush), key);
+        control.ResetInvalidations();
+
+        control.Resources[key] = gradient;
+        control.ResetInvalidations();
+        solid.PaintColor = Color.Blue;
+        gradient.GradientStops[0].PaintColor = Color.Purple;
+
+        Assert.Same(gradient, control.BackgroundBrush);
+        Assert.Equal(1, control.Invalidations);
+    }
+
+    [Fact]
+    public void RemovingResourceRestoresCapturedColorFallbackAndItsSubscription()
+    {
+        object key = NewKey();
+        var fallback = new SolidColorBrush(Color.Gray);
+        var resource = Gradient(Color.Red, Color.Blue);
+        using var control = new InvalidationProbeControl { BackgroundBrush = fallback };
+        using var surface = new SkiaControlSurface(control);
+        control.Resources[key] = resource;
+        control.SetResourceReference(nameof(Control.BackgroundBrush), key);
+
+        Assert.True(control.Resources.Remove(key));
+        control.ResetInvalidations();
+        resource.Opacity = 0.4f;
+        fallback.PaintColor = Color.DarkGray;
+
+        Assert.Same(fallback, control.BackgroundBrush);
+        Assert.Equal(1, control.Invalidations);
+    }
+
+    [Fact]
+    public void SharedBrushAcrossTwoPropertiesUsesOneInvalidationAndReferenceCounting()
+    {
+        var shared = Gradient(Color.Red, Color.Blue);
+        using var control = new InvalidationProbeControl
+        {
+            BackgroundBrush = shared,
+            TextBrush = shared
+        };
+        using var surface = new SkiaControlSurface(control);
+        control.ResetInvalidations();
+
+        shared.GradientStops[0].Offset = 0.1f;
+        Assert.Equal(1, control.Invalidations);
+
+        control.BackgroundBrush = null;
+        control.ResetInvalidations();
+        shared.GradientStops[0].Offset = 0.2f;
+        Assert.Equal(1, control.Invalidations);
+
+        control.TextBrush = null;
+        control.ResetInvalidations();
+        shared.GradientStops[0].Offset = 0.3f;
+        Assert.Equal(0, control.Invalidations);
+    }
+
+    [Fact]
+    public void DisposalDetachesBrushInvalidation()
+    {
+        var brush = new SolidColorBrush(Color.Red);
+        var control = new InvalidationProbeControl { BackgroundBrush = brush };
+        using var surface = new SkiaControlSurface(control);
+        control.ResetInvalidations();
+
+        control.Dispose();
+        brush.PaintColor = Color.Blue;
+
+        Assert.Equal(0, control.Invalidations);
+    }
+
+    [Fact]
+    public void LongLivedResourceBrushDoesNotKeepForgottenControlAlive()
+    {
+        object key = NewKey();
+        var brush = new SolidColorBrush(Color.Red);
+        Application.Resources[key] = brush;
+
+        try
+        {
+            WeakReference reference = CreateCollectibleBrushBoundControl(key);
+
+            CollectGarbage();
+            brush.PaintColor = Color.Blue;
+
+            Assert.False(reference.IsAlive);
+        }
+        finally
+        {
+            Application.Resources.Remove(key);
+        }
+    }
+
+    private static LinearGradientBrush Gradient(Color start, Color end)
+    {
+        var brush = new LinearGradientBrush();
+        brush.GradientStops.AddRange([new GradientStop(start, 0f), new GradientStop(end, 1f)]);
+        return brush;
+    }
+
+    private static object NewKey() => $"BrushResourceTests.{Guid.NewGuid():N}";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateCollectibleBrushBoundControl(object key)
+    {
+        var control = new Control();
+        control.SetResourceReference(nameof(Control.BackgroundBrush), key);
+        return new WeakReference(control);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CollectGarbage()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    private sealed class InvalidationProbeControl : Control
+    {
+        public int Invalidations { get; private set; }
+
+        public void ResetInvalidations() => Invalidations = 0;
+
+        protected override void OnInvalidated(EventArgs<Rectangle> e)
+        {
+            Invalidations++;
+            base.OnInvalidated(e);
+        }
+    }
+
+    private sealed class TestWindow : WindowBase
+    {
+        public TestWindow()
+            : base(DispatchProxy.Create<IWindowBaseImpl, WindowImplProxy>())
+        {
+        }
+    }
+
+    private class WindowImplProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod is null || targetMethod.ReturnType == typeof(void))
+                return null;
+
+            return targetMethod.ReturnType.IsValueType
+                ? Activator.CreateInstance(targetMethod.ReturnType)
+                : null;
+        }
+    }
+}

--- a/ModernFormsNext/BrushEditDialog.cs
+++ b/ModernFormsNext/BrushEditDialog.cs
@@ -69,10 +69,12 @@ namespace ModernFormsNext
         private readonly TextBox alphaText;
         private readonly BrushPreviewPanel preview;
         private readonly List<EditableGradientStop> stops = [];
+        private readonly MfnBrush? initialBrush;
         private bool updatingFields;
 
         public BrushEditDialogForm(MfnBrush? initialBrush)
         {
+            this.initialBrush = initialBrush;
             Text = "Brush Editor";
             Name = "BrushEditDialog";
             Size = new Size(560, 500);
@@ -492,14 +494,18 @@ namespace ModernFormsNext
             var primary = orderedStops.Length > 0 ? orderedStops[0].Color : SKColors.Transparent;
 
             if (brushType.SelectedIndex == 0)
-                return new SolidColorBrush(primary);
+                return CopyCommonProperties(initialBrush, new SolidColorBrush(primary));
 
             var brush = brushType.SelectedIndex switch
             {
-                2 => (GradientBrush)new RadialGradientBrush(),
-                3 => new SweepGradientBrush(),
-                _ => new LinearGradientBrush()
+                2 => (GradientBrush)CreateRadialGradientBrush(),
+                3 => CreateSweepGradientBrush(),
+                _ => CreateLinearGradientBrush()
             };
+
+            CopyCommonProperties(initialBrush, brush);
+            if (initialBrush is GradientBrush initialGradient)
+                brush.SpreadMode = initialGradient.SpreadMode;
 
             if (orderedStops.Length == 0)
                 brush.GradientStops.Add(new GradientStop(SKColors.Transparent, 0f));
@@ -510,6 +516,43 @@ namespace ModernFormsNext
             }
 
             return brush;
+        }
+
+        private LinearGradientBrush CreateLinearGradientBrush()
+            => initialBrush is LinearGradientBrush source
+                ? new LinearGradientBrush { Start = source.Start, End = source.End }
+                : new LinearGradientBrush();
+
+        private RadialGradientBrush CreateRadialGradientBrush()
+            => initialBrush is RadialGradientBrush source
+                ? new RadialGradientBrush
+                {
+                    CenterPoint = source.CenterPoint,
+                    GradientOrigin = source.GradientOrigin,
+                    Radius = source.Radius
+                }
+                : new RadialGradientBrush();
+
+        private SweepGradientBrush CreateSweepGradientBrush()
+            => initialBrush is SweepGradientBrush source
+                ? new SweepGradientBrush
+                {
+                    CenterPoint = source.CenterPoint,
+                    StartAngle = source.StartAngle,
+                    EndAngle = source.EndAngle
+                }
+                : new SweepGradientBrush();
+
+        private static TBrush CopyCommonProperties<TBrush>(MfnBrush? source, TBrush target)
+            where TBrush : MfnBrush
+        {
+            if (source is not null)
+            {
+                target.Opacity = source.Opacity;
+                target.Transform = source.Transform;
+            }
+
+            return target;
         }
 
         private static string ToHex(SKColor color)

--- a/ModernFormsNext/BrushEditDialog.cs
+++ b/ModernFormsNext/BrushEditDialog.cs
@@ -23,7 +23,7 @@ namespace ModernFormsNext
     /// <code>
     /// var dialog = new BrushEditDialog
     /// {
-    ///     Brush = new SolidColorBrush(SKColors.SteelBlue)
+    ///     Brush = new SolidColorBrush(System.Drawing.Color.SteelBlue)
     /// };
     ///
     /// if (await dialog.ShowDialog(this) == DialogResult.OK)

--- a/ModernFormsNext/Control.Brushes.cs
+++ b/ModernFormsNext/Control.Brushes.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using ModernFormsNext.Drawing;
+
+namespace ModernFormsNext;
+
+public partial class Control
+{
+    private Dictionary<Brush, WeakBrushInvalidationSubscription>? brushInvalidationSubscriptions;
+
+    /// <summary>
+    /// Replaces a brush-valued field, updates its weak invalidation subscription, and invalidates
+    /// this control when the effective reference changes.
+    /// </summary>
+    /// <param name="field">The brush backing field to replace.</param>
+    /// <param name="value">The new brush, or <see langword="null"/> for the property's fallback.</param>
+    /// <returns><see langword="true"/> when the field changed; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Derived controls should use this helper for public brush properties. Multiple properties
+    /// that reference the same brush share one event handler through reference counting. The
+    /// subscription keeps only a weak reference to the control, so a long-lived dynamic-resource
+    /// brush cannot retain a control if disposal is missed. Brush changes request repaint only and
+    /// must occur on the control's UI thread.
+    /// </remarks>
+    protected bool SetBrushField(ref Brush? field, Brush? value)
+    {
+        if (ReferenceEquals(field, value))
+            return false;
+
+        Brush? previous = field;
+        field = value;
+        if (previous is not null)
+            ReleaseBrushInvalidation(previous);
+        if (value is not null)
+            AcquireBrushInvalidation(value);
+
+        Invalidate();
+        return true;
+    }
+
+    private void AcquireBrushInvalidation(Brush brush)
+    {
+        brushInvalidationSubscriptions ??= new Dictionary<Brush, WeakBrushInvalidationSubscription>(ReferenceEqualityComparer.Instance);
+        if (brushInvalidationSubscriptions.TryGetValue(brush, out WeakBrushInvalidationSubscription? subscription))
+        {
+            subscription.AddReference();
+            return;
+        }
+
+        brushInvalidationSubscriptions.Add(brush, new WeakBrushInvalidationSubscription(this, brush));
+    }
+
+    private void ReleaseBrushInvalidation(Brush brush)
+    {
+        if (brushInvalidationSubscriptions is null ||
+            !brushInvalidationSubscriptions.TryGetValue(brush, out WeakBrushInvalidationSubscription? subscription) ||
+            !subscription.ReleaseReference())
+        {
+            return;
+        }
+
+        brushInvalidationSubscriptions.Remove(brush);
+        subscription.Dispose();
+        if (brushInvalidationSubscriptions.Count == 0)
+            brushInvalidationSubscriptions = null;
+    }
+
+    private void DisposeBrushInvalidationSubscriptions()
+    {
+        if (brushInvalidationSubscriptions is null)
+            return;
+
+        foreach (WeakBrushInvalidationSubscription subscription in brushInvalidationSubscriptions.Values)
+            subscription.Dispose();
+
+        brushInvalidationSubscriptions.Clear();
+        brushInvalidationSubscriptions = null;
+    }
+
+    private sealed class WeakBrushInvalidationSubscription : IDisposable
+    {
+        private readonly WeakReference<Control> target;
+        private Brush? source;
+        private int referenceCount = 1;
+
+        public WeakBrushInvalidationSubscription(Control target, Brush source)
+        {
+            this.target = new WeakReference<Control>(target);
+            this.source = source;
+            source.Changed += HandleBrushChanged;
+        }
+
+        public void AddReference() => referenceCount++;
+
+        public bool ReleaseReference()
+        {
+            referenceCount--;
+            return referenceCount == 0;
+        }
+
+        public void Dispose()
+        {
+            Brush? current = source;
+            if (current is null)
+                return;
+
+            source = null;
+            current.Changed -= HandleBrushChanged;
+        }
+
+        private void HandleBrushChanged(object? sender, EventArgs e)
+        {
+            if (target.TryGetTarget(out Control? control) && !control.disposedValue)
+            {
+                control.Invalidate();
+                return;
+            }
+
+            Dispose();
+        }
+    }
+}

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -229,12 +229,12 @@ namespace ModernFormsNext
         /// <code>
         /// var brush = new ModernFormsNext.Drawing.LinearGradientBrush
         /// {
-        ///     StartPoint = new SKPoint(0, 0),
-        ///     EndPoint = new SKPoint(1, 1)
+        ///     Start = new System.Drawing.PointF(0, 0),
+        ///     End = new System.Drawing.PointF(1, 1)
         /// };
         ///
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(SKColors.White, 0));
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(Theme.AccentColor, 1));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.White, 0));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.CornflowerBlue, 1));
         ///
         /// label.BackgroundBrush = brush;
         /// </code>
@@ -315,12 +315,12 @@ namespace ModernFormsNext
         /// <code>
         /// var brush = new ModernFormsNext.Drawing.LinearGradientBrush
         /// {
-        ///     StartPoint = new SKPoint(0, 0),
-        ///     EndPoint = new SKPoint(1, 0)
+        ///     Start = new System.Drawing.PointF(0, 0),
+        ///     End = new System.Drawing.PointF(1, 0)
         /// };
         ///
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(Theme.AccentColor, 0));
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(Theme.AccentColor2, 1));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.RoyalBlue, 0));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.MediumPurple, 1));
         ///
         /// label.TextBrush = brush;
         /// </code>

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -241,13 +241,7 @@ namespace ModernFormsNext
         /// </example>
         public ModernFormsNext.Drawing.Brush? BackgroundBrush {
             get => backgroundBrush;
-            set {
-                if (backgroundBrush == value)
-                    return;
-
-                backgroundBrush = value;
-                Invalidate ();
-            }
+            set => SetBrushField(ref backgroundBrush, value);
         }
 
         /// <summary>
@@ -333,13 +327,7 @@ namespace ModernFormsNext
         /// </example>
         public ModernFormsNext.Drawing.Brush? TextBrush {
             get => textBrush;
-            set {
-                if (textBrush == value)
-                    return;
-
-                textBrush = value;
-                Invalidate ();
-            }
+            set => SetBrushField(ref textBrush, value);
         }
 
         /// <summary>
@@ -2384,6 +2372,7 @@ namespace ModernFormsNext
         {
             if (!disposedValue) {
                 DisposeResourceReferences ();
+                DisposeBrushInvalidationSubscriptions ();
                 FreeBackBuffer ();
 
                 foreach (var c in Controls.GetAllControls (true))

--- a/ModernFormsNext/Drawing/Brush.cs
+++ b/ModernFormsNext/Drawing/Brush.cs
@@ -1,9 +1,134 @@
-﻿namespace ModernFormsNext.Drawing
+using System;
+using System.Numerics;
+
+namespace ModernFormsNext.Drawing
 {
     /// <summary>
-    /// Base class for background brushes.
+    /// Defines a mutable, shareable value that paints an area or a text mask.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Brushes are platform-neutral visual values. A single brush may be shared by multiple
+    /// controls or stored in a dynamic resource. Changing the brush raises <see cref="Changed"/>
+    /// so every live consumer can invalidate its rendering. Mutate brushes on the UI thread.
+    /// </para>
+    /// <para>
+    /// The renderer resolves relative gradient coordinates against the current paint bounds. The
+    /// same brush therefore adapts to control resizing and is rendered identically by the Windows
+    /// and experimental Android Skia surfaces.
+    /// </para>
+    /// </remarks>
     public abstract class Brush
     {
+        private float opacity = 1f;
+        private Matrix3x2 transform = Matrix3x2.Identity;
+
+        /// <summary>
+        /// Initializes a new brush with full opacity and an identity transform.
+        /// </summary>
+        protected Brush()
+        {
+        }
+
+        /// <summary>
+        /// Occurs when a property or nested gradient stop changes the rendered result.
+        /// </summary>
+        /// <remarks>
+        /// The event is raised synchronously on the mutation thread. Controls use weak
+        /// subscriptions, so sharing a brush from a long-lived resource does not retain a control.
+        /// </remarks>
+        public event EventHandler? Changed;
+
+        /// <summary>
+        /// Gets or sets the opacity multiplier applied to every color produced by this brush.
+        /// </summary>
+        /// <value>A finite value in the inclusive range 0 through 1. The default is 1.</value>
+        /// <remarks>
+        /// Changing opacity invalidates controls using this brush but does not request layout.
+        /// Color alpha and brush opacity are multiplied during rendering.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when the assigned value is not finite or is outside the inclusive range 0..1.
+        /// </exception>
+        public float Opacity
+        {
+            get => opacity;
+            set
+            {
+                ValidateUnitValue(value, nameof(Opacity));
+                if (opacity.Equals(value))
+                    return;
+
+                opacity = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the platform-neutral transform applied to this brush's coordinate space.
+        /// </summary>
+        /// <value>
+        /// A finite <see cref="Matrix3x2"/>. The default is <see cref="Matrix3x2.Identity"/>.
+        /// Translation components use the same logical coordinate space as the resolved paint
+        /// bounds; relative gradient points are resolved before this transform is applied.
+        /// </value>
+        /// <remarks>
+        /// Use <see cref="Matrix3x2.CreateTranslation(float, float)"/>,
+        /// <see cref="Matrix3x2.CreateScale(float)"/>, and
+        /// <see cref="Matrix3x2.CreateRotation(float)"/> to compose transforms without depending
+        /// on renderer-specific matrix types. Changing the transform invalidates rendering only.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when any matrix component is NaN or infinity.
+        /// </exception>
+        public Matrix3x2 Transform
+        {
+            get => transform;
+            set
+            {
+                ValidateTransform(value);
+                if (transform.Equals(value))
+                    return;
+
+                transform = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Raises <see cref="Changed"/> after a rendered value changes.
+        /// </summary>
+        /// <param name="e">Event data for the change.</param>
+        /// <remarks>
+        /// Derived classes should update their backing field before calling this method and should
+        /// raise it only when the effective value changes.
+        /// </remarks>
+        protected virtual void OnChanged(EventArgs e)
+        {
+            ArgumentNullException.ThrowIfNull(e);
+            Changed?.Invoke(this, e);
+        }
+
+        internal static void ValidateUnitValue(float value, string parameterName)
+        {
+            if (!float.IsFinite(value) || value < 0f || value > 1f)
+                throw new ArgumentOutOfRangeException(parameterName, value, "The value must be finite and in the inclusive range 0 through 1.");
+        }
+
+        internal static void ValidatePoint(System.Drawing.PointF value, string parameterName)
+        {
+            if (!float.IsFinite(value.X) || !float.IsFinite(value.Y))
+                throw new ArgumentException("Point coordinates must be finite.", parameterName);
+        }
+
+        private static void ValidateTransform(Matrix3x2 value)
+        {
+            if (!float.IsFinite(value.M11) || !float.IsFinite(value.M12) ||
+                !float.IsFinite(value.M21) || !float.IsFinite(value.M22) ||
+                !float.IsFinite(value.M31) || !float.IsFinite(value.M32))
+            {
+                throw new ArgumentException("Transform components must be finite.", nameof(value));
+            }
+        }
     }
 }

--- a/ModernFormsNext/Drawing/GlassBrush.cs
+++ b/ModernFormsNext/Drawing/GlassBrush.cs
@@ -1,41 +1,136 @@
-﻿using SkiaSharp;
+using System;
+using DrawingColor = System.Drawing.Color;
+using SkiaSharp;
 
 namespace ModernFormsNext.Drawing
 {
     /// <summary>
-    /// Represents a translucent glass-like background brush.
-    /// This is a visual glass effect, not a true background blur.
+    /// Represents a translucent glass-like visual effect without background blur.
     /// </summary>
     public class GlassBrush : Brush
     {
-        /// <summary>
-        /// Gets or sets the main tint color of the glass surface.
-        /// </summary>
-        public SKColor TintColor { get; set; } = new SKColor (255, 255, 255, 28);
+        private DrawingColor tint = DrawingColor.FromArgb(28, 255, 255, 255);
+        private DrawingColor secondaryTint = DrawingColor.FromArgb(12, 255, 255, 255);
+        private DrawingColor highlight = DrawingColor.FromArgb(38, 255, 255, 255);
+        private DrawingColor border = DrawingColor.FromArgb(65, 255, 255, 255);
+        private bool showHighlight = true;
+        private bool showInnerBorder = true;
 
         /// <summary>
-        /// Gets or sets the optional secondary tint color used to create a subtle vertical depth gradient.
+        /// Gets or sets the platform-neutral main tint color, including alpha.
         /// </summary>
-        public SKColor SecondaryTintColor { get; set; } = new SKColor (255, 255, 255, 12);
+        public DrawingColor Tint
+        {
+            get => tint;
+            set => SetColor(ref tint, value);
+        }
 
         /// <summary>
-        /// Gets or sets the highlight color drawn near the top of the glass.
+        /// Gets or sets the platform-neutral secondary tint used for vertical depth.
         /// </summary>
-        public SKColor HighlightColor { get; set; } = new SKColor (255, 255, 255, 38);
+        public DrawingColor SecondaryTint
+        {
+            get => secondaryTint;
+            set => SetColor(ref secondaryTint, value);
+        }
 
         /// <summary>
-        /// Gets or sets the border color of the glass surface.
+        /// Gets or sets the platform-neutral soft highlight color.
         /// </summary>
-        public SKColor BorderColor { get; set; } = new SKColor (255, 255, 255, 65);
+        public DrawingColor Highlight
+        {
+            get => highlight;
+            set => SetColor(ref highlight, value);
+        }
 
         /// <summary>
-        /// Gets or sets whether the glass surface should draw the soft top highlight.
+        /// Gets or sets the platform-neutral border color.
         /// </summary>
-        public bool ShowHighlight { get; set; } = true;
+        public DrawingColor Border
+        {
+            get => border;
+            set => SetColor(ref border, value);
+        }
 
         /// <summary>
-        /// Gets or sets whether the glass surface should draw the inner border.
+        /// Gets or sets whether the glass surface draws the soft top highlight.
         /// </summary>
-        public bool ShowInnerBorder { get; set; } = true;
+        public bool ShowHighlight
+        {
+            get => showHighlight;
+            set
+            {
+                if (showHighlight == value)
+                    return;
+                showHighlight = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether the glass surface draws the inner border.
+        /// </summary>
+        public bool ShowInnerBorder
+        {
+            get => showInnerBorder;
+            set
+            {
+                if (showInnerBorder == value)
+                    return;
+                showInnerBorder = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="Tint"/>.
+        /// </summary>
+        public SKColor TintColor
+        {
+            get => ToSkia(tint);
+            set => Tint = FromSkia(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="SecondaryTint"/>.
+        /// </summary>
+        public SKColor SecondaryTintColor
+        {
+            get => ToSkia(secondaryTint);
+            set => SecondaryTint = FromSkia(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="Highlight"/>.
+        /// </summary>
+        public SKColor HighlightColor
+        {
+            get => ToSkia(highlight);
+            set => Highlight = FromSkia(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="Border"/>.
+        /// </summary>
+        public SKColor BorderColor
+        {
+            get => ToSkia(border);
+            set => Border = FromSkia(value);
+        }
+
+        private void SetColor(ref DrawingColor field, DrawingColor value)
+        {
+            DrawingColor normalized = DrawingColor.FromArgb(value.ToArgb());
+            if (field.ToArgb() == normalized.ToArgb())
+                return;
+
+            field = normalized;
+            OnChanged(EventArgs.Empty);
+        }
+
+        private static DrawingColor FromSkia(SKColor color)
+            => DrawingColor.FromArgb(color.Alpha, color.Red, color.Green, color.Blue);
+
+        private static SKColor ToSkia(DrawingColor color) => new(color.R, color.G, color.B, color.A);
     }
 }

--- a/ModernFormsNext/Drawing/GradientBrush.cs
+++ b/ModernFormsNext/Drawing/GradientBrush.cs
@@ -1,15 +1,71 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Linq;
 
 namespace ModernFormsNext.Drawing
 {
     /// <summary>
-    /// Base class for gradient brushes.
+    /// Provides observable stops and spread behavior for gradient brushes.
     /// </summary>
     public abstract class GradientBrush : Brush
     {
+        private GradientStop[]? orderedStops;
+        private GradientSpreadMode spreadMode;
+
         /// <summary>
-        /// Gets the collection of gradient stops.
+        /// Initializes a gradient brush with an observable stop collection and pad spread mode.
         /// </summary>
-        public List<GradientStop> GradientStops { get; } = new ();
+        protected GradientBrush()
+        {
+            GradientStops.Changed += HandleGradientStopsChanged;
+        }
+
+        /// <summary>
+        /// Gets the observable collection of gradient stops.
+        /// </summary>
+        /// <remarks>
+        /// Stops may be stored in any order. Rendering uses a stable sort by offset, preserving
+        /// collection order when offsets are equal. Collection and item changes raise
+        /// <see cref="Brush.Changed"/>. Mutate the collection on the UI thread while it is in use.
+        /// </remarks>
+        public GradientStopCollection GradientStops { get; } = new();
+
+        /// <summary>
+        /// Gets or sets how colors continue outside the first and last gradient stop.
+        /// </summary>
+        /// <remarks>
+        /// The value maps identically to Skia shader tile behavior on Windows and Android.
+        /// Changing it invalidates controls using this brush without affecting layout.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when the assigned value is not a defined <see cref="GradientSpreadMode"/>.
+        /// </exception>
+        public GradientSpreadMode SpreadMode
+        {
+            get => spreadMode;
+            set
+            {
+                if (!Enum.IsDefined(value))
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The gradient spread mode is not defined.");
+                if (spreadMode == value)
+                    return;
+
+                spreadMode = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        internal GradientStop[] GetOrderedStops()
+            => orderedStops ??= GradientStops
+                .Select(static (stop, index) => (Stop: stop, Index: index))
+                .OrderBy(static item => item.Stop.Offset)
+                .ThenBy(static item => item.Index)
+                .Select(static item => item.Stop)
+                .ToArray();
+
+        private void HandleGradientStopsChanged(object? sender, EventArgs e)
+        {
+            orderedStops = null;
+            OnChanged(EventArgs.Empty);
+        }
     }
 }

--- a/ModernFormsNext/Drawing/GradientSpreadMode.cs
+++ b/ModernFormsNext/Drawing/GradientSpreadMode.cs
@@ -1,0 +1,22 @@
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Specifies how a gradient paints positions outside its first and last stop.
+/// </summary>
+public enum GradientSpreadMode
+{
+    /// <summary>
+    /// Extends the nearest edge color before the first stop and after the last stop.
+    /// </summary>
+    Pad,
+
+    /// <summary>
+    /// Repeats the gradient in the same direction for every interval.
+    /// </summary>
+    Repeat,
+
+    /// <summary>
+    /// Repeats the gradient while mirroring every alternate interval.
+    /// </summary>
+    Reflect
+}

--- a/ModernFormsNext/Drawing/GradientStop.cs
+++ b/ModernFormsNext/Drawing/GradientStop.cs
@@ -1,37 +1,126 @@
-﻿using System;
+using System;
+using DrawingColor = System.Drawing.Color;
 using SkiaSharp;
 
 namespace ModernFormsNext.Drawing
 {
     /// <summary>
-    /// Represents a color stop in a gradient brush.
+    /// Represents an observable color stop in a gradient brush.
     /// </summary>
     public class GradientStop
     {
+        private DrawingColor paintColor;
         private float offset;
 
         /// <summary>
-        /// Gets or sets the color of the gradient stop.
+        /// Initializes a gradient stop with a platform-neutral color and validated offset.
         /// </summary>
-        public SKColor Color { get; set; }
-
-        /// <summary>
-        /// Gets or sets the position of the gradient stop in the range from 0 to 1.
-        /// </summary>
-        public float Offset {
-            get => offset;
-            set => offset = Math.Clamp (value, 0f, 1f);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GradientStop"/> class.
-        /// </summary>
-        /// <param name="color">The stop color.</param>
-        /// <param name="offset">The stop position in the range from 0 to 1.</param>
-        public GradientStop (SKColor color, float offset)
+        /// <param name="color">The stop color, including alpha.</param>
+        /// <param name="offset">The finite stop position in the inclusive range 0 through 1.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="offset"/> is not finite or is outside 0..1.
+        /// </exception>
+        public GradientStop(DrawingColor color, float offset)
         {
-            Color = color;
+            paintColor = Normalize(color);
             Offset = offset;
         }
+
+        /// <summary>
+        /// Initializes a gradient stop from an existing Skia-compatible color.
+        /// </summary>
+        /// <param name="color">The stop color, including alpha.</param>
+        /// <param name="offset">The finite stop position in the inclusive range 0 through 1.</param>
+        /// <remarks>
+        /// This overload preserves the ModernFormsNext 1.8 source surface. New platform-neutral
+        /// code can use <see cref="GradientStop(DrawingColor, float)"/>.
+        /// </remarks>
+        public GradientStop(SKColor color, float offset)
+            : this(DrawingColor.FromArgb(color.Alpha, color.Red, color.Green, color.Blue), offset)
+        {
+        }
+
+        /// <summary>
+        /// Occurs when the color or offset changes.
+        /// </summary>
+        /// <remarks>
+        /// A containing <see cref="GradientStopCollection"/> forwards this event to its brush, so
+        /// mutating one stop invalidates controls using that brush without reassigning the brush.
+        /// The event is raised synchronously on the mutation thread.
+        /// </remarks>
+        public event EventHandler? Changed;
+
+        /// <summary>
+        /// Gets or sets the platform-neutral stop color, including alpha.
+        /// </summary>
+        public DrawingColor PaintColor
+        {
+            get => paintColor;
+            set
+            {
+                DrawingColor normalized = Normalize(value);
+                if (paintColor.ToArgb() == normalized.ToArgb())
+                    return;
+
+                paintColor = normalized;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="PaintColor"/>.
+        /// </summary>
+        /// <remarks>
+        /// This compatibility property and <see cref="PaintColor"/> share one backing value.
+        /// Prefer <see cref="PaintColor"/> in new renderer-neutral code.
+        /// </remarks>
+        public SKColor Color
+        {
+            get => new(paintColor.R, paintColor.G, paintColor.B, paintColor.A);
+            set => PaintColor = DrawingColor.FromArgb(value.Alpha, value.Red, value.Green, value.Blue);
+        }
+
+        /// <summary>
+        /// Gets or sets the normalized position of the gradient stop.
+        /// </summary>
+        /// <value>A finite value in the inclusive range 0 through 1.</value>
+        /// <remarks>
+        /// Stops need not be inserted in offset order. The renderer uses a stable ordered snapshot,
+        /// preserving insertion order for multiple stops at the same offset. Changing the offset
+        /// raises <see cref="Changed"/> and invalidates the containing brush's ordered snapshot.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when the assigned value is not finite or is outside 0..1.
+        /// </exception>
+        public float Offset
+        {
+            get => offset;
+            set
+            {
+                Brush.ValidateUnitValue(value, nameof(Offset));
+                if (offset.Equals(value))
+                    return;
+
+                offset = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Raises <see cref="Changed"/> after a rendered value changes.
+        /// </summary>
+        /// <param name="e">Event data for the change.</param>
+        /// <remarks>
+        /// Derived stops should update their state before calling this method. The current paint
+        /// system does not require derived stop types, but this hook preserves the existing
+        /// non-sealed extension surface.
+        /// </remarks>
+        protected virtual void OnChanged(EventArgs e)
+        {
+            ArgumentNullException.ThrowIfNull(e);
+            Changed?.Invoke(this, e);
+        }
+
+        private static DrawingColor Normalize(DrawingColor color) => DrawingColor.FromArgb(color.ToArgb());
     }
 }

--- a/ModernFormsNext/Drawing/GradientStopCollection.cs
+++ b/ModernFormsNext/Drawing/GradientStopCollection.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Represents an observable, ordered collection of gradient stops.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Collection order is preserved for editing and serialization. Rendering uses a stable sort by
+/// <see cref="GradientStop.Offset"/>, so stops may be added in any order and multiple distinct
+/// stops may share an offset. Mutate the collection on the UI thread when it is used by controls.
+/// </para>
+/// <para>
+/// The collection subscribes to each contained stop. Adding, replacing, moving, removing,
+/// clearing, or mutating a stop raises <see cref="Changed"/> exactly once for that operation.
+/// </para>
+/// </remarks>
+public sealed class GradientStopCollection : IList<GradientStop>, IReadOnlyList<GradientStop>
+{
+    private readonly List<GradientStop> items = [];
+
+    /// <summary>
+    /// Occurs when collection membership, order, or a contained stop changes.
+    /// </summary>
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Gets the number of gradient stops.
+    /// </summary>
+    public int Count => items.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the collection is read-only.
+    /// </summary>
+    public bool IsReadOnly => false;
+
+    /// <summary>
+    /// Gets or replaces the stop at the specified collection position.
+    /// </summary>
+    /// <param name="index">The zero-based collection position.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the assigned stop is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the same stop instance already exists at another position. Distinct stop
+    /// instances with equal offsets are supported.
+    /// </exception>
+    public GradientStop this[int index]
+    {
+        get => items[index];
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            GradientStop previous = items[index];
+            if (ReferenceEquals(previous, value))
+                return;
+
+            EnsureNewInstance(value);
+            previous.Changed -= HandleStopChanged;
+            items[index] = value;
+            value.Changed += HandleStopChanged;
+            OnChanged();
+        }
+    }
+
+    /// <summary>
+    /// Adds a stop to the end of the editable collection order.
+    /// </summary>
+    /// <param name="item">The non-null stop to add.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="item"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the same stop instance is already in this collection.
+    /// </exception>
+    public void Add(GradientStop item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        EnsureNewInstance(item);
+        items.Add(item);
+        item.Changed += HandleStopChanged;
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Adds each stop from a sequence, preserving its collection order.
+    /// </summary>
+    /// <param name="stops">The non-null sequence of non-null, distinct stop instances.</param>
+    /// <remarks>
+    /// The method raises <see cref="Changed"/> once after all stops are added. Validation happens
+    /// before mutation, so a duplicate or null entry leaves the collection unchanged.
+    /// </remarks>
+    public void AddRange(IEnumerable<GradientStop> stops)
+    {
+        ArgumentNullException.ThrowIfNull(stops);
+        GradientStop[] additions = stops is GradientStop[] array ? (GradientStop[])array.Clone() : [.. stops];
+        var unique = new HashSet<GradientStop>(ReferenceEqualityComparer.Instance);
+
+        foreach (GradientStop stop in additions)
+        {
+            ArgumentNullException.ThrowIfNull(stop);
+            EnsureNewInstance(stop);
+            if (!unique.Add(stop))
+                throw new ArgumentException("The sequence contains the same gradient stop instance more than once.", nameof(stops));
+        }
+
+        if (additions.Length == 0)
+            return;
+
+        foreach (GradientStop stop in additions)
+        {
+            items.Add(stop);
+            stop.Changed += HandleStopChanged;
+        }
+
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Removes all stops and their item subscriptions.
+    /// </summary>
+    public void Clear()
+    {
+        if (items.Count == 0)
+            return;
+
+        foreach (GradientStop stop in items)
+            stop.Changed -= HandleStopChanged;
+
+        items.Clear();
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Determines whether the exact stop instance belongs to the collection.
+    /// </summary>
+    /// <param name="item">The stop instance to find.</param>
+    /// <returns><see langword="true"/> when the same instance is present.</returns>
+    public bool Contains(GradientStop item) => IndexOf(item) >= 0;
+
+    /// <summary>
+    /// Copies the editable collection order to an array.
+    /// </summary>
+    /// <param name="array">The destination array.</param>
+    /// <param name="arrayIndex">The zero-based destination index.</param>
+    public void CopyTo(GradientStop[] array, int arrayIndex) => items.CopyTo(array, arrayIndex);
+
+    /// <summary>
+    /// Returns an enumerator over the editable collection order.
+    /// </summary>
+    public IEnumerator<GradientStop> GetEnumerator() => items.GetEnumerator();
+
+    /// <summary>
+    /// Returns the position of the exact stop instance.
+    /// </summary>
+    /// <param name="item">The stop instance to find.</param>
+    /// <returns>The zero-based index, or -1 when absent.</returns>
+    public int IndexOf(GradientStop item)
+    {
+        for (int index = 0; index < items.Count; index++)
+        {
+            if (ReferenceEquals(items[index], item))
+                return index;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Inserts a stop at a specified editable collection position.
+    /// </summary>
+    /// <param name="index">The zero-based insertion position.</param>
+    /// <param name="item">The non-null stop to insert.</param>
+    public void Insert(int index, GradientStop item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        EnsureNewInstance(item);
+        items.Insert(index, item);
+        item.Changed += HandleStopChanged;
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Moves a stop without changing its identity or offset.
+    /// </summary>
+    /// <param name="oldIndex">The current zero-based position.</param>
+    /// <param name="newIndex">The destination zero-based position.</param>
+    /// <remarks>
+    /// Moving matters when two or more stops have the same offset because stable rendering order
+    /// follows this editable order for equal offsets.
+    /// </remarks>
+    public void Move(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex)
+            return;
+
+        GradientStop item = items[oldIndex];
+        items.RemoveAt(oldIndex);
+        items.Insert(newIndex, item);
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Removes the exact stop instance when present.
+    /// </summary>
+    /// <param name="item">The stop instance to remove.</param>
+    /// <returns><see langword="true"/> when a stop was removed.</returns>
+    public bool Remove(GradientStop item)
+    {
+        int index = IndexOf(item);
+        if (index < 0)
+            return false;
+
+        RemoveAt(index);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes and unsubscribes the stop at a specified position.
+    /// </summary>
+    /// <param name="index">The zero-based position.</param>
+    public void RemoveAt(int index)
+    {
+        GradientStop item = items[index];
+        items.RemoveAt(index);
+        item.Changed -= HandleStopChanged;
+        OnChanged();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void EnsureNewInstance(GradientStop item)
+    {
+        if (IndexOf(item) >= 0)
+            throw new ArgumentException("The same gradient stop instance cannot be added more than once.", nameof(item));
+    }
+
+    private void HandleStopChanged(object? sender, EventArgs e) => OnChanged();
+
+    private void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+}

--- a/ModernFormsNext/Drawing/LinearGradientBrush.cs
+++ b/ModernFormsNext/Drawing/LinearGradientBrush.cs
@@ -1,22 +1,94 @@
-﻿using SkiaSharp;
+using System;
+using System.Drawing;
+using SkiaSharp;
 
 namespace ModernFormsNext.Drawing
 {
     /// <summary>
-    /// Represents a linear gradient brush.
+    /// Paints a linear gradient between two points relative to the current paint bounds.
     /// </summary>
     public class LinearGradientBrush : GradientBrush
     {
-        /// <summary>
-        /// Gets or sets the normalized start point of the gradient.
-        /// Values are relative to the painted bounds, usually in the range from 0 to 1.
-        /// </summary>
-        public SKPoint StartPoint { get; set; } = new (0f, 0f);
+        private PointF start = new(0f, 0f);
+        private PointF end = new(1f, 1f);
 
         /// <summary>
-        /// Gets or sets the normalized end point of the gradient.
-        /// Values are relative to the painted bounds, usually in the range from 0 to 1.
+        /// Gets or sets the platform-neutral normalized start position.
         /// </summary>
-        public SKPoint EndPoint { get; set; } = new (1f, 1f);
+        /// <value>
+        /// A finite point resolved as <c>bounds.Left + bounds.Width * X</c> and
+        /// <c>bounds.Top + bounds.Height * Y</c>. Values outside 0..1 are allowed so repeat and
+        /// reflect patterns can be positioned beyond the painted area.
+        /// </value>
+        /// <remarks>
+        /// Coordinates are relative and do not receive a second DPI conversion. Changing the
+        /// point raises <see cref="Brush.Changed"/> and affects rendering, not layout.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when either component is not finite.</exception>
+        public PointF Start
+        {
+            get => start;
+            set
+            {
+                ValidatePoint(value, nameof(Start));
+                if (start.Equals(value))
+                    return;
+
+                start = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the platform-neutral normalized end position.
+        /// </summary>
+        /// <value>
+        /// A finite point resolved against the current paint bounds. Values outside 0..1 are
+        /// allowed.
+        /// </value>
+        /// <remarks>
+        /// Coordinates are relative and do not receive a second DPI conversion. Changing the
+        /// point raises <see cref="Brush.Changed"/> and affects rendering, not layout.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when either component is not finite.</exception>
+        public PointF End
+        {
+            get => end;
+            set
+            {
+                ValidatePoint(value, nameof(End));
+                if (end.Equals(value))
+                    return;
+
+                end = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="Start"/>.
+        /// </summary>
+        /// <remarks>
+        /// This ModernFormsNext 1.8 compatibility property shares the same backing value. Prefer
+        /// <see cref="Start"/> in platform-neutral code.
+        /// </remarks>
+        public SKPoint StartPoint
+        {
+            get => new(start.X, start.Y);
+            set => Start = new PointF(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="End"/>.
+        /// </summary>
+        /// <remarks>
+        /// This ModernFormsNext 1.8 compatibility property shares the same backing value. Prefer
+        /// <see cref="End"/> in platform-neutral code.
+        /// </remarks>
+        public SKPoint EndPoint
+        {
+            get => new(end.X, end.Y);
+            set => End = new PointF(value.X, value.Y);
+        }
     }
 }

--- a/ModernFormsNext/Drawing/NoBrush.cs
+++ b/ModernFormsNext/Drawing/NoBrush.cs
@@ -1,0 +1,20 @@
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Represents an explicit request to paint no fill.
+/// </summary>
+/// <remarks>
+/// Assigning <see cref="NoBrush"/> differs from assigning <see langword="null"/>. A null brush
+/// preserves the existing control behavior and uses its fallback color; <see cref="NoBrush"/>
+/// leaves the paint area untouched. The type is platform-neutral and can be shared through dynamic
+/// resources.
+/// </remarks>
+public sealed class NoBrush : Brush
+{
+    /// <summary>
+    /// Initializes an explicit no-fill brush.
+    /// </summary>
+    public NoBrush()
+    {
+    }
+}

--- a/ModernFormsNext/Drawing/RadialGradientBrush.cs
+++ b/ModernFormsNext/Drawing/RadialGradientBrush.cs
@@ -1,22 +1,109 @@
-﻿using SkiaSharp;
+using System;
+using System.Drawing;
+using SkiaSharp;
 
 namespace ModernFormsNext.Drawing
 {
     /// <summary>
-    /// Represents a radial gradient brush.
+    /// Paints a circular radial gradient with an optional focal origin.
     /// </summary>
     public class RadialGradientBrush : GradientBrush
     {
-        /// <summary>
-        /// Gets or sets the normalized center point of the gradient.
-        /// Values are relative to the painted bounds, usually in the range from 0 to 1.
-        /// </summary>
-        public SKPoint Center { get; set; } = new (0.5f, 0.5f);
+        private PointF centerPoint = new(0.5f, 0.5f);
+        private PointF gradientOrigin = new(0.5f, 0.5f);
+        private float radius = 0.5f;
+        private bool originWasSet;
 
         /// <summary>
-        /// Gets or sets the normalized radius of the gradient.
-        /// A value of 0.5 means half of the smaller painted dimension.
+        /// Gets or sets the platform-neutral normalized center of the outer gradient circle.
         /// </summary>
-        public float Radius { get; set; } = 0.5f;
+        /// <value>A finite point relative to the painted bounds. The default is (0.5, 0.5).</value>
+        /// <remarks>
+        /// Until <see cref="GradientOrigin"/> is assigned explicitly, changing this property keeps
+        /// the origin at the same point for compatibility with the original centered radial brush.
+        /// Coordinates do not receive a second DPI conversion.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when either component is not finite.</exception>
+        public PointF CenterPoint
+        {
+            get => centerPoint;
+            set
+            {
+                ValidatePoint(value, nameof(CenterPoint));
+                if (centerPoint.Equals(value))
+                    return;
+
+                centerPoint = value;
+                if (!originWasSet)
+                    gradientOrigin = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the platform-neutral normalized focal origin of the gradient.
+        /// </summary>
+        /// <value>A finite point relative to the painted bounds. The default follows the center.</value>
+        /// <remarks>
+        /// A different origin creates a two-point conical gradient whose outer circle remains
+        /// centered at <see cref="CenterPoint"/>. Changing it invalidates rendering only.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when either component is not finite.</exception>
+        public PointF GradientOrigin
+        {
+            get => gradientOrigin;
+            set
+            {
+                ValidatePoint(value, nameof(GradientOrigin));
+                originWasSet = true;
+                if (gradientOrigin.Equals(value))
+                    return;
+
+                gradientOrigin = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the normalized circular radius.
+        /// </summary>
+        /// <value>
+        /// A finite non-negative multiplier of the smaller painted dimension. The default is 0.5.
+        /// A zero radius is valid and renders the final stop color across the area.
+        /// </value>
+        /// <remarks>
+        /// The smaller-dimension rule preserves the established circular behavior across control
+        /// resizing and on Windows and Android. Changing the radius invalidates rendering only.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when the assigned value is negative, NaN, or infinity.
+        /// </exception>
+        public float Radius
+        {
+            get => radius;
+            set
+            {
+                if (!float.IsFinite(value) || value < 0f)
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The radius must be finite and non-negative.");
+                if (radius.Equals(value))
+                    return;
+
+                radius = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="CenterPoint"/>.
+        /// </summary>
+        /// <remarks>
+        /// This ModernFormsNext 1.8 compatibility property shares the same backing value. Prefer
+        /// <see cref="CenterPoint"/> in platform-neutral code.
+        /// </remarks>
+        public SKPoint Center
+        {
+            get => new(centerPoint.X, centerPoint.Y);
+            set => CenterPoint = new PointF(value.X, value.Y);
+        }
     }
 }

--- a/ModernFormsNext/Drawing/SolidColorBrush.cs
+++ b/ModernFormsNext/Drawing/SolidColorBrush.cs
@@ -1,4 +1,6 @@
-﻿using SkiaSharp;
+using System;
+using DrawingColor = System.Drawing.Color;
+using SkiaSharp;
 
 namespace ModernFormsNext.Drawing
 {
@@ -7,18 +9,81 @@ namespace ModernFormsNext.Drawing
     /// </summary>
     public class SolidColorBrush : Brush
     {
-        /// <summary>
-        /// Gets or sets the brush color.
-        /// </summary>
-        public SKColor Color { get; set; }
+        private DrawingColor paintColor;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SolidColorBrush"/> class.
+        /// Initializes a new solid brush with a transparent color.
         /// </summary>
-        /// <param name="color">The solid color of the brush.</param>
-        public SolidColorBrush (SKColor color)
+        public SolidColorBrush()
+            : this(DrawingColor.Transparent)
         {
-            Color = color;
         }
+
+        /// <summary>
+        /// Initializes a new solid brush with a platform-neutral color.
+        /// </summary>
+        /// <param name="color">The color, including its alpha channel.</param>
+        public SolidColorBrush(DrawingColor color)
+        {
+            paintColor = Normalize(color);
+        }
+
+        /// <summary>
+        /// Initializes a new solid brush from an existing Skia-compatible color.
+        /// </summary>
+        /// <param name="color">The color, including its alpha channel.</param>
+        /// <remarks>
+        /// This overload preserves the ModernFormsNext 1.8 source surface. New platform-neutral
+        /// code can use <see cref="SolidColorBrush(DrawingColor)"/>.
+        /// </remarks>
+        public SolidColorBrush(SKColor color)
+            : this(DrawingColor.FromArgb(color.Alpha, color.Red, color.Green, color.Blue))
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the platform-neutral solid color, including alpha.
+        /// </summary>
+        /// <remarks>
+        /// Changing the color raises <see cref="Brush.Changed"/> synchronously and invalidates
+        /// controls using the brush. It does not affect layout. The same behavior is used on
+        /// Windows and Android.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var brush = new SolidColorBrush(System.Drawing.Color.CornflowerBlue)
+        /// {
+        ///     Opacity = 0.8f
+        /// };
+        /// </code>
+        /// </example>
+        public DrawingColor PaintColor
+        {
+            get => paintColor;
+            set
+            {
+                DrawingColor normalized = Normalize(value);
+                if (paintColor.ToArgb() == normalized.ToArgb())
+                    return;
+
+                paintColor = normalized;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="PaintColor"/>.
+        /// </summary>
+        /// <remarks>
+        /// This compatibility property and <see cref="PaintColor"/> share one backing value.
+        /// Prefer <see cref="PaintColor"/> in new renderer-neutral code.
+        /// </remarks>
+        public SKColor Color
+        {
+            get => new(paintColor.R, paintColor.G, paintColor.B, paintColor.A);
+            set => PaintColor = DrawingColor.FromArgb(value.Alpha, value.Red, value.Green, value.Blue);
+        }
+
+        private static DrawingColor Normalize(DrawingColor color) => DrawingColor.FromArgb(color.ToArgb());
     }
 }

--- a/ModernFormsNext/Drawing/SweepGradientBrush.cs
+++ b/ModernFormsNext/Drawing/SweepGradientBrush.cs
@@ -1,39 +1,96 @@
-﻿using SkiaSharp;
+using System;
+using System.Drawing;
+using SkiaSharp;
 
 namespace ModernFormsNext.Drawing
 {
     /// <summary>
-    /// Represents a sweep (angular) gradient brush.
+    /// Paints an angular (conical) gradient around a center point.
     /// </summary>
     public class SweepGradientBrush : GradientBrush
     {
-        private SKPoint center = new (0.5f, 0.5f);
-        private float startAngle = 0f;
+        private PointF centerPoint = new(0.5f, 0.5f);
+        private float startAngle;
         private float endAngle = 360f;
 
         /// <summary>
-        /// Gets or sets the normalized center point of the gradient.
-        /// Values are relative to the painted bounds, usually in the range from 0 to 1.
+        /// Gets or sets the platform-neutral normalized center of the angular gradient.
         /// </summary>
-        public SKPoint Center {
-            get => center;
-            set => center = value;
+        /// <value>A finite point relative to current paint bounds. The default is (0.5, 0.5).</value>
+        /// <remarks>
+        /// Coordinates do not receive a second DPI conversion. Changing this property raises
+        /// <see cref="Brush.Changed"/> and affects rendering, not layout.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when either component is not finite.</exception>
+        public PointF CenterPoint
+        {
+            get => centerPoint;
+            set
+            {
+                ValidatePoint(value, nameof(CenterPoint));
+                if (centerPoint.Equals(value))
+                    return;
+
+                centerPoint = value;
+                OnChanged(EventArgs.Empty);
+            }
         }
 
         /// <summary>
-        /// Gets or sets the start angle of the gradient in degrees.
+        /// Gets or sets the start angle in clockwise degrees.
         /// </summary>
-        public float StartAngle {
+        /// <value>A finite angle. The default is 0 degrees.</value>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is not finite.</exception>
+        public float StartAngle
+        {
             get => startAngle;
-            set => startAngle = value;
+            set
+            {
+                ValidateAngle(value, nameof(StartAngle));
+                if (startAngle.Equals(value))
+                    return;
+
+                startAngle = value;
+                OnChanged(EventArgs.Empty);
+            }
         }
 
         /// <summary>
-        /// Gets or sets the end angle of the gradient in degrees.
+        /// Gets or sets the end angle in clockwise degrees.
         /// </summary>
-        public float EndAngle {
+        /// <value>A finite angle. The default is 360 degrees.</value>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is not finite.</exception>
+        public float EndAngle
+        {
             get => endAngle;
-            set => endAngle = value;
+            set
+            {
+                ValidateAngle(value, nameof(EndAngle));
+                if (endAngle.Equals(value))
+                    return;
+
+                endAngle = value;
+                OnChanged(EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Skia-compatible view of <see cref="CenterPoint"/>.
+        /// </summary>
+        /// <remarks>
+        /// This ModernFormsNext 1.8 compatibility property shares the same backing value. Prefer
+        /// <see cref="CenterPoint"/> in platform-neutral code.
+        /// </remarks>
+        public SKPoint Center
+        {
+            get => new(centerPoint.X, centerPoint.Y);
+            set => CenterPoint = new PointF(value.X, value.Y);
+        }
+
+        private static void ValidateAngle(float value, string parameterName)
+        {
+            if (!float.IsFinite(value))
+                throw new ArgumentOutOfRangeException(parameterName, value, "The angle must be finite.");
         }
     }
 }

--- a/ModernFormsNext/Extensions/SkiaExtensions.cs
+++ b/ModernFormsNext/Extensions/SkiaExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Drawing;
-using System.Linq;
 using System.Runtime.Versioning;
 using ModernFormsNext.Drawing;
+using ModernFormsNext.Rendering.Skia;
 using SkiaSharp;
 
 namespace ModernFormsNext
@@ -25,9 +25,6 @@ namespace ModernFormsNext
         /// </summary>
         public static void Clip (this SKCanvas canvas, Rectangle rectangle) => canvas.ClipRect (rectangle.ToSKRect ());
 
-        /// <summary>
-        /// Draws a control's background.
-        /// </summary>
         /// <summary>
         /// Draws a control's background.
         /// </summary>
@@ -74,149 +71,56 @@ namespace ModernFormsNext
             canvas.Clear (style.GetBackgroundColor ());
         }
 
-        private static void RenderLinearGradient (SKCanvas canvas, SKRect bounds, LinearGradientBrush brush, SKBlendMode blendMode = SKBlendMode.SrcOver)
+        private static void RenderGradient(SKCanvas canvas, SKRect bounds, GradientBrush brush, SKBlendMode blendMode)
         {
-            if (brush.GradientStops.Count == 0)
+            GradientStop[] stops = brush.GetOrderedStops();
+            if (stops.Length == 0 || brush.Opacity <= 0f)
                 return;
 
-            if (brush.GradientStops.Count == 1) {
-                using var singlePaint = new SKPaint {
-                    Color = brush.GradientStops[0].Color,
+            // A one-stop gradient is a solid fill. A zero-radius radial gradient also has no
+            // spatial interval, so the final stop is the only well-defined area color.
+            if (stops.Length == 1 || brush is RadialGradientBrush { Radius: 0f })
+            {
+                using var singlePaint = new SKPaint
+                {
+                    Color = SkiaBrushFactory.ApplyOpacity(stops[^1].Color, brush.Opacity),
                     IsAntialias = true,
                     BlendMode = blendMode
                 };
 
-                canvas.DrawRect (bounds, singlePaint);
+                canvas.DrawRect(bounds, singlePaint);
                 return;
             }
 
-            var start = new SKPoint (
-                bounds.Left + bounds.Width * brush.StartPoint.X,
-                bounds.Top + bounds.Height * brush.StartPoint.Y);
+            using SKShader? shader = SkiaBrushFactory.CreateGradientShader(brush, bounds);
+            if (shader is null)
+                return;
 
-            var end = new SKPoint (
-                bounds.Left + bounds.Width * brush.EndPoint.X,
-                bounds.Top + bounds.Height * brush.EndPoint.Y);
-
-            var orderedStops = brush.GradientStops
-    .OrderBy (x => x.Offset)
-    .ToArray ();
-
-            var colors = orderedStops.Select (x => x.Color).ToArray ();
-            var positions = orderedStops.Select (x => x.Offset).ToArray ();
-
-            using var shader = SKShader.CreateLinearGradient (
-                start,
-                end,
-                colors,
-                positions,
-                SKShaderTileMode.Clamp);
-
-            using var paint = new SKPaint {
+            using var paint = new SKPaint
+            {
                 Shader = shader,
                 IsAntialias = true,
                 BlendMode = blendMode
             };
 
-            canvas.DrawRect (bounds, paint);
-        }
-
-        private static void RenderRadialGradient (SKCanvas canvas, SKRect bounds, RadialGradientBrush brush, SKBlendMode blendMode = SKBlendMode.SrcOver)
-        {
-            if (brush.GradientStops.Count == 0)
-                return;
-
-            if (brush.GradientStops.Count == 1) {
-                using var singlePaint = new SKPaint {
-                    Color = brush.GradientStops[0].Color,
-                    IsAntialias = true,
-                    BlendMode = blendMode
-                };
-
-                canvas.DrawRect (bounds, singlePaint);
-                return;
-            }
-
-            var center = new SKPoint (
-                bounds.Left + bounds.Width * brush.Center.X,
-                bounds.Top + bounds.Height * brush.Center.Y);
-
-            var radius = MathF.Min (bounds.Width, bounds.Height) * brush.Radius;
-
-            var orderedStops = brush.GradientStops.OrderBy (x => x.Offset).ToArray ();
-
-            var colors = orderedStops.Select (x => x.Color).ToArray ();
-            var positions = orderedStops.Select (x => x.Offset).ToArray ();
-
-            using var shader = SKShader.CreateRadialGradient (
-                center,
-                radius,
-                colors,
-                positions,
-                SKShaderTileMode.Clamp);
-
-            using var paint = new SKPaint {
-                Shader = shader,
-                IsAntialias = true,
-                BlendMode = blendMode
-            };
-
-            canvas.DrawRect (bounds, paint);
-        }
-
-        private static void RenderSweepGradient (SKCanvas canvas, SKRect bounds, SweepGradientBrush brush, SKBlendMode blendMode = SKBlendMode.SrcOver)
-        {
-            if (brush.GradientStops.Count == 0)
-                return;
-
-            if (brush.GradientStops.Count == 1) {
-                using var singlePaint = new SKPaint {
-                    Color = brush.GradientStops[0].Color,
-                    IsAntialias = true,
-                    BlendMode = blendMode
-                };
-
-                canvas.DrawRect (bounds, singlePaint);
-                return;
-            }
-
-            var orderedStops = brush.GradientStops
-                .OrderBy (x => x.Offset)
-                .ToArray ();
-
-            var colors = orderedStops.Select (x => x.Color).ToArray ();
-            var positions = orderedStops.Select (x => x.Offset).ToArray ();
-
-            var center = new SKPoint (
-                bounds.Left + (bounds.Width * brush.Center.X),
-                bounds.Top + (bounds.Height * brush.Center.Y));
-
-            using var shader = SKShader.CreateSweepGradient (
-                center,
-                colors,
-                positions,
-                SKShaderTileMode.Clamp,
-                brush.StartAngle,
-                brush.EndAngle);
-
-            using var paint = new SKPaint {
-                Shader = shader,
-                IsAntialias = true,
-                BlendMode = blendMode
-            };
-
-            canvas.DrawRect (bounds, paint);
+            canvas.DrawRect(bounds, paint);
         }
 
         private static void RenderGlassBackground (SKCanvas canvas, SKRect bounds, GlassBrush brush, SKBlendMode blendMode = SKBlendMode.SrcOver)
         {
             // Base translucent fill with a very subtle vertical depth gradient
-            using (var shader = SKShader.CreateLinearGradient (
-                new SKPoint (bounds.Left, bounds.Top),
-                new SKPoint (bounds.Left, bounds.Bottom),
-                new[] { brush.HighlightColor, brush.TintColor, brush.SecondaryTintColor },
-                new[] { 0f, 0.28f, 1f },
-                SKShaderTileMode.Clamp))
+            using (var shader = SkiaBrushFactory.ApplyTransform(
+                SKShader.CreateLinearGradient (
+                    new SKPoint (bounds.Left, bounds.Top),
+                    new SKPoint (bounds.Left, bounds.Bottom),
+                    new[] {
+                        SkiaBrushFactory.ApplyOpacity(brush.HighlightColor, brush.Opacity),
+                        SkiaBrushFactory.ApplyOpacity(brush.TintColor, brush.Opacity),
+                        SkiaBrushFactory.ApplyOpacity(brush.SecondaryTintColor, brush.Opacity)
+                    },
+                    new[] { 0f, 0.28f, 1f },
+                    SKShaderTileMode.Clamp),
+                brush.Transform))
             using (var paint = new SKPaint {
                 Shader = shader,
                 IsAntialias = true,
@@ -229,15 +133,18 @@ namespace ModernFormsNext
             if (brush.ShowHighlight) {
                 var highlightHeight = MathF.Max (8f, bounds.Height * 0.32f);
 
-                using var highlightShader = SKShader.CreateLinearGradient (
-                    new SKPoint (bounds.Left, bounds.Top),
-                    new SKPoint (bounds.Left, bounds.Top + highlightHeight),
-                    new[] {
-                brush.HighlightColor,
-                new SKColor (brush.HighlightColor.Red, brush.HighlightColor.Green, brush.HighlightColor.Blue, 0)
-                    },
-                    new[] { 0f, 1f },
-                    SKShaderTileMode.Clamp);
+                SKColor highlightColor = SkiaBrushFactory.ApplyOpacity(brush.HighlightColor, brush.Opacity);
+                using var highlightShader = SkiaBrushFactory.ApplyTransform(
+                    SKShader.CreateLinearGradient (
+                        new SKPoint (bounds.Left, bounds.Top),
+                        new SKPoint (bounds.Left, bounds.Top + highlightHeight),
+                        new[] {
+                            highlightColor,
+                            new SKColor (highlightColor.Red, highlightColor.Green, highlightColor.Blue, 0)
+                        },
+                        new[] { 0f, 1f },
+                        SKShaderTileMode.Clamp),
+                    brush.Transform);
 
                 using var highlightPaint = new SKPaint {
                     Shader = highlightShader,
@@ -252,7 +159,7 @@ namespace ModernFormsNext
 
             // Outer border
             using (var borderPaint = new SKPaint {
-                Color = brush.BorderColor,
+                Color = SkiaBrushFactory.ApplyOpacity(brush.BorderColor, brush.Opacity),
                 IsStroke = true,
                 StrokeWidth = 1f,
                 IsAntialias = true,
@@ -269,7 +176,7 @@ namespace ModernFormsNext
             // Optional inner border for a more glass-like edge
             if (brush.ShowInnerBorder) {
                 using var innerBorderPaint = new SKPaint {
-                    Color = new SKColor (255, 255, 255, 20),
+                    Color = SkiaBrushFactory.ApplyOpacity(new SKColor (255, 255, 255, 20), brush.Opacity),
                     IsStroke = true,
                     StrokeWidth = 1f,
                     IsAntialias = true,
@@ -298,21 +205,28 @@ namespace ModernFormsNext
                 return;
             }
 
+            if (brush is NoBrush || brush.Opacity <= 0f)
+                return;
+
             switch (brush) {
                 case SolidColorBrush solid:
-                    using (var paint = new SKPaint { Color = solid.Color, IsAntialias = true, BlendMode = blendMode })
+                    using (var paint = new SKPaint {
+                        Color = SkiaBrushFactory.ApplyOpacity(solid.Color, solid.Opacity),
+                        IsAntialias = true,
+                        BlendMode = blendMode
+                    })
                         canvas.DrawRect (bounds, paint);
                     break;
 
                 case LinearGradientBrush linear:
-                    RenderLinearGradient (canvas, bounds, linear, blendMode);
+                    RenderGradient (canvas, bounds, linear, blendMode);
                     break;
 
                 case RadialGradientBrush radial:
-                    RenderRadialGradient (canvas, bounds, radial, blendMode);
+                    RenderGradient (canvas, bounds, radial, blendMode);
                     break;
                 case SweepGradientBrush sweep:
-                    RenderSweepGradient (canvas, bounds, sweep, blendMode);
+                    RenderGradient (canvas, bounds, sweep, blendMode);
                     break;
 
                 case GlassBrush glass:

--- a/ModernFormsNext/GroupBox.cs
+++ b/ModernFormsNext/GroupBox.cs
@@ -159,12 +159,12 @@ namespace ModernFormsNext
         /// <code>
         /// var brush = new ModernFormsNext.Drawing.LinearGradientBrush
         /// {
-        ///     StartPoint = new SKPoint(0, 0),
-        ///     EndPoint = new SKPoint(1, 0)
+        ///     Start = new System.Drawing.PointF(0, 0),
+        ///     End = new System.Drawing.PointF(1, 0)
         /// };
         ///
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(Theme.AccentColor, 0));
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(Theme.AccentColor2, 1));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.RoyalBlue, 0));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.MediumPurple, 1));
         ///
         /// groupBox.CaptionBackgroundBrush = brush;
         /// </code>
@@ -349,12 +349,12 @@ namespace ModernFormsNext
         /// <code>
         /// var brush = new ModernFormsNext.Drawing.LinearGradientBrush
         /// {
-        ///     StartPoint = new SKPoint(0, 0),
-        ///     EndPoint = new SKPoint(1, 1)
+        ///     Start = new System.Drawing.PointF(0, 0),
+        ///     End = new System.Drawing.PointF(1, 1)
         /// };
         ///
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(SKColors.White, 0));
-        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(Theme.AccentColor, 1));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.White, 0));
+        /// brush.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.CornflowerBlue, 1));
         ///
         /// groupBox.ContentBackgroundBrush = brush;
         /// </code>

--- a/ModernFormsNext/GroupBox.cs
+++ b/ModernFormsNext/GroupBox.cs
@@ -172,14 +172,7 @@ namespace ModernFormsNext
         public ModernFormsNext.Drawing.Brush? CaptionBackgroundBrush
         {
             get => captionBackgroundBrush;
-            set
-            {
-                if (captionBackgroundBrush == value)
-                    return;
-
-                captionBackgroundBrush = value;
-                Invalidate();
-            }
+            set => SetBrushField(ref captionBackgroundBrush, value);
         }
 
         /// <summary>
@@ -369,14 +362,7 @@ namespace ModernFormsNext
         public ModernFormsNext.Drawing.Brush? ContentBackgroundBrush
         {
             get => contentBackgroundBrush;
-            set
-            {
-                if (contentBackgroundBrush == value)
-                    return;
-
-                contentBackgroundBrush = value;
-                Invalidate();
-            }
+            set => SetBrushField(ref contentBackgroundBrush, value);
         }
 
         /// <summary>

--- a/ModernFormsNext/Rendering/Skia/SkiaBrushFactory.cs
+++ b/ModernFormsNext/Rendering/Skia/SkiaBrushFactory.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Numerics;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Rendering.Skia;
+
+/// <summary>
+/// Converts shared framework brushes into short-lived, bounds-specific Skia shaders.
+/// </summary>
+/// <remarks>
+/// Callers own and must dispose the returned shader. The factory intentionally does not cache
+/// native shaders because their coordinates depend on current bounds and a brush can be shared by
+/// controls of different sizes. Gradient stop ordering is cached by <see cref="GradientBrush"/>.
+/// </remarks>
+internal static class SkiaBrushFactory
+{
+    public static SKShader? CreateGradientShader(GradientBrush brush, SKRect bounds)
+    {
+        ArgumentNullException.ThrowIfNull(brush);
+        GradientStop[] stops = brush.GetOrderedStops();
+        if (stops.Length < 2 || bounds.Width <= 0f || bounds.Height <= 0f)
+            return null;
+
+        SKColor[] colors = new SKColor[stops.Length];
+        float[] positions = new float[stops.Length];
+        for (int index = 0; index < stops.Length; index++)
+        {
+            colors[index] = ApplyOpacity(stops[index].Color, brush.Opacity);
+            positions[index] = stops[index].Offset;
+        }
+
+        SKShaderTileMode tileMode = MapSpreadMode(brush.SpreadMode);
+        SKShader? shader = brush switch
+        {
+            LinearGradientBrush linear => CreateLinearGradient(linear, bounds, colors, positions, tileMode),
+            RadialGradientBrush radial => CreateRadialGradient(radial, bounds, colors, positions, tileMode),
+            SweepGradientBrush sweep => CreateSweepGradient(sweep, bounds, colors, positions, tileMode),
+            _ => null
+        };
+
+        return shader is null ? null : ApplyTransform(shader, brush.Transform);
+    }
+
+    public static SKColor ApplyOpacity(SKColor color, float opacity)
+    {
+        byte alpha = (byte)Math.Clamp((int)MathF.Round(color.Alpha * opacity), byte.MinValue, byte.MaxValue);
+        return new SKColor(color.Red, color.Green, color.Blue, alpha);
+    }
+
+    public static SKShaderTileMode MapSpreadMode(GradientSpreadMode spreadMode)
+        => spreadMode switch
+        {
+            GradientSpreadMode.Pad => SKShaderTileMode.Clamp,
+            GradientSpreadMode.Repeat => SKShaderTileMode.Repeat,
+            GradientSpreadMode.Reflect => SKShaderTileMode.Mirror,
+            _ => throw new ArgumentOutOfRangeException(nameof(spreadMode), spreadMode, "The gradient spread mode is not defined.")
+        };
+
+    public static SKPoint ResolveRelativePoint(System.Drawing.PointF point, SKRect bounds)
+        => new(bounds.Left + (bounds.Width * point.X), bounds.Top + (bounds.Height * point.Y));
+
+    public static SKShader ApplyTransform(SKShader shader, Matrix3x2 transform)
+    {
+        ArgumentNullException.ThrowIfNull(shader);
+        if (transform.IsIdentity)
+            return shader;
+
+        var matrix = new SKMatrix(
+            transform.M11,
+            transform.M21,
+            transform.M31,
+            transform.M12,
+            transform.M22,
+            transform.M32,
+            0f,
+            0f,
+            1f);
+
+        SKShader transformed = shader.WithLocalMatrix(matrix);
+        shader.Dispose();
+        return transformed;
+    }
+
+    private static SKShader CreateLinearGradient(
+        LinearGradientBrush brush,
+        SKRect bounds,
+        SKColor[] colors,
+        float[] positions,
+        SKShaderTileMode tileMode)
+        => SKShader.CreateLinearGradient(
+            ResolveRelativePoint(brush.Start, bounds),
+            ResolveRelativePoint(brush.End, bounds),
+            colors,
+            positions,
+            tileMode);
+
+    private static SKShader? CreateRadialGradient(
+        RadialGradientBrush brush,
+        SKRect bounds,
+        SKColor[] colors,
+        float[] positions,
+        SKShaderTileMode tileMode)
+    {
+        float radius = MathF.Min(bounds.Width, bounds.Height) * brush.Radius;
+        if (radius <= 0f)
+            return null;
+
+        SKPoint center = ResolveRelativePoint(brush.CenterPoint, bounds);
+        SKPoint origin = ResolveRelativePoint(brush.GradientOrigin, bounds);
+        if (center == origin)
+            return SKShader.CreateRadialGradient(center, radius, colors, positions, tileMode);
+
+        return SKShader.CreateTwoPointConicalGradient(origin, 0f, center, radius, colors, positions, tileMode);
+    }
+
+    private static SKShader CreateSweepGradient(
+        SweepGradientBrush brush,
+        SKRect bounds,
+        SKColor[] colors,
+        float[] positions,
+        SKShaderTileMode tileMode)
+        => SKShader.CreateSweepGradient(
+            ResolveRelativePoint(brush.CenterPoint, bounds),
+            colors,
+            positions,
+            tileMode,
+            brush.StartAngle,
+            brush.EndAngle);
+}

--- a/ModernFormsNext/Switch.cs
+++ b/ModernFormsNext/Switch.cs
@@ -359,7 +359,7 @@ namespace ModernFormsNext
         public MfnBrush? OffTrackBrush
         {
             get => offTrackBrush;
-            set => SetInvalidatingField(ref offTrackBrush, value);
+            set => SetBrushField(ref offTrackBrush, value);
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace ModernFormsNext
         public MfnBrush? NegativeTrackBrush
         {
             get => negativeTrackBrush;
-            set => SetInvalidatingField(ref negativeTrackBrush, value);
+            set => SetBrushField(ref negativeTrackBrush, value);
         }
 
         /// <summary>
@@ -377,7 +377,7 @@ namespace ModernFormsNext
         public MfnBrush? OnTrackBrush
         {
             get => onTrackBrush;
-            set => SetInvalidatingField(ref onTrackBrush, value);
+            set => SetBrushField(ref onTrackBrush, value);
         }
 
         /// <summary>
@@ -493,7 +493,7 @@ namespace ModernFormsNext
         public MfnBrush? ThumbBrush
         {
             get => thumbBrush;
-            set => SetInvalidatingField(ref thumbBrush, value);
+            set => SetBrushField(ref thumbBrush, value);
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace ModernFormsNext
         public MfnBrush? OffThumbBrush
         {
             get => offThumbBrush;
-            set => SetInvalidatingField(ref offThumbBrush, value);
+            set => SetBrushField(ref offThumbBrush, value);
         }
 
         /// <summary>
@@ -511,7 +511,7 @@ namespace ModernFormsNext
         public MfnBrush? NegativeThumbBrush
         {
             get => negativeThumbBrush;
-            set => SetInvalidatingField(ref negativeThumbBrush, value);
+            set => SetBrushField(ref negativeThumbBrush, value);
         }
 
         /// <summary>
@@ -520,7 +520,7 @@ namespace ModernFormsNext
         public MfnBrush? OnThumbBrush
         {
             get => onThumbBrush;
-            set => SetInvalidatingField(ref onThumbBrush, value);
+            set => SetBrushField(ref onThumbBrush, value);
         }
 
         /// <summary>

--- a/ModernFormsNext/Switch.cs
+++ b/ModernFormsNext/Switch.cs
@@ -477,12 +477,12 @@ namespace ModernFormsNext
         /// <code>
         /// var thumbGradient = new ModernFormsNext.Drawing.LinearGradientBrush
         /// {
-        ///     StartPoint = new SKPoint(0, 0),
-        ///     EndPoint = new SKPoint(1, 1)
+        ///     Start = new System.Drawing.PointF(0, 0),
+        ///     End = new System.Drawing.PointF(1, 1)
         /// };
         ///
-        /// thumbGradient.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(SKColors.White, 0f));
-        /// thumbGradient.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(SKColors.SteelBlue, 1f));
+        /// thumbGradient.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.White, 0f));
+        /// thumbGradient.GradientStops.Add(new ModernFormsNext.Drawing.GradientStop(System.Drawing.Color.SteelBlue, 1f));
         ///
         /// var control = new Switch
         /// {

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ declared as a publishable NuGet package.
 - [Android platform status](docs/platforms/android.md)
 - [Designer architecture](docs/designer-architecture.md)
 - [Dynamic resources](docs/dynamic-resources.md)
+- [Paint and gradients](docs/paint-and-gradients.md)
 - [Markdown viewing](docs/markdown.md) and [Markdown editing](docs/markdown-editor.md)
 - [Data binding](docs/data-binding.md)
 - [Styling](docs/styling.md)

--- a/docs/architecture/decisions/ADR-Dynamic-Resources.md
+++ b/docs/architecture/decisions/ADR-Dynamic-Resources.md
@@ -58,8 +58,9 @@ weak registrations prevent a missed disposal from retaining a control.
 - Direct property assignment does not automatically clear a reference; callers must use
   `ClearResourceReference`.
 - Updates run synchronously on the mutation thread, so live resources have UI-thread affinity.
-- A resource object mutated in place does not generate a dictionary change. Replace the value or add
-  a future observable resource type when in-place updates are required.
+- A resource object mutated in place does not generate a dictionary change. The observable `Brush`
+  hierarchy handles this through its own weak control subscriptions; arbitrary mutable values still
+  require replacement or a future type-specific observation contract.
 
 ## Rejected alternatives
 

--- a/docs/architecture/decisions/ADR-Paint-And-Gradient-System.md
+++ b/docs/architecture/decisions/ADR-Paint-And-Gradient-System.md
@@ -1,0 +1,79 @@
+# ADR: Evolve Brush as the canonical paint value
+
+- Status: Accepted for implementation
+- Date: 2026-07-19
+- Scope: `ModernFormsNext.Drawing`, control brush properties, dynamic resources, and Skia rendering
+
+## Context
+
+ModernFormsNext 1.8.0 already exposes a public `Brush` hierarchy for solid, linear, radial, sweep,
+and glass fills. Controls, ControlGallery, the Visual Studio Designer, `.mfdesign` serialization,
+and C# generation use those types. The hierarchy is nevertheless Skia-coupled, does not notify
+when mutable values change, stores gradient stops in a raw list, and supports only clamp spread.
+
+The roadmap needs a reusable visual value for ThemeManager, dynamic resources, future shapes,
+charts, control backgrounds, borders, and text. It must remain shared between Windows and the
+experimental Android backend and must not introduce another rendering or property system.
+
+## Problem
+
+Choose whether the framework should replace `Brush` with `Paint`, keep two independent models, or
+harden the existing hierarchy. The result must support runtime mutation and targeted invalidation,
+retain color-based compatibility, centralize Skia shader ownership, and provide a preferred public
+surface that is not defined in terms of Skia types.
+
+## Options considered
+
+1. Replace all existing brushes and control properties with a new `Paint` hierarchy.
+2. Keep `Brush` for existing controls and add an independent `Paint` hierarchy for themes/shapes.
+3. Make `Paint` a new base class and adapt every old brush into parallel new paint types.
+4. Evolve `Brush` as the single model, add neutral preferred members and mutation notification,
+   and retain existing Skia members only as compatibility adapters to the same backing values.
+5. Make brushes immutable and require complete replacement for every change.
+
+## Decision
+
+Use option 4. `Brush` remains the canonical framework paint value. It becomes observable and
+shareable, with opacity and a platform-neutral transform. Gradients gain an observable typed stop
+collection and pad/repeat/reflect spread. Linear, radial, and sweep coordinates gain neutral .NET
+properties. Existing `SKColor` and `SKPoint` properties remain adapters backed by the same values;
+they do not create a second source of truth.
+
+Controls subscribe to assigned brushes through weak, reference-counted invalidation subscriptions.
+Dynamic-resource replacement continues to invoke ordinary property setters, while mutation inside
+a shared brush raises its own `Changed` event. The shared Skia adapter creates bounds-specific
+shaders, maps spread modes, and disposes every native shader after the draw. It caches only a
+managed stable ordering of gradient stops.
+
+`null` keeps its established meaning of using a color fallback. A distinct no-fill brush represents
+"paint nothing". Relative coordinates remain the supported mapping mode; an absolute mode is
+deferred until all framework paint surfaces share a documented logical-unit contract. JSON field
+names are documented for future ThemeManager work, but no partial theme serializer is introduced.
+
+## Consequences
+
+- Existing control property names, brush types, color fallbacks, Designer documents, and common
+  source code continue to work.
+- New theme/shape code can use the same values as controls instead of converting between `Paint`
+  and `Brush` objects.
+- Preferred new values use `System.Drawing.Color`, `PointF`, and `Matrix3x2`; existing public Skia
+  adapters cannot be removed before a separately planned breaking release.
+- In-place mutation invalidates every live control sharing the brush, so mutations retain UI-thread
+  affinity and future animation must use the UI dispatcher.
+- An observable collection changes the binary type of `GradientStops`. This is the smallest
+  necessary compatibility cost for reliable item and collection mutation.
+- Strict offset validation surfaces bad theme/serialized data early rather than silently clamping.
+- Bounds-specific shader allocation remains per draw. Avoiding it safely requires a later bounded
+  cache informed by rendering diagnostics and animation workloads.
+- Windows, Android, the Designer, and off-screen tests share all brush math and shader construction.
+
+## Rejected alternatives
+
+- Replacing `Brush` would break controls, generated code, Designer documents, and users for a naming
+  preference rather than a missing capability.
+- Independent `Paint` and `Brush` models would duplicate gradients, serialization, resources,
+  invalidation, adapters, and precedence rules.
+- A new `Paint` base with parallel derived types would still leave two public construction paths
+  and force controls to accept a wider base solely for compatibility.
+- Immutable brushes make sharing safe but require replacing an entire resource to animate one
+  color or stop. That conflicts with targeted live theme updates and the requested runtime model.

--- a/docs/architecture/paint-and-gradients.md
+++ b/docs/architecture/paint-and-gradients.md
@@ -1,0 +1,211 @@
+# Paint and gradient architecture
+
+## Status and scope
+
+This document records the state found after the 1.8.0 release and the target architecture for the
+paint/brush hardening stage. The stage deliberately stops before ThemeManager, shapes, charts, a
+new animation scheduler, or a theme JSON loader. Its output is a reusable visual-value contract for
+those later features.
+
+## 1. Current color, brush, and gradient system
+
+ModernFormsNext already has a public `ModernFormsNext.Drawing.Brush` hierarchy. It contains
+`SolidColorBrush`, `GradientBrush`, `LinearGradientBrush`, `RadialGradientBrush`,
+`SweepGradientBrush`, and `GlassBrush`. A `GradientBrush` owns a mutable `List<GradientStop>`.
+Controls expose `BackgroundBrush` and `TextBrush`; `GroupBox` and `Switch` expose additional
+brush-valued properties. `BackColor`, `ForeColor`, `ControlStyle`, borders, and most specialized
+renderers continue to use `SKColor`.
+
+The shared text path supports brush-filled text by painting a text mask and applying the brush with
+`SrcIn`. Background and state brushes are rendered by `SkiaExtensions.RenderBrushBackground`.
+The Visual Studio Designer serializes the existing brush hierarchy into `.mfdesign` and generates
+matching C# object initializers.
+
+## 2. Existing types to reuse
+
+- `Brush` and its existing derived types are the established user-facing vocabulary.
+- `GradientStop` already provides the expected color/offset concept.
+- `Control.BackgroundBrush`, `Control.TextBrush`, `GroupBox` brush properties, and `Switch` brush
+  properties are existing integration points.
+- `ResourceDictionary` and `Control.SetResourceReference` already provide application, window,
+  ancestor-control, and local-control precedence through normal CLR setters.
+- `SkiaExtensions.RenderBrushBackground` is the existing shared rendering entry point.
+- `Control.Invalidate`, renderer clipping, and the per-control Skia back buffer are the existing
+  redraw pipeline on Windows, Android, the Designer, and headless surfaces.
+- Designer structured values and `CSharpLiteralWriter` are the existing serialization/code
+  generation contract.
+
+## 3. Problems in the current architecture
+
+1. Brushes and stops are mutable but publish no change notification. Mutating a shared brush does
+   not invalidate controls that use it.
+2. `GradientStops` is a raw `List<T>`. Adding, removing, replacing, reordering, or mutating a stop
+   cannot invalidate cached/rendered state safely.
+3. Stops are sorted and copied with LINQ every time a gradient is painted.
+4. Gradient spread is hard-coded to Skia `Clamp`; repeat and reflect are unavailable.
+5. The public coordinate and color members use `SKPoint` and `SKColor`, coupling visual values to a
+   renderer implementation.
+6. Shader construction is mixed into `SkiaExtensions`, and every gradient path repeats ownership
+   and single-stop handling.
+7. `null` means "use the fallback color", so there is no explicit value for "paint nothing".
+8. The current radial model has one circular radius and no separate gradient origin.
+9. Existing control brush setters only invalidate on replacement and do not manage subscriptions.
+10. Brush serialization does not preserve spread, opacity, or future transform data.
+
+## 4. Naming consistency
+
+The repository and its public control API consistently use `Brush`, while the low-level Skia type
+is named `SKPaint`. Introducing a second public `Paint` hierarchy would make `BackgroundBrush` and
+the existing Designer contract adapters to a competing abstraction. This stage therefore keeps
+`Brush` as the canonical framework visual value. "Paint" is used as the general architectural
+concept and for internal renderer operations, not as a duplicate public object model.
+
+New platform-neutral members use .NET primitives (`System.Drawing.Color`, `PointF`, and
+`System.Numerics.Matrix3x2`). Existing `SKColor`/`SKPoint` members remain compatibility adapters to
+the same backing values. They are not a second source of truth.
+
+## 5. Direct SkiaSharp dependencies
+
+The existing dependency surface includes brush colors and points, `ControlStyle`, `Theme`, border
+styles, paint event/canvas APIs, text measurement, control renderers, and the Designer's brush
+editor. Removing every public Skia type is a separate breaking migration. This stage removes Skia
+from the preferred brush coordinate/color/transform API while retaining the already-published Skia
+members for source compatibility.
+
+All new shader construction belongs in one internal Skia brush adapter. Specialized color pickers
+may continue to construct their own procedural shaders because those shaders are control
+implementation details rather than reusable `Brush` values.
+
+## 6. Windows and Android impact
+
+The model, validation, ordering, mutation notification, coordinate math, and resource behavior live
+in the multi-targeted shared framework project. Windows and Android therefore use identical paint
+semantics. The adapter consumes the bounds already supplied by the current Skia canvas pipeline and
+does not apply DPI a second time. Relative points remain stable when controls resize and when a
+window moves between DPI contexts.
+
+Android remains experimental. This work does not change its lifecycle, windowing, input, AOT, or
+publication status. Paint behavior must be verified through the shared headless Skia tests and an
+Android target build; a physical-device GPU check remains manual.
+
+## 7. Dynamic resources
+
+A mutable brush may be stored at application, window, or control scope. Resource replacement still
+uses the existing CLR property setter. Once assigned, a control holds one weak invalidation
+subscription per distinct brush, reference-counted across its brush properties. Mutating a brush or
+one of its stops invalidates only controls currently using it. Replacement, fallback, explicit
+reference removal, and control disposal detach subscriptions. The brush's event must not keep a
+forgotten, unreachable control alive.
+
+Resource dictionaries continue to notify only when the resource entry changes. In-place brush
+changes flow through the brush's own notification contract; no global resource broadcast is added.
+Mutations have the same UI-thread affinity as current resource updates and control setters.
+
+## 8. Future ThemeManager impact
+
+ThemeManager can publish shared brushes under stable dynamic-resource keys. Runtime changes can
+update a brush in place for targeted invalidation, while atomic theme replacement can replace the
+resource value. Opacity, spread mode, stable stop ordering, and neutral values form a future JSON
+schema without embedding Skia names. This stage documents that schema direction but does not add a
+partial theme serializer.
+
+Advanced color interpolation is intentionally not exposed until ThemeManager can define and
+validate color spaces consistently. The initial renderer preserves Skia's current sRGB-compatible
+color behavior.
+
+## 9. Future Shape impact
+
+Shapes will be able to reuse `Brush` for fills and, later, stroke paint without depending on a
+control. Relative gradient coordinates are resolved against the geometry's paint bounds by the
+same adapter. The model does not reference `Control`, Windows, Android, or the Designer. Stroke
+caps, joins, dashes, and geometry are outside this stage.
+
+## 10. Target architecture
+
+- `Brush` is mutable, shareable, observable, and platform-neutral through its preferred API.
+- `Brush.Opacity` is in the inclusive range 0..1 and affects color alpha at render time.
+- `Brush.Transform` is a finite `Matrix3x2`; it prepares translate, scale, rotate, and matrix
+  composition without exposing `SKMatrix`.
+- `NoBrush` explicitly suppresses a fill; `null` retains its existing fallback-color meaning.
+- `SolidColorBrush.PaintColor` is the preferred neutral color property. Legacy `Color` maps to the
+  same backing value.
+- `GradientBrush` owns `GradientStopCollection`, `SpreadMode`, and a cached stable ordered snapshot.
+- `GradientStop` is observable, validates offsets strictly, and exposes a neutral preferred color
+  alongside the legacy Skia adapter.
+- Linear, radial, and sweep brushes expose neutral points. Existing Skia point properties delegate
+  to the same fields.
+- Relative coordinates are the only public mapping mode in this stage. Absolute coordinates are
+  deferred until the framework has a single documented logical-coordinate contract across normal,
+  Designer, export, and off-screen surfaces.
+- Radial gradients add a neutral gradient origin while retaining the compatible circular radius.
+- A single internal Skia adapter maps spread modes, coordinates, alpha, transforms, and stop
+  snapshots to shaders. Bounds-dependent shaders are short-lived and disposed after drawing.
+
+## 11. Migration plan
+
+Existing `BackgroundBrush`, `TextBrush`, `CaptionBackgroundBrush`, `ContentBackgroundBrush`, and
+switch brush assignments continue to accept the same brush types. Existing `BackColor` and
+`ForeColor` remain fallback colors; an assigned brush takes precedence. Clearing a brush restores
+the existing color path. `NoBrush` differs deliberately by painting no fill.
+
+New code should use `PaintColor`, neutral point members, `SpreadMode`, `Opacity`, and `Transform`.
+The Designer may continue reading older structured values containing `Color`, `StartPoint`,
+`EndPoint`, `Center`, and `Radius`; newly saved values add optional properties with backward-
+compatible defaults. Generated code remains valid C# and uses the existing brush hierarchy.
+
+## 12. Potential breaking changes
+
+Changing `GradientStops` from `List<GradientStop>` to `GradientStopCollection` changes the binary
+property signature and removes reliance on `List<T>`-specific APIs. It is required to observe all
+collection and item mutations. Common source operations (`Add`, collection initializers, indexing,
+enumeration, `Remove`, and `Clear`) remain compatible, and `AddRange` is provided.
+
+Out-of-range or non-finite offsets will throw `ArgumentOutOfRangeException` instead of being
+silently clamped. This prevents invalid serialized/theme data from producing ambiguous gradients.
+The legacy Skia color and point properties remain available, so no deliberate source break is made
+for those members.
+
+## 13. Performance risks
+
+Shared mutable brushes can invalidate many controls, which is intentional but can be expensive if
+callers mutate every property separately during animation. A future update scope may coalesce
+notifications. The stop collection caches a stable offset-ordered snapshot so render frames do not
+repeat LINQ sorting. Color and position arrays are still produced for Skia shader creation; shader
+creation itself dominates and cannot be eliminated safely for bounds-dependent gradients without a
+bounded cache policy.
+
+Text brushes require a temporary alpha layer as before. Animated brush properties rebuild shaders
+and should be driven by the future UI-thread animation scheduler, not worker-thread callbacks.
+
+## 14. Native memory and shader cache risks
+
+`SKShader` and `SKPaint` own native resources. The adapter returns explicit shader ownership to a
+single rendering scope, which disposes the shader and paint after drawing. Replacing a shader on a
+paint never abandons an undisposed shader. No global shader cache is introduced: linear/radial/
+sweep shaders depend on current bounds, spread, transform, colors, and offsets, and a shared brush
+can be rendered at multiple sizes simultaneously.
+
+Only managed, renderer-neutral stop ordering is cached on the brush. A collection or stop mutation
+invalidates that cache before it raises `Changed`. This avoids stale native state and keeps Windows
+CPU surfaces, Android GPU/CPU surfaces, the Designer, and tests on the same path.
+
+## 15. Completion criteria
+
+This stage is complete when:
+
+- solid, no-fill, linear, radial, and sweep brushes share one observable hierarchy;
+- opacity, stable validated stops, pad/repeat/reflect, relative bounds, radial origin, and neutral
+  transforms render through one Skia adapter;
+- preferred new brush APIs do not require Skia types, while existing brush code remains usable;
+- control, group-box, and switch properties subscribe weakly, invalidate on nested mutation, and
+  detach on replacement/disposal;
+- application/window/control resource precedence, type replacement, in-place mutation, fallback,
+  and garbage collection are tested;
+- Designer round trips and generated C# preserve the supported brush contract;
+- focused rendering tests cover bounds, alpha, spread, stop edge cases, and shader disposal scopes;
+- ControlGallery demonstrates solid, linear, radial, spread, runtime mutation, and a dynamic brush
+  resource without changing the default template application;
+- shared, Windows, Android, Designer, VSIX, samples, tests, and local packages pass release
+  validation; and
+- the roadmap marks only paint/gradient hardening complete and recommends UI animation scheduler
+  hardening next.

--- a/docs/dynamic-resources.md
+++ b/docs/dynamic-resources.md
@@ -26,6 +26,31 @@ Application.Resources["Button.Primary.Background"] = SKColors.MediumSeaGreen;
 Resources may contain any assignable type, not just colors. Brushes, fonts, `Thickness`, styles,
 animation configuration, and localized strings can use the same mechanism.
 
+### Observable brushes
+
+Brushes are observable resource values. Once a brush is assigned to a standard brush-valued control
+property, changing its color, opacity, transform, gradient geometry, stop collection, or an
+individual stop invalidates only controls that still consume it. Replacing the dictionary entry is
+not required:
+
+```csharp
+var brush = new LinearGradientBrush();
+brush.GradientStops.AddRange([
+    new GradientStop(System.Drawing.Color.MidnightBlue, 0f),
+    new GradientStop(System.Drawing.Color.CornflowerBlue, 1f)
+]);
+
+Application.Resources["Card.Background"] = brush;
+card.SetResourceReference(nameof(Control.BackgroundBrush), "Card.Background");
+
+brush.GradientStops[0].PaintColor = System.Drawing.Color.Teal;
+```
+
+Control subscriptions are weak and reference-counted. Replacing a brush, applying a fallback,
+clearing a reference, or disposing a control detaches the obsolete subscription. Other arbitrary
+mutable resource objects do not become observable automatically; they still need replacement or a
+future type-specific change contract.
+
 ## Lookup order and fallback
 
 For a control, lookup proceeds from the most specific scope to the broadest:
@@ -89,5 +114,7 @@ worker thread.
   must be settled before enabling aggressive member trimming for applications.
 - Merged dictionaries, explicit dictionary inheritance, resource factories, and transition
   animation are future ThemeManager work.
+- In-place updates are currently observed for the framework brush hierarchy only, not for every
+  mutable resource object.
 - Resource values are applied directly. General-purpose implicit conversion is intentionally not
   performed because it would make theme errors dependent on culture and converter availability.

--- a/docs/paint-and-gradients.md
+++ b/docs/paint-and-gradients.md
@@ -1,0 +1,238 @@
+# Paint and gradients
+
+ModernFormsNext uses one public visual-value hierarchy rooted at
+`ModernFormsNext.Drawing.Brush`. The name is retained for compatibility with the existing controls,
+Designer, and generated code; there is no parallel `Paint` hierarchy. Brushes are mutable,
+shareable, observable, and rendered through the same Skia adapter on Windows and the experimental
+Android surface host.
+
+For the architectural rationale and migration analysis, see
+[Paint and gradient architecture](architecture/paint-and-gradients.md) and
+[ADR: Evolve Brush as the canonical paint value](architecture/decisions/ADR-Paint-And-Gradient-System.md).
+
+## Available brush types
+
+| Type | Purpose |
+| --- | --- |
+| `SolidColorBrush` | One color, including alpha. |
+| `LinearGradientBrush` | A gradient between two relative points. |
+| `RadialGradientBrush` | A circular gradient with an optional separate focal origin. |
+| `SweepGradientBrush` | An angular gradient around a relative center. |
+| `GlassBrush` | The existing layered glass treatment. |
+| `NoBrush` | An explicit request to paint no fill. |
+
+`Brush.Opacity` multiplies the alpha of every produced color. `Brush.Transform` applies a
+platform-neutral `Matrix3x2` to the resolved brush coordinate space. Both affect rendering only;
+they do not request layout.
+
+## Solid colors
+
+Use `System.Drawing.Color` through the platform-neutral `PaintColor` member in new code:
+
+```csharp
+using ModernFormsNext;
+using ModernFormsNext.Drawing;
+using Color = System.Drawing.Color;
+
+var card = new Panel
+{
+    BackgroundBrush = new SolidColorBrush(Color.CornflowerBlue)
+    {
+        Opacity = 0.8f
+    }
+};
+```
+
+The existing Skia-compatible `Color` member and constructor remain available. `Color` and
+`PaintColor` are views of the same backing value, not independent settings.
+
+## Linear gradients
+
+`Start` and `End` use relative coordinates resolved against the current paint bounds. `(0, 0)` is
+the top-left corner and `(1, 1)` is the bottom-right corner. The renderer resolves these points for
+every current bounds and does not apply DPI scaling a second time.
+
+```csharp
+using System.Drawing;
+using ModernFormsNext.Drawing;
+
+var gradient = new LinearGradientBrush
+{
+    Start = new PointF(0f, 0f),
+    End = new PointF(1f, 0f),
+    SpreadMode = GradientSpreadMode.Pad
+};
+
+gradient.GradientStops.AddRange([
+    new GradientStop(Color.MidnightBlue, 0f),
+    new GradientStop(Color.DeepSkyBlue, 0.55f),
+    new GradientStop(Color.White, 1f)
+]);
+
+panel.BackgroundBrush = gradient;
+```
+
+Finite coordinates outside `0..1` are accepted. They are useful when positioning a repeated or
+reflected interval outside the painted area. Absolute coordinate mapping is not part of the current
+contract.
+
+## Radial and sweep gradients
+
+A radial radius is a non-negative multiplier of the smaller bounds dimension. A zero radius is
+valid and deterministically paints the final stop color. `GradientOrigin` defaults to following
+`CenterPoint`; assigning it explicitly creates a focal/two-point radial gradient.
+
+```csharp
+var radial = new RadialGradientBrush
+{
+    CenterPoint = new PointF(0.55f, 0.5f),
+    GradientOrigin = new PointF(0.25f, 0.3f),
+    Radius = 0.7f
+};
+
+radial.GradientStops.AddRange([
+    new GradientStop(Color.White, 0f),
+    new GradientStop(Color.RoyalBlue, 0.5f),
+    new GradientStop(Color.MidnightBlue, 1f)
+]);
+```
+
+`SweepGradientBrush` uses `CenterPoint`, `StartAngle`, and `EndAngle`. Angles are finite clockwise
+degrees. Sweep gradients use the same observable stops, opacity, and transform contract.
+
+## Gradient stops and spread
+
+Every stop offset must be finite and in the inclusive range `0..1`. Invalid values throw
+`ArgumentOutOfRangeException`; values are not silently clamped. Stops may be added in any order.
+Rendering uses a stable offset sort, so distinct stops with the same offset retain collection order
+and can form a hard transition.
+
+`GradientStopCollection` observes membership, order, and each contained `GradientStop`. `Add`,
+`AddRange`, `Insert`, replacement by index, `Move`, `Remove`, `RemoveAt`, and `Clear` all update the
+rendered result. The same stop instance cannot occur twice in one collection, but distinct instances
+with equal values are supported.
+
+Spread modes map consistently to the shared renderer:
+
+- `Pad` extends the nearest edge color;
+- `Repeat` repeats every interval in the same direction;
+- `Reflect` mirrors alternating intervals.
+
+Color interpolation currently follows Skia's standard color interpolation. A selectable linear-
+light or color-space API is deferred until ThemeManager can define and validate it consistently.
+
+## Opacity and transforms
+
+Opacity is a finite value from `0` through `1` and multiplies the alpha already present in colors.
+Transforms are finite `System.Numerics.Matrix3x2` values:
+
+```csharp
+using System.Numerics;
+
+gradient.Opacity = 0.75f;
+gradient.Transform =
+    Matrix3x2.CreateScale(1.15f) *
+    Matrix3x2.CreateRotation(0.15f) *
+    Matrix3x2.CreateTranslation(8f, 0f);
+```
+
+Relative points are resolved against the current logical paint bounds before the transform is sent
+to the renderer. Translation components therefore use the same logical coordinate space as those
+bounds. Resize and DPI changes rebuild the bounds-specific shader; a cached shader is never reused
+for a different size.
+
+## Color fallback and no fill
+
+The established color APIs remain supported. For a standard control background:
+
+1. a non-null `BackgroundBrush` is rendered;
+2. `BackgroundBrush == null` uses `BackColor`/the resolved `ControlStyle` background;
+3. `BackgroundBrush = new NoBrush()` explicitly suppresses the control's fill so the already
+   painted parent/background can show through.
+
+Assigning `BackColor` does not discard an assigned brush. Clear `BackgroundBrush` to return to the
+color fallback.
+
+## Runtime mutation and dynamic resources
+
+Brushes raise `Changed` synchronously after a rendered value changes. Standard brush-valued control
+properties use weak, reference-counted subscriptions and invalidate only live controls that
+currently reference that brush. Mutating one stop does not require replacing or reassigning the
+brush.
+
+```csharp
+const string key = "Card.Background";
+
+Application.Resources[key] = gradient;
+card.SetResourceReference(nameof(Control.BackgroundBrush), key);
+
+// Repaints card through the brush notification; the dictionary entry is unchanged.
+gradient.GradientStops[0].PaintColor = Color.Teal;
+
+// Re-resolves normal application/window/ancestor/control precedence.
+card.Resources[key] = new SolidColorBrush(Color.Gold);
+```
+
+Resource replacement, fallback, clearing the reference, replacing the control property, and control
+disposal detach the previous subscription. Multiple properties on one control that share a brush
+use one handler with reference counting. A long-lived resource brush holds only a weak reference to
+its consumers.
+
+Resource and brush mutations that affect live controls must run on the UI/dispatcher thread. The
+current model raises one notification per property or collection operation; it does not yet provide
+a batch-update scope for coalescing animation frames.
+
+## Designer compatibility
+
+Designer documents and generated `.Designer.cs` code preserve opacity, transform, spread mode,
+radial focal origin, geometry, and stops. Documents created before these fields existed are read
+with compatible defaults: full opacity, identity transform, `Pad`, and a radial origin that follows
+the center. The existing Skia-compatible point/color members remain readable and generated code
+continues to use the established brush type names.
+
+Changing `GradientStops` from `List<GradientStop>` to `GradientStopCollection` is a binary signature
+change. Common source operations remain available, including indexing, enumeration, collection
+initializers, `Add`, `AddRange`, `Remove`, and `Clear`. Code that explicitly requires `List<T>` must
+accept `IList<GradientStop>` or `GradientStopCollection` instead.
+
+## Planned JSON representation
+
+There is no runtime brush JSON converter in this stage. Implementing half of ThemeManager's loading
+and validation pipeline would create a second, premature contract. The planned schema direction is
+renderer-neutral, camel-cased, and discriminated by `type`:
+
+```json
+{
+  "type": "linearGradient",
+  "opacity": 0.85,
+  "transform": [1, 0, 0, 1, 8, 0],
+  "spread": "reflect",
+  "start": { "x": 0, "y": 0.5 },
+  "end": { "x": 0.35, "y": 0.5 },
+  "stops": [
+    { "offset": 0, "color": "#FF165DAD" },
+    { "offset": 1, "color": "#FFF8C24A" }
+  ]
+}
+```
+
+The intended discriminators are `solid`, `linearGradient`, `radialGradient`, `sweepGradient`, and
+`none`. Eight-digit colors use `#AARRGGBB`; six-digit colors are opaque. A radial value adds
+`center`, `origin`, and `radius`; a sweep value adds `center`, `startAngle`, and `endAngle`. The
+future ThemeManager work must version this schema, validate unknown/missing fields, produce path-
+specific errors, and test round trips before it becomes a supported file format.
+
+## Current limitations
+
+- Relative mapping is the only supported coordinate mode; absolute mapping is deferred.
+- Radial gradients are circular and use one radius, not independent X/Y radii.
+- Existing public Skia-compatible members remain for source compatibility; use the neutral members
+  in new application, theme, and future shape code.
+- Advanced color-space interpolation and brush animation helpers are not implemented.
+- Shader objects are intentionally short-lived and disposed per rendering scope; there is no global
+  bounds-dependent native shader cache.
+- Android uses the same model and shader factory, but Android support as a whole remains
+  experimental and still requires physical-device GPU validation.
+
+See the **Paint & Gradients** page in `samples/ControlGallery` for manual resize, spread, transform,
+runtime mutation, and dynamic-resource checks.

--- a/docs/roadmap/ModernFormsNext-Framework-Roadmap.md
+++ b/docs/roadmap/ModernFormsNext-Framework-Roadmap.md
@@ -1,6 +1,7 @@
 # ModernFormsNext framework roadmap
 
 - Baseline audited: 2026-07-17
+- Paint/gradient foundation implemented: 2026-07-19
 - SDK baseline: .NET 10 (`10.0.201`)
 - Runtime priority: Windows first; Android is an experimental shared-control Skia vertical slice
 - Purpose: architecture and delivery sequence, not a promise that every listed API is implemented
@@ -19,13 +20,14 @@ or the complete WindowKit service set.
 The architecture should therefore be extended, not replaced. The implementation order is:
 
 1. dynamic resources (first vertical slice implemented with this roadmap);
-2. paint/brush contracts and theme tokens;
-3. ThemeManager and localization;
-4. page lifecycle, navigation, routing, tabs, flyout, and shell;
-5. virtualized data controls and SearchBar;
-6. shapes and path geometry;
-7. modular document providers and viewers;
-8. charts, then diagrams.
+2. paint/brush contracts (implemented foundation; theme tokens remain ThemeManager work);
+3. UI animation scheduler hardening;
+4. ThemeManager and localization;
+5. page lifecycle, navigation, routing, tabs, flyout, and shell;
+6. virtualized data controls and SearchBar;
+7. shapes and path geometry;
+8. modular document providers and viewers;
+9. charts, then diagrams.
 
 The most important change from the suggested order is document work: provider/viewport contracts and
 compatibility planning for the existing `DocumentViewer` must precede a PDF engine. Implementing
@@ -43,7 +45,7 @@ already exist.
 | Properties | CLR properties plus compact internal `PropertyStore` | Dynamic resources and future generated descriptors invoke existing setters. No dependency-property clone. |
 | Layout | `LayoutEngine`, `DefaultLayout`, `FlowLayoutPanel`, `TableLayoutPanel`, `Dock`, `Anchor`, margin/padding/min/max/AutoSize | Page hosts, collection presenters, shell panes, and shapes must use these transactions and constraints. |
 | Styles | `ControlStyle`, parent-style fallback, normal/hover state, compatibility `BackColor`/`ForeColor` | Extend state/style representation incrementally; preserve renderer-facing style objects. |
-| Paints | `Drawing.Brush`, solid, glass, linear/radial/sweep gradient brushes, gradient stops, Skia extension renderers | Define lifetime, opacity, transforms, spread/tile behavior, immutability/notification, and JSON contracts. |
+| Paints | Observable `Drawing.Brush`; solid, glass, no-fill, linear/radial/sweep gradients; typed stops; opacity/transform/spread; shared Skia adapter | Reuse for ThemeManager and future shapes/charts. Version and implement the documented JSON direction only with ThemeManager validation. |
 | Rendering | Per-control `SKBitmap` back buffers, renderer classes, `PaintEventArgs`, Skia canvas helpers | Shapes/charts/documents render through Skia and existing clipping/invalidation. Avoid native control substitution. |
 | Invalidation | Property setters call `Invalidate`, layout setters use layout transactions; windows invalidate platform surfaces | Dynamic values call normal setters and do not globally repaint. Add dirty-region precision later. |
 | Animation | `AnimationManager`, easing functions, opacity/translation/scale/rotation extensions | Reuse interpolation concepts, but move callbacks onto UI dispatcher before theme/shape transitions. |
@@ -63,8 +65,8 @@ already exist.
   validation, inheritance, scoped overrides, state styles, system-theme adapter, or atomic update.
 - `ControlStyle` has only a small normal/hover model. It lacks pressed/selected/disabled/focused state
   resolution, brushes for every surface, typography records, shadow, radius, and transitions.
-- Existing brushes are mutable data objects with no standard opacity/transform/change notification,
-  frozen lifetime, tile mode, or serializer.
+- Brush mutation, opacity, transforms, stable stop ordering, spread modes, and targeted invalidation
+  are implemented. A batch update scope, advanced interpolation, and a versioned JSON loader remain.
 - The animation loop can resume on a worker thread and invoke control setters there. It is not yet a
   safe scheduler for theme transitions or arbitrary animated properties.
 - No localization catalog/provider, plural rules, missing-key diagnostics, dynamic culture change,
@@ -100,6 +102,7 @@ already exist.
 ```text
 Dynamic resources
   -> Paint/brush value contracts
+  -> UI animation scheduler hardening
   -> ThemeManager -> state styles -> every visual feature
   -> Localization -> pages and shell labels
 
@@ -191,22 +194,27 @@ serialization, factories, and transitions remain later work.
 
 ### Stage 1 — visual values, themes, and localization
 
-#### 2. Paint and gradient contracts — difficulty: Medium
+#### 2. Paint and gradient contracts — implemented foundation
 
 Purpose: harden the existing brush hierarchy into reusable theme/shape/chart values rather than add
-a duplicate `Paint` abstraction immediately.
+a duplicate `Paint` abstraction. The foundation is implemented.
 
-Proposed API: evolve `Brush` with `Opacity`, optional transform, immutable/frozen snapshots or
-change notification; add gradient spread/tile mode and typed stop collection. Consider a `Paint`
-name only if stroke/fill semantics cannot be expressed without breaking existing `Brush` APIs.
+Implemented API: observable, shared `Brush` values with `Opacity`, `Matrix3x2` transform,
+`NoBrush`, platform-neutral color/point members, `GradientStopCollection`, stable stop ordering,
+radial focal origin, and `Pad`/`Repeat`/`Reflect`. Existing Skia members remain compatibility views
+of the same backing values.
 
-Dependencies: dynamic resources, current Skia extension renderers.
+Dependencies: dynamic resources and the shared Skia renderer; both are integrated.
 
-Risks/platform: mutable resources need invalidation; shared Skia behavior must match on GPU/CPU
-surfaces; shader ownership and allocation in paint loops. Windows/Android should share all math.
+Risks/platform: bounds-dependent shaders remain short-lived allocations. Windows and Android share
+the model, coordinate math, and shader factory, but physical-device Android GPU validation remains
+manual while the backend is experimental.
 
-Done/tests: solid/linear/radial/sweep rendering golden tests; opacity/transform/tile tests; invalid
-stops rejected; no per-frame shader leaks; JSON round trip deferred until ThemeManager schema.
+Done/tests: solid/linear/radial/focal/sweep/no-fill rendering, opacity, transform, tile modes,
+bounds, strict offsets, stable duplicate offsets, mutation, resource precedence/fallback, weak
+subscriptions, Designer round-trip, and scoped shader disposal are covered. ControlGallery provides
+manual visual checks. A versioned JSON converter, batch notifications, absolute mapping, and advanced
+color interpolation are explicitly deferred.
 
 #### 3. ThemeManager — difficulty: Very high
 
@@ -582,7 +590,8 @@ when specialized render models are clearer.
 Exact semantic versions are intentionally not assigned until release capacity is known. Use these
 dependency-based bands:
 
-- Foundation release: dynamic resources, paint hardening, non-animated ThemeManager core.
+- Foundation work: dynamic resources and paint hardening are implemented; a non-animated
+  ThemeManager core remains after scheduler affinity is safe.
 - Globalization release: JSON themes, system variants, localization and diagnostics.
 - Navigation preview: Page/ContentPage/NavigationPage/routing; Windows host plus Android surface host.
 - Shell preview: TabbedPage/FlyoutPage/AppShell after lifecycle/back tests are stable.
@@ -609,7 +618,8 @@ dependency-based bands:
 
 ## Recommended next stage
 
-Harden the existing brush/gradient model and fix animation dispatcher affinity, then implement the
-non-animated ThemeManager core on dynamic resources. This validates arbitrary typed values, atomic
-theme publication, compatibility with `Theme`/`ControlStyle`, and targeted invalidation before page
-and control work multiplies the number of consumers.
+**UI animation scheduler hardening.** Move frame callbacks and property mutation onto the UI
+dispatcher, define cancellation/interruption and exception behavior, and add deterministic tests
+before any public theme or shape transition API is promised. After that, implement the non-animated
+ThemeManager core on dynamic resources and the completed brush foundation. Full ThemeManager and
+Shape remain unimplemented.

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -44,6 +44,7 @@ namespace ControlGallery
             tree.Items.Add ("NavigationPane", ImageLoader.Get ("button.png"));
             tree.Items.Add ("NotifyIcon", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Panel", ImageLoader.Get ("button.png"));
+            tree.Items.Add ("Paint & Gradients", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("PictureBox", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Printing", ImageLoader.Get ("print.png"));
             tree.Items.Add ("ProgressBar", ImageLoader.Get ("button.png"));
@@ -147,6 +148,8 @@ namespace ControlGallery
                     return new NotifyIconPanel ();
                 case "Panel":
                     return new PanelPanel ();
+                case "Paint & Gradients":
+                    return new PaintAndGradientsPanel ();
                 case "PictureBox":
                     return new PictureBoxPanel ();
                 case "Printing":

--- a/samples/ControlGallery/Panels/PaintAndGradientsPanel.cs
+++ b/samples/ControlGallery/Panels/PaintAndGradientsPanel.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Numerics;
+using ModernFormsNext;
+using ModernFormsNext.Drawing;
+using Color = System.Drawing.Color;
+using PointF = System.Drawing.PointF;
+
+namespace ControlGallery.Panels;
+
+/// <summary>
+/// Provides a manual visual test surface for solid, gradient, transformed, and resource-backed brushes.
+/// </summary>
+public sealed class PaintAndGradientsPanel : Panel
+{
+    private const string DynamicBrushKey = "ControlGallery.Paint.Dynamic";
+    private readonly LinearGradientBrush dynamicBrush;
+    private readonly Panel dynamicCard;
+    private bool alternateState;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PaintAndGradientsPanel"/> class.
+    /// </summary>
+    public PaintAndGradientsPanel()
+    {
+        AutoScroll = true;
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 18,
+            Width = 720,
+            Height = 30,
+            Text = "Paint and gradients",
+            Font = new Font("Segoe UI", 16)
+        });
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 52,
+            Width = 760,
+            Height = 42,
+            Multiline = true,
+            Text = "Relative coordinates follow each control's bounds. The bottom card uses a dynamic resource; mutate or replace it without reassigning BackgroundBrush."
+        });
+
+        AddCard(24, 108, "Solid + opacity", new SolidColorBrush(Color.CornflowerBlue) { Opacity = 0.72f });
+        AddCard(280, 108, "Linear / Reflect", CreateLinearGradient(GradientSpreadMode.Reflect));
+        AddCard(536, 108, "Radial + focal origin", CreateRadialGradient());
+        AddCard(24, 248, "Sweep", CreateSweepGradient());
+        AddCard(280, 248, "Transform", CreateTransformedGradient());
+
+        dynamicBrush = CreateDynamicGradient();
+        Resources[DynamicBrushKey] = dynamicBrush;
+        dynamicCard = AddCard(536, 248, "Dynamic resource", brush: null);
+        dynamicCard.SetResourceReference(nameof(Control.BackgroundBrush), DynamicBrushKey);
+
+        var mutateButton = Controls.Add(new Button
+        {
+            Left = 536,
+            Top = 390,
+            Width = 118,
+            Height = 32,
+            Text = "Mutate stops"
+        });
+        mutateButton.Click += (_, _) => MutateDynamicBrush();
+
+        var replaceButton = Controls.Add(new Button
+        {
+            Left = 662,
+            Top = 390,
+            Width = 118,
+            Height = 32,
+            Text = "Replace resource"
+        });
+        replaceButton.Click += (_, _) => ReplaceDynamicResource();
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 446,
+            Width = 756,
+            Height = 72,
+            Multiline = true,
+            Text = "Manual checks: resize the gallery, verify smooth gradients and stable relative geometry, then use both buttons. Changes should repaint immediately without flashes, stale shaders, or a second DPI scale."
+        });
+    }
+
+    private Panel AddCard(int left, int top, string caption, ModernFormsNext.Drawing.Brush brush)
+    {
+        var card = Controls.Add(new Panel
+        {
+            Left = left,
+            Top = top,
+            Width = 232,
+            Height = 112,
+            BackgroundBrush = brush
+        });
+        card.Style.Border.Width = 1;
+        card.Style.Border.Color = Theme.BorderMidColor;
+        card.Controls.Add(new Label
+        {
+            Left = 10,
+            Top = 76,
+            Width = 210,
+            Height = 25,
+            Text = caption,
+            BackColor = new SkiaSharp.SKColor(255, 255, 255, 210)
+        });
+        return card;
+    }
+
+    private static LinearGradientBrush CreateLinearGradient(GradientSpreadMode spreadMode)
+    {
+        var brush = new LinearGradientBrush
+        {
+            Start = new PointF(0f, 0f),
+            End = new PointF(0.38f, 0f),
+            SpreadMode = spreadMode
+        };
+        brush.GradientStops.AddRange([
+            new GradientStop(Color.FromArgb(255, 22, 93, 173), 0f),
+            new GradientStop(Color.FromArgb(255, 91, 219, 195), 0.55f),
+            new GradientStop(Color.FromArgb(255, 248, 194, 74), 1f)
+        ]);
+        return brush;
+    }
+
+    private static RadialGradientBrush CreateRadialGradient()
+    {
+        var brush = new RadialGradientBrush
+        {
+            CenterPoint = new PointF(0.55f, 0.52f),
+            GradientOrigin = new PointF(0.28f, 0.28f),
+            Radius = 0.72f
+        };
+        brush.GradientStops.AddRange([
+            new GradientStop(Color.White, 0f),
+            new GradientStop(Color.DeepSkyBlue, 0.42f),
+            new GradientStop(Color.MidnightBlue, 1f)
+        ]);
+        return brush;
+    }
+
+    private static SweepGradientBrush CreateSweepGradient()
+    {
+        var brush = new SweepGradientBrush
+        {
+            CenterPoint = new PointF(0.5f, 0.5f),
+            StartAngle = -45f,
+            EndAngle = 315f
+        };
+        brush.GradientStops.AddRange([
+            new GradientStop(Color.Crimson, 0f),
+            new GradientStop(Color.Gold, 0.25f),
+            new GradientStop(Color.MediumSeaGreen, 0.5f),
+            new GradientStop(Color.RoyalBlue, 0.75f),
+            new GradientStop(Color.Crimson, 1f)
+        ]);
+        return brush;
+    }
+
+    private static LinearGradientBrush CreateTransformedGradient()
+    {
+        var brush = CreateLinearGradient(GradientSpreadMode.Repeat);
+        brush.End = new PointF(0.3f, 0f);
+        brush.Transform = Matrix3x2.CreateRotation(0.22f, new Vector2(116f, 56f));
+        return brush;
+    }
+
+    private static LinearGradientBrush CreateDynamicGradient()
+    {
+        var brush = new LinearGradientBrush { Start = new PointF(0f, 0f), End = new PointF(1f, 1f) };
+        brush.GradientStops.AddRange([
+            new GradientStop(Color.MediumPurple, 0f),
+            new GradientStop(Color.HotPink, 0.5f),
+            new GradientStop(Color.Orange, 1f)
+        ]);
+        return brush;
+    }
+
+    private void MutateDynamicBrush()
+    {
+        alternateState = !alternateState;
+        dynamicBrush.GradientStops[0].PaintColor = alternateState ? Color.Teal : Color.MediumPurple;
+        dynamicBrush.GradientStops[1].Offset = alternateState ? 0.72f : 0.5f;
+        dynamicBrush.Opacity = alternateState ? 0.68f : 1f;
+    }
+
+    private void ReplaceDynamicResource()
+    {
+        alternateState = !alternateState;
+        Resources[DynamicBrushKey] = alternateState
+            ? CreateRadialGradient()
+            : CreateDynamicGradient();
+    }
+}


### PR DESCRIPTION
## Problem

ModernFormsNext already exposed several brush and gradient types, but mutation, invalidation, resource sharing, coordinate semantics, and Skia shader creation were inconsistent. That made the existing surface difficult to reuse safely for dynamic themes and the planned Shape controls.

## Current state

The framework used the `Brush` hierarchy directly and already supported solid, linear, radial, sweep, and glass rendering. Several public properties exposed SkiaSharp types, gradient stops were plain mutable data, shader construction was distributed through rendering extensions, and controls did not observe internal brush mutations.

## Solution

- Keep the existing `Brush` hierarchy as the single canonical model instead of introducing a parallel `Paint` hierarchy.
- Make brushes, gradient stops, and the typed stop collection observable and shareable.
- Add opacity, platform-neutral transforms, relative gradient geometry, focal radial origins, pad/repeat/reflect spread modes, and `NoBrush`.
- Centralize bounds-aware Skia shader construction in `SkiaBrushFactory`.
- Observe mutable brushes from controls with weak, reference-counted subscriptions and render-only invalidation.
- Extend Designer serialization and editing so the new values survive `.Designer.cs` round trips.
- Add a focused ControlGallery page and user/architecture documentation.

## Public API

The preferred platform-neutral API uses `System.Drawing.Color`, `PointF`, and `System.Numerics.Matrix3x2`. The extended surface includes `Brush.Opacity`, `Brush.Transform`, `GradientSpreadMode`, `GradientStopCollection`, relative geometry on linear/radial/sweep brushes, `RadialGradientBrush.GradientOrigin`, and `NoBrush`.

Existing `SKColor` and `SKPoint` members remain as compatibility views over the same backing values. They are documented as legacy integration surfaces; new application code does not need SkiaSharp types.

## Compatibility

Existing `BackColor`, `ForeColor`, and legacy brush constructors continue to work. `BackgroundBrush` takes precedence when assigned; clearing it restores the color fallback, so there are not two independent rendering sources of truth.

The main compatibility risk is that `GradientStops` now returns `GradientStopCollection` rather than `List<GradientStop>`, and invalid offsets are rejected instead of flowing into rendering. Existing source that only uses normal collection operations remains straightforward to migrate, but already compiled consumers must rebuild.

## Dynamic resources

Brush values participate in the existing application/window/control resource hierarchy. Tests cover hierarchy overrides, object replacement, in-place gradient mutation, removal and fallback, duplicate-subscription prevention, and release of controls without a durable brush subscription.

## SkiaSharp integration

`SkiaBrushFactory` is the single conversion boundary. It maps spread modes to Skia tile modes, applies relative bounds and transforms once, and creates short-lived shaders owned by the drawing operation. Bounds-dependent native shaders are deliberately not cached, avoiding stale-size entries and unclear native lifetime.

## Validation

- `dotnet restore ModernFormsNext.slnx`: passed.
- Debug and Release solution builds: passed.
- Full solution tests: 536/536 passed.
- Focused brush/gradient tests: 32/32 passed.
- Dynamic-resource and brush-resource tests: 20/20 passed.
- Designer serialization tests: 3/3 passed.
- Windows target build: passed.
- Android backend, cross-platform Android sample, and Android smoke-test builds: passed.
- Designer, VSIX Debug/Release, ControlGallery, and template/reference app builds: passed.
- Local package validation: eight 1.8.0 `.nupkg` files, seven expected `.snupkg` files, README and XML documentation present.

Known warnings are pre-existing dependency/security advisories in the VSIX graph, .NET Framework compatibility warnings for older Visual Studio SDK packages, nullable/generated interop warnings, obsolete Skia text/filter APIs, Windows platform annotations, and Android 16 KB page-size warnings for the bundled HarfBuzz native library. No warning was suppressed.

## Windows impact

The primary Windows rendering and Designer paths use the shared brush factory. Designer code generation now preserves opacity, transform, spread mode, and radial focal origin while legacy brush expressions continue to deserialize.

## Android impact

The Android backend consumes the same shared brush and Skia conversion layers. Its target builds and backend tests pass. Android remains experimental; GPU behavior, performance, lifecycle interactions, and rendering on physical devices still require manual validation.

## ControlGallery

A dedicated Paint and Gradients panel demonstrates solid, linear, radial/focal, sweep, spread, transform, opacity, resource replacement, and in-place resource mutation. No screenshot is attached because an interactive visual session was not performed in this environment.

## Limitations

- Gradient coordinates are relative-only in this stage.
- Advanced linear-light/color-space interpolation is not exposed yet.
- JSON theme serialization is designed and documented but intentionally not implemented without ThemeManager.
- There is no native shader cache; render-time allocation is preferred over unsafe bounds-dependent caching for now.
- Legacy public SkiaSharp compatibility members remain to avoid a broad breaking change.
- No animation scheduler or Shape controls are included.

## Next steps

1. Harden the shared UI animation scheduler so mutable brush values can be animated without a second timing system.
2. Add the ThemeManager and its renderer-neutral JSON brush converter.
3. Build Shape controls on the common brush contract after the animation and theme foundations are stable.