### PR TITLE
Add composable animations and interaction effects

### DIFF
--- a/ModernFormsNext.Tests/AnimationCompositionTests.cs
+++ b/ModernFormsNext.Tests/AnimationCompositionTests.cs
@@ -1,0 +1,340 @@
+using ModernFormsNext.Animations;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class AnimationCompositionTests
+{
+    [Fact]
+    public async Task CustomDefinitionReceivesTimingAndReleasesContextTarget()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var frames = new List<(float Progress, TimeSpan Elapsed)>();
+        var animation = new CallbackAnimation((context, progress) =>
+        {
+            Assert.Same(target, context.Target);
+            frames.Add((progress, context.Elapsed));
+        })
+        {
+            Duration = TimeSpan.FromMilliseconds(100)
+        };
+
+        AnimationRun run = animation.Start(target, harness.Scheduler);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.Equal(AnimationState.Completed, await run.Completion);
+        Assert.Equal([(0.5f, TimeSpan.FromMilliseconds(50)), (1f, TimeSpan.FromMilliseconds(100))], frames);
+        Assert.NotNull(animation.LastContext);
+        Assert.Throws<ObjectDisposedException>(() => _ = animation.LastContext!.Target);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task SequenceRunsChildrenInDeclarationOrder()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var order = new List<int>();
+
+        AnimationDefinition sequence = Animation.Sequence(
+            Immediate(_ => order.Add(1)),
+            Immediate(_ => order.Add(2)),
+            Immediate(_ => order.Add(3)));
+
+        AnimationState state = await sequence.RunAsync(target, harness.Scheduler);
+
+        Assert.Equal(AnimationState.Completed, state);
+        Assert.Equal([1, 2, 3], order);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public async Task SequenceStopsAfterFaultAndDoesNotStartLaterChildren()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        bool laterChildStarted = false;
+
+        AnimationRun run = Animation.Sequence(
+            Immediate(_ => { }),
+            Immediate(_ => throw new TestAnimationException("sequence")),
+            Immediate(_ => laterChildStarted = true))
+            .Start(target, harness.Scheduler);
+
+        Assert.Equal(AnimationState.Faulted, await run.Completion);
+        Assert.IsType<TestAnimationException>(run.Exception);
+        Assert.False(laterChildStarted);
+    }
+
+    [Fact]
+    public async Task SequenceCancellationStopsActiveChildAndDoesNotStartLaterChildren()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        bool laterChildStarted = false;
+        var active = new CallbackAnimation((_, _) => { })
+        {
+            Duration = TimeSpan.FromMilliseconds(100)
+        };
+        AnimationRun run = Animation.Sequence(
+            active,
+            Immediate(_ => laterChildStarted = true))
+            .Start(target, harness.Scheduler);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(25));
+        run.Cancel();
+
+        Assert.Equal(AnimationState.Canceled, await run.Completion);
+        Assert.False(laterChildStarted);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task ParallelStartsEveryChildAndAggregatesFaultsInDeclarationOrder()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        int starts = 0;
+
+        AnimationRun run = Animation.Parallel(
+            Immediate(_ =>
+            {
+                starts++;
+                throw new TestAnimationException("first");
+            }),
+            Immediate(_ =>
+            {
+                starts++;
+                throw new InvalidOperationException("second");
+            }))
+            .Start(target, harness.Scheduler);
+
+        Assert.Equal(AnimationState.Faulted, await run.Completion);
+        var aggregate = Assert.IsType<AggregateException>(run.Exception);
+        Assert.Equal(2, starts);
+        Assert.Collection(
+            aggregate.InnerExceptions,
+            error => Assert.Equal("first", error.Message),
+            error => Assert.Equal("second", error.Message));
+    }
+
+    [Fact]
+    public async Task ParallelCancellationPropagatesToEveryActiveChild()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var first = new CallbackAnimation((_, _) => { }) { Duration = TimeSpan.FromMilliseconds(100) };
+        var second = new CallbackAnimation((_, _) => { }) { Duration = TimeSpan.FromMilliseconds(200) };
+        AnimationRun run = Animation.Parallel(first, second).Start(target, harness.Scheduler);
+
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        run.Cancel();
+
+        Assert.Equal(AnimationState.Canceled, await run.Completion);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().CanceledCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task TimelineStartsEntriesOnceAtMonotonicOffsets()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var starts = new List<string>();
+        var timeline = new AnimationTimeline()
+            .At(TimeSpan.Zero, Immediate(_ => starts.Add("zero")))
+            .At(TimeSpan.FromMilliseconds(100), Immediate(_ => starts.Add("hundred")));
+
+        AnimationRun run = timeline.Start(target, harness.Scheduler);
+        Assert.Equal(["zero"], starts);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(99));
+        Assert.Equal(["zero"], starts);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(1));
+        Assert.Equal(AnimationState.Completed, await run.Completion);
+        Assert.Equal(["zero", "hundred"], starts);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task TimelineCancellationPreventsDelayedEntriesFromStarting()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        int delayedStarts = 0;
+        var timeline = new AnimationTimeline()
+            .At(TimeSpan.FromMilliseconds(100), Immediate(_ => delayedStarts++))
+            .At(TimeSpan.FromMilliseconds(200), Immediate(_ => delayedStarts++));
+        AnimationRun run = timeline.Start(target, harness.Scheduler);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        run.Cancel();
+
+        Assert.Equal(AnimationState.Canceled, await run.Completion);
+        Assert.Equal(0, delayedStarts);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task RepeatAndAutoReverseApplyExactEndpointsWithoutAccumulatingHandles()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var progress = new List<float>();
+        AnimationDefinition animation = Immediate(value => progress.Add(value));
+        animation.Repeat(3).AutoReverse();
+
+        AnimationState state = await animation.RunAsync(target, harness.Scheduler);
+
+        Assert.Equal(AnimationState.Completed, state);
+        Assert.Equal([1f, 0f, 1f, 0f, 1f, 0f], progress);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public async Task InfiniteRepeatCollapsesUnderReducedMotion()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        harness.Policy.ReducedMotion = true;
+        var target = new Control();
+        int updates = 0;
+        AnimationDefinition animation = Immediate(_ => updates++);
+        animation.RepeatForever();
+
+        AnimationState state = await animation.RunAsync(target, harness.Scheduler);
+
+        Assert.Equal(AnimationState.Completed, state);
+        Assert.Equal(1, updates);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task InfiniteRepeatEndsThroughCancellationAndLeavesSchedulerIdle()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var animation = new CallbackAnimation((_, _) => { })
+        {
+            Duration = TimeSpan.FromMilliseconds(100)
+        };
+        animation.RepeatForever();
+
+        AnimationRun run = animation.Start(new Control(), harness.Scheduler);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        run.Cancel();
+
+        Assert.Equal(AnimationState.Canceled, await run.Completion);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void KeyframesValidateOrderDuplicatesAndFiniteInput()
+    {
+        var animation = KeyframeAnimation<float>
+            .Create(new Control(), _ => { })
+            .Keyframe(0f, 0f)
+            .Keyframe(0.5f, 1f);
+
+        Assert.Throws<ArgumentException>(() => animation.Keyframe(0.25f, 2f));
+        Assert.Throws<ArgumentException>(() => animation.Keyframe(0.5f, 2f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => animation.Keyframe(float.NaN, 2f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => animation.Sample(float.PositiveInfinity));
+    }
+
+    [Fact]
+    public void KeyframesSampleEndpointsSegmentsDuplicatesAndCustomInterpolation()
+    {
+        var target = new Control();
+        float applied = -1f;
+        var animation = KeyframeAnimation<float>
+            .Create(target, value => applied = value, new OffsetInterpolator())
+            .Keyframe(0f, 0f)
+            .Keyframe(0.5f, 10f, static progress => progress * progress);
+        animation.DuplicatePositionPolicy = KeyframeDuplicatePositionPolicy.KeepBoth;
+        animation
+            .Keyframe(0.5f, 20f)
+            .Keyframe(1f, 30f);
+
+        Assert.Equal(0f, animation.Sample(0f));
+        Assert.Equal(3.5f, animation.Sample(0.25f));
+        Assert.Equal(20f, animation.Sample(0.5f));
+        Assert.Equal(26f, animation.Seek(0.75f));
+        Assert.Equal(26f, applied);
+        Assert.Equal(30f, animation.Sample(1f));
+    }
+
+    [Fact]
+    public void KeyframesEnforceLimitReplaceDuplicatesAndRejectInvalidSegmentEasing()
+    {
+        var target = new Control();
+        var replacement = KeyframeAnimation<float>
+            .Create(target, _ => { });
+        replacement.DuplicatePositionPolicy = KeyframeDuplicatePositionPolicy.ReplacePrevious;
+        replacement
+            .Keyframe(0f, 1f)
+            .Keyframe(0f, 2f)
+            .Keyframe(1f, 3f, static _ => float.NaN);
+
+        Assert.Equal(2, replacement.Count);
+        Assert.Equal(2f, replacement.Sample(0f));
+        Assert.Throws<InvalidOperationException>(() => replacement.Sample(0.5f));
+
+        var maximum = KeyframeAnimation<float>.Create(target, _ => { });
+        for (int index = 0; index < KeyframeAnimation<float>.MaximumKeyframeCount; index++)
+            maximum.Keyframe(index / (float)(KeyframeAnimation<float>.MaximumKeyframeCount - 1), index);
+        Assert.Throws<InvalidOperationException>(() => maximum.Keyframe(1f, 999f));
+    }
+
+    [Fact]
+    public async Task NestedGroupCancellationDoesNotCancelUnrelatedTargetWork()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var child = new CallbackAnimation((_, _) => { }) { Duration = TimeSpan.FromMilliseconds(100) };
+        AnimationRun group = Animation.Parallel(
+            Animation.Sequence(child),
+            new CallbackAnimation((_, _) => { }) { Duration = TimeSpan.FromMilliseconds(100) })
+            .Start(target, harness.Scheduler);
+        AnimationHandle unrelated = harness.Scheduler.Start(
+            target,
+            "Unrelated",
+            _ => { },
+            new AnimationOptions { Duration = TimeSpan.FromMilliseconds(100) });
+
+        group.Dispose();
+
+        Assert.Equal(AnimationState.Canceled, await group.Completion);
+        Assert.Equal(AnimationState.Running, unrelated.State);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        unrelated.Cancel();
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    private static CallbackAnimation Immediate(Action<float> update)
+        => new((_, progress) => update(progress)) { Duration = TimeSpan.Zero };
+
+    private sealed class CallbackAnimation(Action<AnimationContext, float> update) : AnimationDefinition
+    {
+        public AnimationContext? LastContext { get; private set; }
+
+        protected override void Update(AnimationContext context, float progress)
+        {
+            LastContext = context;
+            update(context, progress);
+        }
+    }
+
+    private sealed class OffsetInterpolator : IAnimationInterpolator<float>
+    {
+        public float Interpolate(float from, float to, float progress)
+            => from + ((to - from) * progress) + (progress is > 0f and < 1f ? 1f : 0f);
+    }
+
+    private sealed class TestAnimationException(string message) : Exception(message);
+}

--- a/ModernFormsNext.Tests/AnimationCompositionTests.cs
+++ b/ModernFormsNext.Tests/AnimationCompositionTests.cs
@@ -153,6 +153,25 @@ public sealed class AnimationCompositionTests
     }
 
     [Fact]
+    public async Task ParallelAggregatesChildSetupFaultsInDeclarationOrder()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        KeyframeAnimation<float> first = KeyframeAnimation<float>.Create(target, _ => { });
+        KeyframeAnimation<float> second = KeyframeAnimation<float>.Create(target, _ => { });
+
+        AnimationRun run = Animation.Parallel(first, second).Start(harness.Scheduler);
+
+        Assert.Equal(AnimationState.Faulted, await run.Completion);
+        var aggregate = Assert.IsType<AggregateException>(run.Exception);
+        Assert.Collection(
+            aggregate.InnerExceptions,
+            error => Assert.Contains("at least one keyframe", error.Message, StringComparison.Ordinal),
+            error => Assert.Contains("at least one keyframe", error.Message, StringComparison.Ordinal));
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
     public async Task ParallelCancellationPropagatesToEveryActiveChild()
     {
         using var harness = new AnimationSchedulerTestHarness();
@@ -213,6 +232,25 @@ public sealed class AnimationCompositionTests
     }
 
     [Fact]
+    public async Task TimelineAggregatesEntrySetupFaultsInDeclarationOrder()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var timeline = new AnimationTimeline()
+            .At(TimeSpan.Zero, KeyframeAnimation<float>.Create(target, _ => { }))
+            .At(TimeSpan.Zero, KeyframeAnimation<float>.Create(target, _ => { }));
+
+        AnimationRun run = timeline.Start(harness.Scheduler);
+
+        Assert.Equal(AnimationState.Faulted, await run.Completion);
+        var aggregate = Assert.IsType<AggregateException>(run.Exception);
+        Assert.Equal(2, aggregate.InnerExceptions.Count);
+        Assert.All(
+            aggregate.InnerExceptions,
+            error => Assert.Contains("at least one keyframe", error.Message, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task RepeatAndAutoReverseApplyExactEndpointsWithoutAccumulatingHandles()
     {
         using var harness = new AnimationSchedulerTestHarness();
@@ -260,6 +298,20 @@ public sealed class AnimationCompositionTests
         run.Cancel();
 
         Assert.Equal(AnimationState.Canceled, await run.Completion);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task EmptyCompositionCannotEnterATightInfiniteRepeatLoop()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        AnimationDefinition empty = Animation.Sequence().RepeatForever();
+
+        AnimationRun run = empty.Start(harness.Scheduler);
+
+        Assert.Equal(AnimationState.Faulted, await run.Completion);
+        Assert.IsType<InvalidOperationException>(run.Exception);
         Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
         Assert.False(harness.TickSource.IsRunning);
     }
@@ -398,6 +450,28 @@ public sealed class AnimationCompositionTests
         Assert.Equal(AnimationState.Completed, await ignored.Completion);
         Assert.Equal(0.5f, target.Opacity, 3);
         Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task BoundMultiAxisFactoryKeepsStableReplacementChannelsAcrossRuns()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var slow = new AnimationOptions { Duration = TimeSpan.FromMilliseconds(200) };
+        var fast = new AnimationOptions { Duration = TimeSpan.FromMilliseconds(100) };
+        AnimationRun stale = target.TranslateTo(100f, 200f, slow).Start(harness.Scheduler);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        AnimationRun latest = target.TranslateTo(20f, 40f, fast).Start(harness.Scheduler);
+
+        Assert.Equal(AnimationState.Canceled, await stale.Completion);
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(AnimationState.Completed, await latest.Completion);
+        Assert.Equal(20f, target.TranslationX, 3);
+        Assert.Equal(40f, target.TranslationY, 3);
         Assert.False(harness.TickSource.IsRunning);
     }
 

--- a/ModernFormsNext.Tests/AnimationCompositionTests.cs
+++ b/ModernFormsNext.Tests/AnimationCompositionTests.cs
@@ -475,6 +475,26 @@ public sealed class AnimationCompositionTests
         Assert.False(harness.TickSource.IsRunning);
     }
 
+    [Fact]
+    public async Task ConcurrentRunCancellationAndNaturalCompletionAreExceptionSafe()
+    {
+        for (int iteration = 0; iteration < 1_000; iteration++)
+        {
+            var execution = new TaskCompletionSource<AnimationExecutionResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var run = new AnimationRun();
+            run.Start(_ => execution.Task, CancellationToken.None);
+
+            Task cancel = Task.Run(run.Cancel);
+            Task complete = Task.Run(() =>
+                execution.TrySetResult(AnimationExecutionResult.Completed));
+
+            await Task.WhenAll(cancel, complete);
+            AnimationState state = await run.Completion;
+            Assert.True(state is AnimationState.Canceled or AnimationState.Completed);
+        }
+    }
+
     private static CallbackAnimation Immediate(Action<float> update)
         => new((_, progress) => update(progress)) { Duration = TimeSpan.Zero };
 

--- a/ModernFormsNext.Tests/AnimationCompositionTests.cs
+++ b/ModernFormsNext.Tests/AnimationCompositionTests.cs
@@ -32,6 +32,37 @@ public sealed class AnimationCompositionTests
     }
 
     [Fact]
+    public async Task PropertyAnimationCapturesStartValueOnSchedulerUiCallback()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var getterThreads = new List<int>();
+        var animation = new PropertyAnimation<float>(
+            target,
+            "ThreadAffinity",
+            () =>
+            {
+                getterThreads.Add(Environment.CurrentManagedThreadId);
+                return target.Opacity;
+            },
+            0.5f,
+            AnimationInterpolators.Float,
+            value => target.Opacity = value)
+        {
+            Duration = TimeSpan.FromMilliseconds(100)
+        };
+
+        AnimationRun run = await Task.Run(() => animation.Start(harness.Scheduler));
+        Assert.Empty(getterThreads);
+
+        int tickThread = Environment.CurrentManagedThreadId;
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(AnimationState.Completed, await run.Completion);
+        Assert.Equal([tickThread], getterThreads);
+    }
+
+    [Fact]
     public async Task SequenceRunsChildrenInDeclarationOrder()
     {
         using var harness = new AnimationSchedulerTestHarness();
@@ -244,6 +275,8 @@ public sealed class AnimationCompositionTests
         Assert.Throws<ArgumentException>(() => animation.Keyframe(0.25f, 2f));
         Assert.Throws<ArgumentException>(() => animation.Keyframe(0.5f, 2f));
         Assert.Throws<ArgumentOutOfRangeException>(() => animation.Keyframe(float.NaN, 2f));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => KeyframeAnimation<float>.Create(new Control(), _ => { }).Keyframe(0f, float.NaN));
         Assert.Throws<ArgumentOutOfRangeException>(() => animation.Sample(float.PositiveInfinity));
     }
 
@@ -289,6 +322,12 @@ public sealed class AnimationCompositionTests
         for (int index = 0; index < KeyframeAnimation<float>.MaximumKeyframeCount; index++)
             maximum.Keyframe(index / (float)(KeyframeAnimation<float>.MaximumKeyframeCount - 1), index);
         Assert.Throws<InvalidOperationException>(() => maximum.Keyframe(1f, 999f));
+
+        var invalidInterpolation = KeyframeAnimation<float>
+            .Create(target, _ => { }, new NonFiniteInterpolator())
+            .Keyframe(0f, 0f)
+            .Keyframe(1f, 1f);
+        Assert.Throws<ArgumentOutOfRangeException>(() => invalidInterpolation.Sample(0.5f));
     }
 
     [Fact]
@@ -316,6 +355,52 @@ public sealed class AnimationCompositionTests
         Assert.False(harness.TickSource.IsRunning);
     }
 
+    [Fact]
+    public async Task CancelingIgnoredDefinitionRunDoesNotCancelExistingChannel()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var options = new AnimationOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(100),
+            ReplacementMode = AnimationReplacementMode.IgnoreNew
+        };
+        AnimationRun existing = target.FadeTo(0.5f, options).Start(harness.Scheduler);
+        AnimationRun ignored = target.FadeTo(0.25f, options).Start(harness.Scheduler);
+
+        ignored.Cancel();
+
+        Assert.Equal(AnimationState.Canceled, await ignored.Completion);
+        Assert.Equal(AnimationState.Running, existing.State);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(AnimationState.Completed, await existing.Completion);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public async Task IgnoredRepeatedDefinitionDoesNotTakeOverAfterExistingCompletion()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var target = new Control();
+        var options = new AnimationOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(100),
+            ReplacementMode = AnimationReplacementMode.IgnoreNew
+        };
+        AnimationRun existing = target.FadeTo(0.5f, options).Start(harness.Scheduler);
+        AnimationDefinition ignoredDefinition = target.FadeTo(0.25f, options).Repeat(3);
+        AnimationRun ignored = ignoredDefinition.Start(harness.Scheduler);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(AnimationState.Completed, await existing.Completion);
+        Assert.Equal(AnimationState.Completed, await ignored.Completion);
+        Assert.Equal(0.5f, target.Opacity, 3);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
     private static CallbackAnimation Immediate(Action<float> update)
         => new((_, progress) => update(progress)) { Duration = TimeSpan.Zero };
 
@@ -334,6 +419,11 @@ public sealed class AnimationCompositionTests
     {
         public float Interpolate(float from, float to, float progress)
             => from + ((to - from) * progress) + (progress is > 0f and < 1f ? 1f : 0f);
+    }
+
+    private sealed class NonFiniteInterpolator : IAnimationInterpolator<float>
+    {
+        public float Interpolate(float from, float to, float progress) => float.NaN;
     }
 
     private sealed class TestAnimationException(string message) : Exception(message);

--- a/ModernFormsNext.Tests/AnimationPublicApiCompatibilityTests.cs
+++ b/ModernFormsNext.Tests/AnimationPublicApiCompatibilityTests.cs
@@ -1,0 +1,37 @@
+using System.Drawing;
+using ModernFormsNext.Extensions;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public class AnimationPublicApiCompatibilityTests
+{
+    [Fact]
+    public void MouseEventArgsRetainsLegacyConstructorSignature()
+    {
+        var constructor = typeof(MouseEventArgs).GetConstructor(
+            [
+                typeof(MouseButtons),
+                typeof(int),
+                typeof(int),
+                typeof(int),
+                typeof(Point),
+                typeof(int?),
+                typeof(int?),
+                typeof(Keys)
+            ]);
+
+        Assert.NotNull(constructor);
+    }
+
+    [Fact]
+    public void DrawBorderRetainsLegacyExtensionSignature()
+    {
+        var method = typeof(SkiaExtensions).GetMethod(
+            nameof(SkiaExtensions.DrawBorder),
+            [typeof(SKCanvas), typeof(Rectangle), typeof(ControlStyle)]);
+
+        Assert.NotNull(method);
+    }
+}

--- a/ModernFormsNext.Tests/AnimationSchedulerTestInfrastructure.cs
+++ b/ModernFormsNext.Tests/AnimationSchedulerTestInfrastructure.cs
@@ -136,6 +136,41 @@ internal sealed class ManualAnimationTickSource : IAnimationTickSource
     }
 }
 
+internal sealed class BlockingStartAnimationTickSource : IAnimationTickSource
+{
+    private readonly ManualResetEventSlim releaseStart = new();
+    private int isRunning;
+    private int isDisposed;
+
+    public ManualResetEventSlim StartEntered { get; } = new();
+
+    public bool IsRunning => Volatile.Read(ref isRunning) != 0;
+
+    public void Start(Action tickRequested)
+    {
+        ArgumentNullException.ThrowIfNull(tickRequested);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref isDisposed) != 0, this);
+        StartEntered.Set();
+        if (!releaseStart.Wait(TimeSpan.FromSeconds(10)))
+            throw new TimeoutException("The test did not release the blocked tick-source start.");
+        Volatile.Write(ref isRunning, 1);
+    }
+
+    public void Stop() => Volatile.Write(ref isRunning, 0);
+
+    public void ReleaseStart() => releaseStart.Set();
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref isDisposed, 1) != 0)
+            return;
+        releaseStart.Set();
+        Volatile.Write(ref isRunning, 0);
+        StartEntered.Dispose();
+        releaseStart.Dispose();
+    }
+}
+
 internal sealed class ImmediateAnimationDispatcher : IAnimationDispatcher
 {
     public int PostCount { get; private set; }

--- a/ModernFormsNext.Tests/AnimationSchedulerTests.cs
+++ b/ModernFormsNext.Tests/AnimationSchedulerTests.cs
@@ -1,5 +1,6 @@
 using ModernFormsNext.Animations;
 using ModernFormsNext.WindowKit.Backend.Lifecycle;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace ModernFormsNext.Tests;
@@ -552,6 +553,65 @@ public sealed class AnimationSchedulerTests
     }
 
     [Fact]
+    public async Task CancellationCannotBeOvertakenByAnInFlightTickSourceStart()
+    {
+        var clock = new ManualAnimationClock();
+        using var tickSource = new BlockingStartAnimationTickSource();
+        using var scheduler = new AnimationScheduler(
+            clock,
+            new ImmediateAnimationDispatcher(),
+            tickSource,
+            new AnimationPolicy());
+        var owner = new object();
+
+        Task<AnimationHandle> startTask = Task.Run(() =>
+            scheduler.Start(owner, "Race", _ => { }, Options(100)));
+        Assert.True(tickSource.StartEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        using var cancellationAttempted = new ManualResetEventSlim();
+        Task cancelTask = Task.Run(() =>
+        {
+            cancellationAttempted.Set();
+            scheduler.Cancel(owner, "Race");
+        });
+
+        try
+        {
+            Assert.True(cancellationAttempted.Wait(TimeSpan.FromSeconds(5)));
+            // Give the cancellation thread an opportunity to acquire the scheduler lock. Before
+            // tick-source transitions were serialized, cancellation completed here and the stale
+            // Start call subsequently turned the source back on with no runnable animations.
+            _ = await Task.WhenAny(cancelTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        }
+        finally
+        {
+            tickSource.ReleaseStart();
+        }
+
+        AnimationHandle handle = await startTask;
+        await cancelTask;
+
+        Assert.Equal(AnimationState.Canceled, handle.State);
+        Assert.False(tickSource.IsRunning);
+        Assert.Equal(0, scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void TerminalHandleDoesNotRetainCapturedEasingCallback()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        (AnimationHandle handle, WeakReference callbackOwner) =
+            CreateAnimationWithCollectibleEasing(harness.Scheduler);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        CollectGarbage();
+
+        Assert.Equal(AnimationState.Completed, handle.State);
+        Assert.False(callbackOwner.IsAlive);
+        GC.KeepAlive(handle);
+    }
+
+    [Fact]
     public void OptionsAndPolicyRejectInvalidTimeConfiguration()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new AnimationOptions { Duration = TimeSpan.FromTicks(-1) });
@@ -562,4 +622,35 @@ public sealed class AnimationSchedulerTests
 
     private static AnimationOptions Options(int durationMilliseconds)
         => new() { Duration = TimeSpan.FromMilliseconds(durationMilliseconds) };
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (AnimationHandle Handle, WeakReference CallbackOwner)
+        CreateAnimationWithCollectibleEasing(AnimationScheduler scheduler)
+    {
+        var callbackOwner = new EasingCallbackOwner();
+        var weakReference = new WeakReference(callbackOwner);
+        AnimationHandle handle = scheduler.Start(
+            new object(),
+            "CollectibleEasing",
+            _ => { },
+            new AnimationOptions
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                Easing = callbackOwner.Ease
+            });
+        return (handle, weakReference);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CollectGarbage()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    private sealed class EasingCallbackOwner
+    {
+        public float Ease(float progress) => progress;
+    }
 }

--- a/ModernFormsNext.Tests/AnimationSchedulerTests.cs
+++ b/ModernFormsNext.Tests/AnimationSchedulerTests.cs
@@ -216,6 +216,29 @@ public sealed class AnimationSchedulerTests
     }
 
     [Fact]
+    public void OwnerCancellationSuppressesPolicyCompletionAlreadyQueuedToDispatcher()
+    {
+        var dispatcher = new QueuedAnimationDispatcher();
+        using var harness = new AnimationSchedulerTestHarness(dispatcher);
+        var owner = new object();
+        int updates = 0;
+        AnimationHandle handle = harness.Scheduler.Start(
+            owner,
+            "PolicyCompletion",
+            _ => updates++,
+            Options(100));
+
+        harness.Policy.ReducedMotion = true;
+        harness.Scheduler.CancelAll(owner);
+        dispatcher.Drain();
+
+        Assert.Equal(AnimationState.Canceled, handle.State);
+        Assert.Equal(0, updates);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public void CancelAndCancelAllAreIdempotentAndLeaveOtherOwnersRunning()
     {
         using var harness = new AnimationSchedulerTestHarness();

--- a/ModernFormsNext.Tests/BrushAnimationTests.cs
+++ b/ModernFormsNext.Tests/BrushAnimationTests.cs
@@ -240,6 +240,18 @@ public sealed class DefaultAnimationSchedulerCollection
 public sealed class ControlAnimationLifecycleTests
 {
     [Fact]
+    public async Task LegacyAsyncHelperStillClampsNegativeDurationAndNullCancellationIsANoOp()
+    {
+        using var control = new Control();
+
+        Task animation = control.FadeToAsync(0.5f, duration: -10);
+        ((Control)null!).CancelAnimations();
+        control.CancelAnimations();
+
+        await animation;
+    }
+
+    [Fact]
     public async Task DisposingControlCancelsItsOwnedDefaultAnimation()
     {
         var control = new Control();

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -160,13 +160,18 @@ public sealed class InteractionEffectTests
     public void TouchPointersRemainIndependentAndCancelClearsEffectState()
     {
         using var harness = new AnimationSchedulerTestHarness();
-        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(80, 30)
+        };
         control.PressEffect = new PressScaleEffect
         {
             PressedScale = 0.8f,
             PressDuration = TimeSpan.Zero,
             ReleaseDuration = TimeSpan.Zero
         };
+        control.Ripple = new RippleEffect { Duration = TimeSpan.FromMilliseconds(100) };
 
         MouseEventArgs first = Mouse(2, 2, 11, PointerDeviceKind.Touch);
         MouseEventArgs second = Mouse(3, 3, 12, PointerDeviceKind.Touch);
@@ -176,9 +181,14 @@ public sealed class InteractionEffectTests
 
         control.UpForTest(first);
         Assert.Equal(VisualState.Pressed, control.VisualState);
-        control.CancelPointerForTest();
+        Assert.Equal(2, control.Ripple.ActiveRippleCount);
+        control.CancelPointerForTest(11);
+        Assert.Equal(VisualState.Pressed, control.VisualState);
+        Assert.Equal(1, control.Ripple.ActiveRippleCount);
+        control.CancelPointerForTest(12);
 
         Assert.NotEqual(VisualState.Pressed, control.VisualState);
+        Assert.Equal(0, control.Ripple.ActiveRippleCount);
         Assert.Equal(1f, control.EffectiveScaleX, 3);
         Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
     }
@@ -233,6 +243,24 @@ public sealed class InteractionEffectTests
     }
 
     [Fact]
+    public void RemovingConvenienceEffectClearsPropertyAndAllowsReattachment()
+    {
+        var control = new TestButton();
+        var ripple = new RippleEffect();
+        control.Ripple = ripple;
+
+        Assert.True(control.InteractionEffects.Remove(ripple));
+        Assert.Null(control.Ripple);
+        Assert.Null(ripple.Target);
+
+        control.Ripple = ripple;
+
+        Assert.Same(ripple, control.Ripple);
+        Assert.Same(control, ripple.Target);
+        Assert.Single(control.InteractionEffects);
+    }
+
+    [Fact]
     public void DisabledAndDesignerTargetsDoNotStartRuntimeRippleWork()
     {
         using var harness = new AnimationSchedulerTestHarness();
@@ -267,6 +295,12 @@ public sealed class InteractionEffectTests
         designer.UpForTest(Mouse(4, 4));
         Assert.Equal(1f, designer.EffectiveScaleX, 3);
         Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+
+        var custom = new DesignerSchedulerProbeEffect();
+        designer.InteractionEffects.Add(custom);
+        designer.DownForTest(Mouse(5, 5));
+        Assert.Equal(1, custom.UpdateCount);
         Assert.False(harness.TickSource.IsRunning);
     }
 
@@ -391,7 +425,7 @@ public sealed class InteractionEffectTests
         public void KeyDownForTest(Keys key) => OnKeyDown(new KeyEventArgs(key));
         public void KeyUpForTest(Keys key) => OnKeyUp(new KeyEventArgs(key));
         public void LostFocusForTest() => OnLostFocus(EventArgs.Empty);
-        public void CancelPointerForTest() => CancelPointerInteraction();
+        public void CancelPointerForTest(int? pointerId = null) => CancelPointerInteraction(pointerId);
     }
 
     private sealed class InvalidationCountingButton : TestButton
@@ -420,6 +454,18 @@ public sealed class InteractionEffectTests
         public override InteractionEffectLayer RenderLayer => layer;
 
         protected override void OnRender(InteractionEffectRenderContext context) => render();
+    }
+
+    private sealed class DesignerSchedulerProbeEffect : InteractionEffect
+    {
+        public int UpdateCount { get; private set; }
+
+        protected override void OnPointerDown(MouseEventArgs e)
+            => Scheduler.Start(
+                this,
+                "DesignerProbe",
+                _ => UpdateCount++,
+                new AnimationOptions { Duration = TimeSpan.FromSeconds(1) });
     }
 
     private sealed class DesignModeSite(IComponent component) : ISite

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -541,8 +541,11 @@ public sealed class InteractionEffectTests
             x,
             y,
             Point.Empty,
-            pointerId: pointerId,
-            pointerKind: kind);
+            null,
+            null,
+            Keys.None,
+            pointerId,
+            kind);
 
     private static SKBitmap RenderEffect(Control control, InteractionEffectLayer layer)
     {

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -121,6 +121,24 @@ public sealed class InteractionEffectTests
     }
 
     [Fact]
+    public void FailedRippleSchedulingDoesNotLeaveAStaleRenderableWave()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(80, 30),
+            Ripple = new RippleEffect()
+        };
+        harness.Scheduler.Shutdown();
+
+        Assert.Throws<ObjectDisposedException>(() => control.DownForTest(Mouse(4, 4)));
+
+        Assert.Equal(0, control.Ripple.ActiveRippleCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public void PressScaleComposesWithControlScaleAndReleasesWithoutSticking()
     {
         using var harness = new AnimationSchedulerTestHarness();
@@ -218,6 +236,29 @@ public sealed class InteractionEffectTests
     }
 
     [Fact]
+    public void RoutedActivationKeyReleaseCannotLeavePressEffectStuckWhenOverrideConsumesKeyUp()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new CheckBox { AnimationSchedulerOverride = harness.Scheduler };
+        control.PressEffect = new PressScaleEffect
+        {
+            PressedScale = 0.8f,
+            PressDuration = TimeSpan.Zero,
+            ReleaseDuration = TimeSpan.Zero
+        };
+
+        control.RaiseKeyDown(new KeyEventArgs(Keys.Space));
+        Assert.Equal(VisualState.Pressed, control.VisualState);
+        Assert.Equal(0.8f, control.EffectiveScaleX, 3);
+
+        control.RaiseKeyUp(new KeyEventArgs(Keys.Space));
+
+        Assert.NotEqual(VisualState.Pressed, control.VisualState);
+        Assert.Equal(1f, control.EffectiveScaleX, 3);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public void CollectionAttachDetachIsIdempotentAndDisposeCancelsOwnedWork()
     {
         using var harness = new AnimationSchedulerTestHarness();
@@ -240,6 +281,44 @@ public sealed class InteractionEffectTests
         Assert.Null(ripple.Target);
         Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
         Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void EffectDisposeDetachesExactlyOnceAndFailedAttachReleasesTarget()
+    {
+        var control = new TestButton();
+        var attached = new LifecycleProbeEffect();
+        control.InteractionEffects.Add(attached);
+
+        attached.Dispose();
+        attached.Dispose();
+
+        Assert.Equal(1, attached.DetachCount);
+        Assert.Null(attached.Target);
+        Assert.Empty(control.InteractionEffects);
+
+        var failing = new FailingAttachEffect();
+        Assert.Throws<InvalidOperationException>(() => control.InteractionEffects.Add(failing));
+        Assert.Null(failing.Target);
+        Assert.Empty(control.InteractionEffects);
+    }
+
+    [Fact]
+    public void EffectCanRemoveItselfDuringDispatchWithoutSkippingRemainingEffects()
+    {
+        var control = new TestButton();
+        var selfRemoving = new SelfRemovingEffect();
+        var remaining = new PointerProbeEffect();
+        control.InteractionEffects.Add(selfRemoving);
+        control.InteractionEffects.Add(remaining);
+
+        control.DownForTest(Mouse(4, 4));
+
+        Assert.Equal(1, selfRemoving.PointerDownCount);
+        Assert.Equal(1, selfRemoving.DetachCount);
+        Assert.Equal(1, remaining.PointerDownCount);
+        Assert.Single(control.InteractionEffects);
+        Assert.Same(remaining, control.InteractionEffects[0]);
     }
 
     [Fact]
@@ -380,6 +459,28 @@ public sealed class InteractionEffectTests
         Assert.Equal(["below", "content", "above", "focus"], order);
     }
 
+    [Fact]
+    public void RoundedEffectClipScalesCornerRadiusWithWindowDpi()
+    {
+        using var window = new TestWindow(renderScaling: 2d);
+        var control = new TestButton { Size = new Size(50, 25) };
+        control.Style.Border.Radius = 10;
+        window.Controls.Add(control);
+        using var bitmap = new SKBitmap(control.ScaledWidth, control.ScaledHeight);
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+
+        ControlBoundsInteractionEffectClip.Instance.Apply(
+            canvas,
+            control,
+            new Rectangle(0, 0, control.ScaledWidth, control.ScaledHeight));
+        canvas.DrawColor(SKColors.Red);
+        canvas.Flush();
+
+        Assert.Equal(0, bitmap.GetPixel(3, 3).Alpha);
+        Assert.NotEqual(0, bitmap.GetPixel(10, 10).Alpha);
+    }
+
     private static MouseEventArgs Mouse(
         int x,
         int y,
@@ -465,7 +566,41 @@ public sealed class InteractionEffectTests
                 this,
                 "DesignerProbe",
                 _ => UpdateCount++,
-                new AnimationOptions { Duration = TimeSpan.FromSeconds(1) });
+            new AnimationOptions { Duration = TimeSpan.FromSeconds(1) });
+    }
+
+    private sealed class LifecycleProbeEffect : InteractionEffect
+    {
+        public int DetachCount { get; private set; }
+
+        protected override void OnDetached() => DetachCount++;
+    }
+
+    private sealed class FailingAttachEffect : InteractionEffect
+    {
+        protected override void OnAttached()
+            => throw new InvalidOperationException("Expected attach failure.");
+    }
+
+    private sealed class SelfRemovingEffect : InteractionEffect
+    {
+        public int PointerDownCount { get; private set; }
+        public int DetachCount { get; private set; }
+
+        protected override void OnPointerDown(MouseEventArgs e)
+        {
+            PointerDownCount++;
+            Target!.InteractionEffects.Remove(this);
+        }
+
+        protected override void OnDetached() => DetachCount++;
+    }
+
+    private sealed class PointerProbeEffect : InteractionEffect
+    {
+        public int PointerDownCount { get; private set; }
+
+        protected override void OnPointerDown(MouseEventArgs e) => PointerDownCount++;
     }
 
     private sealed class DesignModeSite(IComponent component) : ISite
@@ -481,15 +616,16 @@ public sealed class InteractionEffectTests
     {
         private readonly RecordingWindowProxy proxy;
 
-        public TestWindow()
-            : this(DispatchProxy.Create<IWindowBaseImpl, RecordingWindowProxy>())
+        public TestWindow(double renderScaling = 1d)
+            : this(DispatchProxy.Create<IWindowBaseImpl, RecordingWindowProxy>(), renderScaling)
         {
         }
 
-        private TestWindow(IWindowBaseImpl implementation)
+        private TestWindow(IWindowBaseImpl implementation, double renderScaling)
             : base(implementation)
         {
             proxy = (RecordingWindowProxy)implementation;
+            proxy.RenderScaling = renderScaling;
         }
 
         public int InvalidationCount => proxy.InvalidationCount;
@@ -501,10 +637,14 @@ public sealed class InteractionEffectTests
     {
         public int InvalidationCount { get; set; }
 
+        public double RenderScaling { get; set; } = 1d;
+
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
         {
             if (targetMethod?.Name == nameof(IWindowBaseImpl.Invalidate))
                 InvalidationCount++;
+            if (targetMethod?.Name == "get_RenderScaling")
+                return RenderScaling;
             if (targetMethod is null || targetMethod.ReturnType == typeof(void))
                 return null;
             return targetMethod.ReturnType.IsValueType

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -139,6 +139,29 @@ public sealed class InteractionEffectTests
     }
 
     [Fact]
+    public void FaultedRippleEasingRemovesWaveAndReturnsSchedulerToIdle()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(80, 30),
+            Ripple = new RippleEffect
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                Easing = static _ => float.NaN
+            }
+        };
+
+        control.DownForTest(Mouse(4, 4));
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.Equal(0, control.Ripple.ActiveRippleCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().FaultedCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public void PressScaleComposesWithControlScaleAndReleasesWithoutSticking()
     {
         using var harness = new AnimationSchedulerTestHarness();
@@ -172,6 +195,32 @@ public sealed class InteractionEffectTests
         control.Enabled = false;
         Assert.Equal(2f, control.EffectiveScaleX, 3);
         Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void FaultedPressEasingStillRestoresReleaseEndpoint()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        control.PressEffect = new PressScaleEffect
+        {
+            PressedScale = 0.8f,
+            PressDuration = TimeSpan.FromMilliseconds(100),
+            ReleaseDuration = TimeSpan.FromMilliseconds(100),
+            Easing = static _ => throw new InvalidOperationException("Expected easing fault.")
+        };
+        MouseEventArgs pointer = Mouse(4, 4);
+
+        control.DownForTest(pointer);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        Assert.Equal(0.8f, control.EffectiveScaleX, 3);
+
+        control.UpForTest(pointer);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.Equal(1f, control.EffectiveScaleX, 3);
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().FaultedCount);
+        Assert.False(harness.TickSource.IsRunning);
     }
 
     [Fact]

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -1,0 +1,464 @@
+using System.ComponentModel;
+using System.Drawing;
+using System.Reflection;
+using ModernFormsNext.Animations;
+using ModernFormsNext.WindowKit.Platform;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+[Collection(DefaultAnimationSchedulerCollection.Name)]
+public sealed class InteractionEffectTests
+{
+    [Fact]
+    public void RippleStartsAtPointerAndRendersRadiusFadeAndRoundedClip()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(100, 50)
+        };
+        control.Style.Border.Radius = 18;
+        var ripple = new RippleEffect
+        {
+            Color = Color.FromArgb(100, 20, 40, 60),
+            Duration = TimeSpan.FromMilliseconds(100),
+            Easing = Easings.Linear
+        };
+        control.Ripple = ripple;
+
+        control.DownForTest(Mouse(10, 10, pointerId: 7, PointerDeviceKind.Touch));
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        using SKBitmap bitmap = RenderEffect(control, InteractionEffectLayer.AboveBackgroundBelowContent);
+
+        Assert.Equal(1, ripple.ActiveRippleCount);
+        SKColor center = bitmap.GetPixel(10, 10);
+        Assert.Equal(50, center.Alpha);
+        Assert.InRange(center.Red, (byte)14, (byte)20);
+        Assert.InRange(center.Green, (byte)34, (byte)40);
+        Assert.InRange(center.Blue, (byte)54, (byte)60);
+        Assert.Equal(0, bitmap.GetPixel(99, 49).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+
+        control.Size = new Size(160, 80);
+        using SKBitmap resized = RenderEffect(control, InteractionEffectLayer.AboveBackgroundBelowContent);
+        Assert.NotEqual(0, resized.GetPixel(70, 10).Alpha);
+    }
+
+    [Fact]
+    public void CenterRippleUsesKeyboardActivationAndReducedMotionSkipsDecoration()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(80, 40)
+        };
+        var ripple = new RippleEffect
+        {
+            StartFromPointer = false,
+            RadiusMode = RippleRadiusMode.Fixed,
+            FixedRadius = 20,
+            Duration = TimeSpan.FromMilliseconds(100),
+            Easing = Easings.Linear
+        };
+        control.Ripple = ripple;
+
+        control.KeyUpForTest(Keys.Space);
+        Assert.Equal(1, ripple.ActiveRippleCount);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        using SKBitmap bitmap = RenderEffect(control, InteractionEffectLayer.AboveBackgroundBelowContent);
+        Assert.NotEqual(0, bitmap.GetPixel(40, 20).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(10, 10).Alpha);
+
+        ripple.CancelForTest();
+        ripple.Enabled = true;
+        harness.Policy.ReducedMotion = true;
+        control.KeyUpForTest(Keys.Enter);
+        Assert.Equal(0, ripple.ActiveRippleCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void RapidRippleHonorsBoundAndEvictsOldestHandle()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(100, 40)
+        };
+        var ripple = new RippleEffect
+        {
+            Duration = TimeSpan.FromMilliseconds(100),
+            MaxConcurrentRipples = 4
+        };
+        control.Ripple = ripple;
+
+        for (int index = 0; index < 5; index++)
+            control.DownForTest(Mouse(10 + index, 10, index, PointerDeviceKind.Touch));
+
+        Assert.Equal(4, ripple.ActiveRippleCount);
+        Assert.Equal(4, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().CanceledCount);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(0, ripple.ActiveRippleCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void PressScaleComposesWithControlScaleAndReleasesWithoutSticking()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            ScaleX = 2f,
+            ScaleY = 2f
+        };
+        var press = new PressScaleEffect
+        {
+            PressedScale = 0.9f,
+            PressDuration = TimeSpan.FromMilliseconds(100),
+            ReleaseDuration = TimeSpan.FromMilliseconds(100),
+            Easing = Easings.Linear
+        };
+        control.PressEffect = press;
+
+        MouseEventArgs pointer = Mouse(5, 5, pointerId: 3, PointerDeviceKind.Touch);
+        control.DownForTest(pointer);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        Assert.Equal(1.9f, control.EffectiveScaleX, 3);
+
+        control.UpForTest(pointer);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(2f, control.EffectiveScaleX, 3);
+        Assert.False(harness.TickSource.IsRunning);
+
+        control.DownForTest(pointer);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        control.Enabled = false;
+        Assert.Equal(2f, control.EffectiveScaleX, 3);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void TouchPointersRemainIndependentAndCancelClearsEffectState()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        control.PressEffect = new PressScaleEffect
+        {
+            PressedScale = 0.8f,
+            PressDuration = TimeSpan.Zero,
+            ReleaseDuration = TimeSpan.Zero
+        };
+
+        MouseEventArgs first = Mouse(2, 2, 11, PointerDeviceKind.Touch);
+        MouseEventArgs second = Mouse(3, 3, 12, PointerDeviceKind.Touch);
+        control.DownForTest(first);
+        control.DownForTest(second);
+        Assert.Equal(VisualState.Pressed, control.VisualState);
+
+        control.UpForTest(first);
+        Assert.Equal(VisualState.Pressed, control.VisualState);
+        control.CancelPointerForTest();
+
+        Assert.NotEqual(VisualState.Pressed, control.VisualState);
+        Assert.Equal(1f, control.EffectiveScaleX, 3);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void FocusLossReleasesKeyboardPressWithoutWaitingForKeyUp()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        control.PressEffect = new PressScaleEffect
+        {
+            PressedScale = 0.8f,
+            PressDuration = TimeSpan.Zero,
+            ReleaseDuration = TimeSpan.FromMilliseconds(100),
+            Easing = Easings.Linear
+        };
+
+        control.KeyDownForTest(Keys.Space);
+        Assert.Equal(0.8f, control.EffectiveScaleX, 3);
+
+        control.LostFocusForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(1f, control.EffectiveScaleX, 3);
+        Assert.NotEqual(VisualState.Pressed, control.VisualState);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void CollectionAttachDetachIsIdempotentAndDisposeCancelsOwnedWork()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(80, 30)
+        };
+        var ripple = new RippleEffect { Duration = TimeSpan.FromMilliseconds(100) };
+
+        control.InteractionEffects.Add(ripple);
+        control.InteractionEffects.Add(ripple);
+        Assert.Single(control.InteractionEffects);
+        Assert.Same(control, ripple.Target);
+        control.DownForTest(Mouse(4, 4));
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        control.Dispose();
+
+        Assert.Null(ripple.Target);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void DisabledAndDesignerTargetsDoNotStartRuntimeRippleWork()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var disabled = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Enabled = false,
+            Size = new Size(80, 30),
+            Ripple = new RippleEffect()
+        };
+
+        disabled.DownForTest(Mouse(4, 4));
+        Assert.Equal(0, disabled.Ripple!.ActiveRippleCount);
+
+        var designer = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(80, 30),
+            Ripple = new RippleEffect(),
+            PressEffect = new PressScaleEffect
+            {
+                PressedScale = 0.9f,
+                PressDuration = TimeSpan.FromSeconds(1),
+                ReleaseDuration = TimeSpan.FromSeconds(1)
+            }
+        };
+        designer.Site = new DesignModeSite(designer);
+
+        designer.DownForTest(Mouse(4, 4));
+        Assert.Equal(0, designer.Ripple!.ActiveRippleCount);
+        Assert.Equal(0.9f, designer.EffectiveScaleX, 3);
+        designer.UpForTest(Mouse(4, 4));
+        Assert.Equal(1f, designer.EffectiveScaleX, 3);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void ReparentDoesNotDuplicateEffectsAndDisposalStopsFutureRepaint()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var firstParent = new Panel();
+        var secondParent = new Panel();
+        var control = new InvalidationCountingButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(80, 30),
+            Ripple = new RippleEffect { Duration = TimeSpan.FromMilliseconds(100) }
+        };
+        firstParent.Controls.Add(control);
+        firstParent.Controls.Remove(control);
+        secondParent.Controls.Add(control);
+
+        control.ResetInvalidations();
+        control.DownForTest(Mouse(4, 4));
+        Assert.Single(control.InteractionEffects);
+        Assert.Equal(1, control.Ripple!.ActiveRippleCount);
+
+        control.Dispose();
+        int afterDispose = control.InvalidationCount;
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(afterDispose, control.InvalidationCount);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void OneSchedulerTickBatchesVisualInvalidationPerWindowWithoutLayout()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var firstWindow = new TestWindow();
+        using var secondWindow = new TestWindow();
+        var first = CreatePressButton(harness);
+        var second = CreatePressButton(harness);
+        int layouts = 0;
+        first.Layout += (_, _) => layouts++;
+        second.Layout += (_, _) => layouts++;
+        firstWindow.Controls.Add(first);
+        secondWindow.Controls.Add(second);
+        first.DownForTest(Mouse(4, 4));
+        second.DownForTest(Mouse(4, 4));
+        firstWindow.ResetInvalidations();
+        secondWindow.ResetInvalidations();
+        layouts = 0;
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.Equal(1, firstWindow.InvalidationCount);
+        Assert.Equal(1, secondWindow.InvalidationCount);
+        Assert.Equal(0, layouts);
+    }
+
+    [Fact]
+    public void SharedRenderHookPreservesBelowContentAboveFocusOrdering()
+    {
+        var order = new List<string>();
+        var control = new RenderOrderButton(order) { Size = new Size(40, 20) };
+        control.InteractionEffects.Add(new RecordingEffect(
+            InteractionEffectLayer.AboveBackgroundBelowContent,
+            () => order.Add("below")));
+        control.InteractionEffects.Add(new RecordingEffect(
+            InteractionEffectLayer.AboveContent,
+            () => order.Add("above")));
+        using var bitmap = new SKBitmap(40, 20);
+        using var canvas = new SKCanvas(bitmap);
+        var args = new PaintEventArgs(bitmap.Info, canvas, 1d);
+
+        control.RaisePaint(args);
+
+        Assert.Equal(["below", "content", "above", "focus"], order);
+    }
+
+    private static MouseEventArgs Mouse(
+        int x,
+        int y,
+        int pointerId = 0,
+        PointerDeviceKind kind = PointerDeviceKind.Mouse)
+        => new(
+            MouseButtons.Left,
+            1,
+            x,
+            y,
+            Point.Empty,
+            pointerId: pointerId,
+            pointerKind: kind);
+
+    private static SKBitmap RenderEffect(Control control, InteractionEffectLayer layer)
+    {
+        var bitmap = new SKBitmap(control.Width, control.Height);
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+        control.RenderInteractionEffects(
+            layer,
+            new PaintEventArgs(bitmap.Info, canvas, 1d));
+        canvas.Flush();
+        return bitmap;
+    }
+
+    private static TestButton CreatePressButton(AnimationSchedulerTestHarness harness)
+    {
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        control.PressEffect = new PressScaleEffect
+        {
+            PressedScale = 0.9f,
+            PressDuration = TimeSpan.FromMilliseconds(100),
+            Easing = Easings.Linear
+        };
+        return control;
+    }
+
+    private class TestButton : Button
+    {
+        public void DownForTest(MouseEventArgs e) => OnMouseDown(e);
+        public void UpForTest(MouseEventArgs e) => OnMouseUp(e);
+        public void KeyDownForTest(Keys key) => OnKeyDown(new KeyEventArgs(key));
+        public void KeyUpForTest(Keys key) => OnKeyUp(new KeyEventArgs(key));
+        public void LostFocusForTest() => OnLostFocus(EventArgs.Empty);
+        public void CancelPointerForTest() => CancelPointerInteraction();
+    }
+
+    private sealed class InvalidationCountingButton : TestButton
+    {
+        public int InvalidationCount { get; private set; }
+
+        public void ResetInvalidations() => InvalidationCount = 0;
+
+        protected override void OnInvalidated(EventArgs<Rectangle> e)
+        {
+            InvalidationCount++;
+            base.OnInvalidated(e);
+        }
+    }
+
+    private sealed class RenderOrderButton(List<string> order) : TestButton
+    {
+        protected override void OnPaint(PaintEventArgs e) => order.Add("content");
+        internal override void RenderFocusOverlay(PaintEventArgs e) => order.Add("focus");
+    }
+
+    private sealed class RecordingEffect(
+        InteractionEffectLayer layer,
+        Action render) : InteractionEffect
+    {
+        public override InteractionEffectLayer RenderLayer => layer;
+
+        protected override void OnRender(InteractionEffectRenderContext context) => render();
+    }
+
+    private sealed class DesignModeSite(IComponent component) : ISite
+    {
+        public IComponent Component { get; } = component;
+        public IContainer? Container => null;
+        public bool DesignMode => true;
+        public string? Name { get; set; }
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class TestWindow : WindowBase
+    {
+        private readonly RecordingWindowProxy proxy;
+
+        public TestWindow()
+            : this(DispatchProxy.Create<IWindowBaseImpl, RecordingWindowProxy>())
+        {
+        }
+
+        private TestWindow(IWindowBaseImpl implementation)
+            : base(implementation)
+        {
+            proxy = (RecordingWindowProxy)implementation;
+        }
+
+        public int InvalidationCount => proxy.InvalidationCount;
+
+        public void ResetInvalidations() => proxy.InvalidationCount = 0;
+    }
+
+    private class RecordingWindowProxy : DispatchProxy
+    {
+        public int InvalidationCount { get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IWindowBaseImpl.Invalidate))
+                InvalidationCount++;
+            if (targetMethod is null || targetMethod.ReturnType == typeof(void))
+                return null;
+            return targetMethod.ReturnType.IsValueType
+                ? Activator.CreateInstance(targetMethod.ReturnType)
+                : null;
+        }
+    }
+}
+
+internal static class RippleEffectTestExtensions
+{
+    public static void CancelForTest(this RippleEffect effect)
+        => effect.Enabled = false;
+}

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -110,6 +110,17 @@ public sealed class InteractionEffectTests
     }
 
     [Fact]
+    public void RippleRejectsUndefinedRadiusAndEvictionPolicies()
+    {
+        var ripple = new RippleEffect();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ripple.RadiusMode = (RippleRadiusMode)int.MaxValue);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ripple.EvictionPolicy = (RippleEvictionPolicy)int.MaxValue);
+    }
+
+    [Fact]
     public void PressScaleComposesWithControlScaleAndReleasesWithoutSticking()
     {
         using var harness = new AnimationSchedulerTestHarness();

--- a/ModernFormsNext.Tests/VisualStateTransitionTests.cs
+++ b/ModernFormsNext.Tests/VisualStateTransitionTests.cs
@@ -163,6 +163,64 @@ public sealed class VisualStateTransitionTests
         Assert.False(harness.TickSource.IsRunning);
     }
 
+    [Fact]
+    public void StateStylesInheritBrushesAndTransformsTheyDoNotOverride()
+    {
+        var control = new TestButton();
+        var background = new SolidColorBrush(SKColors.Orange);
+        var foreground = new SolidColorBrush(SKColors.White);
+        var border = new SolidColorBrush(SKColors.Black);
+        control.Style.BackgroundBrush = background;
+        control.Style.ForegroundBrush = foreground;
+        control.Style.BorderBrush = border;
+        control.Style.Opacity = 0.8f;
+        control.Style.ScaleX = 1.1f;
+        control.Style.TranslationX = 4f;
+
+        control.FocusForTest();
+
+        Assert.Equal(VisualState.Focused, control.VisualState);
+        Assert.Same(background, control.EffectiveBackgroundBrush);
+        Assert.Same(foreground, control.EffectiveTextBrush);
+        Assert.Same(border, control.EffectiveBorderBrush);
+        Assert.Equal(0.8f, control.EffectiveOpacity, 3);
+        Assert.Equal(1.1f, control.EffectiveScaleX, 3);
+        Assert.Equal(4f, control.EffectiveTranslationX, 3);
+    }
+
+    [Fact]
+    public void ActiveStateBrushMutationInvalidatesWithoutAnotherPointerEvent()
+    {
+        using var control = new TestButton();
+        using var surface = new SkiaControlSurface(control);
+        var hoverBrush = new SolidColorBrush(SKColors.Blue);
+        control.StyleHover.BackgroundBrush = hoverBrush;
+        control.EnterForTest();
+
+        Assert.Same(hoverBrush, control.EffectiveBackgroundBrush);
+        control.ResetInvalidations();
+        hoverBrush.Color = SKColors.Purple;
+
+        Assert.Equal(1, control.InvalidationCount);
+        Assert.Equal(VisualState.Hover, control.VisualState);
+        Assert.Same(control.StyleHover, control.CurrentStyle);
+    }
+
+    [Fact]
+    public void DisposingControlCancelsActiveStateTransitionBeforeAnotherRepaint()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = CreateTransitionButton(harness);
+        control.EnterForTest();
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        control.Dispose();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
     private static TestButton CreateTransitionButton(AnimationSchedulerTestHarness harness)
     {
         var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
@@ -184,6 +242,10 @@ public sealed class VisualStateTransitionTests
 
     private sealed class TestButton : Button
     {
+        public int InvalidationCount { get; private set; }
+
+        public void ResetInvalidations() => InvalidationCount = 0;
+
         public void EnterForTest()
             => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, System.Drawing.Point.Empty));
 
@@ -193,5 +255,11 @@ public sealed class VisualStateTransitionTests
         public void FocusForTest() => OnGotFocus(EventArgs.Empty);
 
         public void ThemeChangedForTest() => OnThemeChanged(EventArgs.Empty);
+
+        protected override void OnInvalidated(EventArgs<System.Drawing.Rectangle> e)
+        {
+            InvalidationCount++;
+            base.OnInvalidated(e);
+        }
     }
 }

--- a/ModernFormsNext.Tests/VisualStateTransitionTests.cs
+++ b/ModernFormsNext.Tests/VisualStateTransitionTests.cs
@@ -1,0 +1,197 @@
+using ModernFormsNext.Animations;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class VisualStateTransitionTests
+{
+    [Fact]
+    public void StatePriorityCoversNormalFocusedHoverPressedAndDisabled()
+    {
+        var control = new TestButton();
+
+        Assert.Equal(VisualState.Normal, control.VisualState);
+        control.FocusForTest();
+        Assert.Equal(VisualState.Focused, control.VisualState);
+        control.EnterForTest();
+        Assert.Equal(VisualState.Hover, control.VisualState);
+        control.DownForTest();
+        Assert.Equal(VisualState.Pressed, control.VisualState);
+        control.Enabled = false;
+        Assert.Equal(VisualState.Disabled, control.VisualState);
+    }
+
+    [Fact]
+    public void TransitionInterpolatesColorsBrushesAndTransformsWithoutLayout()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = CreateTransitionButton(harness);
+        control.Style.BackgroundColor = SKColors.Red;
+        control.Style.ForegroundColor = SKColors.Black;
+        control.Style.Border.Color = SKColors.Green;
+        control.Style.BackgroundBrush = new SolidColorBrush(SKColors.Red);
+        control.StyleHover.BackgroundColor = SKColors.Blue;
+        control.StyleHover.ForegroundColor = SKColors.White;
+        control.StyleHover.Border.Color = SKColors.Yellow;
+        control.StyleHover.BackgroundBrush = new SolidColorBrush(SKColors.Blue);
+        control.StyleHover.Opacity = 0.5f;
+        control.StyleHover.ScaleX = 1.2f;
+        control.StyleHover.TranslationX = 8f;
+        control.StyleHover.Rotation = 10f;
+        control.StyleHover.Border.Width = 8;
+        int layouts = 0;
+        control.Layout += (_, _) => layouts++;
+
+        control.EnterForTest();
+        Assert.Equal(8, control.CurrentStyle.Border.GetWidth());
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.Equal(new SKColor(128, 0, 128), control.CurrentStyle.GetBackgroundColor());
+        Assert.Equal(new SKColor(128, 128, 128), control.CurrentStyle.GetForegroundColor());
+        Assert.Equal(new SKColor(128, 192, 0), control.CurrentStyle.Border.GetColor());
+        var brush = Assert.IsType<SolidColorBrush>(control.EffectiveBackgroundBrush);
+        Assert.Equal(new SKColor(128, 0, 128), brush.Color);
+        Assert.Equal(0.75f, control.EffectiveOpacity, 3);
+        Assert.Equal(1.1f, control.EffectiveScaleX, 3);
+        Assert.Equal(4f, control.EffectiveTranslationX, 3);
+        Assert.Equal(5f, control.EffectiveRotation, 3);
+        Assert.Equal(0, layouts);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        Assert.Same(control.StyleHover, control.CurrentStyle);
+        Assert.Equal(SKColors.Blue, control.CurrentStyle.GetBackgroundColor());
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void RapidStateChangesUseLatestStateAndCancelStaleTransition()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = CreateTransitionButton(harness);
+        control.Style.BackgroundColor = SKColors.Black;
+        control.StyleHover.BackgroundColor = SKColors.Blue;
+        control.StylePressed.BackgroundColor = SKColors.Red;
+        AddTransition(control, VisualState.Hover, VisualState.Pressed);
+
+        control.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(30));
+        control.DownForTest();
+
+        Assert.Equal(VisualState.Pressed, control.VisualState);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Same(control.StylePressed, control.CurrentStyle);
+        Assert.Equal(SKColors.Red, control.CurrentStyle.GetBackgroundColor());
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().CanceledCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void ReducedMotionAppliesTargetOnceWithoutStartingTicks()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        harness.Policy.ReducedMotion = true;
+        var control = CreateTransitionButton(harness);
+        control.StyleHover.BackgroundColor = SKColors.CornflowerBlue;
+
+        control.EnterForTest();
+
+        Assert.Same(control.StyleHover, control.CurrentStyle);
+        Assert.Equal(SKColors.CornflowerBlue, control.CurrentStyle.GetBackgroundColor());
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void ThemeRefreshCancelsTransitionAndResolvesCurrentStateAgain()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = CreateTransitionButton(harness);
+        control.StyleHover.BackgroundColor = SKColors.Blue;
+        control.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(30));
+
+        control.StyleHover.BackgroundColor = SKColors.Purple;
+        control.ThemeChangedForTest();
+
+        Assert.Equal(VisualState.Hover, control.VisualState);
+        Assert.Same(control.StyleHover, control.CurrentStyle);
+        Assert.Equal(SKColors.Purple, control.CurrentStyle.GetBackgroundColor());
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void FocusedPressedAndDisabledTransitionsRefreshTheirActiveStyles()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+
+        var focused = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        focused.Style.BackgroundColor = SKColors.Black;
+        focused.StyleFocused.BackgroundColor = SKColors.Green;
+        AddTransition(focused, VisualState.Normal, VisualState.Focused);
+        focused.FocusForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(VisualState.Focused, focused.VisualState);
+        Assert.Same(focused.StyleFocused, focused.CurrentStyle);
+        Assert.Equal(SKColors.Green, focused.CurrentStyle.GetBackgroundColor());
+
+        var pressed = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        pressed.Style.BackgroundColor = SKColors.Black;
+        pressed.StylePressed.BackgroundColor = SKColors.Red;
+        AddTransition(pressed, VisualState.Normal, VisualState.Pressed);
+        pressed.DownForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(VisualState.Pressed, pressed.VisualState);
+        Assert.Same(pressed.StylePressed, pressed.CurrentStyle);
+        Assert.Equal(SKColors.Red, pressed.CurrentStyle.GetBackgroundColor());
+
+        var disabled = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        disabled.Style.BackgroundColor = SKColors.Black;
+        disabled.StyleDisabled.BackgroundColor = SKColors.Gray;
+        AddTransition(disabled, VisualState.Normal, VisualState.Disabled);
+        disabled.Enabled = false;
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(VisualState.Disabled, disabled.VisualState);
+        Assert.Same(disabled.StyleDisabled, disabled.CurrentStyle);
+        Assert.Equal(SKColors.Gray, disabled.CurrentStyle.GetBackgroundColor());
+
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    private static TestButton CreateTransitionButton(AnimationSchedulerTestHarness harness)
+    {
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        AddTransition(control, VisualState.Normal, VisualState.Hover);
+        return control;
+    }
+
+    private static void AddTransition(TestButton control, VisualState from, VisualState to)
+    {
+        control.StyleTransitions.Add(
+            from,
+            to,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                Easing = Easings.Linear
+            });
+    }
+
+    private sealed class TestButton : Button
+    {
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, System.Drawing.Point.Empty));
+
+        public void DownForTest()
+            => OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
+
+        public void FocusForTest() => OnGotFocus(EventArgs.Empty);
+
+        public void ThemeChangedForTest() => OnThemeChanged(EventArgs.Empty);
+    }
+}

--- a/ModernFormsNext.Tests/VisualStateTransitionTests.cs
+++ b/ModernFormsNext.Tests/VisualStateTransitionTests.cs
@@ -90,6 +90,35 @@ public sealed class VisualStateTransitionTests
     }
 
     [Fact]
+    public void OvershootingEasingDoesNotFinishVisualStateBeforeRawTimelineCompletion()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        control.Style.BackgroundColor = SKColors.Black;
+        control.StyleHover.BackgroundColor = SKColors.Blue;
+        control.StyleTransitions.Add(
+            VisualState.Normal,
+            VisualState.Hover,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                Easing = static _ => 1.25f
+            });
+
+        control.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.NotSame(control.StyleHover, control.CurrentStyle);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.Same(control.StyleHover, control.CurrentStyle);
+        Assert.Equal(SKColors.Blue, control.CurrentStyle.GetBackgroundColor());
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public void ReducedMotionAppliesTargetOnceWithoutStartingTicks()
     {
         using var harness = new AnimationSchedulerTestHarness();

--- a/ModernFormsNext/Animations/Animation.cs
+++ b/ModernFormsNext/Animations/Animation.cs
@@ -1,0 +1,27 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Creates scheduler-backed animation compositions.
+/// </summary>
+public static class Animation
+{
+    /// <summary>Creates a composition that runs its children in declaration order.</summary>
+    /// <param name="animations">The non-null child definitions.</param>
+    /// <returns>A reusable sequential definition.</returns>
+    public static AnimationDefinition Sequence(params AnimationDefinition[] animations)
+        => new SequenceAnimation(animations);
+
+    /// <summary>Creates a composition that starts all children together.</summary>
+    /// <param name="animations">The non-null child definitions.</param>
+    /// <returns>A reusable parallel definition.</returns>
+    public static AnimationDefinition Parallel(params AnimationDefinition[] animations)
+        => new ParallelAnimation(animations);
+
+    /// <summary>
+    /// Creates a scheduler-driven delay that observes lifecycle pause and reduced-motion policy.
+    /// </summary>
+    /// <param name="duration">The non-negative delay interval.</param>
+    /// <returns>A reusable delay definition.</returns>
+    public static AnimationDefinition Delay(TimeSpan duration)
+        => new DelayAnimation(duration);
+}

--- a/ModernFormsNext/Animations/Animation.cs
+++ b/ModernFormsNext/Animations/Animation.cs
@@ -17,6 +17,10 @@ public static class Animation
     public static AnimationDefinition Parallel(params AnimationDefinition[] animations)
         => new ParallelAnimation(animations);
 
+    internal static AnimationDefinition ParallelPreservingChildChannels(
+        params AnimationDefinition[] animations)
+        => new ParallelAnimation(animations, preserveChildChannels: true);
+
     /// <summary>
     /// Creates a scheduler-driven delay that observes lifecycle pause and reduced-motion policy.
     /// </summary>

--- a/ModernFormsNext/Animations/AnimationContext.cs
+++ b/ModernFormsNext/Animations/AnimationContext.cs
@@ -1,0 +1,56 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Describes the target and timing values for one custom-animation update.
+/// </summary>
+/// <remarks>
+/// One context instance is reused for every frame in a run. The target is available only while an
+/// update callback is executing; the framework clears it before completion becomes observable so
+/// a retained context cannot keep a completed target alive. Updates run on the scheduler UI
+/// dispatcher and must not block.
+/// </remarks>
+public sealed class AnimationContext
+{
+    private Control? target;
+
+    internal AnimationContext(Control target, CancellationToken cancellationToken)
+    {
+        this.target = target;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>Gets the control targeted by the current animation update.</summary>
+    /// <exception cref="ObjectDisposedException">The run has already released its target.</exception>
+    public Control Target
+        => target ?? throw new ObjectDisposedException(
+            nameof(AnimationContext),
+            "The completed animation context no longer retains its target.");
+
+    /// <summary>Gets direction-aware linear progress in the inclusive range 0 through 1.</summary>
+    public float Progress { get; private set; }
+
+    /// <summary>Gets direction-aware eased progress. Overshoot curves may exceed 0 through 1.</summary>
+    public float EasedProgress { get; private set; }
+
+    /// <summary>Gets monotonic elapsed time within the current playback leg.</summary>
+    public TimeSpan Elapsed { get; private set; }
+
+    /// <summary>Gets the scaled duration of the current playback leg.</summary>
+    public TimeSpan Duration { get; private set; }
+
+    /// <summary>
+    /// Gets a token signaled when the run is canceled explicitly, by replacement, or by owner
+    /// lifetime cleanup.
+    /// </summary>
+    public CancellationToken CancellationToken { get; }
+
+    internal void SetFrame(AnimationFrame frame, bool reverse)
+    {
+        Progress = reverse ? 1f - frame.Progress : frame.Progress;
+        EasedProgress = reverse ? 1f - frame.EasedProgress : frame.EasedProgress;
+        Elapsed = frame.Elapsed;
+        Duration = frame.Duration;
+    }
+
+    internal void ReleaseTarget() => target = null;
+}

--- a/ModernFormsNext/Animations/AnimationDefinition.cs
+++ b/ModernFormsNext/Animations/AnimationDefinition.cs
@@ -1,0 +1,302 @@
+using System.ComponentModel;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Defines a reusable scheduler-backed animation that can be run directly or composed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Derive from this class and implement <see cref="Update"/> for custom animations. The same
+/// definition can be run more than once; per-run timing and target state are held by
+/// <see cref="AnimationRun"/>, not by the definition.
+/// </para>
+/// <para>
+/// Repeat count is the number of forward iterations. When auto-reverse is enabled, each iteration
+/// has one forward and one reverse leg. Infinite repeat requires cancellation in normal-motion
+/// mode and collapses to one deterministic sample under reduced motion.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public sealed class ShakeAnimation : AnimationDefinition
+/// {
+///     public float Distance { get; set; } = 8f;
+///     public int Oscillations { get; set; } = 4;
+///
+///     protected override void Update(AnimationContext context, float progress)
+///     {
+///         context.Target.TranslationX =
+///             MathF.Sin(progress * MathF.PI * 2f * Oscillations)
+///             * Distance
+///             * (1f - progress);
+///     }
+/// }
+///
+/// await new ShakeAnimation().RunAsync(button);
+/// </code>
+/// </example>
+public abstract class AnimationDefinition
+{
+    private TimeSpan duration = TimeSpan.FromMilliseconds(250);
+    private TimeSpan delay;
+    private Func<float, float> easing = Easings.Linear;
+    private string? key;
+    private AnimationReplacementMode replacementMode = AnimationReplacementMode.Replace;
+    private int repeatCount = 1;
+    private bool repeatsForever;
+    private bool autoReverse;
+
+    /// <summary>Gets or sets the unscaled duration of one playback leg.</summary>
+    public TimeSpan Duration
+    {
+        get => duration;
+        set
+        {
+            if (value < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Animation duration cannot be negative.");
+            duration = value;
+        }
+    }
+
+    /// <summary>Gets or sets the unscaled delay before each playback leg.</summary>
+    public TimeSpan Delay
+    {
+        get => delay;
+        set
+        {
+            if (value < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Animation delay cannot be negative.");
+            delay = value;
+        }
+    }
+
+    /// <summary>Gets or sets the easing used by one playback leg.</summary>
+    public Func<float, float> Easing
+    {
+        get => easing;
+        set => easing = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the owner-local replacement key. A generated type-based key is used when null.
+    /// </summary>
+    public string? Key
+    {
+        get => key;
+        set
+        {
+            if (value is not null)
+                ArgumentException.ThrowIfNullOrWhiteSpace(value);
+            key = value;
+        }
+    }
+
+    /// <summary>Gets or sets owner/key replacement behavior.</summary>
+    public AnimationReplacementMode ReplacementMode
+    {
+        get => replacementMode;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value));
+            replacementMode = value;
+        }
+    }
+
+    /// <summary>Gets the configured finite forward-iteration count.</summary>
+    public int RepeatCount => repeatCount;
+
+    /// <summary>Gets whether the definition repeats until cancellation.</summary>
+    public bool RepeatsForever => repeatsForever;
+
+    /// <summary>Gets whether every forward iteration has a reverse leg.</summary>
+    public bool IsAutoReversed => autoReverse;
+
+    /// <summary>Configures a finite number of forward iterations.</summary>
+    /// <param name="count">A positive iteration count.</param>
+    /// <returns>This definition.</returns>
+    public AnimationDefinition Repeat(int count)
+    {
+        if (count <= 0)
+            throw new ArgumentOutOfRangeException(nameof(count), count, "Repeat count must be positive.");
+        repeatCount = count;
+        repeatsForever = false;
+        return this;
+    }
+
+    /// <summary>Repeats until the returned run is canceled.</summary>
+    /// <returns>This definition.</returns>
+    public AnimationDefinition RepeatForever()
+    {
+        repeatsForever = true;
+        return this;
+    }
+
+    /// <summary>Adds a reverse leg after every forward iteration.</summary>
+    /// <returns>This definition.</returns>
+    public AnimationDefinition AutoReverse()
+    {
+        autoReverse = true;
+        return this;
+    }
+
+    /// <summary>Starts a definition whose target is already bound by a factory or composition.</summary>
+    public AnimationRun Start(
+        AnimationScheduler? scheduler = null,
+        CancellationToken cancellationToken = default)
+    {
+        Control? target = BoundTarget;
+        if (target is null && RequiresTarget)
+            throw new InvalidOperationException("This animation definition requires a target control.");
+        return StartCore(target, scheduler ?? AnimationScheduler.Default, cancellationToken);
+    }
+
+    /// <summary>Starts this definition for the specified target control.</summary>
+    public AnimationRun Start(
+        Control target,
+        AnimationScheduler? scheduler = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return StartCore(target, scheduler ?? AnimationScheduler.Default, cancellationToken);
+    }
+
+    /// <summary>Runs a bound definition and returns its terminal state.</summary>
+    public Task<AnimationState> RunAsync(
+        AnimationScheduler? scheduler = null,
+        CancellationToken cancellationToken = default)
+        => Start(scheduler, cancellationToken).Completion;
+
+    /// <summary>Runs this definition for the specified target and returns its terminal state.</summary>
+    public Task<AnimationState> RunAsync(
+        Control target,
+        AnimationScheduler? scheduler = null,
+        CancellationToken cancellationToken = default)
+        => Start(target, scheduler, cancellationToken).Completion;
+
+    /// <summary>Updates one frame of a custom definition.</summary>
+    /// <param name="context">The reused timing and target context for this run.</param>
+    /// <param name="progress">Direction-aware eased progress.</param>
+    protected abstract void Update(AnimationContext context, float progress);
+
+    internal virtual Control? BoundTarget => null;
+
+    internal virtual bool RequiresTarget => true;
+
+    internal virtual async Task<AnimationExecutionResult> ExecuteAsync(AnimationExecutionScope scope, bool reverse = false)
+    {
+        int iteration = 0;
+        bool collapseInfinite = repeatsForever && scope.Scheduler.Policy.ShouldCompleteImmediately;
+
+        while (repeatsForever || iteration < repeatCount)
+        {
+            scope.CancellationToken.ThrowIfCancellationRequested();
+            AnimationExecutionResult forward = await ExecuteCoreAsync(scope, reverse).ConfigureAwait(false);
+            if (forward.State != AnimationState.Completed)
+                return forward;
+
+            if (autoReverse)
+            {
+                AnimationExecutionResult backward = await ExecuteCoreAsync(scope, !reverse).ConfigureAwait(false);
+                if (backward.State != AnimationState.Completed)
+                    return backward;
+            }
+
+            iteration++;
+            if (collapseInfinite)
+                break;
+        }
+
+        return AnimationExecutionResult.Completed;
+    }
+
+    internal virtual Task<AnimationExecutionResult> ExecuteCoreAsync(
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        Control target = BoundTarget ?? scope.DefaultTarget
+            ?? throw new InvalidOperationException("This animation definition requires a target control.");
+        return ScheduleAsync(scope, target, ResolveKey(), reverse, Update);
+    }
+
+    internal Task<AnimationExecutionResult> ScheduleAsync(
+        AnimationExecutionScope scope,
+        Control target,
+        string key,
+        bool reverse,
+        Action<AnimationContext, float> update)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(update);
+
+        var context = new AnimationContext(target, scope.CancellationToken);
+        AnimationHandle handle = scope.Scheduler.StartFrames(
+            target,
+            scope.KeyPrefix + key,
+            frame =>
+            {
+                context.SetFrame(frame, reverse);
+                update(context, context.EasedProgress);
+            },
+            CreateOptions());
+
+        return AwaitLeafAsync(handle, context, scope.CancellationToken);
+    }
+
+    internal AnimationOptions CreateOptions()
+        => new()
+        {
+            Duration = Duration,
+            Delay = Delay,
+            Easing = Easing,
+            ReplacementMode = ReplacementMode
+        };
+
+    internal string ResolveKey() => Key ?? GetType().FullName ?? GetType().Name;
+
+    private AnimationRun StartCore(
+        Control? target,
+        AnimationScheduler scheduler,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+        var run = new AnimationRun();
+        run.Start(
+            token => ExecuteAsync(new AnimationExecutionScope(
+                scheduler,
+                target,
+                token,
+                string.Empty,
+                new object())),
+            cancellationToken);
+        return run;
+    }
+
+    internal static async Task<AnimationExecutionResult> AwaitLeafAsync(
+        AnimationHandle handle,
+        AnimationContext? context,
+        CancellationToken cancellationToken)
+    {
+        using CancellationTokenRegistration registration =
+            cancellationToken.CanBeCanceled ? cancellationToken.Register(handle.Cancel) : default;
+
+        try
+        {
+            AnimationState state = await handle.Completion.ConfigureAwait(false);
+            return state switch
+            {
+                AnimationState.Completed => AnimationExecutionResult.Completed,
+                AnimationState.Canceled => AnimationExecutionResult.Canceled,
+                AnimationState.Faulted => AnimationExecutionResult.Faulted(
+                    handle.Exception ?? new InvalidOperationException("The animation fault did not provide an exception.")),
+                _ => throw new InvalidOperationException($"Unexpected terminal animation state '{state}'.")
+            };
+        }
+        finally
+        {
+            context?.ReleaseTarget();
+        }
+    }
+}

--- a/ModernFormsNext/Animations/AnimationDefinition.cs
+++ b/ModernFormsNext/Animations/AnimationDefinition.cs
@@ -127,6 +127,11 @@ public abstract class AnimationDefinition
 
     /// <summary>Repeats until the returned run is canceled.</summary>
     /// <returns>This definition.</returns>
+    /// <remarks>
+    /// A composition with no scheduler-backed children faults its run instead of entering a
+    /// synchronous busy loop. Reduced-motion policy collapses a non-empty infinite repeat to one
+    /// deterministic iteration.
+    /// </remarks>
     public AnimationDefinition RepeatForever()
     {
         repeatsForever = true;
@@ -184,8 +189,16 @@ public abstract class AnimationDefinition
 
     internal virtual bool RequiresTarget => true;
 
+    internal virtual bool HasSchedulableWork => true;
+
     internal virtual async Task<AnimationExecutionResult> ExecuteAsync(AnimationExecutionScope scope, bool reverse = false)
     {
+        if (repeatsForever && !HasSchedulableWork)
+        {
+            return AnimationExecutionResult.Faulted(new InvalidOperationException(
+                "An empty animation composition cannot repeat forever because it has no scheduler-backed work to yield."));
+        }
+
         int iteration = 0;
         bool collapseInfinite = repeatsForever && scope.Scheduler.Policy.ShouldCompleteImmediately;
 

--- a/ModernFormsNext/Animations/AnimationDefinition.cs
+++ b/ModernFormsNext/Animations/AnimationDefinition.cs
@@ -193,13 +193,13 @@ public abstract class AnimationDefinition
         {
             scope.CancellationToken.ThrowIfCancellationRequested();
             AnimationExecutionResult forward = await ExecuteCoreAsync(scope, reverse).ConfigureAwait(false);
-            if (forward.State != AnimationState.Completed)
+            if (forward.State != AnimationState.Completed || forward.WasIgnored)
                 return forward;
 
             if (autoReverse)
             {
                 AnimationExecutionResult backward = await ExecuteCoreAsync(scope, !reverse).ConfigureAwait(false);
-                if (backward.State != AnimationState.Completed)
+                if (backward.State != AnimationState.Completed || backward.WasIgnored)
                     return backward;
             }
 
@@ -240,9 +240,10 @@ public abstract class AnimationDefinition
                 context.SetFrame(frame, reverse);
                 update(context, context.EasedProgress);
             },
-            CreateOptions());
+            CreateOptions(),
+            out bool scheduled);
 
-        return AwaitLeafAsync(handle, context, scope.CancellationToken);
+        return AwaitLeafAsync(handle, context, scope.CancellationToken, scheduled);
     }
 
     internal AnimationOptions CreateOptions()
@@ -277,17 +278,39 @@ public abstract class AnimationDefinition
     internal static async Task<AnimationExecutionResult> AwaitLeafAsync(
         AnimationHandle handle,
         AnimationContext? context,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool cancelHandleOnCancellation = true)
     {
-        using CancellationTokenRegistration registration =
-            cancellationToken.CanBeCanceled ? cancellationToken.Register(handle.Cancel) : default;
+        TaskCompletionSource? ignoredRunCancellation = null;
+        using CancellationTokenRegistration registration = cancellationToken.CanBeCanceled
+            ? cancellationToken.Register(
+                cancelHandleOnCancellation
+                    ? handle.Cancel
+                    : () => ignoredRunCancellation?.TrySetResult())
+            : default;
 
         try
         {
-            AnimationState state = await handle.Completion.ConfigureAwait(false);
+            Task<AnimationState> completion = handle.Completion;
+            if (!cancelHandleOnCancellation && cancellationToken.CanBeCanceled && !completion.IsCompleted)
+            {
+                ignoredRunCancellation =
+                    new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                if (cancellationToken.IsCancellationRequested)
+                    ignoredRunCancellation.TrySetResult();
+                Task finished = await Task.WhenAny(
+                    completion,
+                    ignoredRunCancellation.Task).ConfigureAwait(false);
+                if (!ReferenceEquals(finished, completion))
+                    return AnimationExecutionResult.Canceled;
+            }
+
+            AnimationState state = await completion.ConfigureAwait(false);
             return state switch
             {
-                AnimationState.Completed => AnimationExecutionResult.Completed,
+                AnimationState.Completed => cancelHandleOnCancellation
+                    ? AnimationExecutionResult.Completed
+                    : AnimationExecutionResult.Ignored,
                 AnimationState.Canceled => AnimationExecutionResult.Canceled,
                 AnimationState.Faulted => AnimationExecutionResult.Faulted(
                     handle.Exception ?? new InvalidOperationException("The animation fault did not provide an exception.")),

--- a/ModernFormsNext/Animations/AnimationExecutionScope.cs
+++ b/ModernFormsNext/Animations/AnimationExecutionScope.cs
@@ -1,0 +1,17 @@
+namespace ModernFormsNext.Animations;
+
+internal readonly record struct AnimationExecutionScope(
+    AnimationScheduler Scheduler,
+    Control? DefaultTarget,
+    CancellationToken CancellationToken,
+    string KeyPrefix,
+    object RunOwner)
+{
+    private static long nextScopeId;
+
+    public AnimationExecutionScope CreateChild(int childIndex)
+    {
+        long scopeId = Interlocked.Increment(ref nextScopeId);
+        return this with { KeyPrefix = $"{KeyPrefix}Group:{scopeId}:{childIndex}:" };
+    }
+}

--- a/ModernFormsNext/Animations/AnimationInterpolatorResolver.cs
+++ b/ModernFormsNext/Animations/AnimationInterpolatorResolver.cs
@@ -1,0 +1,26 @@
+using System.Drawing;
+using System.Numerics;
+
+namespace ModernFormsNext.Animations;
+
+internal static class AnimationInterpolatorResolver
+{
+    public static IAnimationInterpolator<T> Get<T>()
+    {
+        object? interpolator =
+            typeof(T) == typeof(float) ? AnimationInterpolators.Float :
+            typeof(T) == typeof(double) ? AnimationInterpolators.Double :
+            typeof(T) == typeof(int) ? AnimationInterpolators.Int32 :
+            typeof(T) == typeof(PointF) ? AnimationInterpolators.PointF :
+            typeof(T) == typeof(SizeF) ? AnimationInterpolators.SizeF :
+            typeof(T) == typeof(RectangleF) ? AnimationInterpolators.RectangleF :
+            typeof(T) == typeof(Color) ? AnimationInterpolators.Color :
+            typeof(T) == typeof(Matrix3x2) ? AnimationInterpolators.Matrix3x2 :
+            null;
+
+        return interpolator is IAnimationInterpolator<T> typed
+            ? typed
+            : throw new NotSupportedException(
+                $"No built-in animation interpolator is registered for '{typeof(T).FullName}'.");
+    }
+}

--- a/ModernFormsNext/Animations/AnimationReplacementMode.cs
+++ b/ModernFormsNext/Animations/AnimationReplacementMode.cs
@@ -8,6 +8,11 @@ public enum AnimationReplacementMode
     /// <summary>Cancel the existing animation and install the new animation.</summary>
     Replace,
 
+    /// <summary>
+    /// Alias for <see cref="Replace"/> that emphasizes cancellation of the previous handle.
+    /// </summary>
+    CancelPrevious = Replace,
+
     /// <summary>Keep the existing animation and return its handle without scheduling the new one.</summary>
     IgnoreNew
 }

--- a/ModernFormsNext/Animations/AnimationRun.cs
+++ b/ModernFormsNext/Animations/AnimationRun.cs
@@ -140,9 +140,14 @@ public sealed class AnimationRun : IDisposable
     }
 }
 
-internal readonly record struct AnimationExecutionResult(AnimationState State, Exception? Exception = null)
+internal readonly record struct AnimationExecutionResult(
+    AnimationState State,
+    Exception? Exception = null,
+    bool WasIgnored = false)
 {
     public static AnimationExecutionResult Completed { get; } = new(AnimationState.Completed);
+    public static AnimationExecutionResult Ignored { get; } =
+        new(AnimationState.Completed, WasIgnored: true);
     public static AnimationExecutionResult Canceled { get; } = new(AnimationState.Canceled);
 
     public static AnimationExecutionResult Faulted(Exception exception)

--- a/ModernFormsNext/Animations/AnimationRun.cs
+++ b/ModernFormsNext/Animations/AnimationRun.cs
@@ -1,0 +1,150 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Controls and observes one animation-definition run, including composed child animations.
+/// </summary>
+/// <remarks>
+/// Cancellation is propagated to active descendants and completion is published only after those
+/// descendants have released scheduler handles. Retaining a terminal run does not retain its
+/// animation targets.
+/// </remarks>
+public sealed class AnimationRun : IDisposable
+{
+    private readonly CancellationTokenSource cancellation = new();
+    private readonly TaskCompletionSource<AnimationState> completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int state = (int)AnimationState.Created;
+    private Exception? exception;
+    private int started;
+    private int finished;
+
+    internal CancellationToken CancellationToken => cancellation.Token;
+
+    /// <summary>Gets the current lifecycle state.</summary>
+    public AnimationState State => (AnimationState)Volatile.Read(ref state);
+
+    /// <summary>Gets the terminal completion task.</summary>
+    public Task<AnimationState> Completion => completion.Task;
+
+    /// <summary>Gets the fault or deterministic parallel-fault aggregate, if any.</summary>
+    public Exception? Exception => Volatile.Read(ref exception);
+
+    /// <summary>
+    /// Requests cancellation of this run and every active descendant.
+    /// </summary>
+    /// <remarks>
+    /// Cancellation is idempotent. The completion task is released after descendant cleanup, so
+    /// awaiting it is sufficient before asserting that the shared scheduler returned to idle.
+    /// </remarks>
+    public void Cancel()
+    {
+        while (true)
+        {
+            AnimationState current = State;
+            if (current is AnimationState.Completed or AnimationState.Canceled or AnimationState.Faulted)
+                return;
+            if (Interlocked.CompareExchange(
+                    ref state,
+                    (int)AnimationState.Canceled,
+                    (int)current) == (int)current)
+                break;
+        }
+
+        try
+        {
+            cancellation.Cancel(throwOnFirstException: false);
+        }
+        catch (AggregateException cancellationFailure)
+        {
+            System.Diagnostics.Trace.TraceError(
+                "An animation-run cancellation callback faulted: {0}",
+                cancellationFailure);
+        }
+    }
+
+    /// <summary>Cancels the run. Disposal is idempotent.</summary>
+    public void Dispose() => Cancel();
+
+    internal void Start(Func<CancellationToken, Task<AnimationExecutionResult>> execute, CancellationToken externalToken)
+    {
+        ArgumentNullException.ThrowIfNull(execute);
+        if (Interlocked.Exchange(ref started, 1) != 0)
+            throw new InvalidOperationException("An animation run can be started only once.");
+
+        if (externalToken.IsCancellationRequested)
+        {
+            Volatile.Write(ref state, (int)AnimationState.Canceled);
+            Finish(AnimationExecutionResult.Canceled);
+            return;
+        }
+
+        Volatile.Write(ref state, (int)AnimationState.Running);
+        _ = ExecuteAsync(execute, externalToken);
+    }
+
+    private async Task ExecuteAsync(
+        Func<CancellationToken, Task<AnimationExecutionResult>> execute,
+        CancellationToken externalToken)
+    {
+        using CancellationTokenRegistration registration =
+            externalToken.CanBeCanceled ? externalToken.Register(Cancel) : default;
+
+        AnimationExecutionResult result;
+        try
+        {
+            result = await execute(cancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested || externalToken.IsCancellationRequested)
+        {
+            result = AnimationExecutionResult.Canceled;
+        }
+        catch (Exception fault)
+        {
+            result = AnimationExecutionResult.Faulted(fault);
+        }
+
+        Finish(result);
+    }
+
+    private void Finish(AnimationExecutionResult result)
+    {
+        if (Interlocked.Exchange(ref finished, 1) != 0)
+            return;
+
+        AnimationState finalState;
+        while (true)
+        {
+            AnimationState current = State;
+            if (current == AnimationState.Canceled)
+            {
+                finalState = AnimationState.Canceled;
+                break;
+            }
+            if (current is AnimationState.Completed or AnimationState.Faulted)
+            {
+                finalState = current;
+                break;
+            }
+            if (Interlocked.CompareExchange(ref state, (int)result.State, (int)current) == (int)current)
+            {
+                finalState = result.State;
+                break;
+            }
+        }
+
+        if (finalState == AnimationState.Faulted)
+            Volatile.Write(ref exception, result.Exception);
+
+        completion.TrySetResult(finalState);
+        cancellation.Dispose();
+    }
+}
+
+internal readonly record struct AnimationExecutionResult(AnimationState State, Exception? Exception = null)
+{
+    public static AnimationExecutionResult Completed { get; } = new(AnimationState.Completed);
+    public static AnimationExecutionResult Canceled { get; } = new(AnimationState.Canceled);
+
+    public static AnimationExecutionResult Faulted(Exception exception)
+        => new(AnimationState.Faulted, exception ?? throw new ArgumentNullException(nameof(exception)));
+}

--- a/ModernFormsNext/Animations/AnimationRun.cs
+++ b/ModernFormsNext/Animations/AnimationRun.cs
@@ -11,12 +11,14 @@ namespace ModernFormsNext.Animations;
 public sealed class AnimationRun : IDisposable
 {
     private readonly CancellationTokenSource cancellation = new();
+    private readonly object cancellationSync = new();
     private readonly TaskCompletionSource<AnimationState> completion =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int state = (int)AnimationState.Created;
     private Exception? exception;
     private int started;
     private int finished;
+    private bool cancellationDisposed;
 
     internal CancellationToken CancellationToken => cancellation.Token;
 
@@ -50,15 +52,21 @@ public sealed class AnimationRun : IDisposable
                 break;
         }
 
-        try
+        lock (cancellationSync)
         {
-            cancellation.Cancel(throwOnFirstException: false);
-        }
-        catch (AggregateException cancellationFailure)
-        {
-            System.Diagnostics.Trace.TraceError(
-                "An animation-run cancellation callback faulted: {0}",
-                cancellationFailure);
+            if (cancellationDisposed)
+                return;
+
+            try
+            {
+                cancellation.Cancel(throwOnFirstException: false);
+            }
+            catch (AggregateException cancellationFailure)
+            {
+                System.Diagnostics.Trace.TraceError(
+                    "An animation-run cancellation callback faulted: {0}",
+                    cancellationFailure);
+            }
         }
     }
 
@@ -136,7 +144,11 @@ public sealed class AnimationRun : IDisposable
             Volatile.Write(ref exception, result.Exception);
 
         completion.TrySetResult(finalState);
-        cancellation.Dispose();
+        lock (cancellationSync)
+        {
+            cancellationDisposed = true;
+            cancellation.Dispose();
+        }
     }
 }
 

--- a/ModernFormsNext/Animations/AnimationScheduler.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.cs
@@ -114,6 +114,16 @@ public sealed partial class AnimationScheduler : IDisposable
         Action<float> update,
         AnimationOptions? options = null)
     {
+        ArgumentNullException.ThrowIfNull(update);
+        return StartFrames(owner, key, frame => update(frame.EasedProgress), options);
+    }
+
+    internal AnimationHandle StartFrames(
+        object owner,
+        string key,
+        Action<AnimationFrame> update,
+        AnimationOptions? options = null)
+    {
         ArgumentNullException.ThrowIfNull(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
         ArgumentNullException.ThrowIfNull(update);
@@ -138,7 +148,7 @@ public sealed partial class AnimationScheduler : IDisposable
                     return existing.Handle;
 
                 RemoveEntryLocked(existing);
-                if (existing.TrySetTerminal(AnimationState.Canceled))
+                if (existing.TryBeginTerminal(AnimationState.Canceled))
                 {
                     canceledCount++;
                     replaced = existing;
@@ -181,11 +191,15 @@ public sealed partial class AnimationScheduler : IDisposable
             else
             {
                 entry.SetState(AnimationState.Running);
+                keyedAnimations.Add(identity, entry);
             }
         }
 
         if (replaced is not null)
+        {
+            replaced.FinishTerminal(signalCancellation: true);
             StopTickSourceIfIdle();
+        }
 
         if (shouldCompleteImmediately)
             PostImmediateCompletion(entry);
@@ -250,11 +264,24 @@ public sealed partial class AnimationScheduler : IDisposable
             for (int index = activeAnimations.Count - 1; index >= 0; index--)
             {
                 AnimationEntry entry = activeAnimations[index];
-                if (!ReferenceEquals(entry.Owner, owner))
+                if (!ReferenceEquals(entry.OwnerOrNull, owner))
                     continue;
 
                 RemoveEntryLocked(entry);
-                if (entry.TrySetTerminal(AnimationState.Canceled))
+                if (entry.TryBeginTerminal(AnimationState.Canceled))
+                {
+                    canceledCount++;
+                    (canceled ??= []).Add(entry);
+                }
+            }
+
+            foreach (AnimationEntry entry in keyedAnimations.Values.ToArray())
+            {
+                if (!ReferenceEquals(entry.OwnerOrNull, owner) || activeAnimations.Contains(entry))
+                    continue;
+
+                RemoveEntryLocked(entry);
+                if (entry.TryBeginTerminal(AnimationState.Canceled))
                 {
                     canceledCount++;
                     (canceled ??= []).Add(entry);
@@ -263,7 +290,11 @@ public sealed partial class AnimationScheduler : IDisposable
         }
 
         if (canceled is not null)
+        {
+            foreach (AnimationEntry entry in canceled)
+                entry.FinishTerminal(signalCancellation: true);
             StopTickSourceIfIdle();
+        }
     }
 
     /// <summary>
@@ -363,6 +394,7 @@ public sealed partial class AnimationScheduler : IDisposable
     /// </remarks>
     public void Shutdown()
     {
+        List<AnimationEntry> canceled = [];
         lock (sync)
         {
             if (isShutdown)
@@ -373,12 +405,28 @@ public sealed partial class AnimationScheduler : IDisposable
             {
                 AnimationEntry entry = activeAnimations[index];
                 RemoveEntryLocked(entry);
-                if (entry.TrySetTerminal(AnimationState.Canceled))
+                if (entry.TryBeginTerminal(AnimationState.Canceled))
+                {
                     canceledCount++;
+                    canceled.Add(entry);
+                }
+            }
+
+            foreach (AnimationEntry entry in keyedAnimations.Values.ToArray())
+            {
+                RemoveEntryLocked(entry);
+                if (entry.TryBeginTerminal(AnimationState.Canceled))
+                {
+                    canceledCount++;
+                    canceled.Add(entry);
+                }
             }
             activeAnimations.Clear();
             keyedAnimations.Clear();
         }
+
+        foreach (AnimationEntry entry in canceled)
+            entry.FinishTerminal(signalCancellation: true);
 
         Policy.Changed -= HandlePolicyChanged;
         UnbindPlatformLifecycle();
@@ -407,13 +455,16 @@ public sealed partial class AnimationScheduler : IDisposable
         lock (sync)
         {
             RemoveEntryLocked(entry);
-            canceled = entry.TrySetTerminal(AnimationState.Canceled);
+            canceled = entry.TryBeginTerminal(AnimationState.Canceled);
             if (canceled)
                 canceledCount++;
         }
 
         if (canceled)
+        {
+            entry.FinishTerminal(signalCancellation: true);
             StopTickSourceIfIdle();
+        }
     }
 
     internal void Pause(AnimationEntry entry)
@@ -495,6 +546,7 @@ public sealed partial class AnimationScheduler : IDisposable
 
         try
         {
+            using Application.VisualInvalidationBatchScope batch = Application.BeginVisualInvalidationBatch();
             foreach (AnimationEntry entry in tickBuffer)
             {
                 AnimationState state = entry.State;
@@ -530,7 +582,18 @@ public sealed partial class AnimationScheduler : IDisposable
 
                     if (entry.State == AnimationState.Canceled)
                         continue;
-                    entry.Update(easedProgress);
+                    TimeSpan animationElapsed = elapsed - entry.Options.Delay;
+                    if (animationElapsed < TimeSpan.Zero)
+                        animationElapsed = TimeSpan.Zero;
+                    if (animationElapsed > entry.Options.Duration)
+                        animationElapsed = entry.Options.Duration;
+
+                    entry.Invoke(new AnimationFrame(
+                        rawProgress,
+                        easedProgress,
+                        animationElapsed,
+                        entry.Options.Duration,
+                        entry.CancellationToken));
 
                     if (rawProgress >= 1f)
                         Complete(entry);
@@ -555,25 +618,36 @@ public sealed partial class AnimationScheduler : IDisposable
 
     private void Complete(AnimationEntry entry)
     {
+        bool completed;
         lock (sync)
         {
             RemoveEntryLocked(entry);
-            if (entry.TrySetTerminal(AnimationState.Completed))
+            completed = entry.TryBeginTerminal(AnimationState.Completed);
+            if (completed)
                 completedCount++;
         }
+
+        if (completed)
+            entry.FinishTerminal(signalCancellation: false);
     }
 
     private void Fault(AnimationEntry entry, Exception exception)
     {
+        string ownerType = entry.OwnerOrNull?.GetType().FullName ?? "<released>";
+        bool faulted;
         lock (sync)
         {
             RemoveEntryLocked(entry);
-            if (!entry.TrySetTerminal(AnimationState.Faulted, exception))
-                return;
-            faultedCount++;
+            faulted = entry.TryBeginTerminal(AnimationState.Faulted, exception);
+            if (faulted)
+                faultedCount++;
         }
 
-        Trace.TraceError("Animation '{0}' owned by '{1}' faulted: {2}", entry.Key, entry.Owner.GetType().FullName, exception);
+        if (!faulted)
+            return;
+
+        entry.FinishTerminal(signalCancellation: false);
+        Trace.TraceError("Animation '{0}' owned by '{1}' faulted: {2}", entry.Key, ownerType, exception);
     }
 
     private void PostImmediateCompletion(AnimationEntry entry)
@@ -595,7 +669,13 @@ public sealed partial class AnimationScheduler : IDisposable
 
         try
         {
-            entry.Update(1f);
+            using Application.VisualInvalidationBatchScope batch = Application.BeginVisualInvalidationBatch();
+            entry.Invoke(new AnimationFrame(
+                1f,
+                1f,
+                entry.Options.Duration,
+                entry.Options.Duration,
+                entry.CancellationToken));
             Complete(entry);
         }
         catch (Exception exception)
@@ -634,7 +714,10 @@ public sealed partial class AnimationScheduler : IDisposable
     private void RemoveEntryLocked(AnimationEntry entry)
     {
         activeAnimations.Remove(entry);
-        var identity = new AnimationIdentity(entry.Owner, entry.Key);
+        if (entry.OwnerOrNull is not { } owner)
+            return;
+
+        var identity = new AnimationIdentity(owner, entry.Key);
         if (keyedAnimations.TryGetValue(identity, out AnimationEntry? current) && ReferenceEquals(current, entry))
             keyedAnimations.Remove(identity);
     }
@@ -670,7 +753,7 @@ public sealed partial class AnimationScheduler : IDisposable
         List<AnimationEntry> entries;
         lock (sync)
         {
-            entries = [.. activeAnimations];
+            entries = keyedAnimations.Values.Distinct().ToList();
             activeAnimations.Clear();
             keyedAnimations.Clear();
         }

--- a/ModernFormsNext/Animations/AnimationScheduler.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.cs
@@ -123,6 +123,14 @@ public sealed partial class AnimationScheduler : IDisposable
         string key,
         Action<AnimationFrame> update,
         AnimationOptions? options = null)
+        => StartFrames(owner, key, update, options, out _);
+
+    internal AnimationHandle StartFrames(
+        object owner,
+        string key,
+        Action<AnimationFrame> update,
+        AnimationOptions? options,
+        out bool scheduled)
     {
         ArgumentNullException.ThrowIfNull(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
@@ -130,7 +138,8 @@ public sealed partial class AnimationScheduler : IDisposable
 
         BindPlatformLifecycleIfAvailable();
         AnimationOptionsSnapshot snapshot = (options ?? new AnimationOptions()).CreateSnapshot(Policy);
-        if (owner is IComponent { Site.DesignMode: true })
+        if (owner is IComponent { Site.DesignMode: true } ||
+            owner is InteractionEffect { Target.Site.DesignMode: true })
             snapshot = snapshot with { CompleteImmediately = true };
 
         AnimationEntry? replaced = null;
@@ -145,7 +154,10 @@ public sealed partial class AnimationScheduler : IDisposable
             if (keyedAnimations.TryGetValue(identity, out AnimationEntry? existing))
             {
                 if (snapshot.ReplacementMode == AnimationReplacementMode.IgnoreNew)
+                {
+                    scheduled = false;
                     return existing.Handle;
+                }
 
                 RemoveEntryLocked(existing);
                 if (existing.TryBeginTerminal(AnimationState.Canceled))
@@ -195,6 +207,7 @@ public sealed partial class AnimationScheduler : IDisposable
             }
         }
 
+        scheduled = true;
         if (replaced is not null)
         {
             replaced.FinishTerminal(signalCancellation: true);
@@ -736,7 +749,9 @@ public sealed partial class AnimationScheduler : IDisposable
             for (int index = activeAnimations.Count - 1; index >= 0; index--)
             {
                 AnimationEntry entry = activeAnimations[index];
-                RemoveEntryLocked(entry);
+                // Keep the keyed entry until the queued final-value callback runs. Owner
+                // cancellation, replacement, or disposal can then still cancel that callback.
+                activeAnimations.RemoveAt(index);
                 (completing ??= []).Add(entry);
             }
         }

--- a/ModernFormsNext/Animations/AnimationScheduler.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.cs
@@ -144,7 +144,6 @@ public sealed partial class AnimationScheduler : IDisposable
 
         AnimationEntry? replaced = null;
         AnimationEntry entry;
-        bool shouldStartTickSource = false;
         bool shouldCompleteImmediately;
 
         lock (sync)
@@ -198,26 +197,22 @@ public sealed partial class AnimationScheduler : IDisposable
 
                 activeAnimations.Add(entry);
                 keyedAnimations.Add(identity, entry);
-                shouldStartTickSource = !isPaused && HasRunnableAnimationsLocked();
+                StartTickSourceIfNeededLocked();
             }
             else
             {
                 entry.SetState(AnimationState.Running);
                 keyedAnimations.Add(identity, entry);
+                StopTickSourceIfIdleLocked();
             }
         }
 
         scheduled = true;
         if (replaced is not null)
-        {
             replaced.FinishTerminal(signalCancellation: true);
-            StopTickSourceIfIdle();
-        }
 
         if (shouldCompleteImmediately)
             PostImmediateCompletion(entry);
-        else if (shouldStartTickSource)
-            tickSource.Start(RequestTick);
 
         return entry.Handle;
     }
@@ -300,13 +295,14 @@ public sealed partial class AnimationScheduler : IDisposable
                     (canceled ??= []).Add(entry);
                 }
             }
+
+            StopTickSourceIfIdleLocked();
         }
 
         if (canceled is not null)
         {
             foreach (AnimationEntry entry in canceled)
                 entry.FinishTerminal(signalCancellation: true);
-            StopTickSourceIfIdle();
         }
     }
 
@@ -334,15 +330,14 @@ public sealed partial class AnimationScheduler : IDisposable
                 entry.IsPausedByScheduler = true;
                 entry.SetState(AnimationState.Paused);
             }
-        }
 
-        tickSource.Stop();
+            tickSource.Stop();
+        }
     }
 
     /// <summary>Resumes globally paused time without including the background interval.</summary>
     public void Resume()
     {
-        bool shouldStart;
         lock (sync)
         {
             if (!isPaused || isShutdown)
@@ -360,11 +355,8 @@ public sealed partial class AnimationScheduler : IDisposable
                     entry.SetState(entry.ResumeState);
             }
 
-            shouldStart = HasRunnableAnimationsLocked();
+            StartTickSourceIfNeededLocked();
         }
-
-        if (shouldStart)
-            tickSource.Start(RequestTick);
     }
 
     /// <summary>Returns a thread-safe snapshot of active counts, outcomes, and tick timing.</summary>
@@ -436,6 +428,7 @@ public sealed partial class AnimationScheduler : IDisposable
             }
             activeAnimations.Clear();
             keyedAnimations.Clear();
+            tickSource.Stop();
         }
 
         foreach (AnimationEntry entry in canceled)
@@ -443,7 +436,6 @@ public sealed partial class AnimationScheduler : IDisposable
 
         Policy.Changed -= HandlePolicyChanged;
         UnbindPlatformLifecycle();
-        tickSource.Stop();
         tickSource.Dispose();
     }
 
@@ -471,18 +463,15 @@ public sealed partial class AnimationScheduler : IDisposable
             canceled = entry.TryBeginTerminal(AnimationState.Canceled);
             if (canceled)
                 canceledCount++;
+            StopTickSourceIfIdleLocked();
         }
 
         if (canceled)
-        {
             entry.FinishTerminal(signalCancellation: true);
-            StopTickSourceIfIdle();
-        }
     }
 
     internal void Pause(AnimationEntry entry)
     {
-        bool shouldStop = false;
         lock (sync)
         {
             if (entry.IsTerminal || entry.IsIndividuallyPaused)
@@ -493,16 +482,12 @@ public sealed partial class AnimationScheduler : IDisposable
             if (!entry.IsPausedByScheduler)
                 entry.ResumeState = entry.State;
             entry.SetState(AnimationState.Paused);
-            shouldStop = !HasRunnableAnimationsLocked();
+            StopTickSourceIfIdleLocked();
         }
-
-        if (shouldStop)
-            tickSource.Stop();
     }
 
     internal void Resume(AnimationEntry entry)
     {
-        bool shouldStart = false;
         lock (sync)
         {
             if (entry.IsTerminal || !entry.IsIndividuallyPaused)
@@ -513,11 +498,8 @@ public sealed partial class AnimationScheduler : IDisposable
             entry.IsIndividuallyPaused = false;
             if (!entry.IsPausedByScheduler)
                 entry.SetState(entry.ResumeState);
-            shouldStart = !isPaused && HasRunnableAnimationsLocked();
+            StartTickSourceIfNeededLocked();
         }
-
-        if (shouldStart)
-            tickSource.Start(RequestTick);
     }
 
     private static AnimationScheduler CreateDefault() => new();
@@ -588,7 +570,7 @@ public sealed partial class AnimationScheduler : IDisposable
                     else if (rawProgress >= 1f)
                         easedProgress = 1f;
                     else
-                        easedProgress = entry.Options.Easing(rawProgress);
+                        easedProgress = entry.ApplyEasing(rawProgress);
 
                     if (!float.IsFinite(easedProgress))
                         throw new InvalidOperationException("The animation easing function returned NaN or infinity.");
@@ -625,7 +607,8 @@ public sealed partial class AnimationScheduler : IDisposable
                 Interlocked.Increment(ref tickCount);
                 Interlocked.Add(ref totalTickTimestampDelta, Stopwatch.GetTimestamp() - tickStarted);
             }
-            StopTickSourceIfIdle();
+            lock (sync)
+                StopTickSourceIfIdleLocked();
         }
     }
 
@@ -697,12 +680,19 @@ public sealed partial class AnimationScheduler : IDisposable
         }
     }
 
-    private void StopTickSourceIfIdle()
+    // Tick-source state transitions are serialized with scheduler state. Computing a transition
+    // under the lock and performing it afterward lets a concurrent start overtake a stale stop
+    // (or a cancellation overtake a stale start), leaving active work unticked or an idle timer
+    // running indefinitely.
+    private void StartTickSourceIfNeededLocked()
     {
-        bool shouldStop;
-        lock (sync)
-            shouldStop = isShutdown || isPaused || !HasRunnableAnimationsLocked();
-        if (shouldStop)
+        if (!isShutdown && !isPaused && HasRunnableAnimationsLocked())
+            tickSource.Start(RequestTick);
+    }
+
+    private void StopTickSourceIfIdleLocked()
+    {
+        if (isShutdown || isPaused || !HasRunnableAnimationsLocked())
             tickSource.Stop();
     }
 
@@ -754,9 +744,9 @@ public sealed partial class AnimationScheduler : IDisposable
                 activeAnimations.RemoveAt(index);
                 (completing ??= []).Add(entry);
             }
-        }
 
-        tickSource.Stop();
+            tickSource.Stop();
+        }
         if (completing is null)
             return;
         foreach (AnimationEntry entry in completing)
@@ -771,9 +761,8 @@ public sealed partial class AnimationScheduler : IDisposable
             entries = keyedAnimations.Values.Distinct().ToList();
             activeAnimations.Clear();
             keyedAnimations.Clear();
+            tickSource.Stop();
         }
-
-        tickSource.Stop();
         foreach (AnimationEntry entry in entries)
             Fault(entry, exception);
     }

--- a/ModernFormsNext/Animations/AnimationTimeline.cs
+++ b/ModernFormsNext/Animations/AnimationTimeline.cs
@@ -29,6 +29,10 @@ public sealed class AnimationTimeline : AnimationDefinition
 
     internal override bool RequiresTarget => false;
 
+    internal override bool HasSchedulableWork
+        => entries.Any(static entry =>
+            entry.Offset > TimeSpan.Zero || entry.Animation.HasSchedulableWork);
+
     /// <inheritdoc/>
     protected override void Update(AnimationContext context, float progress)
     {
@@ -72,18 +76,29 @@ public sealed class AnimationTimeline : AnimationDefinition
         AnimationExecutionScope scope,
         bool reverse)
     {
-        if (offset > TimeSpan.Zero)
+        try
         {
-            var delay = new DelayAnimation(offset);
-            AnimationExecutionResult delayResult =
-                await delay.ExecuteAsync(scope.CreateChild(0)).ConfigureAwait(false);
-            if (delayResult.State != AnimationState.Completed)
-                return delayResult;
-        }
+            if (offset > TimeSpan.Zero)
+            {
+                var delay = new DelayAnimation(offset);
+                AnimationExecutionResult delayResult =
+                    await delay.ExecuteAsync(scope.CreateChild(0)).ConfigureAwait(false);
+                if (delayResult.State != AnimationState.Completed)
+                    return delayResult;
+            }
 
-        return await entry.Animation
-            .ExecuteAsync(scope.CreateChild(1), reverse)
-            .ConfigureAwait(false);
+            return await entry.Animation
+                .ExecuteAsync(scope.CreateChild(1), reverse)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (scope.CancellationToken.IsCancellationRequested)
+        {
+            return AnimationExecutionResult.Canceled;
+        }
+        catch (Exception exception)
+        {
+            return AnimationExecutionResult.Faulted(exception);
+        }
     }
 
     private readonly record struct TimelineEntry(

--- a/ModernFormsNext/Animations/AnimationTimeline.cs
+++ b/ModernFormsNext/Animations/AnimationTimeline.cs
@@ -1,0 +1,93 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Schedules definitions at monotonic offsets on the shared animation scheduler.
+/// </summary>
+/// <remarks>
+/// Timeline offsets are implemented as scheduler-backed delays, so application lifecycle pause
+/// excludes background time. Each entry starts exactly once per timeline leg.
+/// </remarks>
+public sealed class AnimationTimeline : AnimationDefinition
+{
+    private readonly List<TimelineEntry> entries = [];
+
+    /// <summary>Adds an animation at the specified non-negative offset.</summary>
+    /// <param name="offset">Time from the beginning of the timeline leg.</param>
+    /// <param name="animation">The definition to start at that offset.</param>
+    /// <returns>This timeline.</returns>
+    public AnimationTimeline At(TimeSpan offset, AnimationDefinition animation)
+    {
+        if (offset < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(offset), offset, "Timeline offsets cannot be negative.");
+        ArgumentNullException.ThrowIfNull(animation);
+        entries.Add(new TimelineEntry(offset, animation, entries.Count));
+        return this;
+    }
+
+    /// <summary>Gets the number of scheduled timeline entries.</summary>
+    public int Count => entries.Count;
+
+    internal override bool RequiresTarget => false;
+
+    /// <inheritdoc/>
+    protected override void Update(AnimationContext context, float progress)
+    {
+    }
+
+    internal override async Task<AnimationExecutionResult> ExecuteCoreAsync(
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        if (entries.Count == 0)
+            return AnimationExecutionResult.Completed;
+
+        TimeSpan lastOffset = entries.Max(static entry => entry.Offset);
+        var tasks = new Task<AnimationExecutionResult>[entries.Count];
+        for (int index = 0; index < entries.Count; index++)
+        {
+            TimelineEntry entry = entries[index];
+            TimeSpan offset = reverse ? lastOffset - entry.Offset : entry.Offset;
+            tasks[index] = ExecuteEntryAsync(entry, offset, scope.CreateChild(entry.Index), reverse);
+        }
+
+        AnimationExecutionResult[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        List<Exception>? faults = null;
+        bool canceled = false;
+        foreach (AnimationExecutionResult result in results)
+        {
+            if (result.State == AnimationState.Faulted)
+                (faults ??= []).Add(result.Exception!);
+            else if (result.State == AnimationState.Canceled)
+                canceled = true;
+        }
+
+        if (faults is not null)
+            return AnimationExecutionResult.Faulted(new AggregateException(faults));
+        return canceled ? AnimationExecutionResult.Canceled : AnimationExecutionResult.Completed;
+    }
+
+    private static async Task<AnimationExecutionResult> ExecuteEntryAsync(
+        TimelineEntry entry,
+        TimeSpan offset,
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        if (offset > TimeSpan.Zero)
+        {
+            var delay = new DelayAnimation(offset);
+            AnimationExecutionResult delayResult =
+                await delay.ExecuteAsync(scope.CreateChild(0)).ConfigureAwait(false);
+            if (delayResult.State != AnimationState.Completed)
+                return delayResult;
+        }
+
+        return await entry.Animation
+            .ExecuteAsync(scope.CreateChild(1), reverse)
+            .ConfigureAwait(false);
+    }
+
+    private readonly record struct TimelineEntry(
+        TimeSpan Offset,
+        AnimationDefinition Animation,
+        int Index);
+}

--- a/ModernFormsNext/Animations/ControlAnimationExtensions.cs
+++ b/ModernFormsNext/Animations/ControlAnimationExtensions.cs
@@ -155,7 +155,9 @@ namespace ModernFormsNext.Animations
         /// <param name="control">The target control.</param>
         public static void CancelAnimations (this Control control)
         {
-            ArgumentNullException.ThrowIfNull(control);
+            // Preserve the original helper's null-tolerant cancellation behavior.
+            if (control is null)
+                return;
             AnimationScheduler.Default.CancelAll(control);
         }
 
@@ -257,12 +259,11 @@ namespace ModernFormsNext.Animations
 
         private static AnimationOptions CreateOptions(int duration, Func<float, float>? easing)
         {
-            if (duration < 0)
-                throw new ArgumentOutOfRangeException(nameof(duration), duration, "Animation duration cannot be negative.");
-
             return new AnimationOptions
             {
-                Duration = TimeSpan.FromMilliseconds(duration),
+                // The legacy helpers accepted every integer and used a one-millisecond minimum.
+                // Keep that behavior while the composable TimeSpan APIs retain strict validation.
+                Duration = TimeSpan.FromMilliseconds(Math.Max(1, duration)),
                 Easing = easing ?? Easings.Linear
             };
         }

--- a/ModernFormsNext/Animations/ControlAnimationExtensions.cs
+++ b/ModernFormsNext/Animations/ControlAnimationExtensions.cs
@@ -110,7 +110,10 @@ namespace ModernFormsNext.Animations
                 control, "TranslationX", () => control.TranslationX, x, value => control.TranslationX = value, options);
             var yAnimation = CreateFloatProperty(
                 control, "TranslationY", () => control.TranslationY, y, value => control.TranslationY = value, options);
-            return Animation.Parallel(xAnimation, yAnimation);
+            // Preserve the established TranslationX/TranslationY replacement channels at the
+            // root. Generic parallel groups intentionally isolate child keys, but doing that here
+            // lets an older convenience-helper run overwrite a newer target value.
+            return Animation.ParallelPreservingChildChannels(xAnimation, yAnimation);
         }
 
         /// <summary>Creates a reusable uniform scale animation bound to the control.</summary>
@@ -132,7 +135,7 @@ namespace ModernFormsNext.Animations
                 control, "ScaleX", () => control.ScaleX, scaleX, value => control.ScaleX = value, options);
             var yAnimation = CreateFloatProperty(
                 control, "ScaleY", () => control.ScaleY, scaleY, value => control.ScaleY = value, options);
-            return Animation.Parallel(xAnimation, yAnimation);
+            return Animation.ParallelPreservingChildChannels(xAnimation, yAnimation);
         }
 
         /// <summary>Creates a reusable rotation animation bound to the control.</summary>

--- a/ModernFormsNext/Animations/ControlAnimationExtensions.cs
+++ b/ModernFormsNext/Animations/ControlAnimationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ModernFormsNext.Animations
@@ -44,6 +45,107 @@ namespace ModernFormsNext.Animations
                 });
         }
 
+        /// <summary>Runs a typed control animation on the shared scheduler.</summary>
+        /// <typeparam name="T">The value type produced on each UI-dispatcher frame.</typeparam>
+        /// <param name="control">The target and owner of the animation.</param>
+        /// <param name="key">The owner-local replacement channel.</param>
+        /// <param name="from">The captured start value.</param>
+        /// <param name="to">The target value.</param>
+        /// <param name="interpolator">The typed value interpolator.</param>
+        /// <param name="options">Optional duration, delay, easing, and replacement settings.</param>
+        /// <param name="update">The UI-thread callback that applies the value.</param>
+        /// <param name="cancellationToken">A token that cancels only this scheduled handle.</param>
+        /// <returns>The terminal scheduler state.</returns>
+        public static async Task<AnimationState> AnimateAsync<T>(
+            this Control control,
+            string key,
+            T from,
+            T to,
+            IAnimationInterpolator<T> interpolator,
+            AnimationOptions? options,
+            Action<T> update,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(control);
+            AnimationHandle handle = AnimationScheduler.Default.Animate(
+                control,
+                key,
+                from,
+                to,
+                interpolator,
+                update,
+                options);
+            using CancellationTokenRegistration registration =
+                cancellationToken.CanBeCanceled ? cancellationToken.Register(handle.Cancel) : default;
+            return await handle.Completion.ConfigureAwait(false);
+        }
+
+        /// <summary>Creates a reusable opacity animation bound to the control.</summary>
+        public static PropertyAnimation<float> FadeTo(
+            this Control control,
+            float opacity,
+            AnimationOptions? options = null)
+        {
+            ArgumentNullException.ThrowIfNull(control);
+            var definition = new PropertyAnimation<float>(
+                control,
+                "Opacity",
+                () => control.Opacity,
+                Math.Clamp(opacity, 0f, 1f),
+                AnimationInterpolators.Float,
+                value => control.Opacity = value);
+            ApplyOptions(definition, options);
+            return definition;
+        }
+
+        /// <summary>Creates a reusable translation animation bound to the control.</summary>
+        public static AnimationDefinition TranslateTo(
+            this Control control,
+            float x,
+            float y,
+            AnimationOptions? options = null)
+        {
+            ArgumentNullException.ThrowIfNull(control);
+            var xAnimation = CreateFloatProperty(
+                control, "TranslationX", () => control.TranslationX, x, value => control.TranslationX = value, options);
+            var yAnimation = CreateFloatProperty(
+                control, "TranslationY", () => control.TranslationY, y, value => control.TranslationY = value, options);
+            return Animation.Parallel(xAnimation, yAnimation);
+        }
+
+        /// <summary>Creates a reusable uniform scale animation bound to the control.</summary>
+        public static AnimationDefinition ScaleTo(
+            this Control control,
+            float scale,
+            AnimationOptions? options = null)
+            => ScaleTo(control, scale, scale, options);
+
+        /// <summary>Creates a reusable two-axis scale animation bound to the control.</summary>
+        public static AnimationDefinition ScaleTo(
+            this Control control,
+            float scaleX,
+            float scaleY,
+            AnimationOptions? options = null)
+        {
+            ArgumentNullException.ThrowIfNull(control);
+            var xAnimation = CreateFloatProperty(
+                control, "ScaleX", () => control.ScaleX, scaleX, value => control.ScaleX = value, options);
+            var yAnimation = CreateFloatProperty(
+                control, "ScaleY", () => control.ScaleY, scaleY, value => control.ScaleY = value, options);
+            return Animation.Parallel(xAnimation, yAnimation);
+        }
+
+        /// <summary>Creates a reusable rotation animation bound to the control.</summary>
+        public static PropertyAnimation<float> RotateTo(
+            this Control control,
+            float rotation,
+            AnimationOptions? options = null)
+        {
+            ArgumentNullException.ThrowIfNull(control);
+            return CreateFloatProperty(
+                control, "Rotation", () => control.Rotation, rotation, value => control.Rotation = value, options);
+        }
+
         /// <summary>
         /// Cancels all animations running on the control.
         /// </summary>
@@ -64,16 +166,7 @@ namespace ModernFormsNext.Animations
         /// <returns>A task that completes when the animation finishes.</returns>
         public static Task FadeToAsync (this Control control, float opacity, int duration = 250, Func<float, float>? easing = null)
         {
-            opacity = Math.Clamp (opacity, 0f, 1f);
-
-            return AnimationScheduler.Default.Animate(
-                control,
-                "Opacity",
-                control.Opacity,
-                opacity,
-                AnimationInterpolators.Float,
-                value => control.Opacity = value,
-                CreateOptions(duration, easing)).Completion;
+            return control.FadeTo(opacity, CreateOptions(duration, easing)).RunAsync();
         }
 
         /// <summary>
@@ -87,25 +180,7 @@ namespace ModernFormsNext.Animations
         /// <returns>A task that completes when the animation finishes.</returns>
         public static Task TranslateToAsync (this Control control, float x, float y, int duration = 250, Func<float, float>? easing = null)
         {
-            AnimationHandle xAnimation = AnimationScheduler.Default.Animate(
-                control,
-                "TranslationX",
-                control.TranslationX,
-                x,
-                AnimationInterpolators.Float,
-                value => control.TranslationX = value,
-                CreateOptions(duration, easing));
-
-            AnimationHandle yAnimation = AnimationScheduler.Default.Animate(
-                control,
-                "TranslationY",
-                control.TranslationY,
-                y,
-                AnimationInterpolators.Float,
-                value => control.TranslationY = value,
-                CreateOptions(duration, easing));
-
-            return Task.WhenAll(xAnimation.Completion, yAnimation.Completion);
+            return control.TranslateTo(x, y, CreateOptions(duration, easing)).RunAsync();
         }
 
         /// <summary>
@@ -132,25 +207,7 @@ namespace ModernFormsNext.Animations
         /// <returns>A task that completes when the animation finishes.</returns>
         public static Task ScaleToAsync (this Control control, float scaleX, float scaleY, int duration = 250, Func<float, float>? easing = null)
         {
-            AnimationHandle xAnimation = AnimationScheduler.Default.Animate(
-                control,
-                "ScaleX",
-                control.ScaleX,
-                scaleX,
-                AnimationInterpolators.Float,
-                value => control.ScaleX = value,
-                CreateOptions(duration, easing));
-
-            AnimationHandle yAnimation = AnimationScheduler.Default.Animate(
-                control,
-                "ScaleY",
-                control.ScaleY,
-                scaleY,
-                AnimationInterpolators.Float,
-                value => control.ScaleY = value,
-                CreateOptions(duration, easing));
-
-            return Task.WhenAll(xAnimation.Completion, yAnimation.Completion);
+            return control.ScaleTo(scaleX, scaleY, CreateOptions(duration, easing)).RunAsync();
         }
 
         /// <summary>
@@ -163,14 +220,36 @@ namespace ModernFormsNext.Animations
         /// <returns>A task that completes when the animation finishes.</returns>
         public static Task RotateToAsync (this Control control, float rotation, int duration = 250, Func<float, float>? easing = null)
         {
-            return AnimationScheduler.Default.Animate(
+            return control.RotateTo(rotation, CreateOptions(duration, easing)).RunAsync();
+        }
+
+        private static PropertyAnimation<float> CreateFloatProperty(
+            Control control,
+            string key,
+            Func<float> from,
+            float to,
+            Action<float> update,
+            AnimationOptions? options)
+        {
+            var definition = new PropertyAnimation<float>(
                 control,
-                "Rotation",
-                control.Rotation,
-                rotation,
+                key,
+                from,
+                to,
                 AnimationInterpolators.Float,
-                value => control.Rotation = value,
-                CreateOptions(duration, easing)).Completion;
+                update);
+            ApplyOptions(definition, options);
+            return definition;
+        }
+
+        private static void ApplyOptions(AnimationDefinition definition, AnimationOptions? options)
+        {
+            if (options is null)
+                return;
+            definition.Duration = options.Duration;
+            definition.Delay = options.Delay;
+            definition.Easing = options.Easing;
+            definition.ReplacementMode = options.ReplacementMode;
         }
 
         private static AnimationOptions CreateOptions(int duration, Func<float, float>? easing)

--- a/ModernFormsNext/Animations/ControlBoundsInteractionEffectClip.cs
+++ b/ModernFormsNext/Animations/ControlBoundsInteractionEffectClip.cs
@@ -1,0 +1,37 @@
+using System.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>Clips effects to control bounds and the current style corner radius.</summary>
+public sealed class ControlBoundsInteractionEffectClip : IInteractionEffectClip
+{
+    /// <summary>Gets the reusable stateless clip instance.</summary>
+    public static ControlBoundsInteractionEffectClip Instance { get; } = new();
+
+    private ControlBoundsInteractionEffectClip()
+    {
+    }
+
+    /// <inheritdoc/>
+    public void Apply(SKCanvas canvas, Control target, Rectangle bounds)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+        ArgumentNullException.ThrowIfNull(target);
+        BorderStyle border = target.CurrentStyle.Border;
+        int radius = border.GetRadius();
+        if (radius == 0 && border.Radius is null)
+            radius = target.Style.Border.GetRadius();
+        if (radius <= 0)
+        {
+            canvas.ClipRect(new SKRect(0, 0, bounds.Width, bounds.Height));
+            return;
+        }
+
+        using var roundRect = new SKRoundRect(
+            new SKRect(0, 0, bounds.Width, bounds.Height),
+            radius,
+            radius);
+        canvas.ClipRoundRect(roundRect, SKClipOperation.Intersect, antialias: true);
+    }
+}

--- a/ModernFormsNext/Animations/ControlBoundsInteractionEffectClip.cs
+++ b/ModernFormsNext/Animations/ControlBoundsInteractionEffectClip.cs
@@ -22,6 +22,7 @@ public sealed class ControlBoundsInteractionEffectClip : IInteractionEffectClip
         int radius = border.GetRadius();
         if (radius == 0 && border.Radius is null)
             radius = target.Style.Border.GetRadius();
+        radius = target.LogicalToDeviceUnits(radius);
         if (radius <= 0)
         {
             canvas.ClipRect(new SKRect(0, 0, bounds.Width, bounds.Height));

--- a/ModernFormsNext/Animations/DelayAnimation.cs
+++ b/ModernFormsNext/Animations/DelayAnimation.cs
@@ -1,0 +1,35 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Represents a scheduler-driven pause inside a composition or timeline.
+/// </summary>
+public sealed class DelayAnimation : AnimationDefinition
+{
+    /// <summary>Creates a delay with the specified non-negative interval.</summary>
+    public DelayAnimation(TimeSpan duration)
+    {
+        if (duration < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(duration), duration, "Delay cannot be negative.");
+        Duration = duration;
+        Key = "Delay";
+    }
+
+    internal override bool RequiresTarget => false;
+
+    /// <inheritdoc/>
+    protected override void Update(AnimationContext context, float progress)
+    {
+    }
+
+    internal override Task<AnimationExecutionResult> ExecuteCoreAsync(
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        AnimationHandle handle = scope.Scheduler.StartFrames(
+            scope.RunOwner,
+            scope.KeyPrefix + ResolveKey(),
+            static _ => { },
+            CreateOptions());
+        return AwaitLeafAsync(handle, context: null, scope.CancellationToken);
+    }
+}

--- a/ModernFormsNext/Animations/Easings.cs
+++ b/ModernFormsNext/Animations/Easings.cs
@@ -66,6 +66,58 @@ namespace ModernFormsNext.Animations
         }
 
         /// <summary>
+        /// Represents cubic ease-in. This naming pairs with <see cref="CubicOut"/>.
+        /// </summary>
+        /// <param name="t">The normalized progress in the range from 0 to 1.</param>
+        /// <returns>The eased value.</returns>
+        public static float CubicIn(float t)
+        {
+            ValidateProgress(t);
+            return t * t * t;
+        }
+
+        /// <summary>
+        /// Represents cubic ease-out.
+        /// </summary>
+        /// <param name="t">The normalized progress in the range from 0 to 1.</param>
+        /// <returns>The eased value.</returns>
+        public static float CubicOut(float t) => EaseOutCubic(t);
+
+        /// <summary>
+        /// Represents cubic ease-in-out.
+        /// </summary>
+        /// <param name="t">The normalized progress in the range from 0 to 1.</param>
+        /// <returns>The eased value.</returns>
+        public static float CubicInOut(float t) => EaseInOutCubic(t);
+
+        /// <summary>
+        /// Represents a bounded ease-out bounce curve.
+        /// </summary>
+        /// <param name="t">The normalized progress in the range from 0 to 1.</param>
+        /// <returns>The eased value.</returns>
+        public static float BounceOut(float t)
+        {
+            ValidateProgress(t);
+            const float n1 = 7.5625f;
+            const float d1 = 2.75f;
+            if (t < 1f / d1)
+                return n1 * t * t;
+            if (t < 2f / d1)
+            {
+                t -= 1.5f / d1;
+                return n1 * t * t + 0.75f;
+            }
+            if (t < 2.5f / d1)
+            {
+                t -= 2.25f / d1;
+                return n1 * t * t + 0.9375f;
+            }
+
+            t -= 2.625f / d1;
+            return n1 * t * t + 0.984375f;
+        }
+
+        /// <summary>
         /// Represents cubic ease-in-out.
         /// </summary>
         /// <param name="t">The normalized progress in the range from 0 to 1.</param>

--- a/ModernFormsNext/Animations/IInteractionEffectClip.cs
+++ b/ModernFormsNext/Animations/IInteractionEffectClip.cs
@@ -1,0 +1,17 @@
+using System.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Applies a render clip for interaction effects.
+/// </summary>
+/// <remarks>
+/// The abstraction intentionally accepts the shared Skia canvas so future shape or geometry
+/// implementations can provide non-rectangular clips without changing effect APIs.
+/// </remarks>
+public interface IInteractionEffectClip
+{
+    /// <summary>Intersects the current canvas clip with the target's effect region.</summary>
+    void Apply(SKCanvas canvas, Control target, Rectangle bounds);
+}

--- a/ModernFormsNext/Animations/InteractionEffect.cs
+++ b/ModernFormsNext/Animations/InteractionEffect.cs
@@ -16,6 +16,7 @@ public abstract class InteractionEffect : IDisposable
     private Control? target;
     private InteractionEffectRenderContext? renderContext;
     private bool disposed;
+    private bool detaching;
 
     /// <summary>Gets or sets whether this effect handles input and renders.</summary>
     [DefaultValue(true)]
@@ -52,8 +53,9 @@ public abstract class InteractionEffect : IDisposable
         if (disposed)
             return;
         disposed = true;
-        target?.InteractionEffects.Remove(this);
-        DetachCore();
+        Control? attachedTarget = target;
+        if (attachedTarget is null || !attachedTarget.InteractionEffects.Remove(this))
+            DetachCore();
         GC.SuppressFinalize(this);
     }
 
@@ -123,7 +125,23 @@ public abstract class InteractionEffect : IDisposable
         if (target is not null)
             throw new InvalidOperationException("An interaction effect can be attached to only one control.");
         target = value;
-        OnAttached();
+        try
+        {
+            OnAttached();
+        }
+        catch
+        {
+            try
+            {
+                CancelCore();
+            }
+            finally
+            {
+                target = null;
+                renderContext = null;
+            }
+            throw;
+        }
     }
 
     internal void Detach()
@@ -186,9 +204,21 @@ public abstract class InteractionEffect : IDisposable
 
     private void DetachCore()
     {
-        CancelCore();
-        OnDetached();
-        target = null;
-        renderContext = null;
+        if (target is null || detaching)
+            return;
+
+        detaching = true;
+        try
+        {
+            CancelCore();
+            OnDetached();
+        }
+        finally
+        {
+            // Custom cleanup must not keep the control or last canvas alive even when it faults.
+            target = null;
+            renderContext = null;
+            detaching = false;
+        }
     }
 }

--- a/ModernFormsNext/Animations/InteractionEffect.cs
+++ b/ModernFormsNext/Animations/InteractionEffect.cs
@@ -1,0 +1,185 @@
+using System.ComponentModel;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Defines attachable input and rendering behavior driven by the shared animation scheduler.
+/// </summary>
+/// <remarks>
+/// Effects are attached through <see cref="Control.InteractionEffects"/>. They receive input
+/// directly from the control pipeline rather than installing duplicate public event
+/// subscriptions. Detach and disposal cancel only animations owned by this effect.
+/// </remarks>
+public abstract class InteractionEffect : IDisposable
+{
+    private bool enabled = true;
+    private Control? target;
+    private bool disposed;
+
+    /// <summary>Gets or sets whether this effect handles input and renders.</summary>
+    [DefaultValue(true)]
+    public bool Enabled
+    {
+        get => enabled;
+        set
+        {
+            if (enabled == value)
+                return;
+            enabled = value;
+            if (!value)
+                CancelCore();
+            target?.Invalidate();
+        }
+    }
+
+    /// <summary>Gets the attached target, or null while detached.</summary>
+    [Browsable(false)]
+    public Control? Target => target;
+
+    /// <summary>Gets or sets the effect clip. The default respects bounds and corner radius.</summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public IInteractionEffectClip? Clip { get; set; } = ControlBoundsInteractionEffectClip.Instance;
+
+    /// <summary>Gets the shared layer on which this effect renders.</summary>
+    public virtual InteractionEffectLayer RenderLayer
+        => InteractionEffectLayer.AboveContent;
+
+    /// <summary>Disposes and detaches this effect. The operation is idempotent.</summary>
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+        disposed = true;
+        target?.InteractionEffects.Remove(this);
+        DetachCore();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Called after the effect is attached to a control.</summary>
+    protected virtual void OnAttached()
+    {
+    }
+
+    /// <summary>Called before the effect releases its target.</summary>
+    protected virtual void OnDetached()
+    {
+    }
+
+    /// <summary>Called for target-local pointer down input.</summary>
+    protected virtual void OnPointerDown(MouseEventArgs e)
+    {
+    }
+
+    /// <summary>Called for target-local pointer up input.</summary>
+    protected virtual void OnPointerUp(MouseEventArgs e)
+    {
+    }
+
+    /// <summary>Called when an active pointer sequence is canceled.</summary>
+    protected virtual void OnPointerCanceled()
+    {
+    }
+
+    /// <summary>Called for target key down input.</summary>
+    protected virtual void OnKeyDown(KeyEventArgs e)
+    {
+    }
+
+    /// <summary>Called for target key up input.</summary>
+    protected virtual void OnKeyUp(KeyEventArgs e)
+    {
+    }
+
+    /// <summary>Renders one effect frame inside the configured clip.</summary>
+    protected virtual void OnRender(InteractionEffectRenderContext context)
+    {
+    }
+
+    /// <summary>Cancels effect-owned scheduler work and resets transient state.</summary>
+    protected virtual void CancelCore()
+    {
+        if (target is not null)
+            target.CancelInteractionAnimations(this);
+    }
+
+    /// <summary>Requests visual-only invalidation of the attached target.</summary>
+    protected void InvalidateTarget() => target?.Invalidate();
+
+    /// <summary>Gets the shared scheduler selected by the attached control.</summary>
+    protected AnimationScheduler Scheduler
+        => target?.InteractionAnimationScheduler
+            ?? throw new InvalidOperationException("The interaction effect is not attached.");
+
+    internal void Attach(Control value)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        if (ReferenceEquals(target, value))
+            return;
+        if (target is not null)
+            throw new InvalidOperationException("An interaction effect can be attached to only one control.");
+        target = value;
+        OnAttached();
+    }
+
+    internal void Detach()
+    {
+        if (target is null)
+            return;
+        DetachCore();
+    }
+
+    internal void DispatchPointerDown(MouseEventArgs e)
+    {
+        if (enabled && target?.Enabled == true)
+            OnPointerDown(e);
+    }
+
+    internal void DispatchPointerUp(MouseEventArgs e)
+    {
+        if (enabled)
+            OnPointerUp(e);
+    }
+
+    internal void DispatchPointerCanceled()
+    {
+        if (enabled)
+            OnPointerCanceled();
+    }
+
+    internal void DispatchKeyDown(KeyEventArgs e)
+    {
+        if (enabled && target?.Enabled == true)
+            OnKeyDown(e);
+    }
+
+    internal void DispatchKeyUp(KeyEventArgs e)
+    {
+        if (enabled)
+            OnKeyUp(e);
+    }
+
+    internal void DispatchRender(PaintEventArgs e)
+    {
+        if (!enabled || target is null)
+            return;
+        e.Canvas.Save();
+        try
+        {
+            var bounds = new System.Drawing.Rectangle(0, 0, target.ScaledWidth, target.ScaledHeight);
+            Clip?.Apply(e.Canvas, target, bounds);
+            OnRender(new InteractionEffectRenderContext(target, e.Canvas, bounds, e.Scaling));
+        }
+        finally
+        {
+            e.Canvas.Restore();
+        }
+    }
+
+    private void DetachCore()
+    {
+        CancelCore();
+        OnDetached();
+        target = null;
+    }
+}

--- a/ModernFormsNext/Animations/InteractionEffect.cs
+++ b/ModernFormsNext/Animations/InteractionEffect.cs
@@ -14,6 +14,7 @@ public abstract class InteractionEffect : IDisposable
 {
     private bool enabled = true;
     private Control? target;
+    private InteractionEffectRenderContext? renderContext;
     private bool disposed;
 
     /// <summary>Gets or sets whether this effect handles input and renders.</summary>
@@ -76,8 +77,11 @@ public abstract class InteractionEffect : IDisposable
     {
     }
 
-    /// <summary>Called when an active pointer sequence is canceled.</summary>
-    protected virtual void OnPointerCanceled()
+    /// <summary>Called when one pointer or the entire active pointer sequence is canceled.</summary>
+    /// <param name="pointerId">
+    /// The canceled platform pointer identifier, or <see langword="null"/> for global cancellation.
+    /// </param>
+    protected virtual void OnPointerCanceled(int? pointerId)
     {
     }
 
@@ -141,10 +145,10 @@ public abstract class InteractionEffect : IDisposable
             OnPointerUp(e);
     }
 
-    internal void DispatchPointerCanceled()
+    internal void DispatchPointerCanceled(int? pointerId)
     {
         if (enabled)
-            OnPointerCanceled();
+            OnPointerCanceled(pointerId);
     }
 
     internal void DispatchKeyDown(KeyEventArgs e)
@@ -168,7 +172,11 @@ public abstract class InteractionEffect : IDisposable
         {
             var bounds = new System.Drawing.Rectangle(0, 0, target.ScaledWidth, target.ScaledHeight);
             Clip?.Apply(e.Canvas, target, bounds);
-            OnRender(new InteractionEffectRenderContext(target, e.Canvas, bounds, e.Scaling));
+            if (renderContext is null)
+                renderContext = new InteractionEffectRenderContext(target, e.Canvas, bounds, e.Scaling);
+            else
+                renderContext.Reset(target, e.Canvas, bounds, e.Scaling);
+            OnRender(renderContext);
         }
         finally
         {
@@ -181,5 +189,6 @@ public abstract class InteractionEffect : IDisposable
         CancelCore();
         OnDetached();
         target = null;
+        renderContext = null;
     }
 }

--- a/ModernFormsNext/Animations/InteractionEffectCollection.cs
+++ b/ModernFormsNext/Animations/InteractionEffectCollection.cs
@@ -1,0 +1,141 @@
+using System.Collections;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>Owns and attaches the interaction effects configured for one control.</summary>
+public sealed class InteractionEffectCollection : IList<InteractionEffect>
+{
+    private readonly Control owner;
+    private readonly List<InteractionEffect> effects = [];
+
+    internal InteractionEffectCollection(Control owner)
+        => this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
+
+    /// <inheritdoc/>
+    public int Count => effects.Count;
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public InteractionEffect this[int index]
+    {
+        get => effects[index];
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            InteractionEffect previous = effects[index];
+            if (ReferenceEquals(previous, value))
+                return;
+            if (effects.Contains(value))
+                throw new ArgumentException("The effect is already attached to this control.", nameof(value));
+            value.Attach(owner);
+            effects[index] = value;
+            previous.Detach();
+            owner.Invalidate();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Add(InteractionEffect item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        if (effects.Contains(item))
+            return;
+        item.Attach(owner);
+        effects.Add(item);
+        owner.Invalidate();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        foreach (InteractionEffect effect in effects)
+            effect.Detach();
+        effects.Clear();
+        owner.Invalidate();
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(InteractionEffect item) => effects.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(InteractionEffect[] array, int arrayIndex) => effects.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public IEnumerator<InteractionEffect> GetEnumerator() => effects.GetEnumerator();
+
+    /// <inheritdoc/>
+    public int IndexOf(InteractionEffect item) => effects.IndexOf(item);
+
+    /// <inheritdoc/>
+    public void Insert(int index, InteractionEffect item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        if (effects.Contains(item))
+            return;
+        item.Attach(owner);
+        effects.Insert(index, item);
+        owner.Invalidate();
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(InteractionEffect item)
+    {
+        if (!effects.Remove(item))
+            return false;
+        item.Detach();
+        owner.Invalidate();
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        InteractionEffect effect = effects[index];
+        effects.RemoveAt(index);
+        effect.Detach();
+        owner.Invalidate();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    internal void PointerDown(MouseEventArgs e)
+    {
+        foreach (InteractionEffect effect in effects)
+            effect.DispatchPointerDown(e);
+    }
+
+    internal void PointerUp(MouseEventArgs e)
+    {
+        foreach (InteractionEffect effect in effects)
+            effect.DispatchPointerUp(e);
+    }
+
+    internal void PointerCanceled()
+    {
+        foreach (InteractionEffect effect in effects)
+            effect.DispatchPointerCanceled();
+    }
+
+    internal void KeyDown(KeyEventArgs e)
+    {
+        foreach (InteractionEffect effect in effects)
+            effect.DispatchKeyDown(e);
+    }
+
+    internal void KeyUp(KeyEventArgs e)
+    {
+        foreach (InteractionEffect effect in effects)
+            effect.DispatchKeyUp(e);
+    }
+
+    internal void Render(InteractionEffectLayer layer, PaintEventArgs e)
+    {
+        foreach (InteractionEffect effect in effects)
+        {
+            if (effect.RenderLayer == layer)
+                effect.DispatchRender(e);
+        }
+    }
+}

--- a/ModernFormsNext/Animations/InteractionEffectCollection.cs
+++ b/ModernFormsNext/Animations/InteractionEffectCollection.cs
@@ -32,6 +32,7 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
             value.Attach(owner);
             effects[index] = value;
             previous.Detach();
+            owner.NotifyInteractionEffectDetached(previous);
             owner.Invalidate();
         }
     }
@@ -51,7 +52,10 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
     public void Clear()
     {
         foreach (InteractionEffect effect in effects)
+        {
             effect.Detach();
+            owner.NotifyInteractionEffectDetached(effect);
+        }
         effects.Clear();
         owner.Invalidate();
     }
@@ -85,6 +89,7 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
         if (!effects.Remove(item))
             return false;
         item.Detach();
+        owner.NotifyInteractionEffectDetached(item);
         owner.Invalidate();
         return true;
     }
@@ -95,6 +100,7 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
         InteractionEffect effect = effects[index];
         effects.RemoveAt(index);
         effect.Detach();
+        owner.NotifyInteractionEffectDetached(effect);
         owner.Invalidate();
     }
 
@@ -112,10 +118,10 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
             effect.DispatchPointerUp(e);
     }
 
-    internal void PointerCanceled()
+    internal void PointerCanceled(int? pointerId)
     {
         foreach (InteractionEffect effect in effects)
-            effect.DispatchPointerCanceled();
+            effect.DispatchPointerCanceled(pointerId);
     }
 
     internal void KeyDown(KeyEventArgs e)

--- a/ModernFormsNext/Animations/InteractionEffectCollection.cs
+++ b/ModernFormsNext/Animations/InteractionEffectCollection.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Collections;
 
 namespace ModernFormsNext.Animations;
@@ -7,6 +8,8 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
 {
     private readonly Control owner;
     private readonly List<InteractionEffect> effects = [];
+    private InteractionEffect[] dispatchBuffer = [];
+    private int dispatchDepth;
 
     internal InteractionEffectCollection(Control owner)
         => this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
@@ -51,12 +54,15 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
     /// <inheritdoc/>
     public void Clear()
     {
-        foreach (InteractionEffect effect in effects)
+        // Remove before invoking extensibility callbacks so an effect may dispose itself or
+        // another effect without invalidating collection enumeration.
+        while (effects.Count > 0)
         {
+            InteractionEffect effect = effects[0];
+            effects.RemoveAt(0);
             effect.Detach();
             owner.NotifyInteractionEffectDetached(effect);
         }
-        effects.Clear();
         owner.Invalidate();
     }
 
@@ -107,41 +113,100 @@ public sealed class InteractionEffectCollection : IList<InteractionEffect>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     internal void PointerDown(MouseEventArgs e)
-    {
-        foreach (InteractionEffect effect in effects)
-            effect.DispatchPointerDown(e);
-    }
+        => Dispatch(EffectDispatchKind.PointerDown, mouseEvent: e);
 
     internal void PointerUp(MouseEventArgs e)
-    {
-        foreach (InteractionEffect effect in effects)
-            effect.DispatchPointerUp(e);
-    }
+        => Dispatch(EffectDispatchKind.PointerUp, mouseEvent: e);
 
     internal void PointerCanceled(int? pointerId)
-    {
-        foreach (InteractionEffect effect in effects)
-            effect.DispatchPointerCanceled(pointerId);
-    }
+        => Dispatch(EffectDispatchKind.PointerCanceled, pointerId: pointerId);
 
     internal void KeyDown(KeyEventArgs e)
-    {
-        foreach (InteractionEffect effect in effects)
-            effect.DispatchKeyDown(e);
-    }
+        => Dispatch(EffectDispatchKind.KeyDown, keyEvent: e);
 
     internal void KeyUp(KeyEventArgs e)
-    {
-        foreach (InteractionEffect effect in effects)
-            effect.DispatchKeyUp(e);
-    }
+        => Dispatch(EffectDispatchKind.KeyUp, keyEvent: e);
 
     internal void Render(InteractionEffectLayer layer, PaintEventArgs e)
+        => Dispatch(EffectDispatchKind.Render, layer: layer, paintEvent: e);
+
+    private void Dispatch(
+        EffectDispatchKind kind,
+        MouseEventArgs? mouseEvent = null,
+        KeyEventArgs? keyEvent = null,
+        int? pointerId = null,
+        InteractionEffectLayer layer = default,
+        PaintEventArgs? paintEvent = null)
     {
-        foreach (InteractionEffect effect in effects)
+        int count = effects.Count;
+        if (count == 0)
+            return;
+
+        bool rented = dispatchDepth > 0;
+        InteractionEffect[] buffer;
+        if (rented)
         {
-            if (effect.RenderLayer == layer)
-                effect.DispatchRender(e);
+            buffer = ArrayPool<InteractionEffect>.Shared.Rent(count);
         }
+        else
+        {
+            if (dispatchBuffer.Length < count)
+                Array.Resize(ref dispatchBuffer, Math.Max(count, dispatchBuffer.Length * 2));
+            buffer = dispatchBuffer;
+        }
+
+        effects.CopyTo(buffer, 0);
+        dispatchDepth++;
+        try
+        {
+            for (int index = 0; index < count; index++)
+            {
+                InteractionEffect effect = buffer[index];
+                if (!ReferenceEquals(effect.Target, owner))
+                    continue;
+
+                switch (kind)
+                {
+                    case EffectDispatchKind.PointerDown:
+                        effect.DispatchPointerDown(mouseEvent!);
+                        break;
+                    case EffectDispatchKind.PointerUp:
+                        effect.DispatchPointerUp(mouseEvent!);
+                        break;
+                    case EffectDispatchKind.PointerCanceled:
+                        effect.DispatchPointerCanceled(pointerId);
+                        break;
+                    case EffectDispatchKind.KeyDown:
+                        effect.DispatchKeyDown(keyEvent!);
+                        break;
+                    case EffectDispatchKind.KeyUp:
+                        effect.DispatchKeyUp(keyEvent!);
+                        break;
+                    case EffectDispatchKind.Render:
+                        if (effect.RenderLayer == layer)
+                            effect.DispatchRender(paintEvent!);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(kind));
+                }
+            }
+        }
+        finally
+        {
+            Array.Clear(buffer, 0, count);
+            dispatchDepth--;
+            if (rented)
+                ArrayPool<InteractionEffect>.Shared.Return(buffer);
+        }
+    }
+
+    private enum EffectDispatchKind
+    {
+        PointerDown,
+        PointerUp,
+        PointerCanceled,
+        KeyDown,
+        KeyUp,
+        Render
     }
 }

--- a/ModernFormsNext/Animations/InteractionEffectLayer.cs
+++ b/ModernFormsNext/Animations/InteractionEffectLayer.cs
@@ -1,0 +1,11 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>Identifies a shared rendering layer for interaction effects.</summary>
+public enum InteractionEffectLayer
+{
+    /// <summary>After the background and border, before control content.</summary>
+    AboveBackgroundBelowContent,
+
+    /// <summary>After control content and before the framework focus overlay.</summary>
+    AboveContent
+}

--- a/ModernFormsNext/Animations/InteractionEffectRenderContext.cs
+++ b/ModernFormsNext/Animations/InteractionEffectRenderContext.cs
@@ -4,9 +4,20 @@ using SkiaSharp;
 namespace ModernFormsNext.Animations;
 
 /// <summary>Provides shared render data to a custom interaction effect.</summary>
+/// <remarks>
+/// The attached effect reuses this context between frames to avoid render-loop allocations.
+/// Read it only during <c>OnRender</c>; do not retain the context or its borrowed canvas.
+/// </remarks>
 public sealed class InteractionEffectRenderContext
 {
     internal InteractionEffectRenderContext(
+        Control target,
+        SKCanvas canvas,
+        Rectangle bounds,
+        double scaling)
+        => Reset(target, canvas, bounds, scaling);
+
+    internal void Reset(
         Control target,
         SKCanvas canvas,
         Rectangle bounds,
@@ -19,14 +30,14 @@ public sealed class InteractionEffectRenderContext
     }
 
     /// <summary>Gets the attached target control.</summary>
-    public Control Target { get; }
+    public Control Target { get; private set; } = null!;
 
     /// <summary>Gets the target-local Skia canvas.</summary>
-    public SKCanvas Canvas { get; }
+    public SKCanvas Canvas { get; private set; } = null!;
 
     /// <summary>Gets target-local device-pixel bounds.</summary>
-    public Rectangle Bounds { get; }
+    public Rectangle Bounds { get; private set; }
 
     /// <summary>Gets the current logical-to-device scale.</summary>
-    public double Scaling { get; }
+    public double Scaling { get; private set; }
 }

--- a/ModernFormsNext/Animations/InteractionEffectRenderContext.cs
+++ b/ModernFormsNext/Animations/InteractionEffectRenderContext.cs
@@ -1,0 +1,32 @@
+using System.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>Provides shared render data to a custom interaction effect.</summary>
+public sealed class InteractionEffectRenderContext
+{
+    internal InteractionEffectRenderContext(
+        Control target,
+        SKCanvas canvas,
+        Rectangle bounds,
+        double scaling)
+    {
+        Target = target;
+        Canvas = canvas;
+        Bounds = bounds;
+        Scaling = scaling;
+    }
+
+    /// <summary>Gets the attached target control.</summary>
+    public Control Target { get; }
+
+    /// <summary>Gets the target-local Skia canvas.</summary>
+    public SKCanvas Canvas { get; }
+
+    /// <summary>Gets target-local device-pixel bounds.</summary>
+    public Rectangle Bounds { get; }
+
+    /// <summary>Gets the current logical-to-device scale.</summary>
+    public double Scaling { get; }
+}

--- a/ModernFormsNext/Animations/Internal/AnimationEntry.cs
+++ b/ModernFormsNext/Animations/Internal/AnimationEntry.cs
@@ -4,16 +4,31 @@ internal sealed class AnimationEntry
 {
     private readonly TaskCompletionSource<AnimationState> completion =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly CancellationTokenSource cancellation = new();
     private int state = (int)AnimationState.Created;
     private Exception? exception;
+    private object? owner;
+    private Action<AnimationFrame>? update;
 
-    public required object Owner { get; init; }
+    public required object Owner
+    {
+        get => Volatile.Read(ref owner)
+            ?? throw new InvalidOperationException("A terminal animation no longer has an owner.");
+        init => owner = value;
+    }
+
+    public object? OwnerOrNull => Volatile.Read(ref owner);
 
     public required string Key { get; init; }
 
     public required AnimationOptionsSnapshot Options { get; init; }
 
-    public required Action<float> Update { get; init; }
+    public required Action<AnimationFrame> Update
+    {
+        get => Volatile.Read(ref update)
+            ?? throw new InvalidOperationException("A terminal animation no longer has an update callback.");
+        init => update = value;
+    }
 
     public required AnimationScheduler Scheduler { get; init; }
 
@@ -35,11 +50,16 @@ internal sealed class AnimationEntry
 
     public Exception? Exception => Volatile.Read(ref exception);
 
+    public CancellationToken CancellationToken => cancellation.Token;
+
     public bool IsTerminal => State is AnimationState.Completed or AnimationState.Canceled or AnimationState.Faulted;
 
     public void SetState(AnimationState value) => Volatile.Write(ref state, (int)value);
 
-    public bool TrySetTerminal(AnimationState terminalState, Exception? fault = null)
+    public void Invoke(AnimationFrame frame)
+        => Volatile.Read(ref update)?.Invoke(frame);
+
+    public bool TryBeginTerminal(AnimationState terminalState, Exception? fault = null)
     {
         while (true)
         {
@@ -52,8 +72,33 @@ internal sealed class AnimationEntry
 
             if (fault is not null)
                 Volatile.Write(ref exception, fault);
-            completion.TrySetResult(terminalState);
             return true;
         }
+    }
+
+    public void FinishTerminal(bool signalCancellation)
+    {
+        AnimationState terminalState = State;
+        if (terminalState is not (AnimationState.Completed or AnimationState.Canceled or AnimationState.Faulted))
+            throw new InvalidOperationException("Only a terminal animation can release its retained references.");
+
+        if (signalCancellation)
+        {
+            try
+            {
+                cancellation.Cancel(throwOnFirstException: false);
+            }
+            catch (AggregateException exception)
+            {
+                System.Diagnostics.Trace.TraceError(
+                    "An animation cancellation callback faulted after terminal transition: {0}",
+                    exception);
+            }
+        }
+
+        Volatile.Write(ref update, null);
+        Volatile.Write(ref owner, null);
+        completion.TrySetResult(terminalState);
+        cancellation.Dispose();
     }
 }

--- a/ModernFormsNext/Animations/Internal/AnimationEntry.cs
+++ b/ModernFormsNext/Animations/Internal/AnimationEntry.cs
@@ -9,6 +9,8 @@ internal sealed class AnimationEntry
     private Exception? exception;
     private object? owner;
     private Action<AnimationFrame>? update;
+    private Func<float, float>? easing;
+    private AnimationOptionsSnapshot options;
 
     public required object Owner
     {
@@ -21,7 +23,18 @@ internal sealed class AnimationEntry
 
     public required string Key { get; init; }
 
-    public required AnimationOptionsSnapshot Options { get; init; }
+    public required AnimationOptionsSnapshot Options
+    {
+        get => options;
+        init
+        {
+            // Keep scalar option data on the handle-facing entry, but retain a caller-provided
+            // easing delegate only while the animation can still invoke it. A terminal handle may
+            // legitimately live much longer than its callback target.
+            options = value with { Easing = Easings.Linear };
+            easing = value.Easing;
+        }
+    }
 
     public required Action<AnimationFrame> Update
     {
@@ -58,6 +71,9 @@ internal sealed class AnimationEntry
 
     public void Invoke(AnimationFrame frame)
         => Volatile.Read(ref update)?.Invoke(frame);
+
+    public float ApplyEasing(float progress)
+        => Volatile.Read(ref easing)?.Invoke(progress) ?? progress;
 
     public bool TryBeginTerminal(AnimationState terminalState, Exception? fault = null)
     {
@@ -97,6 +113,7 @@ internal sealed class AnimationEntry
         }
 
         Volatile.Write(ref update, null);
+        Volatile.Write(ref easing, null);
         Volatile.Write(ref owner, null);
         completion.TrySetResult(terminalState);
         cancellation.Dispose();

--- a/ModernFormsNext/Animations/Internal/AnimationFrame.cs
+++ b/ModernFormsNext/Animations/Internal/AnimationFrame.cs
@@ -1,0 +1,15 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Carries one scheduler-computed frame to higher-level animation definitions.
+/// </summary>
+/// <remarks>
+/// This internal value keeps raw and eased progress together so custom definitions do not need a
+/// second clock. It is allocated on the stack and never retained by the scheduler.
+/// </remarks>
+internal readonly record struct AnimationFrame(
+    float Progress,
+    float EasedProgress,
+    TimeSpan Elapsed,
+    TimeSpan Duration,
+    CancellationToken CancellationToken);

--- a/ModernFormsNext/Animations/KeyframeAnimation.cs
+++ b/ModernFormsNext/Animations/KeyframeAnimation.cs
@@ -1,0 +1,201 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Defines a typed, seekable animation composed of normalized keyframes.
+/// </summary>
+/// <typeparam name="T">The interpolated value type.</typeparam>
+/// <remarks>
+/// Segment easing belongs to the ending keyframe. Keyframe positions must be added in
+/// non-decreasing order and remain in the inclusive range 0..1. A definition contains at most
+/// <see cref="MaximumKeyframeCount"/> keyframes.
+/// </remarks>
+public sealed class KeyframeAnimation<T> : AnimationDefinition
+{
+    /// <summary>Gets the maximum number of keyframes accepted by one definition.</summary>
+    public const int MaximumKeyframeCount = 256;
+
+    private readonly Control target;
+    private readonly Action<T> update;
+    private readonly IAnimationInterpolator<T> interpolator;
+    private readonly List<Frame> keyframes = [];
+    private KeyframeDuplicatePositionPolicy duplicatePositionPolicy;
+
+    private KeyframeAnimation(
+        Control target,
+        Action<T> update,
+        IAnimationInterpolator<T> interpolator)
+    {
+        this.target = target;
+        this.update = update;
+        this.interpolator = interpolator;
+        Key = $"Keyframes:{typeof(T).FullName}";
+    }
+
+    /// <summary>
+    /// Creates a keyframe animation using the built-in interpolator for <typeparamref name="T"/>.
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// No built-in interpolator exists for <typeparamref name="T"/>. Use the overload that accepts
+    /// an interpolator.
+    /// </exception>
+    public static KeyframeAnimation<T> Create(Control target, Action<T> update)
+        => Create(target, update, AnimationInterpolatorResolver.Get<T>());
+
+    /// <summary>Creates a keyframe animation with an explicit typed interpolator.</summary>
+    public static KeyframeAnimation<T> Create(
+        Control target,
+        Action<T> update,
+        IAnimationInterpolator<T> interpolator)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(update);
+        ArgumentNullException.ThrowIfNull(interpolator);
+        return new KeyframeAnimation<T>(target, update, interpolator);
+    }
+
+    /// <summary>Gets or sets the explicit duplicate-position policy.</summary>
+    public KeyframeDuplicatePositionPolicy DuplicatePositionPolicy
+    {
+        get => duplicatePositionPolicy;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value));
+            duplicatePositionPolicy = value;
+        }
+    }
+
+    /// <summary>Gets the number of declared keyframes.</summary>
+    public int Count => keyframes.Count;
+
+    /// <summary>Adds a typed keyframe and optional easing for the segment ending at it.</summary>
+    /// <param name="position">A finite normalized position from 0 through 1.</param>
+    /// <param name="value">The value at the exact position.</param>
+    /// <param name="easing">Optional easing for the segment ending at this frame.</param>
+    /// <returns>This definition.</returns>
+    public KeyframeAnimation<T> Keyframe(
+        float position,
+        T value,
+        Func<float, float>? easing = null)
+    {
+        ValidateProgress(position, nameof(position));
+        if (keyframes.Count >= MaximumKeyframeCount)
+            throw new InvalidOperationException(
+                $"A keyframe animation cannot contain more than {MaximumKeyframeCount} frames.");
+
+        if (keyframes.Count > 0)
+        {
+            Frame previous = keyframes[^1];
+            if (position < previous.Position)
+                throw new ArgumentException(
+                    "Keyframes must be declared in non-decreasing position order.",
+                    nameof(position));
+            if (position == previous.Position)
+            {
+                if (DuplicatePositionPolicy == KeyframeDuplicatePositionPolicy.Reject)
+                    throw new ArgumentException(
+                        "A keyframe already exists at this position.",
+                        nameof(position));
+                if (DuplicatePositionPolicy == KeyframeDuplicatePositionPolicy.ReplacePrevious)
+                {
+                    keyframes[^1] = new Frame(position, value, easing);
+                    return this;
+                }
+            }
+        }
+
+        keyframes.Add(new Frame(position, value, easing));
+        return this;
+    }
+
+    /// <summary>Samples a value deterministically without starting the scheduler.</summary>
+    /// <param name="progress">A finite normalized timeline position from 0 through 1.</param>
+    /// <returns>The exact endpoint or interpolated segment value.</returns>
+    public T Sample(float progress)
+    {
+        ValidateProgress(progress, nameof(progress));
+        EnsureFrames();
+        return SampleCore(keyframes, progress);
+    }
+
+    /// <summary>Samples and immediately applies a value without scheduling an animation.</summary>
+    /// <param name="progress">A finite normalized timeline position from 0 through 1.</param>
+    /// <returns>The applied value.</returns>
+    /// <remarks>The update callback runs synchronously on the calling thread.</remarks>
+    public T Seek(float progress)
+    {
+        T value = Sample(progress);
+        update(value);
+        return value;
+    }
+
+    internal override Control? BoundTarget => target;
+
+    /// <inheritdoc/>
+    protected override void Update(AnimationContext context, float progress)
+    {
+    }
+
+    internal override Task<AnimationExecutionResult> ExecuteCoreAsync(
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        EnsureFrames();
+        Frame[] snapshot = keyframes.ToArray();
+        return ScheduleAsync(
+            scope,
+            target,
+            ResolveKey(),
+            reverse,
+            (_, progress) => update(SampleCore(snapshot, progress)));
+    }
+
+    private T SampleCore(IReadOnlyList<Frame> frames, float progress)
+    {
+        if (progress <= frames[0].Position)
+            return frames[0].Value;
+        if (progress >= frames[^1].Position)
+            return frames[^1].Value;
+
+        int leftIndex = 0;
+        while (leftIndex + 1 < frames.Count && frames[leftIndex + 1].Position <= progress)
+            leftIndex++;
+
+        Frame left = frames[leftIndex];
+        if (left.Position == progress || leftIndex == frames.Count - 1)
+            return left.Value;
+
+        Frame right = frames[leftIndex + 1];
+        float segmentLength = right.Position - left.Position;
+        if (segmentLength <= 0f)
+            return right.Value;
+
+        float segmentProgress = (progress - left.Position) / segmentLength;
+        float easedProgress = right.Easing is null
+            ? segmentProgress
+            : right.Easing(segmentProgress);
+        if (!float.IsFinite(easedProgress))
+            throw new InvalidOperationException("A keyframe easing function returned NaN or infinity.");
+        return interpolator.Interpolate(left.Value, right.Value, easedProgress);
+    }
+
+    private void EnsureFrames()
+    {
+        if (keyframes.Count == 0)
+            throw new InvalidOperationException("A keyframe animation requires at least one keyframe.");
+    }
+
+    private static void ValidateProgress(float progress, string parameterName)
+    {
+        if (!float.IsFinite(progress) || progress < 0f || progress > 1f)
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                progress,
+                "Keyframe progress must be finite and in the inclusive range 0 through 1.");
+    }
+
+    private readonly record struct Frame(
+        float Position,
+        T Value,
+        Func<float, float>? Easing);
+}

--- a/ModernFormsNext/Animations/KeyframeAnimation.cs
+++ b/ModernFormsNext/Animations/KeyframeAnimation.cs
@@ -1,3 +1,6 @@
+using System.Drawing;
+using System.Numerics;
+
 namespace ModernFormsNext.Animations;
 
 /// <summary>
@@ -79,6 +82,7 @@ public sealed class KeyframeAnimation<T> : AnimationDefinition
         Func<float, float>? easing = null)
     {
         ValidateProgress(position, nameof(position));
+        ValidateFiniteValue(value, nameof(value));
         if (keyframes.Count >= MaximumKeyframeCount)
             throw new InvalidOperationException(
                 $"A keyframe animation cannot contain more than {MaximumKeyframeCount} frames.");
@@ -176,7 +180,9 @@ public sealed class KeyframeAnimation<T> : AnimationDefinition
             : right.Easing(segmentProgress);
         if (!float.IsFinite(easedProgress))
             throw new InvalidOperationException("A keyframe easing function returned NaN or infinity.");
-        return interpolator.Interpolate(left.Value, right.Value, easedProgress);
+        T result = interpolator.Interpolate(left.Value, right.Value, easedProgress);
+        ValidateFiniteValue(result, "interpolatedValue");
+        return result;
     }
 
     private void EnsureFrames()
@@ -192,6 +198,35 @@ public sealed class KeyframeAnimation<T> : AnimationDefinition
                 parameterName,
                 progress,
                 "Keyframe progress must be finite and in the inclusive range 0 through 1.");
+    }
+
+    private static void ValidateFiniteValue(T value, string parameterName)
+    {
+        bool finite = value switch
+        {
+            float number => float.IsFinite(number),
+            double number => double.IsFinite(number),
+            PointF point => float.IsFinite(point.X) && float.IsFinite(point.Y),
+            SizeF size => float.IsFinite(size.Width) && float.IsFinite(size.Height),
+            RectangleF rectangle =>
+                float.IsFinite(rectangle.X) &&
+                float.IsFinite(rectangle.Y) &&
+                float.IsFinite(rectangle.Width) &&
+                float.IsFinite(rectangle.Height),
+            Matrix3x2 matrix =>
+                float.IsFinite(matrix.M11) &&
+                float.IsFinite(matrix.M12) &&
+                float.IsFinite(matrix.M21) &&
+                float.IsFinite(matrix.M22) &&
+                float.IsFinite(matrix.M31) &&
+                float.IsFinite(matrix.M32),
+            _ => true
+        };
+        if (!finite)
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                value,
+                "Built-in numeric and geometric keyframe values must contain only finite components.");
     }
 
     private readonly record struct Frame(

--- a/ModernFormsNext/Animations/KeyframeDuplicatePositionPolicy.cs
+++ b/ModernFormsNext/Animations/KeyframeDuplicatePositionPolicy.cs
@@ -1,0 +1,18 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Specifies how a keyframe animation handles two keyframes at the same position.
+/// </summary>
+public enum KeyframeDuplicatePositionPolicy
+{
+    /// <summary>Rejects a duplicate position. This is the default.</summary>
+    Reject,
+
+    /// <summary>Replaces the previously declared keyframe at the position.</summary>
+    ReplacePrevious,
+
+    /// <summary>
+    /// Keeps both keyframes and selects the last declared value at the exact position.
+    /// </summary>
+    KeepBoth
+}

--- a/ModernFormsNext/Animations/ParallelAnimation.cs
+++ b/ModernFormsNext/Animations/ParallelAnimation.cs
@@ -11,20 +11,32 @@ namespace ModernFormsNext.Animations;
 public sealed class ParallelAnimation : AnimationDefinition
 {
     private readonly AnimationDefinition[] children;
+    private readonly bool preserveChildChannels;
 
     /// <summary>Creates a parallel composition from the specified children.</summary>
     public ParallelAnimation(IEnumerable<AnimationDefinition> animations)
+        : this(animations, preserveChildChannels: false)
+    {
+    }
+
+    internal ParallelAnimation(
+        IEnumerable<AnimationDefinition> animations,
+        bool preserveChildChannels)
     {
         ArgumentNullException.ThrowIfNull(animations);
         children = animations.ToArray();
         if (children.Any(static child => child is null))
             throw new ArgumentException("Animation compositions cannot contain null children.", nameof(animations));
+        this.preserveChildChannels = preserveChildChannels;
     }
 
     /// <summary>Gets the children in declaration order.</summary>
     public IReadOnlyList<AnimationDefinition> Children => children;
 
     internal override bool RequiresTarget => false;
+
+    internal override bool HasSchedulableWork
+        => children.Any(static child => child.HasSchedulableWork);
 
     /// <inheritdoc/>
     protected override void Update(AnimationContext context, float progress)
@@ -37,7 +49,12 @@ public sealed class ParallelAnimation : AnimationDefinition
     {
         var tasks = new Task<AnimationExecutionResult>[children.Length];
         for (int index = 0; index < children.Length; index++)
-            tasks[index] = children[index].ExecuteAsync(scope.CreateChild(index), reverse);
+        {
+            AnimationExecutionScope childScope = preserveChildChannels
+                ? scope
+                : scope.CreateChild(index);
+            tasks[index] = ExecuteChildAsync(children[index], childScope, reverse);
+        }
 
         AnimationExecutionResult[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
         List<Exception>? faults = null;
@@ -53,5 +70,24 @@ public sealed class ParallelAnimation : AnimationDefinition
         if (faults is not null)
             return AnimationExecutionResult.Faulted(new AggregateException(faults));
         return canceled ? AnimationExecutionResult.Canceled : AnimationExecutionResult.Completed;
+    }
+
+    private static async Task<AnimationExecutionResult> ExecuteChildAsync(
+        AnimationDefinition child,
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        try
+        {
+            return await child.ExecuteAsync(scope, reverse).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (scope.CancellationToken.IsCancellationRequested)
+        {
+            return AnimationExecutionResult.Canceled;
+        }
+        catch (Exception exception)
+        {
+            return AnimationExecutionResult.Faulted(exception);
+        }
     }
 }

--- a/ModernFormsNext/Animations/ParallelAnimation.cs
+++ b/ModernFormsNext/Animations/ParallelAnimation.cs
@@ -1,0 +1,57 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Runs child animation definitions concurrently on the shared scheduler.
+/// </summary>
+/// <remarks>
+/// All children are started before completion is awaited. Faults are reported in declaration
+/// order through an <see cref="AggregateException"/>; cancellation is returned when no child
+/// faulted and at least one child was canceled.
+/// </remarks>
+public sealed class ParallelAnimation : AnimationDefinition
+{
+    private readonly AnimationDefinition[] children;
+
+    /// <summary>Creates a parallel composition from the specified children.</summary>
+    public ParallelAnimation(IEnumerable<AnimationDefinition> animations)
+    {
+        ArgumentNullException.ThrowIfNull(animations);
+        children = animations.ToArray();
+        if (children.Any(static child => child is null))
+            throw new ArgumentException("Animation compositions cannot contain null children.", nameof(animations));
+    }
+
+    /// <summary>Gets the children in declaration order.</summary>
+    public IReadOnlyList<AnimationDefinition> Children => children;
+
+    internal override bool RequiresTarget => false;
+
+    /// <inheritdoc/>
+    protected override void Update(AnimationContext context, float progress)
+    {
+    }
+
+    internal override async Task<AnimationExecutionResult> ExecuteCoreAsync(
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        var tasks = new Task<AnimationExecutionResult>[children.Length];
+        for (int index = 0; index < children.Length; index++)
+            tasks[index] = children[index].ExecuteAsync(scope.CreateChild(index), reverse);
+
+        AnimationExecutionResult[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        List<Exception>? faults = null;
+        bool canceled = false;
+        foreach (AnimationExecutionResult result in results)
+        {
+            if (result.State == AnimationState.Faulted)
+                (faults ??= []).Add(result.Exception!);
+            else if (result.State == AnimationState.Canceled)
+                canceled = true;
+        }
+
+        if (faults is not null)
+            return AnimationExecutionResult.Faulted(new AggregateException(faults));
+        return canceled ? AnimationExecutionResult.Canceled : AnimationExecutionResult.Completed;
+    }
+}

--- a/ModernFormsNext/Animations/PressScaleEffect.cs
+++ b/ModernFormsNext/Animations/PressScaleEffect.cs
@@ -65,9 +65,17 @@ public sealed class PressScaleEffect : InteractionEffect
     }
 
     /// <inheritdoc/>
-    protected override void OnPointerCanceled()
+    protected override void OnPointerCanceled(int? pointerId)
     {
-        pointers.Clear();
+        if (pointerId is { } id)
+            pointers.Remove(id);
+        else
+        {
+            pointers.Clear();
+            keyboardPressed = false;
+        }
+        if (pointers.Count > 0 || keyboardPressed)
+            return;
         if (Target?.Enabled == true)
             AnimateTo(1f, ReleaseDuration);
         else

--- a/ModernFormsNext/Animations/PressScaleEffect.cs
+++ b/ModernFormsNext/Animations/PressScaleEffect.cs
@@ -1,0 +1,151 @@
+using System.ComponentModel;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>Applies a visual-only scale multiplier while pointer or keyboard activation is held.</summary>
+public sealed class PressScaleEffect : InteractionEffect
+{
+    private readonly HashSet<int> pointers = [];
+    private float pressedScale = 0.97f;
+    private TimeSpan pressDuration = TimeSpan.FromMilliseconds(80);
+    private TimeSpan releaseDuration = TimeSpan.FromMilliseconds(120);
+    private Func<float, float> easing = Easings.CubicOut;
+    private bool keyboardPressed;
+    private float currentScale = 1f;
+
+    /// <summary>Gets or sets the uniform held scale multiplier.</summary>
+    public float PressedScale
+    {
+        get => pressedScale;
+        set
+        {
+            if (!float.IsFinite(value) || value <= 0f)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Pressed scale must be finite and positive.");
+            pressedScale = value;
+        }
+    }
+
+    /// <summary>Gets or sets the down-transition duration.</summary>
+    public TimeSpan PressDuration
+    {
+        get => pressDuration;
+        set => pressDuration = ValidateDuration(value, nameof(PressDuration));
+    }
+
+    /// <summary>Gets or sets the release-transition duration.</summary>
+    public TimeSpan ReleaseDuration
+    {
+        get => releaseDuration;
+        set => releaseDuration = ValidateDuration(value, nameof(ReleaseDuration));
+    }
+
+    /// <summary>Gets or sets the easing used in both directions.</summary>
+    [Browsable(false)]
+    public Func<float, float> Easing
+    {
+        get => easing;
+        set => easing = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerDown(MouseEventArgs e)
+    {
+        if (e.Button != MouseButtons.Left)
+            return;
+        pointers.Add(e.PointerId);
+        AnimateTo(PressedScale, PressDuration);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerUp(MouseEventArgs e)
+    {
+        pointers.Remove(e.PointerId);
+        if (pointers.Count == 0 && !keyboardPressed)
+            AnimateTo(1f, ReleaseDuration);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerCanceled()
+    {
+        pointers.Clear();
+        if (Target?.Enabled == true)
+            AnimateTo(1f, ReleaseDuration);
+        else
+            CancelCore();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (!e.KeyCode.In(Keys.Space, Keys.Enter) || keyboardPressed)
+            return;
+        keyboardPressed = true;
+        AnimateTo(PressedScale, PressDuration);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnKeyUp(KeyEventArgs e)
+    {
+        if (!e.KeyCode.In(Keys.Space, Keys.Enter))
+            return;
+        keyboardPressed = false;
+        if (pointers.Count == 0)
+            AnimateTo(1f, ReleaseDuration);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDetached()
+    {
+        pointers.Clear();
+        keyboardPressed = false;
+        currentScale = 1f;
+        Target?.RemoveInteractionScale(this);
+    }
+
+    /// <inheritdoc/>
+    protected override void CancelCore()
+    {
+        pointers.Clear();
+        keyboardPressed = false;
+        base.CancelCore();
+        currentScale = 1f;
+        Target?.SetInteractionScale(this, 1f);
+    }
+
+    private void AnimateTo(float targetScale, TimeSpan duration)
+    {
+        if (Target is not { Enabled: true } target)
+            return;
+        if (target.Site?.DesignMode == true)
+        {
+            currentScale = targetScale;
+            target.SetInteractionScale(this, currentScale);
+            return;
+        }
+
+        Scheduler.Animate(
+            this,
+            "PressScale",
+            currentScale,
+            targetScale,
+            AnimationInterpolators.Float,
+            value =>
+            {
+                currentScale = value;
+                target.SetInteractionScale(this, value);
+            },
+            new AnimationOptions
+            {
+                Duration = duration,
+                Easing = Easing,
+                ReplacementMode = AnimationReplacementMode.Replace
+            });
+    }
+
+    private static TimeSpan ValidateDuration(TimeSpan value, string parameterName)
+    {
+        if (value < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(parameterName, value, "Effect duration cannot be negative.");
+        return value;
+    }
+}

--- a/ModernFormsNext/Animations/PressScaleEffect.cs
+++ b/ModernFormsNext/Animations/PressScaleEffect.cs
@@ -145,9 +145,32 @@ public sealed class PressScaleEffect : InteractionEffect
             new AnimationOptions
             {
                 Duration = duration,
-                Easing = Easing,
+                Easing = progress => ApplyEasingOrRestoreEndpoint(progress, target, targetScale),
                 ReplacementMode = AnimationReplacementMode.Replace
             });
+    }
+
+    private float ApplyEasingOrRestoreEndpoint(
+        float progress,
+        Control target,
+        float targetScale)
+    {
+        try
+        {
+            float eased = Easing(progress);
+            if (!float.IsFinite(eased))
+                throw new InvalidOperationException("Press-scale easing returned NaN or infinity.");
+            return eased;
+        }
+        catch
+        {
+            // The scheduler correctly faults custom easing, but a press effect must still leave
+            // the target at the requested held/released endpoint rather than getting stuck at an
+            // arbitrary previous frame.
+            currentScale = targetScale;
+            target.SetInteractionScale(this, currentScale);
+            throw;
+        }
     }
 
     private static TimeSpan ValidateDuration(TimeSpan value, string parameterName)

--- a/ModernFormsNext/Animations/PropertyAnimation.cs
+++ b/ModernFormsNext/Animations/PropertyAnimation.cs
@@ -58,7 +58,7 @@ public sealed class PropertyAnimation<T> : AnimationDefinition
         AnimationExecutionScope scope,
         bool reverse = false)
     {
-        T start = from();
+        var start = new StartValueCapture(from);
         int iteration = 0;
         bool collapseInfinite = RepeatsForever && scope.Scheduler.Policy.ShouldCompleteImmediately;
 
@@ -67,14 +67,14 @@ public sealed class PropertyAnimation<T> : AnimationDefinition
             scope.CancellationToken.ThrowIfCancellationRequested();
             AnimationExecutionResult forward =
                 await ExecutePropertyLegAsync(scope, start, reverse).ConfigureAwait(false);
-            if (forward.State != AnimationState.Completed)
+            if (forward.State != AnimationState.Completed || forward.WasIgnored)
                 return forward;
 
             if (IsAutoReversed)
             {
                 AnimationExecutionResult backward =
                     await ExecutePropertyLegAsync(scope, start, !reverse).ConfigureAwait(false);
-                if (backward.State != AnimationState.Completed)
+                if (backward.State != AnimationState.Completed || backward.WasIgnored)
                     return backward;
             }
 
@@ -90,13 +90,13 @@ public sealed class PropertyAnimation<T> : AnimationDefinition
         AnimationExecutionScope scope,
         bool reverse)
     {
-        T start = from();
+        var start = new StartValueCapture(from);
         return ExecutePropertyLegAsync(scope, start, reverse);
     }
 
     private Task<AnimationExecutionResult> ExecutePropertyLegAsync(
         AnimationExecutionScope scope,
-        T start,
+        StartValueCapture start,
         bool reverse)
     {
         return ScheduleAsync(
@@ -104,6 +104,22 @@ public sealed class PropertyAnimation<T> : AnimationDefinition
             target,
             ResolveKey(),
             reverse,
-            (_, progress) => update(interpolator.Interpolate(start, to, progress)));
+            (_, progress) => update(interpolator.Interpolate(start.GetValue(), to, progress)));
+    }
+
+    private sealed class StartValueCapture(Func<T> getValue)
+    {
+        private bool captured;
+        private T? value;
+
+        public T GetValue()
+        {
+            if (!captured)
+            {
+                value = getValue();
+                captured = true;
+            }
+            return value!;
+        }
     }
 }

--- a/ModernFormsNext/Animations/PropertyAnimation.cs
+++ b/ModernFormsNext/Animations/PropertyAnimation.cs
@@ -1,0 +1,109 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Defines a typed property animation using a target, value provider, setter, and interpolator.
+/// </summary>
+/// <typeparam name="T">The value type produced on the UI dispatcher.</typeparam>
+public sealed class PropertyAnimation<T> : AnimationDefinition
+{
+    private readonly Control target;
+    private readonly Func<T> from;
+    private readonly T to;
+    private readonly IAnimationInterpolator<T> interpolator;
+    private readonly Action<T> update;
+
+    /// <summary>Creates a property animation with an explicit fixed start value.</summary>
+    public PropertyAnimation(
+        Control target,
+        string key,
+        T from,
+        T to,
+        IAnimationInterpolator<T> interpolator,
+        Action<T> update)
+        : this(target, key, () => from, to, interpolator, update)
+    {
+    }
+
+    internal PropertyAnimation(
+        Control target,
+        string key,
+        Func<T> from,
+        T to,
+        IAnimationInterpolator<T> interpolator,
+        Action<T> update)
+    {
+        this.target = target ?? throw new ArgumentNullException(nameof(target));
+        Key = key;
+        this.from = from ?? throw new ArgumentNullException(nameof(from));
+        this.to = to;
+        this.interpolator = interpolator ?? throw new ArgumentNullException(nameof(interpolator));
+        this.update = update ?? throw new ArgumentNullException(nameof(update));
+    }
+
+    /// <summary>Gets the bound target control.</summary>
+    public Control Target => target;
+
+    /// <summary>Gets the target value.</summary>
+    public T To => to;
+
+    internal override Control? BoundTarget => target;
+
+    /// <inheritdoc/>
+    protected override void Update(AnimationContext context, float progress)
+    {
+        // Per-run start capture is implemented in ExecuteCoreAsync.
+    }
+
+    internal override async Task<AnimationExecutionResult> ExecuteAsync(
+        AnimationExecutionScope scope,
+        bool reverse = false)
+    {
+        T start = from();
+        int iteration = 0;
+        bool collapseInfinite = RepeatsForever && scope.Scheduler.Policy.ShouldCompleteImmediately;
+
+        while (RepeatsForever || iteration < RepeatCount)
+        {
+            scope.CancellationToken.ThrowIfCancellationRequested();
+            AnimationExecutionResult forward =
+                await ExecutePropertyLegAsync(scope, start, reverse).ConfigureAwait(false);
+            if (forward.State != AnimationState.Completed)
+                return forward;
+
+            if (IsAutoReversed)
+            {
+                AnimationExecutionResult backward =
+                    await ExecutePropertyLegAsync(scope, start, !reverse).ConfigureAwait(false);
+                if (backward.State != AnimationState.Completed)
+                    return backward;
+            }
+
+            iteration++;
+            if (collapseInfinite)
+                break;
+        }
+
+        return AnimationExecutionResult.Completed;
+    }
+
+    internal override Task<AnimationExecutionResult> ExecuteCoreAsync(
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        T start = from();
+        return ExecutePropertyLegAsync(scope, start, reverse);
+    }
+
+    private Task<AnimationExecutionResult> ExecutePropertyLegAsync(
+        AnimationExecutionScope scope,
+        T start,
+        bool reverse)
+    {
+        return ScheduleAsync(
+            scope,
+            target,
+            ResolveKey(),
+            reverse,
+            (_, progress) => update(interpolator.Interpolate(start, to, progress)));
+    }
+}

--- a/ModernFormsNext/Animations/RippleEffect.cs
+++ b/ModernFormsNext/Animations/RippleEffect.cs
@@ -206,26 +206,35 @@ public sealed class RippleEffect : InteractionEffect
 
         var ripple = new RippleInstance(++nextId, pointerId, origin);
         ripples.Add(ripple);
-        AnimationHandle handle = Scheduler.Start(
-            this,
-            $"Ripple:{ripple.Id}",
-            progress =>
-            {
-                ripple.Progress = progress;
-                ripple.EasedProgress = Easing(progress);
-                if (!float.IsFinite(ripple.EasedProgress))
-                    throw new InvalidOperationException("Ripple easing returned NaN or infinity.");
-                if (progress >= 1f)
-                    ripples.Remove(ripple);
-                InvalidateTarget();
-            },
-            new AnimationOptions
-            {
-                Duration = Duration,
-                Easing = Easings.Linear,
-                ReplacementMode = AnimationReplacementMode.Replace
-            });
-        ripple.Handle = handle;
+        try
+        {
+            AnimationHandle handle = Scheduler.Start(
+                this,
+                $"Ripple:{ripple.Id}",
+                progress =>
+                {
+                    ripple.Progress = progress;
+                    ripple.EasedProgress = Easing(progress);
+                    if (!float.IsFinite(ripple.EasedProgress))
+                        throw new InvalidOperationException("Ripple easing returned NaN or infinity.");
+                    if (progress >= 1f)
+                        ripples.Remove(ripple);
+                    InvalidateTarget();
+                },
+                new AnimationOptions
+                {
+                    Duration = Duration,
+                    Easing = Easings.Linear,
+                    ReplacementMode = AnimationReplacementMode.Replace
+                });
+            ripple.Handle = handle;
+        }
+        catch
+        {
+            ripples.Remove(ripple);
+            InvalidateTarget();
+            throw;
+        }
         InvalidateTarget();
     }
 

--- a/ModernFormsNext/Animations/RippleEffect.cs
+++ b/ModernFormsNext/Animations/RippleEffect.cs
@@ -214,9 +214,20 @@ public sealed class RippleEffect : InteractionEffect
                 progress =>
                 {
                     ripple.Progress = progress;
-                    ripple.EasedProgress = Easing(progress);
-                    if (!float.IsFinite(ripple.EasedProgress))
-                        throw new InvalidOperationException("Ripple easing returned NaN or infinity.");
+                    try
+                    {
+                        ripple.EasedProgress = Easing(progress);
+                        if (!float.IsFinite(ripple.EasedProgress))
+                            throw new InvalidOperationException("Ripple easing returned NaN or infinity.");
+                    }
+                    catch
+                    {
+                        // A faulted scheduler entry will not produce another frame. Remove its
+                        // visual state before rethrowing so it cannot remain painted forever.
+                        ripples.Remove(ripple);
+                        InvalidateTarget();
+                        throw;
+                    }
                     if (progress >= 1f)
                         ripples.Remove(ripple);
                     InvalidateTarget();

--- a/ModernFormsNext/Animations/RippleEffect.cs
+++ b/ModernFormsNext/Animations/RippleEffect.cs
@@ -134,7 +134,26 @@ public sealed class RippleEffect : InteractionEffect
     }
 
     /// <inheritdoc/>
-    protected override void OnPointerCanceled() => CancelCore();
+    protected override void OnPointerCanceled(int? pointerId)
+    {
+        if (pointerId is null)
+        {
+            CancelCore();
+            return;
+        }
+
+        bool removed = false;
+        foreach (RippleInstance ripple in ripples
+            .Where(item => item.PointerId == pointerId.Value)
+            .ToArray())
+        {
+            ripples.Remove(ripple);
+            ripple.Handle?.Cancel();
+            removed = true;
+        }
+        if (removed)
+            InvalidateTarget();
+    }
 
     /// <inheritdoc/>
     protected override void OnKeyUp(KeyEventArgs e)

--- a/ModernFormsNext/Animations/RippleEffect.cs
+++ b/ModernFormsNext/Animations/RippleEffect.cs
@@ -1,0 +1,232 @@
+using System.ComponentModel;
+using System.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Draws bounded scheduler-driven waves for pointer, touch, and keyboard activation.
+/// </summary>
+public sealed class RippleEffect : InteractionEffect
+{
+    private readonly List<RippleInstance> ripples = [];
+    private TimeSpan duration = TimeSpan.FromMilliseconds(450);
+    private Func<float, float> easing = Easings.CubicOut;
+    private int maxConcurrentRipples = 4;
+    private float fixedRadius = 48f;
+    private long nextId;
+    private RippleLayer layer = RippleLayer.AboveBackgroundBelowContent;
+
+    /// <summary>Gets or sets the wave color including its initial alpha.</summary>
+    public Color Color { get; set; } = Color.FromArgb(90, 255, 255, 255);
+
+    /// <summary>Gets or sets one wave duration.</summary>
+    public TimeSpan Duration
+    {
+        get => duration;
+        set
+        {
+            if (value < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Ripple duration cannot be negative.");
+            duration = value;
+        }
+    }
+
+    /// <summary>Gets or sets the radius easing. Alpha always fades linearly.</summary>
+    [Browsable(false)]
+    public Func<float, float> Easing
+    {
+        get => easing;
+        set => easing = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>Gets or sets whether pointer waves originate at the contact location.</summary>
+    [DefaultValue(true)]
+    public bool StartFromPointer { get; set; } = true;
+
+    /// <summary>Gets or sets how final radius is resolved.</summary>
+    [DefaultValue(RippleRadiusMode.CoverControl)]
+    public RippleRadiusMode RadiusMode { get; set; } = RippleRadiusMode.CoverControl;
+
+    /// <summary>Gets or sets the fixed radius in logical pixels.</summary>
+    public float FixedRadius
+    {
+        get => fixedRadius;
+        set
+        {
+            if (!float.IsFinite(value) || value < 0f)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Ripple radius must be finite and non-negative.");
+            fixedRadius = value;
+        }
+    }
+
+    /// <summary>Gets or sets the explicit ripple render layer.</summary>
+    [DefaultValue(RippleLayer.AboveBackgroundBelowContent)]
+    public RippleLayer Layer
+    {
+        get => layer;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value));
+            layer = value;
+            InvalidateTarget();
+        }
+    }
+
+    /// <summary>Gets or sets the bounded number of concurrently rendered waves.</summary>
+    public int MaxConcurrentRipples
+    {
+        get => maxConcurrentRipples;
+        set
+        {
+            if (value is < 1 or > 32)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Concurrent ripple count must be from 1 through 32.");
+            maxConcurrentRipples = value;
+            EvictOverflow();
+        }
+    }
+
+    /// <summary>Gets or sets the explicit bounded-wave eviction policy.</summary>
+    [DefaultValue(RippleEvictionPolicy.Oldest)]
+    public RippleEvictionPolicy EvictionPolicy { get; set; } = RippleEvictionPolicy.Oldest;
+
+    /// <summary>Gets the current number of active waves for diagnostics.</summary>
+    [Browsable(false)]
+    public int ActiveRippleCount => ripples.Count;
+
+    /// <inheritdoc/>
+    public override InteractionEffectLayer RenderLayer
+        => Layer == RippleLayer.AboveContent
+            ? InteractionEffectLayer.AboveContent
+            : InteractionEffectLayer.AboveBackgroundBelowContent;
+
+    /// <inheritdoc/>
+    protected override void OnPointerDown(MouseEventArgs e)
+    {
+        if (e.Button != MouseButtons.Left || Target is null)
+            return;
+        PointF origin = StartFromPointer
+            ? new PointF(e.X, e.Y)
+            : GetCenter(Target);
+        StartRipple(origin, e.PointerId);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerCanceled() => CancelCore();
+
+    /// <inheritdoc/>
+    protected override void OnKeyUp(KeyEventArgs e)
+    {
+        if (e.KeyCode.In(Keys.Space, Keys.Enter) && Target is { } target)
+            StartRipple(GetCenter(target), pointerId: -1);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnRender(InteractionEffectRenderContext context)
+    {
+        if (ripples.Count == 0)
+            return;
+
+        float scale = (float)context.Scaling;
+        using var paint = new SKPaint { IsAntialias = true };
+        foreach (RippleInstance ripple in ripples)
+        {
+            float originX = ripple.Origin.X * scale;
+            float originY = ripple.Origin.Y * scale;
+            float radius = ResolveRadius(ripple.Origin, context.Target) * scale * ripple.EasedProgress;
+            int alpha = (int)MathF.Round(Color.A * (1f - ripple.Progress));
+            paint.Color = new SKColor(Color.R, Color.G, Color.B, (byte)Math.Clamp(alpha, 0, 255));
+            context.Canvas.DrawCircle(originX, originY, radius, paint);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void CancelCore()
+    {
+        if (ripples.Count > 0)
+        {
+            foreach (RippleInstance ripple in ripples.ToArray())
+                ripple.Handle?.Cancel();
+            ripples.Clear();
+            InvalidateTarget();
+        }
+        base.CancelCore();
+    }
+
+    private void StartRipple(PointF origin, int pointerId)
+    {
+        if (Target is not { Enabled: true } target ||
+            target.Site?.DesignMode == true ||
+            Scheduler.Policy.ShouldCompleteImmediately)
+            return;
+
+        while (ripples.Count >= MaxConcurrentRipples)
+            EvictOne();
+
+        var ripple = new RippleInstance(++nextId, pointerId, origin);
+        ripples.Add(ripple);
+        AnimationHandle handle = Scheduler.Start(
+            this,
+            $"Ripple:{ripple.Id}",
+            progress =>
+            {
+                ripple.Progress = progress;
+                ripple.EasedProgress = Easing(progress);
+                if (!float.IsFinite(ripple.EasedProgress))
+                    throw new InvalidOperationException("Ripple easing returned NaN or infinity.");
+                if (progress >= 1f)
+                    ripples.Remove(ripple);
+                InvalidateTarget();
+            },
+            new AnimationOptions
+            {
+                Duration = Duration,
+                Easing = Easings.Linear,
+                ReplacementMode = AnimationReplacementMode.Replace
+            });
+        ripple.Handle = handle;
+        InvalidateTarget();
+    }
+
+    private void EvictOverflow()
+    {
+        while (ripples.Count > MaxConcurrentRipples)
+            EvictOne();
+    }
+
+    private void EvictOne()
+    {
+        if (ripples.Count == 0)
+            return;
+        RippleInstance ripple = EvictionPolicy switch
+        {
+            RippleEvictionPolicy.Oldest => ripples[0],
+            _ => throw new ArgumentOutOfRangeException(nameof(EvictionPolicy))
+        };
+        ripples.Remove(ripple);
+        ripple.Handle?.Cancel();
+    }
+
+    private float ResolveRadius(PointF origin, Control target)
+    {
+        if (RadiusMode == RippleRadiusMode.Fixed)
+            return FixedRadius;
+        float farthestX = MathF.Max(origin.X, target.Width - origin.X);
+        float farthestY = MathF.Max(origin.Y, target.Height - origin.Y);
+        return MathF.Sqrt((farthestX * farthestX) + (farthestY * farthestY));
+    }
+
+    private static PointF GetCenter(Control target)
+        => new(target.Width / 2f, target.Height / 2f);
+
+    private sealed class RippleInstance(long id, int pointerId, PointF origin)
+    {
+        public long Id { get; } = id;
+        public int PointerId { get; } = pointerId;
+        public PointF Origin { get; } = origin;
+        public float Progress { get; set; }
+        public float EasedProgress { get; set; }
+        public AnimationHandle? Handle { get; set; }
+    }
+}

--- a/ModernFormsNext/Animations/RippleEffect.cs
+++ b/ModernFormsNext/Animations/RippleEffect.cs
@@ -16,6 +16,8 @@ public sealed class RippleEffect : InteractionEffect
     private float fixedRadius = 48f;
     private long nextId;
     private RippleLayer layer = RippleLayer.AboveBackgroundBelowContent;
+    private RippleRadiusMode radiusMode = RippleRadiusMode.CoverControl;
+    private RippleEvictionPolicy evictionPolicy = RippleEvictionPolicy.Oldest;
 
     /// <summary>Gets or sets the wave color including its initial alpha.</summary>
     public Color Color { get; set; } = Color.FromArgb(90, 255, 255, 255);
@@ -46,7 +48,17 @@ public sealed class RippleEffect : InteractionEffect
 
     /// <summary>Gets or sets how final radius is resolved.</summary>
     [DefaultValue(RippleRadiusMode.CoverControl)]
-    public RippleRadiusMode RadiusMode { get; set; } = RippleRadiusMode.CoverControl;
+    public RippleRadiusMode RadiusMode
+    {
+        get => radiusMode;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value));
+            radiusMode = value;
+            InvalidateTarget();
+        }
+    }
 
     /// <summary>Gets or sets the fixed radius in logical pixels.</summary>
     public float FixedRadius
@@ -89,7 +101,16 @@ public sealed class RippleEffect : InteractionEffect
 
     /// <summary>Gets or sets the explicit bounded-wave eviction policy.</summary>
     [DefaultValue(RippleEvictionPolicy.Oldest)]
-    public RippleEvictionPolicy EvictionPolicy { get; set; } = RippleEvictionPolicy.Oldest;
+    public RippleEvictionPolicy EvictionPolicy
+    {
+        get => evictionPolicy;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value));
+            evictionPolicy = value;
+        }
+    }
 
     /// <summary>Gets the current number of active waves for diagnostics.</summary>
     [Browsable(false)]

--- a/ModernFormsNext/Animations/RippleEffectOptions.cs
+++ b/ModernFormsNext/Animations/RippleEffectOptions.cs
@@ -1,0 +1,28 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>Specifies how the maximum ripple radius is resolved.</summary>
+public enum RippleRadiusMode
+{
+    /// <summary>Recomputes the farthest target corner so the ripple covers resized controls.</summary>
+    CoverControl,
+
+    /// <summary>Uses <see cref="RippleEffect.FixedRadius"/> logical pixels.</summary>
+    Fixed
+}
+
+/// <summary>Specifies the shared layer used to draw ripple waves.</summary>
+public enum RippleLayer
+{
+    /// <summary>Draw after background and border, before content.</summary>
+    AboveBackgroundBelowContent,
+
+    /// <summary>Draw after content and before the framework focus overlay.</summary>
+    AboveContent
+}
+
+/// <summary>Specifies which active wave is evicted when a ripple limit is reached.</summary>
+public enum RippleEvictionPolicy
+{
+    /// <summary>Cancel and remove the oldest active wave.</summary>
+    Oldest
+}

--- a/ModernFormsNext/Animations/SequenceAnimation.cs
+++ b/ModernFormsNext/Animations/SequenceAnimation.cs
@@ -21,6 +21,9 @@ public sealed class SequenceAnimation : AnimationDefinition
 
     internal override bool RequiresTarget => false;
 
+    internal override bool HasSchedulableWork
+        => children.Any(static child => child.HasSchedulableWork);
+
     /// <inheritdoc/>
     protected override void Update(AnimationContext context, float progress)
     {

--- a/ModernFormsNext/Animations/SequenceAnimation.cs
+++ b/ModernFormsNext/Animations/SequenceAnimation.cs
@@ -1,0 +1,46 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Runs child animation definitions sequentially without blocking the UI dispatcher.
+/// </summary>
+public sealed class SequenceAnimation : AnimationDefinition
+{
+    private readonly AnimationDefinition[] children;
+
+    /// <summary>Creates a sequential composition from the specified children.</summary>
+    public SequenceAnimation(IEnumerable<AnimationDefinition> animations)
+    {
+        ArgumentNullException.ThrowIfNull(animations);
+        children = animations.ToArray();
+        if (children.Any(static child => child is null))
+            throw new ArgumentException("Animation compositions cannot contain null children.", nameof(animations));
+    }
+
+    /// <summary>Gets the children in declaration order.</summary>
+    public IReadOnlyList<AnimationDefinition> Children => children;
+
+    internal override bool RequiresTarget => false;
+
+    /// <inheritdoc/>
+    protected override void Update(AnimationContext context, float progress)
+    {
+    }
+
+    internal override async Task<AnimationExecutionResult> ExecuteCoreAsync(
+        AnimationExecutionScope scope,
+        bool reverse)
+    {
+        for (int step = 0; step < children.Length; step++)
+        {
+            int childIndex = reverse ? children.Length - step - 1 : step;
+            AnimationExecutionResult result =
+                await children[childIndex]
+                    .ExecuteAsync(scope.CreateChild(childIndex), reverse)
+                    .ConfigureAwait(false);
+            if (result.State != AnimationState.Completed)
+                return result;
+        }
+
+        return AnimationExecutionResult.Completed;
+    }
+}

--- a/ModernFormsNext/Animations/VisualState.cs
+++ b/ModernFormsNext/Animations/VisualState.cs
@@ -1,0 +1,20 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>Identifies the framework interaction state used by style transitions.</summary>
+public enum VisualState
+{
+    /// <summary>The enabled control is idle and does not have pointer hover or focus.</summary>
+    Normal,
+
+    /// <summary>The pointer is over the enabled control.</summary>
+    Hover,
+
+    /// <summary>A pointer or activation key is currently held on the enabled control.</summary>
+    Pressed,
+
+    /// <summary>The enabled control has keyboard focus without a higher-priority state.</summary>
+    Focused,
+
+    /// <summary>The control is not enabled, including disabled-by-parent state.</summary>
+    Disabled
+}

--- a/ModernFormsNext/Animations/VisualStateTransition.cs
+++ b/ModernFormsNext/Animations/VisualStateTransition.cs
@@ -1,0 +1,27 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>Configures animation between two resolved control visual states.</summary>
+public sealed class VisualStateTransition
+{
+    private TimeSpan duration = TimeSpan.FromMilliseconds(150);
+    private Func<float, float> easing = Easings.CubicOut;
+
+    /// <summary>Gets or sets the unscaled visual-only transition duration.</summary>
+    public TimeSpan Duration
+    {
+        get => duration;
+        set
+        {
+            if (value < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Transition duration cannot be negative.");
+            duration = value;
+        }
+    }
+
+    /// <summary>Gets or sets the transition easing.</summary>
+    public Func<float, float> Easing
+    {
+        get => easing;
+        set => easing = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}

--- a/ModernFormsNext/Animations/VisualStateTransitionCollection.cs
+++ b/ModernFormsNext/Animations/VisualStateTransitionCollection.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.ComponentModel;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>Stores directional visual-state transition settings for one control.</summary>
+[EditorBrowsable(EditorBrowsableState.Advanced)]
+public sealed class VisualStateTransitionCollection : IEnumerable<VisualStateTransition>
+{
+    private readonly Dictionary<(VisualState From, VisualState To), VisualStateTransition> transitions = [];
+
+    /// <summary>Gets the number of configured directional transitions.</summary>
+    public int Count => transitions.Count;
+
+    /// <summary>Adds or replaces a directional transition.</summary>
+    public void Add(VisualState from, VisualState to, VisualStateTransition transition)
+    {
+        ValidateState(from, nameof(from));
+        ValidateState(to, nameof(to));
+        ArgumentNullException.ThrowIfNull(transition);
+        transitions[(from, to)] = transition;
+    }
+
+    /// <summary>Removes a directional transition.</summary>
+    public bool Remove(VisualState from, VisualState to)
+        => transitions.Remove((from, to));
+
+    /// <summary>Removes every configured transition.</summary>
+    public void Clear() => transitions.Clear();
+
+    /// <summary>Returns transitions in deterministic from/to order.</summary>
+    public IEnumerator<VisualStateTransition> GetEnumerator()
+        => transitions
+            .OrderBy(static pair => pair.Key.From)
+            .ThenBy(static pair => pair.Key.To)
+            .Select(static pair => pair.Value)
+            .GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    internal bool TryGet(VisualState from, VisualState to, out VisualStateTransition? transition)
+        => transitions.TryGetValue((from, to), out transition);
+
+    private static void ValidateState(VisualState value, string parameterName)
+    {
+        if (!Enum.IsDefined(value))
+            throw new ArgumentOutOfRangeException(parameterName, value, "The visual state is not defined.");
+    }
+}

--- a/ModernFormsNext/Button.cs
+++ b/ModernFormsNext/Button.cs
@@ -200,6 +200,7 @@ namespace ModernFormsNext
         protected override void OnKeyUp (KeyEventArgs e)
         {
             if (e.KeyCode.In (Keys.Space, Keys.Enter)) {
+                NotifyInteractionKeyUp (e);
                 PerformClick ();
                 e.Handled = true;
                 return;
@@ -214,6 +215,12 @@ namespace ModernFormsNext
             base.OnPaint (e);
 
             RenderManager.Render (this, e);
+        }
+
+        internal override void RenderFocusOverlay (PaintEventArgs e)
+        {
+            if (Selected && ShowFocusCues)
+                e.Canvas.DrawFocusRectangle (TextImageLayoutEngine.Layout (this).Focus, 0);
         }
 
         /// <summary>

--- a/ModernFormsNext/Control.Brushes.cs
+++ b/ModernFormsNext/Control.Brushes.cs
@@ -27,15 +27,22 @@ public partial class Control
         if (ReferenceEquals(field, value))
             return false;
 
+        ReplaceBrushInvalidationReference(ref field, value);
+        Invalidate();
+        return true;
+    }
+
+    private void ReplaceBrushInvalidationReference(ref Brush? field, Brush? value)
+    {
+        if (ReferenceEquals(field, value))
+            return;
+
         Brush? previous = field;
         field = value;
         if (previous is not null)
             ReleaseBrushInvalidation(previous);
         if (value is not null)
             AcquireBrushInvalidation(value);
-
-        Invalidate();
-        return true;
     }
 
     private void AcquireBrushInvalidation(Brush brush)

--- a/ModernFormsNext/Control.InteractionEffects.cs
+++ b/ModernFormsNext/Control.InteractionEffects.cs
@@ -88,6 +88,14 @@ public partial class Control
             effects.Render(layer, e);
     }
 
+    internal void NotifyInteractionEffectDetached(InteractionEffect effect)
+    {
+        if (ReferenceEquals(Properties.GetObject(s_rippleEffectProperty), effect))
+            Properties.RemoveObject(s_rippleEffectProperty);
+        if (ReferenceEquals(Properties.GetObject(s_pressEffectProperty), effect))
+            Properties.RemoveObject(s_pressEffectProperty);
+    }
+
     internal void NotifyInteractionKeyUp(KeyEventArgs e)
     {
         SetKeyboardVisualPressed(false);
@@ -107,10 +115,10 @@ public partial class Control
             effects.PointerUp(e);
     }
 
-    private void NotifyInteractionPointerCanceled()
+    private void NotifyInteractionPointerCanceled(int? pointerId = null)
     {
         if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
-            effects.PointerCanceled();
+            effects.PointerCanceled(pointerId);
     }
 
     private void NotifyInteractionKeyDown(KeyEventArgs e)
@@ -122,7 +130,7 @@ public partial class Control
     private void NotifyInteractionEffectsDisabled()
     {
         if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
-            effects.PointerCanceled();
+            effects.PointerCanceled(pointerId: null);
     }
 
     private void DisposeInteractionEffects()

--- a/ModernFormsNext/Control.InteractionEffects.cs
+++ b/ModernFormsNext/Control.InteractionEffects.cs
@@ -12,6 +12,10 @@ public partial class Control
     private static readonly int s_pressEffectProperty = PropertyStore.CreateKey();
     private static readonly int s_interactionScalesProperty = PropertyStore.CreateKey();
     private float interactionScale = 1f;
+    private int interactionKeyDownRouteDepth;
+    private int interactionKeyDownNotifiedDepth;
+    private int interactionKeyUpRouteDepth;
+    private int interactionKeyUpNotifiedDepth;
 
     /// <summary>Gets the effects attached to this control.</summary>
     /// <remarks>
@@ -98,6 +102,13 @@ public partial class Control
 
     internal void NotifyInteractionKeyUp(KeyEventArgs e)
     {
+        if (interactionKeyUpRouteDepth > 0)
+        {
+            if (interactionKeyUpNotifiedDepth == interactionKeyUpRouteDepth)
+                return;
+            interactionKeyUpNotifiedDepth = interactionKeyUpRouteDepth;
+        }
+
         SetKeyboardVisualPressed(false);
         if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
             effects.KeyUp(e);
@@ -123,6 +134,15 @@ public partial class Control
 
     private void NotifyInteractionKeyDown(KeyEventArgs e)
     {
+        if (interactionKeyDownRouteDepth > 0)
+        {
+            if (interactionKeyDownNotifiedDepth == interactionKeyDownRouteDepth)
+                return;
+            interactionKeyDownNotifiedDepth = interactionKeyDownRouteDepth;
+        }
+
+        if (e.KeyCode.In(Keys.Space, Keys.Enter))
+            SetKeyboardVisualPressed(true);
         if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
             effects.KeyDown(e);
     }

--- a/ModernFormsNext/Control.InteractionEffects.cs
+++ b/ModernFormsNext/Control.InteractionEffects.cs
@@ -1,0 +1,158 @@
+using System.ComponentModel;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Layout;
+
+namespace ModernFormsNext;
+
+/// <summary>Provides attachable scheduler-backed interaction effects for controls.</summary>
+public partial class Control
+{
+    private static readonly int s_interactionEffectsProperty = PropertyStore.CreateKey();
+    private static readonly int s_rippleEffectProperty = PropertyStore.CreateKey();
+    private static readonly int s_pressEffectProperty = PropertyStore.CreateKey();
+    private static readonly int s_interactionScalesProperty = PropertyStore.CreateKey();
+    private float interactionScale = 1f;
+
+    /// <summary>Gets the effects attached to this control.</summary>
+    /// <remarks>
+    /// Effects are code-first objects that can contain easing delegates and runtime state, so the
+    /// collection is intentionally hidden from ordinary designer serialization.
+    /// </remarks>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public InteractionEffectCollection InteractionEffects
+    {
+        get
+        {
+            if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection existing)
+                return existing;
+            var created = new InteractionEffectCollection(this);
+            Properties.SetObject(s_interactionEffectsProperty, created);
+            return created;
+        }
+    }
+
+    /// <summary>Gets or sets the convenience ripple effect attached to this control.</summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public RippleEffect? Ripple
+    {
+        get => Properties.GetObject(s_rippleEffectProperty) as RippleEffect;
+        set => SetConvenienceEffect(s_rippleEffectProperty, value);
+    }
+
+    /// <summary>Gets or sets the convenience press-scale effect attached to this control.</summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public PressScaleEffect? PressEffect
+    {
+        get => Properties.GetObject(s_pressEffectProperty) as PressScaleEffect;
+        set => SetConvenienceEffect(s_pressEffectProperty, value);
+    }
+
+    internal AnimationScheduler InteractionAnimationScheduler
+        => AnimationSchedulerOverride ?? AnimationScheduler.Default;
+
+    internal float InteractionScale => interactionScale;
+
+    internal void SetInteractionScale(InteractionEffect owner, float value)
+    {
+        if (Properties.GetObject(s_interactionScalesProperty) is not Dictionary<InteractionEffect, float> scales)
+        {
+            scales = new Dictionary<InteractionEffect, float>(ReferenceEqualityComparer.Instance);
+            Properties.SetObject(s_interactionScalesProperty, scales);
+        }
+        scales[owner] = value;
+        RecalculateInteractionScale(scales);
+        Invalidate();
+    }
+
+    internal void RemoveInteractionScale(InteractionEffect owner)
+    {
+        if (Properties.GetObject(s_interactionScalesProperty) is not Dictionary<InteractionEffect, float> scales)
+            return;
+        scales.Remove(owner);
+        RecalculateInteractionScale(scales);
+        Invalidate();
+    }
+
+    internal void CancelInteractionAnimations(InteractionEffect effect)
+    {
+        if (AnimationSchedulerOverride is { } scheduler)
+            scheduler.CancelAll(effect);
+        else
+            AnimationScheduler.CancelOwnedIfInitialized(effect);
+    }
+
+    internal void RenderInteractionEffects(InteractionEffectLayer layer, PaintEventArgs e)
+    {
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.Render(layer, e);
+    }
+
+    internal void NotifyInteractionKeyUp(KeyEventArgs e)
+    {
+        SetKeyboardVisualPressed(false);
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.KeyUp(e);
+    }
+
+    private void NotifyInteractionPointerDown(MouseEventArgs e)
+    {
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.PointerDown(e);
+    }
+
+    private void NotifyInteractionPointerUp(MouseEventArgs e)
+    {
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.PointerUp(e);
+    }
+
+    private void NotifyInteractionPointerCanceled()
+    {
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.PointerCanceled();
+    }
+
+    private void NotifyInteractionKeyDown(KeyEventArgs e)
+    {
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.KeyDown(e);
+    }
+
+    private void NotifyInteractionEffectsDisabled()
+    {
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.PointerCanceled();
+    }
+
+    private void DisposeInteractionEffects()
+    {
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects)
+            effects.Clear();
+        Properties.RemoveObject(s_interactionEffectsProperty);
+        Properties.RemoveObject(s_rippleEffectProperty);
+        Properties.RemoveObject(s_pressEffectProperty);
+        Properties.RemoveObject(s_interactionScalesProperty);
+        interactionScale = 1f;
+    }
+
+    private void SetConvenienceEffect(int propertyKey, InteractionEffect? value)
+    {
+        InteractionEffect? previous = Properties.GetObject(propertyKey) as InteractionEffect;
+        if (ReferenceEquals(previous, value))
+            return;
+        if (previous is not null)
+            InteractionEffects.Remove(previous);
+        Properties.AddOrRemoveValue(propertyKey, value);
+        if (value is not null)
+            InteractionEffects.Add(value);
+    }
+
+    private void RecalculateInteractionScale(Dictionary<InteractionEffect, float> scales)
+    {
+        float result = 1f;
+        foreach (float value in scales.Values)
+            result *= value;
+        interactionScale = result;
+    }
+}

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -1,0 +1,362 @@
+using System.ComponentModel;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Drawing;
+using ModernFormsNext.Layout;
+using SkiaSharp;
+
+namespace ModernFormsNext;
+
+/// <summary>Provides visual-state styles and scheduler-backed state transitions.</summary>
+public partial class Control
+{
+    private const string VisualStateAnimationKey = "Control.VisualState";
+    private static readonly int s_stylePressedProperty = PropertyStore.CreateKey();
+    private static readonly int s_styleFocusedProperty = PropertyStore.CreateKey();
+    private static readonly int s_styleDisabledProperty = PropertyStore.CreateKey();
+    private static readonly int s_styleTransitionsProperty = PropertyStore.CreateKey();
+
+    private VisualState currentVisualState;
+    private ControlStyle? transitionStyle;
+    private bool pointerPressed;
+    private bool keyboardPressed;
+    private bool hasVisualFocus;
+    private float visualStateOpacity = 1f;
+    private float visualStateTranslationX;
+    private float visualStateTranslationY;
+    private float visualStateScaleX = 1f;
+    private float visualStateScaleY = 1f;
+    private float visualStateRotation;
+
+    internal AnimationScheduler? AnimationSchedulerOverride { get; set; }
+
+    /// <summary>Gets the style used while pointer or keyboard activation is held.</summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public virtual ControlStyle StylePressed
+        => GetOrCreateStateStyle(s_stylePressedProperty, StyleHover);
+
+    /// <summary>Gets the style used for focused controls without hover or press.</summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public virtual ControlStyle StyleFocused
+        => GetOrCreateStateStyle(s_styleFocusedProperty, Style);
+
+    /// <summary>Gets the style used while the effective control is disabled.</summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public virtual ControlStyle StyleDisabled
+        => GetOrCreateStateStyle(s_styleDisabledProperty, Style);
+
+    /// <summary>Gets directional visual-state transitions for this control.</summary>
+    /// <remarks>
+    /// Delegate-valued easing functions are code-first configuration, so the collection is hidden
+    /// from ordinary designer serialization. Design-time playback completes immediately through
+    /// the existing scheduler policy and does not create a separate timer.
+    /// </remarks>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public VisualStateTransitionCollection StyleTransitions
+    {
+        get
+        {
+            if (Properties.GetObject(s_styleTransitionsProperty) is VisualStateTransitionCollection existing)
+                return existing;
+            var created = new VisualStateTransitionCollection();
+            Properties.SetObject(s_styleTransitionsProperty, created);
+            return created;
+        }
+    }
+
+    /// <summary>Gets the state after Disabled/Pressed/Hover/Focused priority resolution.</summary>
+    [Browsable(false)]
+    public VisualState VisualState => ResolveVisualState();
+
+    internal float EffectiveOpacity => Math.Clamp(Opacity * GetVisualOpacity(), 0f, 1f);
+    internal float EffectiveTranslationX => TranslationX + GetVisualTranslationX();
+    internal float EffectiveTranslationY => TranslationY + GetVisualTranslationY();
+    internal float EffectiveScaleX => ScaleX * GetVisualScaleX();
+    internal float EffectiveScaleY => ScaleY * GetVisualScaleY();
+    internal float EffectiveRotation => Rotation + GetVisualRotation();
+    internal Brush? EffectiveBackgroundBrush => BackgroundBrush ?? CurrentStyle.BackgroundBrush;
+    internal Brush? EffectiveTextBrush => TextBrush ?? CurrentStyle.ForegroundBrush;
+    internal Brush? EffectiveBorderBrush => CurrentStyle.BorderBrush;
+
+    internal ControlStyle ResolveCurrentStyle()
+        => transitionStyle ?? GetStyleForState(currentVisualState);
+
+    internal void SetPointerVisualPressed(bool value)
+    {
+        if (pointerPressed == value)
+            return;
+        pointerPressed = value;
+        UpdateVisualState();
+    }
+
+    internal void SetKeyboardVisualPressed(bool value)
+    {
+        if (keyboardPressed == value)
+            return;
+        keyboardPressed = value;
+        UpdateVisualState();
+    }
+
+    internal void SetVisualFocus(bool value)
+    {
+        if (hasVisualFocus == value)
+            return;
+        hasVisualFocus = value;
+        UpdateVisualState();
+    }
+
+    internal void UpdateVisualState()
+    {
+        VisualState targetState = ResolveVisualState();
+        VisualState previousState = currentVisualState;
+        if (targetState == previousState)
+            return;
+
+        bool continuesActiveTransition = transitionStyle is not null;
+        ControlStyle sourceStyle = transitionStyle ?? GetStyleForState(previousState);
+        ControlStyle targetStyle = GetStyleForState(targetState);
+        currentVisualState = targetState;
+
+        if (Properties.GetObject(s_styleTransitionsProperty) is not VisualStateTransitionCollection transitions ||
+            !transitions.TryGet(previousState, targetState, out VisualStateTransition? transition))
+        {
+            if (transitionStyle is not null)
+                EffectiveAnimationScheduler.Cancel(this, VisualStateAnimationKey);
+            transitionStyle = null;
+            ApplyStateTransforms(targetStyle);
+            Invalidate();
+            return;
+        }
+
+        var runtime = new VisualStateTransitionRuntime(
+            sourceStyle,
+            targetStyle,
+            this,
+            continuesActiveTransition);
+        transitionStyle = runtime.AnimatedStyle;
+        EffectiveAnimationScheduler.Start(
+            this,
+            VisualStateAnimationKey,
+            progress =>
+            {
+                runtime.Apply(progress, this);
+                if (progress >= 1f)
+                    transitionStyle = null;
+                Invalidate();
+            },
+            new AnimationOptions
+            {
+                Duration = transition!.Duration,
+                Easing = transition.Easing,
+                ReplacementMode = AnimationReplacementMode.Replace
+            });
+    }
+
+    internal void RefreshVisualStateAfterThemeChange()
+    {
+        if (transitionStyle is not null)
+            EffectiveAnimationScheduler.Cancel(this, VisualStateAnimationKey);
+        transitionStyle = null;
+        currentVisualState = ResolveVisualState();
+        ApplyStateTransforms(GetStyleForState(currentVisualState));
+    }
+
+    private VisualState ResolveVisualState()
+    {
+        if (!Enabled)
+            return VisualState.Disabled;
+        if (pointerPressed || keyboardPressed)
+            return VisualState.Pressed;
+        if (IsHovering)
+            return VisualState.Hover;
+        if (hasVisualFocus || Focused)
+            return VisualState.Focused;
+        return VisualState.Normal;
+    }
+
+    private AnimationScheduler EffectiveAnimationScheduler
+        => AnimationSchedulerOverride ?? AnimationScheduler.Default;
+
+    private float GetVisualOpacity()
+        => transitionStyle is not null
+            ? visualStateOpacity
+            : Math.Clamp(GetStyleForState(currentVisualState).Opacity ?? 1f, 0f, 1f);
+
+    private float GetVisualTranslationX()
+        => transitionStyle is not null
+            ? visualStateTranslationX
+            : GetStyleForState(currentVisualState).TranslationX ?? 0f;
+
+    private float GetVisualTranslationY()
+        => transitionStyle is not null
+            ? visualStateTranslationY
+            : GetStyleForState(currentVisualState).TranslationY ?? 0f;
+
+    private float GetVisualScaleX()
+        => transitionStyle is not null
+            ? visualStateScaleX
+            : GetStyleForState(currentVisualState).ScaleX ?? 1f;
+
+    private float GetVisualScaleY()
+        => transitionStyle is not null
+            ? visualStateScaleY
+            : GetStyleForState(currentVisualState).ScaleY ?? 1f;
+
+    private float GetVisualRotation()
+        => transitionStyle is not null
+            ? visualStateRotation
+            : GetStyleForState(currentVisualState).Rotation ?? 0f;
+
+    private ControlStyle GetStyleForState(VisualState state)
+        => state switch
+        {
+            VisualState.Normal => Style,
+            VisualState.Hover => StyleHover,
+            VisualState.Pressed => StylePressed,
+            VisualState.Focused => StyleFocused,
+            VisualState.Disabled => StyleDisabled,
+            _ => Style
+        };
+
+    private ControlStyle GetOrCreateStateStyle(int propertyKey, ControlStyle parentStyle)
+    {
+        if (Properties.GetObject(propertyKey) is ControlStyle existing)
+            return existing;
+        var created = new ControlStyle(parentStyle);
+        Properties.SetObject(propertyKey, created);
+        return created;
+    }
+
+    private void ApplyStateTransforms(ControlStyle style)
+    {
+        visualStateOpacity = Math.Clamp(style.Opacity ?? 1f, 0f, 1f);
+        visualStateTranslationX = style.TranslationX ?? 0f;
+        visualStateTranslationY = style.TranslationY ?? 0f;
+        visualStateScaleX = style.ScaleX ?? 1f;
+        visualStateScaleY = style.ScaleY ?? 1f;
+        visualStateRotation = style.Rotation ?? 0f;
+    }
+
+    private sealed class VisualStateTransitionRuntime
+    {
+        private readonly VisualSnapshot from;
+        private readonly VisualSnapshot to;
+        private readonly IAnimationInterpolator<Brush>? backgroundInterpolator;
+        private readonly IAnimationInterpolator<Brush>? foregroundInterpolator;
+        private readonly IAnimationInterpolator<Brush>? borderInterpolator;
+
+        public VisualStateTransitionRuntime(
+            ControlStyle source,
+            ControlStyle target,
+            Control control,
+            bool useCurrentTransform)
+        {
+            from = VisualSnapshot.Capture(source, control, useCurrentTransform);
+            to = VisualSnapshot.Capture(target, control, useCurrentTransform: false);
+            AnimatedStyle = new ControlStyle(target);
+            backgroundInterpolator = TryCreateBrushInterpolator(from.BackgroundBrush, to.BackgroundBrush);
+            foregroundInterpolator = TryCreateBrushInterpolator(from.ForegroundBrush, to.ForegroundBrush);
+            borderInterpolator = TryCreateBrushInterpolator(from.BorderBrush, to.BorderBrush);
+            Apply(0f, control);
+        }
+
+        public ControlStyle AnimatedStyle { get; }
+
+        public void Apply(float progress, Control control)
+        {
+            AnimatedStyle.BackgroundColor = Interpolate(from.BackgroundColor, to.BackgroundColor, progress);
+            AnimatedStyle.ForegroundColor = Interpolate(from.ForegroundColor, to.ForegroundColor, progress);
+            AnimatedStyle.Border.Color = Interpolate(from.BorderColor, to.BorderColor, progress);
+            AnimatedStyle.BackgroundBrush = InterpolateBrush(
+                from.BackgroundBrush, to.BackgroundBrush, backgroundInterpolator, progress);
+            AnimatedStyle.ForegroundBrush = InterpolateBrush(
+                from.ForegroundBrush, to.ForegroundBrush, foregroundInterpolator, progress);
+            AnimatedStyle.BorderBrush = InterpolateBrush(
+                from.BorderBrush, to.BorderBrush, borderInterpolator, progress);
+            control.visualStateOpacity = Lerp(from.Opacity, to.Opacity, progress);
+            control.visualStateTranslationX = Lerp(from.TranslationX, to.TranslationX, progress);
+            control.visualStateTranslationY = Lerp(from.TranslationY, to.TranslationY, progress);
+            control.visualStateScaleX = Lerp(from.ScaleX, to.ScaleX, progress);
+            control.visualStateScaleY = Lerp(from.ScaleY, to.ScaleY, progress);
+            control.visualStateRotation = Lerp(from.Rotation, to.Rotation, progress);
+        }
+
+        private static IAnimationInterpolator<Brush>? TryCreateBrushInterpolator(Brush? from, Brush? to)
+        {
+            if (from is null || to is null || from.GetType() != to.GetType())
+                return null;
+            return AnimationInterpolators.CreateBrushInterpolator();
+        }
+
+        private static Brush? InterpolateBrush(
+            Brush? from,
+            Brush? to,
+            IAnimationInterpolator<Brush>? interpolator,
+            float progress)
+        {
+            if (interpolator is null)
+                return to;
+            try
+            {
+                return interpolator.Interpolate(from!, to!, progress);
+            }
+            catch (InvalidOperationException)
+            {
+                return to;
+            }
+            catch (NotSupportedException)
+            {
+                return to;
+            }
+        }
+
+        private static SKColor Interpolate(SKColor from, SKColor to, float progress)
+            => new(
+                Lerp(from.Red, to.Red, progress),
+                Lerp(from.Green, to.Green, progress),
+                Lerp(from.Blue, to.Blue, progress),
+                Lerp(from.Alpha, to.Alpha, progress));
+
+        private static byte Lerp(byte from, byte to, float progress)
+            => (byte)Math.Clamp(
+                (int)MathF.Round(from + ((to - from) * progress)),
+                byte.MinValue,
+                byte.MaxValue);
+
+        private static float Lerp(float from, float to, float progress)
+            => from + ((to - from) * progress);
+    }
+
+    private readonly record struct VisualSnapshot(
+        SKColor BackgroundColor,
+        SKColor ForegroundColor,
+        SKColor BorderColor,
+        Brush? BackgroundBrush,
+        Brush? ForegroundBrush,
+        Brush? BorderBrush,
+        float Opacity,
+        float TranslationX,
+        float TranslationY,
+        float ScaleX,
+        float ScaleY,
+        float Rotation)
+    {
+        public static VisualSnapshot Capture(
+            ControlStyle style,
+            Control control,
+            bool useCurrentTransform = true)
+            => new(
+                style.GetBackgroundColor(),
+                style.GetForegroundColor(),
+                style.Border.GetColor(),
+                style.BackgroundBrush,
+                style.ForegroundBrush,
+                style.BorderBrush,
+                useCurrentTransform ? control.GetVisualOpacity() : Math.Clamp(style.Opacity ?? 1f, 0f, 1f),
+                useCurrentTransform ? control.GetVisualTranslationX() : style.TranslationX ?? 0f,
+                useCurrentTransform ? control.GetVisualTranslationY() : style.TranslationY ?? 0f,
+                useCurrentTransform ? control.GetVisualScaleX() : style.ScaleX ?? 1f,
+                useCurrentTransform ? control.GetVisualScaleY() : style.ScaleY ?? 1f,
+                useCurrentTransform ? control.GetVisualRotation() : style.Rotation ?? 0f);
+    }
+}

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -174,13 +174,16 @@ public partial class Control
             this,
             continuesActiveTransition);
         transitionStyle = runtime.AnimatedStyle;
-        EffectiveAnimationScheduler.Start(
+        EffectiveAnimationScheduler.StartFrames(
             this,
             VisualStateAnimationKey,
-            progress =>
+            frame =>
             {
-                runtime.Apply(progress, this);
-                if (progress >= 1f)
+                runtime.Apply(frame.EasedProgress, this);
+                // Easing is intentionally allowed to overshoot. Only raw timeline completion may
+                // release the transient style; otherwise an early eased value >= 1 makes the
+                // control jump to the target style while its animation is still active.
+                if (frame.Progress >= 1f)
                     transitionStyle = null;
                 Invalidate();
             },

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -18,6 +18,7 @@ public partial class Control
     private VisualState currentVisualState;
     private ControlStyle? transitionStyle;
     private bool pointerPressed;
+    private HashSet<int>? pressedPointerIds;
     private bool keyboardPressed;
     private bool hasVisualFocus;
     private float visualStateOpacity = 1f;
@@ -71,8 +72,8 @@ public partial class Control
     internal float EffectiveOpacity => Math.Clamp(Opacity * GetVisualOpacity(), 0f, 1f);
     internal float EffectiveTranslationX => TranslationX + GetVisualTranslationX();
     internal float EffectiveTranslationY => TranslationY + GetVisualTranslationY();
-    internal float EffectiveScaleX => ScaleX * GetVisualScaleX();
-    internal float EffectiveScaleY => ScaleY * GetVisualScaleY();
+    internal float EffectiveScaleX => ScaleX * GetVisualScaleX() * InteractionScale;
+    internal float EffectiveScaleY => ScaleY * GetVisualScaleY() * InteractionScale;
     internal float EffectiveRotation => Rotation + GetVisualRotation();
     internal Brush? EffectiveBackgroundBrush => BackgroundBrush ?? CurrentStyle.BackgroundBrush;
     internal Brush? EffectiveTextBrush => TextBrush ?? CurrentStyle.ForegroundBrush;
@@ -81,11 +82,25 @@ public partial class Control
     internal ControlStyle ResolveCurrentStyle()
         => transitionStyle ?? GetStyleForState(currentVisualState);
 
-    internal void SetPointerVisualPressed(bool value)
+    internal void SetPointerVisualPressed(bool value, int pointerId = 0)
     {
-        if (pointerPressed == value)
+        bool wasPressed = pointerPressed;
+        if (value)
+            (pressedPointerIds ??= []).Add(pointerId);
+        else
+            pressedPointerIds?.Remove(pointerId);
+        pointerPressed = pressedPointerIds is { Count: > 0 };
+        if (pointerPressed == wasPressed)
             return;
-        pointerPressed = value;
+        UpdateVisualState();
+    }
+
+    internal void ClearPointerVisualPressed()
+    {
+        if (!pointerPressed)
+            return;
+        pressedPointerIds?.Clear();
+        pointerPressed = false;
         UpdateVisualState();
     }
 

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -27,8 +27,24 @@ public partial class Control
     private float visualStateScaleX = 1f;
     private float visualStateScaleY = 1f;
     private float visualStateRotation;
+    private Brush? subscribedStateBackgroundBrush;
+    private Brush? subscribedStateForegroundBrush;
+    private Brush? subscribedStateBorderBrush;
 
     internal AnimationScheduler? AnimationSchedulerOverride { get; set; }
+
+    internal void CancelOwnedControlAnimations()
+    {
+        if (AnimationSchedulerOverride is { } scheduler)
+            scheduler.CancelAll(this);
+        else
+            AnimationScheduler.CancelOwnedIfInitialized(this);
+        if (transitionStyle is not null)
+        {
+            transitionStyle = null;
+            ApplyStateTransforms(GetStyleForState(currentVisualState));
+        }
+    }
 
     /// <summary>Gets the style used while pointer or keyboard activation is held.</summary>
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
@@ -75,12 +91,16 @@ public partial class Control
     internal float EffectiveScaleX => ScaleX * GetVisualScaleX() * InteractionScale;
     internal float EffectiveScaleY => ScaleY * GetVisualScaleY() * InteractionScale;
     internal float EffectiveRotation => Rotation + GetVisualRotation();
-    internal Brush? EffectiveBackgroundBrush => BackgroundBrush ?? CurrentStyle.BackgroundBrush;
-    internal Brush? EffectiveTextBrush => TextBrush ?? CurrentStyle.ForegroundBrush;
-    internal Brush? EffectiveBorderBrush => CurrentStyle.BorderBrush;
+    internal Brush? EffectiveBackgroundBrush => BackgroundBrush ?? CurrentStyle.GetResolvedBackgroundBrush();
+    internal Brush? EffectiveTextBrush => TextBrush ?? CurrentStyle.GetResolvedForegroundBrush();
+    internal Brush? EffectiveBorderBrush => CurrentStyle.GetResolvedBorderBrush();
 
     internal ControlStyle ResolveCurrentStyle()
-        => transitionStyle ?? GetStyleForState(currentVisualState);
+    {
+        ControlStyle style = transitionStyle ?? GetStyleForState(currentVisualState);
+        UpdateStateBrushInvalidationSubscriptions(style);
+        return style;
+    }
 
     internal void SetPointerVisualPressed(bool value, int pointerId = 0)
     {
@@ -95,12 +115,17 @@ public partial class Control
         UpdateVisualState();
     }
 
-    internal void ClearPointerVisualPressed()
+    internal void ClearPointerVisualPressed(int? pointerId = null)
     {
         if (!pointerPressed)
             return;
-        pressedPointerIds?.Clear();
-        pointerPressed = false;
+        if (pointerId is { } id)
+            pressedPointerIds?.Remove(id);
+        else
+            pressedPointerIds?.Clear();
+        pointerPressed = pressedPointerIds is { Count: > 0 };
+        if (pointerPressed)
+            return;
         UpdateVisualState();
     }
 
@@ -195,32 +220,32 @@ public partial class Control
     private float GetVisualOpacity()
         => transitionStyle is not null
             ? visualStateOpacity
-            : Math.Clamp(GetStyleForState(currentVisualState).Opacity ?? 1f, 0f, 1f);
+            : Math.Clamp(GetStyleForState(currentVisualState).GetResolvedOpacity() ?? 1f, 0f, 1f);
 
     private float GetVisualTranslationX()
         => transitionStyle is not null
             ? visualStateTranslationX
-            : GetStyleForState(currentVisualState).TranslationX ?? 0f;
+            : GetStyleForState(currentVisualState).GetResolvedTranslationX() ?? 0f;
 
     private float GetVisualTranslationY()
         => transitionStyle is not null
             ? visualStateTranslationY
-            : GetStyleForState(currentVisualState).TranslationY ?? 0f;
+            : GetStyleForState(currentVisualState).GetResolvedTranslationY() ?? 0f;
 
     private float GetVisualScaleX()
         => transitionStyle is not null
             ? visualStateScaleX
-            : GetStyleForState(currentVisualState).ScaleX ?? 1f;
+            : GetStyleForState(currentVisualState).GetResolvedScaleX() ?? 1f;
 
     private float GetVisualScaleY()
         => transitionStyle is not null
             ? visualStateScaleY
-            : GetStyleForState(currentVisualState).ScaleY ?? 1f;
+            : GetStyleForState(currentVisualState).GetResolvedScaleY() ?? 1f;
 
     private float GetVisualRotation()
         => transitionStyle is not null
             ? visualStateRotation
-            : GetStyleForState(currentVisualState).Rotation ?? 0f;
+            : GetStyleForState(currentVisualState).GetResolvedRotation() ?? 0f;
 
     private ControlStyle GetStyleForState(VisualState state)
         => state switch
@@ -244,12 +269,29 @@ public partial class Control
 
     private void ApplyStateTransforms(ControlStyle style)
     {
-        visualStateOpacity = Math.Clamp(style.Opacity ?? 1f, 0f, 1f);
-        visualStateTranslationX = style.TranslationX ?? 0f;
-        visualStateTranslationY = style.TranslationY ?? 0f;
-        visualStateScaleX = style.ScaleX ?? 1f;
-        visualStateScaleY = style.ScaleY ?? 1f;
-        visualStateRotation = style.Rotation ?? 0f;
+        visualStateOpacity = Math.Clamp(style.GetResolvedOpacity() ?? 1f, 0f, 1f);
+        visualStateTranslationX = style.GetResolvedTranslationX() ?? 0f;
+        visualStateTranslationY = style.GetResolvedTranslationY() ?? 0f;
+        visualStateScaleX = style.GetResolvedScaleX() ?? 1f;
+        visualStateScaleY = style.GetResolvedScaleY() ?? 1f;
+        visualStateRotation = style.GetResolvedRotation() ?? 0f;
+    }
+
+    private void UpdateStateBrushInvalidationSubscriptions(ControlStyle style)
+    {
+        // State styles are plain code-first objects rather than dependency properties. Keep the
+        // brushes selected by the last style resolution in the control's existing weak,
+        // reference-counted subscription table so an in-place Brush mutation repaints the
+        // active state without requiring another pointer or focus transition.
+        ReplaceBrushInvalidationReference(
+            ref subscribedStateBackgroundBrush,
+            style.GetResolvedBackgroundBrush());
+        ReplaceBrushInvalidationReference(
+            ref subscribedStateForegroundBrush,
+            style.GetResolvedForegroundBrush());
+        ReplaceBrushInvalidationReference(
+            ref subscribedStateBorderBrush,
+            style.GetResolvedBorderBrush());
     }
 
     private sealed class VisualStateTransitionRuntime
@@ -364,14 +406,14 @@ public partial class Control
                 style.GetBackgroundColor(),
                 style.GetForegroundColor(),
                 style.Border.GetColor(),
-                style.BackgroundBrush,
-                style.ForegroundBrush,
-                style.BorderBrush,
-                useCurrentTransform ? control.GetVisualOpacity() : Math.Clamp(style.Opacity ?? 1f, 0f, 1f),
-                useCurrentTransform ? control.GetVisualTranslationX() : style.TranslationX ?? 0f,
-                useCurrentTransform ? control.GetVisualTranslationY() : style.TranslationY ?? 0f,
-                useCurrentTransform ? control.GetVisualScaleX() : style.ScaleX ?? 1f,
-                useCurrentTransform ? control.GetVisualScaleY() : style.ScaleY ?? 1f,
-                useCurrentTransform ? control.GetVisualRotation() : style.Rotation ?? 0f);
+                style.GetResolvedBackgroundBrush(),
+                style.GetResolvedForegroundBrush(),
+                style.GetResolvedBorderBrush(),
+                useCurrentTransform ? control.GetVisualOpacity() : Math.Clamp(style.GetResolvedOpacity() ?? 1f, 0f, 1f),
+                useCurrentTransform ? control.GetVisualTranslationX() : style.GetResolvedTranslationX() ?? 0f,
+                useCurrentTransform ? control.GetVisualTranslationY() : style.GetResolvedTranslationY() ?? 0f,
+                useCurrentTransform ? control.GetVisualScaleX() : style.GetResolvedScaleX() ?? 1f,
+                useCurrentTransform ? control.GetVisualScaleY() : style.GetResolvedScaleY() ?? 1f,
+                useCurrentTransform ? control.GetVisualRotation() : style.GetResolvedRotation() ?? 0f);
     }
 }

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -92,7 +92,7 @@ namespace ModernFormsNext
             // Update the parent
             parent = value;
             if (previousParent is not null && value is null)
-                Animations.AnimationScheduler.CancelOwnedIfInitialized(this);
+                CancelOwnedControlAnimations();
             RefreshResourceBindingsForSubtree ();
             OnParentChanged (EventArgs.Empty);
 
@@ -1365,6 +1365,7 @@ namespace ModernFormsNext
             keyboardPressed = false;
             // A control can lose focus before the matching activation-key release reaches it.
             // Treat that as cancellation so keyboard-driven press effects cannot stay held.
+            ClearPointerVisualPressed();
             NotifyInteractionPointerCanceled();
             SetVisualFocus (false);
             (Events[s_lostFocusEvent] as EventHandler)?.Invoke(this, e);
@@ -2015,11 +2016,11 @@ namespace ModernFormsNext
         // (for example when Android starts scrolling, detaches a surface, or cancels a gesture).
         // Keep this internal so the existing public mouse API remains unchanged while built-in
         // controls still get one deterministic place to clear pressed/drag state.
-        internal virtual void CancelPointerInteraction ()
+        internal virtual void CancelPointerInteraction (int? pointerId = null)
         {
             Capture = false;
-            ClearPointerVisualPressed();
-            NotifyInteractionPointerCanceled ();
+            ClearPointerVisualPressed(pointerId);
+            NotifyInteractionPointerCanceled (pointerId);
             OnMouseLeave (EventArgs.Empty);
             Invalidate ();
         }
@@ -2481,7 +2482,7 @@ namespace ModernFormsNext
         {
             if (!disposedValue) {
                 DisposeInteractionEffects ();
-                Animations.AnimationScheduler.CancelOwnedIfInitialized(this);
+                CancelOwnedControlAnimations();
                 DisposeResourceReferences ();
                 DisposeBrushInvalidationSubscriptions ();
                 FreeBackBuffer ();

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -517,7 +517,7 @@ namespace ModernFormsNext
         /// <summary>
         /// Gets the current style of this control instance.
         /// </summary>
-        public virtual ControlStyle CurrentStyle => IsHovering && Enabled ? StyleHover : Style;
+        public virtual ControlStyle CurrentStyle => ResolveCurrentStyle();
 
         /// <summary>
         /// Gets or sets the mouse cursor to be shown when the mouse is over the control.
@@ -1310,6 +1310,11 @@ namespace ModernFormsNext
         /// </summary>
         protected virtual void OnEnabledChanged (EventArgs e)
         {
+            if (!Enabled) {
+                pointerPressed = false;
+                keyboardPressed = false;
+            }
+            UpdateVisualState ();
             Invalidate ();
 
             (Events[s_enabledChangedEvent] as EventHandler)?.Invoke (this, e);
@@ -1339,6 +1344,7 @@ namespace ModernFormsNext
         /// </summary>
         protected virtual void OnGotFocus (EventArgs e)
         {
+            SetVisualFocus (true);
             (Events[s_gotFocusEvent] as EventHandler)?.Invoke(this, e);
             NotifyAccessibilityClients(AccessibleEvents.Focus);
             NotifyAccessibilityClients(AccessibleEvents.StateChange);
@@ -1354,6 +1360,8 @@ namespace ModernFormsNext
         /// </summary>
         protected virtual void OnLostFocus(EventArgs e)
         {
+            keyboardPressed = false;
+            SetVisualFocus (false);
             (Events[s_lostFocusEvent] as EventHandler)?.Invoke(this, e);
             NotifyAccessibilityClients(AccessibleEvents.StateChange);
         }
@@ -1361,7 +1369,12 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the KeyDown event.
         /// </summary>
-        protected virtual void OnKeyDown (KeyEventArgs e) => (Events[s_keyDownEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
+        protected virtual void OnKeyDown (KeyEventArgs e)
+        {
+            if (e.KeyCode.In(Keys.Space, Keys.Enter))
+                SetKeyboardVisualPressed(true);
+            (Events[s_keyDownEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
+        }
 
         /// <summary>
         /// Raises the KeyPress event.
@@ -1375,7 +1388,12 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the KeyUp event.
         /// </summary>
-        protected virtual void OnKeyUp (KeyEventArgs e) => (Events[s_keyUpEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
+        protected virtual void OnKeyUp (KeyEventArgs e)
+        {
+            if (e.KeyCode.In(Keys.Space, Keys.Enter))
+                SetKeyboardVisualPressed(false);
+            (Events[s_keyUpEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
+        }
 
         /// <summary>
         /// Raises the LocationChanged event.
@@ -1394,7 +1412,12 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the MouseDown event.
         /// </summary>
-        protected virtual void OnMouseDown (MouseEventArgs e) => (Events[s_mouseDownEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
+        protected virtual void OnMouseDown (MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+                SetPointerVisualPressed(true);
+            (Events[s_mouseDownEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
+        }
 
         /// <summary>
         /// Raises the MouseEnter event.
@@ -1405,6 +1428,7 @@ namespace ModernFormsNext
 
             if (behaviors.HasFlag (ControlBehaviors.Hoverable)) {
                 IsHovering = true;
+                UpdateVisualState ();
                 Invalidate ();
             }
 
@@ -1418,6 +1442,7 @@ namespace ModernFormsNext
         {
             if (behaviors.HasFlag (ControlBehaviors.Hoverable)) {
                 IsHovering = false;
+                UpdateVisualState ();
                 Invalidate ();
             }
 
@@ -1432,7 +1457,12 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the MouseUp event.
         /// </summary>
-        protected virtual void OnMouseUp (MouseEventArgs e) => (Events[s_mouseUpEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
+        protected virtual void OnMouseUp (MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+                SetPointerVisualPressed(false);
+            (Events[s_mouseUpEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
+        }
 
         /// <summary>
         /// Raises the MouseWheel event.
@@ -1472,20 +1502,20 @@ namespace ModernFormsNext
                 //e.Canvas.DrawBitmap (buffer, control.ScaledLeft, control.ScaledTop);
 
                 var hasRenderTransform =
-                    control.Opacity < 0.999f ||
-                    Math.Abs (control.Rotation) > 0.0001f ||
-                    Math.Abs (control.ScaleX - 1f) > 0.0001f ||
-                    Math.Abs (control.ScaleY - 1f) > 0.0001f ||
-                    Math.Abs (control.TranslationX) > 0.0001f ||
-                    Math.Abs (control.TranslationY) > 0.0001f;
+                    control.EffectiveOpacity < 0.999f ||
+                    Math.Abs (control.EffectiveRotation) > 0.0001f ||
+                    Math.Abs (control.EffectiveScaleX - 1f) > 0.0001f ||
+                    Math.Abs (control.EffectiveScaleY - 1f) > 0.0001f ||
+                    Math.Abs (control.EffectiveTranslationX) > 0.0001f ||
+                    Math.Abs (control.EffectiveTranslationY) > 0.0001f;
 
                 if (!hasRenderTransform) {
                     e.Canvas.DrawBitmap (buffer, control.ScaledLeft, control.ScaledTop);
                     continue;
                 }
 
-                var drawX = control.ScaledLeft + (control.TranslationX * control.ScaleFactor.Width);
-                var drawY = control.ScaledTop + (control.TranslationY * control.ScaleFactor.Height);
+                var drawX = control.ScaledLeft + (control.EffectiveTranslationX * control.ScaleFactor.Width);
+                var drawY = control.ScaledTop + (control.EffectiveTranslationY * control.ScaleFactor.Height);
                 var drawWidth = control.ScaledWidth;
                 var drawHeight = control.ScaledHeight;
 
@@ -1494,14 +1524,14 @@ namespace ModernFormsNext
 
                 using var paint = new SKPaint {
                     IsAntialias = true,
-                    Color = new SKColor (255, 255, 255, (byte)(255f * control.Opacity))
+                    Color = new SKColor (255, 255, 255, (byte)(255f * control.EffectiveOpacity))
                 };
 
                 e.Canvas.Save ();
                 e.Canvas.Translate (drawX, drawY);
                 e.Canvas.Translate (centerX, centerY);
-                e.Canvas.RotateDegrees (control.Rotation);
-                e.Canvas.Scale (control.ScaleX, control.ScaleY);
+                e.Canvas.RotateDegrees (control.EffectiveRotation);
+                e.Canvas.Scale (control.EffectiveScaleX, control.EffectiveScaleY);
                 e.Canvas.Translate (-centerX, -centerY);
                 e.Canvas.DrawBitmap (buffer, 0, 0, paint);
                 e.Canvas.Restore ();
@@ -1523,8 +1553,8 @@ namespace ModernFormsNext
                 return;
             }
 
-            e.Canvas.DrawBackground (ScaledBounds, CurrentStyle, BackgroundBrush);
-            e.Canvas.DrawBorder (ScaledBounds, CurrentStyle);
+            e.Canvas.DrawBackground (ScaledBounds, CurrentStyle, EffectiveBackgroundBrush);
+            e.Canvas.DrawBorder (ScaledBounds, CurrentStyle, EffectiveBorderBrush);
         }
 
         /// <summary>
@@ -1636,6 +1666,7 @@ namespace ModernFormsNext
         /// </remarks>
         protected internal virtual void OnThemeChanged (EventArgs e)
         {
+            RefreshVisualStateAfterThemeChange ();
             // CurrentStyle is resolved lazily from the control's existing interaction state.
             // Repaint without changing hover, pressed, focus, enabled, or selection state.
             InvalidateThemeVisual ();
@@ -1980,6 +2011,7 @@ namespace ModernFormsNext
         internal virtual void CancelPointerInteraction ()
         {
             Capture = false;
+            SetPointerVisualPressed(false);
             OnMouseLeave (EventArgs.Empty);
             Invalidate ();
         }

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -1377,8 +1377,6 @@ namespace ModernFormsNext
         /// </summary>
         protected virtual void OnKeyDown (KeyEventArgs e)
         {
-            if (e.KeyCode.In(Keys.Space, Keys.Enter))
-                SetKeyboardVisualPressed(true);
             NotifyInteractionKeyDown (e);
             (Events[s_keyDownEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
         }
@@ -1855,8 +1853,21 @@ namespace ModernFormsNext
                 return;
             }
 
-            if (Enabled)
-                OnKeyDown (e);
+            if (Enabled) {
+                int previousNotifiedDepth = interactionKeyDownNotifiedDepth;
+                interactionKeyDownRouteDepth++;
+                try {
+                    // Route interaction state before virtual dispatch. Some established controls
+                    // consume activation keys without calling base, but their press visuals and
+                    // attached effects must still receive the matching down/up pair.
+                    NotifyInteractionKeyDown (e);
+                    OnKeyDown (e);
+                }
+                finally {
+                    interactionKeyDownNotifiedDepth = previousNotifiedDepth;
+                    interactionKeyDownRouteDepth--;
+                }
+            }
         }
 
         /// <summary>
@@ -1921,7 +1932,16 @@ namespace ModernFormsNext
                 return;
             }
 
-            OnKeyUp (e);
+            int previousNotifiedDepth = interactionKeyUpNotifiedDepth;
+            interactionKeyUpRouteDepth++;
+            try {
+                NotifyInteractionKeyUp (e);
+                OnKeyUp (e);
+            }
+            finally {
+                interactionKeyUpNotifiedDepth = previousNotifiedDepth;
+                interactionKeyUpRouteDepth--;
+            }
         }
 
         /// <summary>

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -1311,8 +1311,10 @@ namespace ModernFormsNext
         protected virtual void OnEnabledChanged (EventArgs e)
         {
             if (!Enabled) {
+                pressedPointerIds?.Clear ();
                 pointerPressed = false;
                 keyboardPressed = false;
+                NotifyInteractionEffectsDisabled ();
             }
             UpdateVisualState ();
             Invalidate ();
@@ -1361,6 +1363,9 @@ namespace ModernFormsNext
         protected virtual void OnLostFocus(EventArgs e)
         {
             keyboardPressed = false;
+            // A control can lose focus before the matching activation-key release reaches it.
+            // Treat that as cancellation so keyboard-driven press effects cannot stay held.
+            NotifyInteractionPointerCanceled();
             SetVisualFocus (false);
             (Events[s_lostFocusEvent] as EventHandler)?.Invoke(this, e);
             NotifyAccessibilityClients(AccessibleEvents.StateChange);
@@ -1373,6 +1378,7 @@ namespace ModernFormsNext
         {
             if (e.KeyCode.In(Keys.Space, Keys.Enter))
                 SetKeyboardVisualPressed(true);
+            NotifyInteractionKeyDown (e);
             (Events[s_keyDownEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
         }
 
@@ -1390,8 +1396,7 @@ namespace ModernFormsNext
         /// </summary>
         protected virtual void OnKeyUp (KeyEventArgs e)
         {
-            if (e.KeyCode.In(Keys.Space, Keys.Enter))
-                SetKeyboardVisualPressed(false);
+            NotifyInteractionKeyUp (e);
             (Events[s_keyUpEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
         }
 
@@ -1415,7 +1420,8 @@ namespace ModernFormsNext
         protected virtual void OnMouseDown (MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
-                SetPointerVisualPressed(true);
+                SetPointerVisualPressed(true, e.PointerId);
+            NotifyInteractionPointerDown (e);
             (Events[s_mouseDownEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
         }
 
@@ -1460,7 +1466,8 @@ namespace ModernFormsNext
         protected virtual void OnMouseUp (MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
-                SetPointerVisualPressed(false);
+                SetPointerVisualPressed(false, e.PointerId);
+            NotifyInteractionPointerUp (e);
             (Events[s_mouseUpEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
         }
 
@@ -2011,7 +2018,8 @@ namespace ModernFormsNext
         internal virtual void CancelPointerInteraction ()
         {
             Capture = false;
-            SetPointerVisualPressed(false);
+            ClearPointerVisualPressed();
+            NotifyInteractionPointerCanceled ();
             OnMouseLeave (EventArgs.Empty);
             Invalidate ();
         }
@@ -2034,9 +2042,18 @@ namespace ModernFormsNext
         /// </summary>
         internal void RaisePaint (PaintEventArgs e)
         {
+            RenderInteractionEffects (Animations.InteractionEffectLayer.AboveBackgroundBelowContent, e);
             OnPaint (e);
+            RenderInteractionEffects (Animations.InteractionEffectLayer.AboveContent, e);
+            RenderFocusOverlay (e);
 
             SetState (States.IsDirty, false);
+        }
+
+        // Focus adorners are intentionally composed after every interaction-effect layer.
+        // Controls with a specialized focus geometry override this hook.
+        internal virtual void RenderFocusOverlay (PaintEventArgs e)
+        {
         }
 
         /// <summary>
@@ -2374,7 +2391,17 @@ namespace ModernFormsNext
             if (control == null)
                 return e;
 
-            return new MouseEventArgs (e.Button, e.Clicks, e.Location.X - control.ScaledLeft, e.Location.Y - control.ScaledTop, e.Delta, e.Location.X, e.Location.Y, e.Modifiers);
+            return new MouseEventArgs (
+                e.Button,
+                e.Clicks,
+                e.Location.X - control.ScaledLeft,
+                e.Location.Y - control.ScaledTop,
+                e.Delta,
+                e.Location.X,
+                e.Location.Y,
+                e.Modifiers,
+                e.PointerId,
+                e.PointerKind);
         }
 
 
@@ -2453,6 +2480,7 @@ namespace ModernFormsNext
         protected override void Dispose (bool disposing)
         {
             if (!disposedValue) {
+                DisposeInteractionEffects ();
                 Animations.AnimationScheduler.CancelOwnedIfInitialized(this);
                 DisposeResourceReferences ();
                 DisposeBrushInvalidationSubscriptions ();

--- a/ModernFormsNext/ControlAdapter.cs
+++ b/ModernFormsNext/ControlAdapter.cs
@@ -72,20 +72,20 @@ namespace ModernFormsNext
                 //e.Canvas.DrawBitmap (buffer, form_x + control.ScaledLeft, form_y + control.ScaledTop);
 
                 var hasRenderTransform =
-                    control.Opacity < 0.999f ||
-                    Math.Abs (control.Rotation) > 0.0001f ||
-                    Math.Abs (control.ScaleX - 1f) > 0.0001f ||
-                    Math.Abs (control.ScaleY - 1f) > 0.0001f ||
-                    Math.Abs (control.TranslationX) > 0.0001f ||
-                    Math.Abs (control.TranslationY) > 0.0001f;
+                    control.EffectiveOpacity < 0.999f ||
+                    Math.Abs (control.EffectiveRotation) > 0.0001f ||
+                    Math.Abs (control.EffectiveScaleX - 1f) > 0.0001f ||
+                    Math.Abs (control.EffectiveScaleY - 1f) > 0.0001f ||
+                    Math.Abs (control.EffectiveTranslationX) > 0.0001f ||
+                    Math.Abs (control.EffectiveTranslationY) > 0.0001f;
 
                 if (!hasRenderTransform) {
                     e.Canvas.DrawBitmap (buffer, form_x + control.ScaledLeft, form_y + control.ScaledTop);
                     continue;
                 }
 
-                var drawX = form_x + control.ScaledLeft + (control.TranslationX * control.ScaleFactor.Width);
-                var drawY = form_y + control.ScaledTop + (control.TranslationY * control.ScaleFactor.Height);
+                var drawX = form_x + control.ScaledLeft + (control.EffectiveTranslationX * control.ScaleFactor.Width);
+                var drawY = form_y + control.ScaledTop + (control.EffectiveTranslationY * control.ScaleFactor.Height);
                 var drawWidth = control.ScaledWidth;
                 var drawHeight = control.ScaledHeight;
 
@@ -94,14 +94,14 @@ namespace ModernFormsNext
 
                 using var paint = new SKPaint {
                     IsAntialias = true,
-                    Color = new SKColor (255, 255, 255, (byte)(255f * control.Opacity))
+                    Color = new SKColor (255, 255, 255, (byte)(255f * control.EffectiveOpacity))
                 };
 
                 e.Canvas.Save ();
                 e.Canvas.Translate (drawX, drawY);
                 e.Canvas.Translate (centerX, centerY);
-                e.Canvas.RotateDegrees (control.Rotation);
-                e.Canvas.Scale (control.ScaleX, control.ScaleY);
+                e.Canvas.RotateDegrees (control.EffectiveRotation);
+                e.Canvas.Scale (control.EffectiveScaleX, control.EffectiveScaleY);
                 e.Canvas.Translate (-centerX, -centerY);
                 e.Canvas.DrawBitmap (buffer, 0, 0, paint);
                 e.Canvas.Restore ();

--- a/ModernFormsNext/ControlStyle.cs
+++ b/ModernFormsNext/ControlStyle.cs
@@ -207,6 +207,33 @@ namespace ModernFormsNext
         public SKColor GetForegroundColor ()
             => ResolveValue(TryGetForegroundColor, static () => Theme.ForegroundColor);
 
+        internal Brush? GetResolvedBackgroundBrush()
+            => ResolveReferenceValue(static style => style.BackgroundBrush);
+
+        internal Brush? GetResolvedForegroundBrush()
+            => ResolveReferenceValue(static style => style.ForegroundBrush);
+
+        internal Brush? GetResolvedBorderBrush()
+            => ResolveReferenceValue(static style => style.BorderBrush);
+
+        internal float? GetResolvedOpacity()
+            => ResolveNullableValue(static style => style.Opacity);
+
+        internal float? GetResolvedTranslationX()
+            => ResolveNullableValue(static style => style.TranslationX);
+
+        internal float? GetResolvedTranslationY()
+            => ResolveNullableValue(static style => style.TranslationY);
+
+        internal float? GetResolvedScaleX()
+            => ResolveNullableValue(static style => style.ScaleX);
+
+        internal float? GetResolvedScaleY()
+            => ResolveNullableValue(static style => style.ScaleY);
+
+        internal float? GetResolvedRotation()
+            => ResolveNullableValue(static style => style.Rotation);
+
         internal int GetInheritanceTraversalLimit ()
             => StyleInheritanceTraversal.GetLimit(this, static style => style.ParentStyle);
 
@@ -242,6 +269,34 @@ namespace ModernFormsNext
             }
 
             return getFallback ();
+        }
+
+        private T? ResolveReferenceValue<T>(Func<ControlStyle, T?> getValue)
+            where T : class
+        {
+            var remaining = GetInheritanceTraversalLimit();
+            ControlStyle? current = this;
+            while (current is not null && remaining-- > 0)
+            {
+                if (getValue(current) is { } value)
+                    return value;
+                current = current.ParentStyle;
+            }
+            return null;
+        }
+
+        private T? ResolveNullableValue<T>(Func<ControlStyle, T?> getValue)
+            where T : struct
+        {
+            var remaining = GetInheritanceTraversalLimit();
+            ControlStyle? current = this;
+            while (current is not null && remaining-- > 0)
+            {
+                if (getValue(current) is { } value)
+                    return value;
+                current = current.ParentStyle;
+            }
+            return null;
         }
 
         private static bool TryGetBackgroundColor (ControlStyle style, out SKColor value)

--- a/ModernFormsNext/ControlStyle.cs
+++ b/ModernFormsNext/ControlStyle.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ModernFormsNext.Drawing;
 using SkiaSharp;
 
 namespace ModernFormsNext
@@ -48,6 +49,13 @@ namespace ModernFormsNext
         /// </summary>
         public SKColor? BackgroundColor { get; set; }
 
+        /// <summary>Gets or sets the optional state-specific background brush.</summary>
+        /// <remarks>
+        /// The control-level <see cref="Control.BackgroundBrush"/> takes precedence. Compatible
+        /// built-in brushes are interpolated by visual-state transitions.
+        /// </remarks>
+        public Brush? BackgroundBrush { get; set; }
+
         /// <summary>
         /// Provides access to border style properties.
         /// </summary>
@@ -81,6 +89,30 @@ namespace ModernFormsNext
         /// Gets or sets the foreground color.
         /// </summary>
         public SKColor? ForegroundColor { get; set; }
+
+        /// <summary>Gets or sets the optional state-specific text brush.</summary>
+        public Brush? ForegroundBrush { get; set; }
+
+        /// <summary>Gets or sets the optional state-specific border brush.</summary>
+        public Brush? BorderBrush { get; set; }
+
+        /// <summary>Gets or sets the state opacity multiplier, or null for 1.</summary>
+        public float? Opacity { get; set; }
+
+        /// <summary>Gets or sets the state horizontal translation added at render time.</summary>
+        public float? TranslationX { get; set; }
+
+        /// <summary>Gets or sets the state vertical translation added at render time.</summary>
+        public float? TranslationY { get; set; }
+
+        /// <summary>Gets or sets the state horizontal scale multiplier, or null for 1.</summary>
+        public float? ScaleX { get; set; }
+
+        /// <summary>Gets or sets the state vertical scale multiplier, or null for 1.</summary>
+        public float? ScaleY { get; set; }
+
+        /// <summary>Gets or sets the state rotation added in degrees at render time.</summary>
+        public float? Rotation { get; set; }
 
         /// <summary>
         /// Gets the style from which unset values are inherited.

--- a/ModernFormsNext/Extensions/SkiaExtensions.cs
+++ b/ModernFormsNext/Extensions/SkiaExtensions.cs
@@ -264,8 +264,17 @@ namespace ModernFormsNext
         /// <summary>
         /// Draws a control's border.
         /// </summary>
-        public static void DrawBorder (this SKCanvas canvas, Rectangle bounds, ControlStyle style)
+        public static void DrawBorder (
+            this SKCanvas canvas,
+            Rectangle bounds,
+            ControlStyle style,
+            Drawing.Brush? brush = null)
         {
+            if (brush is not null) {
+                DrawBrushBorder (canvas, bounds, style, brush);
+                return;
+            }
+
             // If using border radius, currently all border sides are drawn, and all are the same color
             var radius = style.Border.GetRadius ();
 
@@ -297,6 +306,78 @@ namespace ModernFormsNext
                 var bottom_offset = style.Border.Bottom.GetWidth () / 2f;
                 canvas.DrawLine (0, bounds.Height - bottom_offset, bounds.Width, bounds.Height - bottom_offset, style.Border.Bottom.GetColor (), style.Border.Bottom.GetWidth ());
             }
+        }
+
+        private static void DrawBrushBorder (
+            SKCanvas canvas,
+            Rectangle bounds,
+            ControlStyle style,
+            Drawing.Brush brush)
+        {
+            if (brush is NoBrush || brush.Opacity <= 0f)
+                return;
+
+            var paint = new SKPaint {
+                IsAntialias = true,
+                IsStroke = true,
+                Color = style.Border.GetColor ()
+            };
+            SKShader? shader = null;
+            try {
+                if (brush is SolidColorBrush solid)
+                    paint.Color = SkiaBrushFactory.ApplyOpacity (solid.Color, solid.Opacity);
+                else if (brush is GradientBrush gradient) {
+                    shader = SkiaBrushFactory.CreateGradientShader (
+                        gradient,
+                        new SKRect (0, 0, bounds.Width, bounds.Height));
+                    paint.Shader = shader;
+                }
+
+                var radius = style.Border.GetRadius ();
+                if (radius > 0) {
+                    paint.StrokeWidth = style.Border.GetWidth ();
+                    canvas.DrawRoundRect (
+                        new SKRect (
+                            paint.StrokeWidth / 2f,
+                            paint.StrokeWidth / 2f,
+                            bounds.Width - (paint.StrokeWidth / 2f),
+                            bounds.Height - (paint.StrokeWidth / 2f)),
+                        radius,
+                        radius,
+                        paint);
+                    return;
+                }
+
+                DrawBrushBorderSide (canvas, paint, style.Border.Left.GetWidth (),
+                    static (target, offset, _, height, value) => target.DrawLine (offset, 0, offset, height, value),
+                    bounds.Width, bounds.Height);
+                DrawBrushBorderSide (canvas, paint, style.Border.Right.GetWidth (),
+                    static (target, offset, width, height, value) => target.DrawLine (width - offset, 0, width - offset, height, value),
+                    bounds.Width, bounds.Height);
+                DrawBrushBorderSide (canvas, paint, style.Border.Top.GetWidth (),
+                    static (target, offset, width, _, value) => target.DrawLine (0, offset, width, offset, value),
+                    bounds.Width, bounds.Height);
+                DrawBrushBorderSide (canvas, paint, style.Border.Bottom.GetWidth (),
+                    static (target, offset, width, height, value) => target.DrawLine (0, height - offset, width, height - offset, value),
+                    bounds.Width, bounds.Height);
+            } finally {
+                shader?.Dispose ();
+                paint.Dispose ();
+            }
+        }
+
+        private static void DrawBrushBorderSide (
+            SKCanvas canvas,
+            SKPaint paint,
+            int width,
+            Action<SKCanvas, float, float, float, SKPaint> draw,
+            float boundsWidth,
+            float boundsHeight)
+        {
+            if (width <= 0)
+                return;
+            paint.StrokeWidth = width;
+            draw (canvas, width / 2f, boundsWidth, boundsHeight, paint);
         }
 
         /// <summary>

--- a/ModernFormsNext/Extensions/SkiaExtensions.cs
+++ b/ModernFormsNext/Extensions/SkiaExtensions.cs
@@ -264,11 +264,21 @@ namespace ModernFormsNext
         /// <summary>
         /// Draws a control's border.
         /// </summary>
+        public static void DrawBorder (this SKCanvas canvas, Rectangle bounds, ControlStyle style)
+            => DrawBorder (canvas, bounds, style, null);
+
+        /// <summary>
+        /// Draws a control's border using the supplied brush when one is available.
+        /// </summary>
+        /// <param name="canvas">The canvas on which the border is drawn.</param>
+        /// <param name="bounds">The control bounds in device pixels.</param>
+        /// <param name="style">The resolved control style that supplies border geometry.</param>
+        /// <param name="brush">The effective border brush, or <see langword="null"/> to use the colors stored in <paramref name="style"/>.</param>
         public static void DrawBorder (
             this SKCanvas canvas,
             Rectangle bounds,
             ControlStyle style,
-            Drawing.Brush? brush = null)
+            Drawing.Brush? brush)
         {
             if (brush is not null) {
                 DrawBrushBorder (canvas, bounds, style, brush);

--- a/ModernFormsNext/Extensions/SkiaTextExtensions.cs
+++ b/ModernFormsNext/Extensions/SkiaTextExtensions.cs
@@ -29,7 +29,7 @@ namespace ModernFormsNext
                 maxLines,
                 ellipsis,
                 control.CurrentStyle.GetFontStyle (),
-                control.Enabled ? control.TextBrush : null);
+                control.Enabled ? control.EffectiveTextBrush : null);
 
         /// <summary>
         /// Draws a string of text.
@@ -111,6 +111,6 @@ namespace ModernFormsNext
                 maxLines: 1,
                 ellipsis: ellipsis,
                 fontStyle: control.CurrentStyle.GetFontStyle (),
-                brush: control.Enabled ? control.TextBrush : null);
+                brush: control.Enabled ? control.EffectiveTextBrush : null);
     }
 }

--- a/ModernFormsNext/MouseEventArgs.cs
+++ b/ModernFormsNext/MouseEventArgs.cs
@@ -26,9 +26,46 @@ namespace ModernFormsNext
             Point delta,
             int? screenX = null,
             int? screenY = null,
-            Keys keyData = Keys.None,
-            int pointerId = 0,
-            PointerDeviceKind pointerKind = PointerDeviceKind.Mouse)
+            Keys keyData = Keys.None)
+            : this (
+                button,
+                clicks,
+                x,
+                y,
+                delta,
+                screenX,
+                screenY,
+                keyData,
+                0,
+                PointerDeviceKind.Mouse)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MouseEventArgs"/> class for a specific
+        /// pointer sequence.
+        /// </summary>
+        /// <param name="button">The mouse button associated with the event.</param>
+        /// <param name="clicks">The number of button presses and releases.</param>
+        /// <param name="x">The pointer x-coordinate relative to the receiving control.</param>
+        /// <param name="y">The pointer y-coordinate relative to the receiving control.</param>
+        /// <param name="delta">The signed wheel delta.</param>
+        /// <param name="screenX">The pointer x-coordinate in screen coordinates, or <see langword="null"/> to use <paramref name="x"/>.</param>
+        /// <param name="screenY">The pointer y-coordinate in screen coordinates, or <see langword="null"/> to use <paramref name="y"/>.</param>
+        /// <param name="keyData">The keyboard modifiers active for the event.</param>
+        /// <param name="pointerId">The platform-stable pointer identifier.</param>
+        /// <param name="pointerKind">The physical pointer source.</param>
+        public MouseEventArgs (
+            MouseButtons button,
+            int clicks,
+            int x,
+            int y,
+            Point delta,
+            int? screenX,
+            int? screenY,
+            Keys keyData,
+            int pointerId,
+            PointerDeviceKind pointerKind)
         {
             Button = button;
             Clicks = clicks;

--- a/ModernFormsNext/MouseEventArgs.cs
+++ b/ModernFormsNext/MouseEventArgs.cs
@@ -18,7 +18,17 @@ namespace ModernFormsNext
         /// <summary>
         ///  Initializes a new instance of the <see cref='MouseEventArgs'/> class.
         /// </summary>
-        public MouseEventArgs (MouseButtons button, int clicks, int x, int y, Point delta, int? screenX = null, int? screenY = null, Keys keyData = Keys.None)
+        public MouseEventArgs (
+            MouseButtons button,
+            int clicks,
+            int x,
+            int y,
+            Point delta,
+            int? screenX = null,
+            int? screenY = null,
+            Keys keyData = Keys.None,
+            int pointerId = 0,
+            PointerDeviceKind pointerKind = PointerDeviceKind.Mouse)
         {
             Button = button;
             Clicks = clicks;
@@ -27,6 +37,8 @@ namespace ModernFormsNext
             Y = y;
             ScreenLocation = new Point (screenX ?? x, screenY ?? y);
             key_data = keyData;
+            PointerId = pointerId;
+            PointerKind = pointerKind;
         }
 
         /// <summary>
@@ -63,6 +75,13 @@ namespace ModernFormsNext
         /// Get the mouse location in screen coordinates.
         /// </summary>
         public Point ScreenLocation { get; }
+
+        /// <summary>Gets the platform-stable identifier for this pointer sequence.</summary>
+        /// <remarks>Desktop mouse events use zero. Touch hosts preserve the platform pointer ID.</remarks>
+        public int PointerId { get; }
+
+        /// <summary>Gets the physical pointer source when the host can identify it.</summary>
+        public PointerDeviceKind PointerKind { get; }
 
         /// <summary>
         /// Gets whether the Alt modifier key was also pressed.

--- a/ModernFormsNext/PointerDeviceKind.cs
+++ b/ModernFormsNext/PointerDeviceKind.cs
@@ -1,0 +1,17 @@
+namespace ModernFormsNext;
+
+/// <summary>Identifies the pointer source associated with a framework mouse-compatible event.</summary>
+public enum PointerDeviceKind
+{
+    /// <summary>The event came from a mouse or mouse-compatible desktop device.</summary>
+    Mouse,
+
+    /// <summary>The event came from a direct touch contact.</summary>
+    Touch,
+
+    /// <summary>The event came from a pen or stylus.</summary>
+    Pen,
+
+    /// <summary>The platform did not report a specific pointer kind.</summary>
+    Unknown
+}

--- a/ModernFormsNext/Renderers/ButtonRenderer.cs
+++ b/ModernFormsNext/Renderers/ButtonRenderer.cs
@@ -20,10 +20,6 @@ namespace ModernFormsNext.Renderers
             if ((control as IHaveTextAndImageAlign).GetImage () is SKBitmap image)
                 e.Canvas.DrawBitmap (image, layout.ImageBounds, !control.Enabled);
 
-            // Draw the focus rectangle
-            if (control.Selected && control.ShowFocusCues)
-                e.Canvas.DrawFocusRectangle (layout.Focus, 0);
-
             // Draw the text
             if (control.Text.HasValue ())
                 e.Canvas.DrawText (control.Text, layout.TextBounds, control, control.TextAlign, maxLines: 1, ellipsis: control.AutoEllipsis);

--- a/ModernFormsNext/ScrollBar.cs
+++ b/ModernFormsNext/ScrollBar.cs
@@ -215,10 +215,10 @@ namespace ModernFormsNext
             thumb_pressed = false;
         }
 
-        internal override void CancelPointerInteraction ()
+        internal override void CancelPointerInteraction (int? pointerId = null)
         {
             thumb_pressed = false;
-            base.CancelPointerInteraction ();
+            base.CancelPointerInteraction (pointerId);
         }
 
         /// <inheritdoc/>

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -172,7 +172,7 @@ public sealed class SkiaControlSurface : IDisposable
 
                 if (target is not null)
                 {
-                    target.RaiseMouseDown(CreateMouseArgs(target, location, MouseButtons.Left, 0));
+                    target.RaiseMouseDown(CreateMouseArgs(target, location, MouseButtons.Left, 0, pointerId));
                     downState.CapturedControl = target;
                 }
 
@@ -208,7 +208,7 @@ public sealed class SkiaControlSurface : IDisposable
                     moveState.GestureOwner = moveState.ScrollCandidate;
                 else if (moveState.GestureOwner is null && moveState.CapturedControl is not null)
                     moveState.CapturedControl.RaiseMouseMove(
-                        CreateMouseArgs(moveState.CapturedControl, location, MouseButtons.Left, 0));
+                        CreateMouseArgs(moveState.CapturedControl, location, MouseButtons.Left, 0, pointerId));
 
                 moveState.LastLocation = location;
                 break;
@@ -225,7 +225,7 @@ public sealed class SkiaControlSurface : IDisposable
                 else if (upState.CapturedControl is not null)
                 {
                     var releasedOnCapture = hit is not null && ReferenceEquals(hit.Value.Control, upState.CapturedControl);
-                    var upArgs = CreateMouseArgs(upState.CapturedControl, location, MouseButtons.Left, 1);
+                    var upArgs = CreateMouseArgs(upState.CapturedControl, location, MouseButtons.Left, 1, pointerId);
                     if (upState.ClickEligible && releasedOnCapture)
                     {
                         upState.CapturedControl.RaiseClick(upArgs);
@@ -599,7 +599,8 @@ public sealed class SkiaControlSurface : IDisposable
         Control target,
         Point surfaceLocation,
         MouseButtons button,
-        int clicks)
+        int clicks,
+        int pointerId)
     {
         var local = SurfaceToControl(target, surfaceLocation);
         return new MouseEventArgs(
@@ -609,7 +610,9 @@ public sealed class SkiaControlSurface : IDisposable
             local.Y,
             Point.Empty,
             surfaceLocation.X,
-            surfaceLocation.Y);
+            surfaceLocation.Y,
+            pointerId: pointerId,
+            pointerKind: PointerDeviceKind.Touch);
     }
 
     private static Point SurfaceToControl(Control target, Point surfaceLocation)

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -611,8 +611,9 @@ public sealed class SkiaControlSurface : IDisposable
             Point.Empty,
             surfaceLocation.X,
             surfaceLocation.Y,
-            pointerId: pointerId,
-            pointerKind: PointerDeviceKind.Touch);
+            Keys.None,
+            pointerId,
+            PointerDeviceKind.Touch);
     }
 
     private static Point SurfaceToControl(Control target, Point surfaceLocation)

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -195,7 +195,7 @@ public sealed class SkiaControlSurface : IDisposable
                     moveState.ClickEligible = false;
                     if (moveState.ScrollCandidate is not null)
                     {
-                        moveState.CapturedControl?.CancelPointerInteraction();
+                        moveState.CapturedControl?.CancelPointerInteraction(pointerId);
                         moveState.CapturedControl = null;
                         moveState.GestureOwner = moveState.ScrollCandidate;
                         moveState.GestureOwner.Capture = true;
@@ -220,7 +220,7 @@ public sealed class SkiaControlSurface : IDisposable
 
                 if (upState.GestureOwner is not null)
                 {
-                    upState.GestureOwner.CancelPointerInteraction();
+                    upState.GestureOwner.CancelPointerInteraction(pointerId);
                 }
                 else if (upState.CapturedControl is not null)
                 {
@@ -550,9 +550,9 @@ public sealed class SkiaControlSurface : IDisposable
 
     private static void CancelPointer(PointerState pointer)
     {
-        pointer.CapturedControl?.CancelPointerInteraction();
+        pointer.CapturedControl?.CancelPointerInteraction(pointer.PointerId);
         if (!ReferenceEquals(pointer.GestureOwner, pointer.CapturedControl))
-            pointer.GestureOwner?.CancelPointerInteraction();
+            pointer.GestureOwner?.CancelPointerInteraction(pointer.PointerId);
     }
 
     private void UnobserveTree(Control control)

--- a/ModernFormsNext/Switch.cs
+++ b/ModernFormsNext/Switch.cs
@@ -1203,7 +1203,7 @@ namespace ModernFormsNext
             Invalidate();
         }
 
-        internal override void CancelPointerInteraction()
+        internal override void CancelPointerInteraction(int? pointerId = null)
         {
             var wasPressed = thumbPressed || dragging;
             thumbPressed = false;
@@ -1215,7 +1215,7 @@ namespace ModernFormsNext
                 NotifyAccessibilityClients(AccessibleEvents.StateChange);
             }
 
-            base.CancelPointerInteraction();
+            base.CancelPointerInteraction(pointerId);
         }
 
         /// <inheritdoc/>

--- a/ModernFormsNext/TextBox.cs
+++ b/ModernFormsNext/TextBox.cs
@@ -392,10 +392,10 @@ namespace ModernFormsNext
             Invalidate ();
         }
 
-        internal override void CancelPointerInteraction ()
+        internal override void CancelPointerInteraction (int? pointerId = null)
         {
             is_highlighting = false;
-            base.CancelPointerInteraction ();
+            base.CancelPointerInteraction (pointerId);
         }
 
         /// <inheritdoc/>

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ declared as a publishable NuGet package.
 - [Dynamic resources](docs/dynamic-resources.md)
 - [Themes](docs/themes.md) and [theme JSON schema](docs/theme-json-schema.md)
 - [Paint and gradients](docs/paint-and-gradients.md)
-- [UI animations](docs/animations.md)
+- [UI animations and interaction effects](docs/animations.md)
 - [Markdown viewing](docs/markdown.md) and [Markdown editing](docs/markdown-editor.md)
 - [Data binding](docs/data-binding.md)
 - [Styling](docs/styling.md)

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -40,6 +40,168 @@ await card.ScaleToAsync(1.08f, duration: 160);
 await card.RotateToAsync(6f, duration: 160);
 ```
 
+The composable equivalents return an `AnimationDefinition` rather than starting immediately:
+
+```csharp
+AnimationDefinition fade = card.FadeTo(
+    0.5f,
+    new AnimationOptions
+    {
+        Duration = TimeSpan.FromMilliseconds(180),
+        Easing = Easings.CubicOut
+    });
+
+AnimationRun run = fade.Start();
+AnimationState terminalState = await run.Completion;
+```
+
+Existing `FadeToAsync`, `TranslateToAsync`, `ScaleToAsync`, and `RotateToAsync` calls remain
+source-compatible. Migrate only when a caller needs composition, repeat, cancellation of a whole
+group, or reuse of a definition.
+
+## Typed control animations
+
+`Control.AnimateAsync<T>` is the compact public entry point for a typed value:
+
+```csharp
+await card.AnimateAsync(
+    key: "fade",
+    from: 0f,
+    to: 1f,
+    interpolator: AnimationInterpolators.Float,
+    options: new AnimationOptions
+    {
+        Duration = TimeSpan.FromMilliseconds(300),
+        Easing = Easings.CubicOut
+    },
+    update: value => card.Opacity = value);
+```
+
+Use `PropertyAnimation<T>` when the same operation must participate in a group or timeline. The
+property setter decides whether a frame is visual-only or layout-affecting; the animation layer
+does not force layout.
+
+## Custom animation definitions
+
+Derive from `AnimationDefinition` for an operation that is more expressive than interpolation
+between two values:
+
+```csharp
+public sealed class ShakeAnimation : AnimationDefinition
+{
+    public float Distance { get; set; } = 8f;
+    public int Oscillations { get; set; } = 4;
+
+    protected override void Update(AnimationContext context, float progress)
+    {
+        context.Target.TranslationX =
+            MathF.Sin(progress * MathF.PI * 2f * Oscillations)
+            * Distance
+            * (1f - progress);
+    }
+}
+
+AnimationRun run = new ShakeAnimation
+{
+    Duration = TimeSpan.FromMilliseconds(500),
+    Easing = Easings.CubicOut
+}.Start(card);
+```
+
+`AnimationContext` exposes `Target`, direction-aware raw `Progress`, `EasedProgress`, monotonic
+`Elapsed`, scaled `Duration`, and the run `CancellationToken`. The scheduler invokes `Update` on
+the UI dispatcher and never under its internal lock. The context releases its target before
+terminal completion becomes observable.
+
+## Sequence, parallel, delay, and timeline
+
+Definitions compose without `Task.Delay`, per-group timers, or a blocking UI wait:
+
+```csharp
+await Animation.Sequence(
+    card.FadeTo(0.4f),
+    Animation.Delay(TimeSpan.FromMilliseconds(80)),
+    card.ScaleTo(1.12f),
+    Animation.Parallel(
+        card.FadeTo(1f),
+        card.ScaleTo(1f),
+        card.TranslateTo(0f, 0f))
+).RunAsync();
+```
+
+Sequence stops at the first cancellation or failure. Parallel starts every child, waits for all
+children, and reports failures in declaration order through `AggregateException`. Canceling the
+returned `AnimationRun` propagates to every active descendant.
+
+Timeline entries use scheduler-backed monotonic delays:
+
+```csharp
+var timeline = new AnimationTimeline()
+    .At(TimeSpan.Zero, card.FadeTo(0.5f))
+    .At(TimeSpan.FromMilliseconds(100), card.ScaleTo(1.1f))
+    .At(TimeSpan.FromMilliseconds(250), card.ScaleTo(1f));
+
+await timeline.RunAsync();
+```
+
+An entry starts at most once per timeline leg. Application background time is excluded by the same
+lifecycle pause used for every other scheduler entry.
+
+## Keyframes and deterministic seeking
+
+```csharp
+var keyframes = KeyframeAnimation<float>
+    .Create(
+        card,
+        value =>
+        {
+            card.ScaleX = value;
+            card.ScaleY = value;
+        })
+    .Keyframe(0f, 1f)
+    .Keyframe(0.4f, 1.15f, Easings.CubicOut)
+    .Keyframe(1f, 1f, Easings.BounceOut);
+
+keyframes.Duration = TimeSpan.FromMilliseconds(600);
+await keyframes.RunAsync();
+```
+
+Positions must be finite, nondecreasing values from 0 through 1. The default duplicate-position
+policy is `Reject`; `ReplacePrevious` and `KeepBoth` are explicit alternatives. Segment easing is
+stored on the segment's ending keyframe. Endpoints are exact and a zero-length duplicate segment
+selects the last value at that exact position. A definition is limited to
+`KeyframeAnimation<T>.MaximumKeyframeCount` frames.
+
+`Sample(progress)` computes a value without scheduling. `Seek(progress)` computes and applies the
+same value synchronously, which is useful for deterministic previews and scrubbing. Supply an
+`IAnimationInterpolator<T>` to `Create` for custom value types.
+
+## Repeat and auto-reverse
+
+```csharp
+AnimationDefinition pulse = card.ScaleTo(1.08f)
+    .Repeat(3)
+    .AutoReverse();
+
+await pulse.RunAsync();
+```
+
+`Repeat(count)` requires a positive forward-iteration count. Auto-reverse adds a reverse leg to
+each iteration. `RepeatForever()` must be canceled through its `AnimationRun`, an external token,
+or owner lifetime cleanup:
+
+```csharp
+using var cancellation = new CancellationTokenSource();
+AnimationRun run = card.RotateTo(360f).RepeatForever().Start(
+    cancellationToken: cancellation.Token);
+
+cancellation.Cancel();
+await run.Completion;
+```
+
+Only the current iteration retains scheduler handles. Under reduced motion or disabled animations,
+an infinite repeat applies one deterministic sample and completes instead of spinning.
+
 ## Typed values and interpolation
 
 Use `AnimationScheduler.Animate<T>` when an animation has explicit start and target values:
@@ -78,6 +240,10 @@ The built-in backend-independent functions are:
 - `Easings.EaseInOut`
 - `Easings.EaseOutCubic`
 - `Easings.EaseInOutCubic`
+- `Easings.CubicIn`
+- `Easings.CubicOut`
+- `Easings.CubicInOut`
+- `Easings.BounceOut`
 
 A custom easing receives raw progress between 0 and 1. Returning `NaN` or infinity, or throwing an
 exception, faults only that animation. A finite value outside 0 through 1 is preserved for
@@ -121,6 +287,11 @@ AnimationScheduler.Default.Start(
 
 Use `AnimationScheduler.Default.Cancel(owner, key)`, `CancelAll(owner)`, or
 `control.CancelAnimations()` for owner-scoped cleanup.
+
+Composed children receive run-local key prefixes. Nested groups therefore do not replace another
+group or unrelated target work even if their leaf definitions use the same property key.
+`AnimationRun.Dispose()` is equivalent to canceling that run only. A stale leaf handle cannot
+remove a newer replacement because scheduler removal checks entry identity.
 
 ## Brush and gradient animation
 
@@ -186,6 +357,118 @@ The animation remains attached to the old object; it is not transferred to the n
 Retain its handle or cancel by its owner/key when a newer theme transition supersedes it. This rule
 prevents one transition from silently mutating a structurally unrelated replacement.
 
+## Visual-state transitions
+
+Controls resolve one of `Normal`, `Hover`, `Pressed`, `Focused`, or `Disabled` with this priority:
+
+```text
+Disabled > Pressed > Hover > Focused > Normal
+```
+
+Add directional transitions without creating another hover or focus state machine:
+
+```csharp
+button.StyleHover.BackgroundColor = SKColors.MediumPurple;
+button.StyleHover.ScaleX = 1.04f;
+button.StyleHover.ScaleY = 1.04f;
+
+button.StyleTransitions.Add(
+    VisualState.Normal,
+    VisualState.Hover,
+    new VisualStateTransition
+    {
+        Duration = TimeSpan.FromMilliseconds(150),
+        Easing = Easings.CubicOut
+    });
+```
+
+`StylePressed`, `StyleFocused`, and `StyleDisabled` complement the existing `Style` and
+`StyleHover`. Compatible foreground, background, and border brushes, plus opacity, translation,
+scale, and rotation, interpolate. Layout metrics such as border width switch immediately and do
+not request layout per frame.
+
+Rapid state changes replace the old transition from its current presentation; the latest state is
+authoritative. Theme and dynamic-resource changes cancel the stale transition, re-resolve the
+currently active state, and use the existing resource and Brush change notifications. Reduced
+motion applies the resolved target presentation immediately.
+
+## Interaction effects
+
+Effects are reusable objects attached through one control-owned collection:
+
+```csharp
+button.InteractionEffects.Add(new RippleEffect());
+button.InteractionEffects.Add(new PressScaleEffect());
+```
+
+An effect has one target at a time, receives shared pointer/keyboard and render hooks, owns its
+scheduler channels, and cancels them on removal or disposal. Adding the same instance to the same
+collection is idempotent; attaching it to a different control while still attached throws.
+`InteractionEffects` is hidden from ordinary Designer serialization. Convenience properties
+support the common cases:
+
+```csharp
+button.Ripple = new RippleEffect
+{
+    Color = Color.FromArgb(90, 255, 255, 255),
+    Duration = TimeSpan.FromMilliseconds(450),
+    StartFromPointer = true,
+    RadiusMode = RippleRadiusMode.CoverControl,
+    Layer = RippleLayer.AboveBackgroundBelowContent,
+    MaxConcurrentRipples = 4,
+    EvictionPolicy = RippleEvictionPolicy.Oldest
+};
+
+button.PressEffect = new PressScaleEffect
+{
+    PressedScale = 0.97f,
+    PressDuration = TimeSpan.FromMilliseconds(80),
+    ReleaseDuration = TimeSpan.FromMilliseconds(120)
+};
+```
+
+### Ripple
+
+Pointer and touch activation starts at the contact location unless `StartFromPointer` is false.
+Space or Enter starts from the center. `CoverControl` computes the farthest current corner on each
+render, so a resize in flight remains covered; `Fixed` uses `FixedRadius`. Alpha fades linearly
+while radius uses the configured easing.
+
+Waves are clipped to control bounds and the current corner radius. `AboveBackgroundBelowContent`
+keeps content legible; `AboveContent` is available for stronger feedback. Active waves are bounded
+from 1 through 32 and `Oldest` explicitly cancels the oldest wave when the limit is reached.
+Disabled controls do not start waves. Cancel, removal, disable, detach, and disposal clear all
+effect-owned work. Decorative ripple is omitted under reduced motion.
+
+### Press, hover, and focus
+
+`PressScaleEffect` tracks independent pointer IDs plus keyboard activation. Its multiplier composes
+with public control transforms and visual-state transforms rather than overwriting `ScaleX` or
+`ScaleY`. Pointer cancel, leave, lost focus, disable, removal, and disposal restore the neutral
+scale, preventing a stuck press. Reduced motion applies the held/released endpoint without
+periodic ticks.
+
+Hover and focus effects use visual-state transitions. There is no parallel hover/focus
+subscription or scheduler.
+
+### Render order and custom clipping
+
+The shared control-buffer path is:
+
+```text
+background and border
+effects below content
+content
+effects above content
+focus ring
+```
+
+Ripple is not implemented by individual renderers. `IInteractionEffectClip` can provide a custom
+Skia clip for future shape/geometry controls. The built-in
+`ControlBoundsInteractionEffectClip.Instance` clips to scaled bounds and the resolved border
+radius. `InteractionEffectRenderContext` borrows the target-local canvas for the current render
+call; effects must never retain it.
+
 ## Lifecycle and thread safety
 
 `Start`, cancellation, pause/resume, state reads, diagnostics, and shutdown are thread-safe.
@@ -235,20 +518,50 @@ animations continue.
 
 Animations started for an `IComponent` whose `Site.DesignMode` is true apply their final value on
 the designer dispatcher without starting periodic ticks. Runtime animation state is not serialized
-into `.Designer.cs` or `.mfdesign` files.
+into `.Designer.cs` or `.mfdesign` files. Ripple does not start in the Designer. Press preview
+applies deterministic endpoints, and complex transition/effect collections stay hidden from the
+ordinary property grid.
+
+## Windows and experimental Android
+
+Windows is the primary supported runtime. Mouse, keyboard activation, focus, capture cancellation,
+resize, minimize/restore, high DPI, multiple windows, and repaint batching use the common control
+and scheduler paths.
+
+Android remains experimental. `SkiaControlSurface` forwards touch down/up/cancel, pointer IDs, and
+multi-touch sequences to the same control/effect pipeline. Lifecycle background/foreground pauses
+monotonic scheduler time. Orientation and resize use current control geometry. Native
+reduced-motion discovery and device-specific frame pacing are not yet validated; do not infer
+runtime parity from a successful Android build.
+
+## Performance and repaint batching
+
+The scheduler opens one application visual-invalidation batch per tick. Parallel property updates,
+state transitions, and ripple frames in one window coalesce to one platform repaint request for
+that tick. Transform, Brush, and effect frames are visual-only; no layout is requested unless a
+user-supplied update changes a layout-affecting property.
+
+There are no per-effect timers, hidden background loops, or per-ripple threads. Keyframe and ripple
+counts are bounded, effect rendering is linear in active effects and waves, and terminal scheduler
+entries release owner/update references before completion is observed. The shared tick source
+stops when no runnable work remains.
 
 ## Current limitations
 
-- Repeat, auto-reverse, queueing, blending, and animation groups are not part of this first API.
-- The shared tick source currently uses timer pacing; a stable native render-loop signal may replace
-  that internal source later without changing elapsed-time semantics.
 - There is no automatic native reduced-motion preference adapter yet.
 - There is no general animated-layout subsystem. Updating bounds or spacing uses the existing
   setters and can be more expensive than render-only transforms.
 - Brush interpolation requires matching built-in concrete types and equal gradient stop counts.
-- Android is experimental; physical-device frame pacing, lifecycle transitions, and rendering still
-  require manual validation.
+- Visual-state layout metrics switch discretely rather than interpolate.
+- Ripple has one bounded eviction policy, `Oldest`; additional policies can be added without
+  changing effect attachment or rendering APIs.
+- Complex effect collections are code-first and do not yet have a dedicated Designer collection
+  editor.
+- Android is experimental; physical-device frame pacing, multi-touch rendering,
+  background/foreground, and orientation changes still require manual validation.
 
 See [the scheduler architecture](architecture/ui-animation-scheduler.md), the
-[architecture decision](architecture/decisions/ADR-UI-Animation-Scheduler.md), and the Animations
-page in `samples/ControlGallery` for implementation rationale and interactive checks.
+[scheduler architecture decision](architecture/decisions/ADR-UI-Animation-Scheduler.md), the
+[composable-animation architecture decision](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md),
+and **Animations and Interaction Effects** in `samples/ControlGallery` for implementation rationale
+and interactive checks.

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -446,8 +446,10 @@ omitted under reduced motion.
 `PressScaleEffect` tracks independent pointer IDs plus keyboard activation. Its multiplier composes
 with public control transforms and visual-state transforms rather than overwriting `ScaleX` or
 `ScaleY`. Pointer cancel, leave, lost focus, disable, removal, and disposal restore the neutral
-scale, preventing a stuck press. Reduced motion applies the held/released endpoint without
-periodic ticks.
+scale, preventing a stuck press. A faulty custom effect easing faults its scheduler entry but also
+removes the ripple or restores the requested press endpoint, so no orphaned visual remains after
+the scheduler returns to idle. Reduced motion applies the held/released endpoint without periodic
+ticks.
 
 Hover and focus effects use visual-state transitions. There is no parallel hover/focus
 subscription or scheduler.

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -445,11 +445,11 @@ omitted under reduced motion.
 
 `PressScaleEffect` tracks independent pointer IDs plus keyboard activation. Its multiplier composes
 with public control transforms and visual-state transforms rather than overwriting `ScaleX` or
-`ScaleY`. Pointer cancel, leave, lost focus, disable, removal, and disposal restore the neutral
-scale, preventing a stuck press. A faulty custom effect easing faults its scheduler entry but also
-removes the ripple or restores the requested press endpoint, so no orphaned visual remains after
-the scheduler returns to idle. Reduced motion applies the held/released endpoint without periodic
-ticks.
+`ScaleY`. Pointer cancellation (including capture loss), lost focus, disable, removal, and disposal
+restore the neutral scale, preventing a stuck press. A faulty custom effect easing faults its
+scheduler entry but also removes the ripple or restores the requested press endpoint, so no
+orphaned visual remains after the scheduler returns to idle. Reduced motion applies the
+held/released endpoint without periodic ticks.
 
 Hover and focus effects use visual-state transitions. There is no parallel hover/focus
 subscription or scheduler.

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -437,8 +437,9 @@ while radius uses the configured easing.
 Waves are clipped to control bounds and the current corner radius. `AboveBackgroundBelowContent`
 keeps content legible; `AboveContent` is available for stronger feedback. Active waves are bounded
 from 1 through 32 and `Oldest` explicitly cancels the oldest wave when the limit is reached.
-Disabled controls do not start waves. Cancel, removal, disable, detach, and disposal clear all
-effect-owned work. Decorative ripple is omitted under reduced motion.
+Disabled controls do not start waves. A touch cancel removes waves for that pointer ID; global
+cancel, removal, disable, detach, and disposal clear all effect-owned work. Decorative ripple is
+omitted under reduced motion.
 
 ### Press, hover, and focus
 
@@ -466,8 +467,8 @@ focus ring
 Ripple is not implemented by individual renderers. `IInteractionEffectClip` can provide a custom
 Skia clip for future shape/geometry controls. The built-in
 `ControlBoundsInteractionEffectClip.Instance` clips to scaled bounds and the resolved border
-radius. `InteractionEffectRenderContext` borrows the target-local canvas for the current render
-call; effects must never retain it.
+radius. Each effect reuses its `InteractionEffectRenderContext` between frames; it borrows the
+target-local canvas for the current render call, so effects must never retain either object.
 
 ## Lifecycle and thread safety
 

--- a/docs/architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md
+++ b/docs/architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md
@@ -1,0 +1,209 @@
+# ADR: Composable animations and interaction effects
+
+- Status: Accepted
+- Date: 2026-07-23
+- Scope: `ModernFormsNext`, `ModernFormsNext.WindowKit`, platform hosts, Designer, and ControlGallery
+
+## Context
+
+ModernFormsNext already has a process-wide `AnimationScheduler`, typed interpolators, monotonic
+elapsed time, owner/key replacement, reduced-motion policy, lifecycle pause/resume, brush
+interpolation, and UI-thread dispatch. Existing helpers such as `FadeToAsync`, `ScaleToAsync`,
+`RotateToAsync`, and `TranslateToAsync` use that scheduler.
+
+The framework needs a public layer for reusable animation definitions, composition, keyframes,
+repeat behavior, visual-state transitions, and interaction effects. Ripple and press feedback must
+not introduce control-specific timers or renderer-specific implementations. The same model must
+remain usable by the primary Windows host and the experimental Android `SkiaControlSurface`.
+
+## Decision
+
+### Layers
+
+The system has four layers:
+
+1. `AnimationScheduler` remains the only clock, tick source, dispatcher, lifecycle, and
+   owner/key registry.
+2. `AnimationDefinition` and `AnimationRun` provide reusable, public run definitions and
+   cancellation/completion ownership.
+3. composition definitions implement sequence, parallel, timeline, delay, keyframes, repeat, and
+   auto-reverse without creating timers or blocking the UI thread;
+4. controls consume definitions through visual-state transitions and an attachable
+   `InteractionEffectCollection`.
+
+Every animated property continues to use its normal setter. Render-only values invalidate visuals;
+layout is requested only by a property whose existing setter is layout-affecting.
+
+### Ownership and lifetime
+
+A leaf animation is owned by the target object and an ordinal channel key. A run scope adds a
+unique key prefix for nested groups so one group cannot replace unrelated work. Direct leaf runs
+retain the existing replacement behavior.
+
+`AnimationRun.Cancel` propagates to all active descendants. Control detach and disposal cancel
+scheduler work owned by that control. Effect detach and disposal cancel effect-owned handles and
+clear render state. Terminal scheduler entries release owner and callback references before their
+completion task becomes observable, so retaining a completed handle does not retain a target.
+
+Callbacks, cancellation-token callbacks, and task continuations are never invoked while the
+scheduler lock is held.
+
+### Cancellation and replacement
+
+`AnimationReplacementMode.Replace` is latest-wins for the same owner/key. `IgnoreNew` returns the
+existing run. A stale handle can only cancel its own entry and cannot remove a newer replacement.
+
+Sequence stops after the first canceled or faulted child. Parallel waits for every child, propagates
+cancellation to all children, and aggregates faults in definition order. Timeline starts each entry
+at most once. Disposing a group cancels only descendants in that run scope.
+
+### Composition
+
+`Animation.Sequence` runs children in order. `Animation.Parallel` starts children together.
+`AnimationTimeline` schedules offsets by running scheduler-owned delay entries, so offsets use the
+same monotonic clock and lifecycle pause/resume behavior as value animation. No composition object
+uses `Task.Delay`, a timer, or a background loop.
+
+### Keyframes
+
+`KeyframeAnimation<T>` captures an immutable keyframe snapshot when a run starts. Positions are
+finite values in the inclusive range 0 through 1 and must be nondecreasing. The default duplicate
+policy rejects duplicate positions; replace and allow policies are explicit. When duplicates are
+allowed, sampling an exact duplicate position selects the last value at that position.
+
+Each segment uses the easing assigned to its ending keyframe. Endpoints are exact. Zero-length
+segments are deterministic, interpolation results must be finite where the value type is numeric,
+and the public keyframe count is bounded. `Sample` and `Seek` use the same deterministic resolver
+as a scheduler tick.
+
+### Repeat and auto-reverse
+
+Finite repeat counts describe forward iterations. Auto-reverse adds a reverse leg to each
+iteration. Infinite repeat requires explicit cancellation in normal motion mode. When animations
+are disabled or reduced motion is active, an infinite definition applies one deterministic final
+sample and completes; it never enters a synchronous infinite loop.
+
+Only the current iteration retains child handles. Completion, cancellation, or fault leaves the
+scheduler idle when no unrelated animations remain.
+
+### Visual-state transitions
+
+Controls expose `Normal`, `Hover`, `Pressed`, `Focused`, and `Disabled` states. State priority is:
+
+```text
+Disabled > Pressed > Hover > Focused > Normal
+```
+
+Transitions are keyed by `(from, to)` and are latest-state-wins. The current presentation is used
+as the source of a rapid replacement, so a stale transition cannot publish a final state.
+Compatible background, foreground, and border brushes are interpolated through the existing brush
+plan. Color, opacity, scale, translation, and rotation are render-only. Fonts, border widths, and
+other layout metrics switch to the target style immediately.
+
+A theme or dynamic-resource change during a transition re-resolves the current target and replaces
+the old transition. Reduced motion applies the target presentation without periodic ticks.
+
+### Interaction effects
+
+`InteractionEffectCollection` attaches reusable effects to a control. Attach is exclusive and
+duplicate attachment is rejected. The control dispatches pointer, keyboard, focus, enabled,
+detach, and render notifications to the collection through one framework hook; effects do not
+subscribe independent event-handler graphs.
+
+Effects receive pointer identity and device kind. Windows mouse input uses pointer zero. The
+experimental Android surface forwards its platform pointer ID and touch device kind. Pointer
+cancel is distinct from normal release.
+
+### Ripple and press feedback
+
+`RippleEffect` starts from a pointer/touch location or the control center. Radius can cover the
+current control bounds, so resizing during a ripple changes the required cover radius. Alpha fades
+while radius grows. A bounded active list enforces an explicit oldest-first or ignore-new eviction
+policy. Each ripple is a scheduler entry, never a timer; scheduler tick batching coalesces repaint
+requests per window.
+
+Keyboard activation starts a centered ripple. Disabled controls do not start effects. Pointer
+cancel removes matching touch ripples. Detach/dispose cancels all remaining ripple handles.
+Reduced motion may omit this decorative effect entirely.
+
+`PressScaleEffect` tracks independent pointer and keyboard presses. It animates a dedicated
+interaction scale multiplier so it composes with the control's public render transform rather than
+competing for `ScaleX` or `ScaleY`. Release, leave, disable, pointer cancel, detach, and disposal
+all restore the neutral multiplier.
+
+Hover and focus animation use the visual-state transition system. No second hover/focus state
+machine is introduced.
+
+### Rendering and clipping
+
+The shared control paint path is:
+
+```text
+background
+effects below content
+content
+effects above content
+focus overlay
+```
+
+The hook is part of the common control-buffer pipeline used by Windows and `SkiaControlSurface`;
+ripple is not added to individual control renderers.
+
+Effects use `IInteractionEffectClip`. The built-in bounds clip respects the current
+`ControlStyle.Border` corner radius. The abstraction intentionally accepts a control and a Skia
+canvas so future Shapes/Geometry implementations can provide a path without changing effect APIs.
+The canvas is borrowed and is never retained.
+
+### Repaint batching and performance
+
+Each scheduler tick enters the existing application visual-invalidation batch. Multiple property
+updates, parallel animations, state transitions, and concurrent ripples in one window therefore
+produce one platform repaint request for that tick. Effect and transform updates never request
+layout.
+
+Per-run delegates and snapshots are allocated at start, not per frame. Ripple count and keyframe
+count are bounded. Rendering remains linear in active effects and active ripples. Finished
+definitions, scheduler entries, and effect states release targets and callbacks.
+
+### Reduced motion
+
+`AnimationPolicy` remains authoritative. Disabled animation or reduced motion applies finite
+definitions at their deterministic endpoint without starting the tick source. Decorative ripple
+is skipped. Press feedback restores its neutral state. Infinite repeat collapses to one sample.
+
+### Designer
+
+Designer-attached controls do not start runtime scheduler or platform services. Complex collections
+are hidden from ordinary property-grid expansion and use content serialization only where safe.
+Effects retain stable configuration but no live handles. Preview sampling is deterministic and
+does not depend on wall-clock time.
+
+### Platform status
+
+Windows is the primary runtime target. Mouse capture, keyboard activation, focus, minimize/restore,
+resize, DPI scaling, multiple windows, and scheduler idle behavior use the shared implementation.
+
+Android remains experimental. `SkiaControlSurface` forwards touch down/up/cancel and pointer IDs,
+supports multiple active pointers, and already participates in application lifecycle pause/resume.
+No runtime-success claim is made without a device or emulator.
+
+## Consequences
+
+- Existing async helpers remain source-compatible and delegate to public definitions.
+- The scheduler gains a richer frame callback and terminal-reference cleanup, but remains the only
+  scheduling service.
+- Common rendering gains effect hooks; individual renderers do not learn about ripple.
+- Visual-state styles become additive public API. Existing `Style` and `StyleHover` behavior remains
+  the default for controls that do not configure transitions.
+- Custom effects can depend on Skia in the shared framework, consistent with the existing rendering
+  architecture.
+
+## Known limitations
+
+- Layout-property interpolation is intentionally not provided by visual-state transitions.
+- Incompatible brush structures switch discretely.
+- Legacy renderers that draw specialized item focus indicators continue to own those indicators;
+  the final focus-overlay hook is available for new effects and control-specific migration.
+- Android frame pacing, multi-touch visuals, background/foreground behavior, and orientation
+  changes require device or emulator validation.
+- Designer collection editors are intentionally minimal; complex effect editing is code-first.

--- a/docs/architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md
+++ b/docs/architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md
@@ -106,7 +106,8 @@ the old transition. Reduced motion applies the target presentation without perio
 ### Interaction effects
 
 `InteractionEffectCollection` attaches reusable effects to a control. Attach is exclusive and
-duplicate attachment is rejected. The control dispatches pointer, keyboard, focus, enabled,
+adding the same instance to the same collection is idempotent; attaching it to another target
+while still attached is rejected. The control dispatches pointer, keyboard, focus, enabled,
 detach, and render notifications to the collection through one framework hook; effects do not
 subscribe independent event-handler graphs.
 
@@ -118,12 +119,12 @@ cancel is distinct from normal release.
 
 `RippleEffect` starts from a pointer/touch location or the control center. Radius can cover the
 current control bounds, so resizing during a ripple changes the required cover radius. Alpha fades
-while radius grows. A bounded active list enforces an explicit oldest-first or ignore-new eviction
-policy. Each ripple is a scheduler entry, never a timer; scheduler tick batching coalesces repaint
+while radius grows. A bounded active list enforces the explicit oldest-first eviction policy.
+Each ripple is a scheduler entry, never a timer; scheduler tick batching coalesces repaint
 requests per window.
 
 Keyboard activation starts a centered ripple. Disabled controls do not start effects. Pointer
-cancel removes matching touch ripples. Detach/dispose cancels all remaining ripple handles.
+cancel clears the active ripple gesture state. Detach/dispose cancels all remaining ripple handles.
 Reduced motion may omit this decorative effect entirely.
 
 `PressScaleEffect` tracks independent pointer and keyboard presses. It animates a dedicated

--- a/docs/architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md
+++ b/docs/architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md
@@ -123,8 +123,9 @@ while radius grows. A bounded active list enforces the explicit oldest-first evi
 Each ripple is a scheduler entry, never a timer; scheduler tick batching coalesces repaint
 requests per window.
 
-Keyboard activation starts a centered ripple. Disabled controls do not start effects. Pointer
-cancel clears the active ripple gesture state. Detach/dispose cancels all remaining ripple handles.
+Keyboard activation starts a centered ripple. Disabled controls do not start effects. A
+platform-specific pointer cancel removes only waves owned by that pointer; global cancellation
+clears the entire gesture state. Detach/dispose cancels all remaining ripple handles.
 Reduced motion may omit this decorative effect entirely.
 
 `PressScaleEffect` tracks independent pointer and keyboard presses. It animates a dedicated

--- a/docs/composable-animations-draft.md
+++ b/docs/composable-animations-draft.md
@@ -1,0 +1,48 @@
+# Draft release notes: composable animations and interaction effects
+
+This is an unreleased, version-neutral draft. It does not change package or assembly versions and
+does not authorize publication.
+
+## Highlights
+
+- Public `AnimationDefinition`, `AnimationRun`, `AnimationContext`, and typed
+  `PropertyAnimation<T>` APIs build on the existing shared `AnimationScheduler`.
+- `Animation.Sequence`, `Animation.Parallel`, `AnimationTimeline`, and scheduler-backed delay
+  compose work without new timers or blocking the UI thread.
+- `KeyframeAnimation<T>` supports bounded typed keyframes, segment easing, explicit duplicate
+  policies, exact endpoints, and deterministic `Sample`/`Seek`.
+- Finite repeat, required-cancellation infinite repeat, and auto-reverse reuse the existing
+  monotonic clock, lifecycle pause, owner/key replacement, and reduced-motion policy.
+- Controls now resolve `Normal`, `Hover`, `Pressed`, `Focused`, and `Disabled` state styles with
+  latest-state-wins transitions for compatible colors, Brushes, opacity, and render transforms.
+- Reusable interaction effects add bounded ripple and press-scale feedback for mouse, keyboard,
+  and experimental Android touch input.
+- The common render order is background, effects below content, content, effects above content,
+  then the focus ring. Built-in clipping respects control bounds and corner radius.
+- One application visual-invalidation batch wraps every scheduler tick, coalescing repaint per
+  window without forcing layout for visual-only frames.
+- Existing `FadeToAsync`, `TranslateToAsync`, `ScaleToAsync`, and `RotateToAsync` helpers remain
+  source-compatible.
+
+## Quality and compatibility
+
+Deterministic tests use the manual clock, tick source, and dispatcher. They cover composition,
+fault/cancellation propagation, repeat and idle behavior, keyframes, all visual states, theme
+refresh, ripple/press input, clipping, resize, multi-touch, Designer behavior, disposal, render
+ordering, multiple windows, repaint batching, and absence of layout during visual frames.
+
+The new **Animations and Interaction Effects** ControlGallery page provides manual controls for
+Start, Cancel, Rapid x5, reduced motion, animations disabled, diagnostics, Replace, IgnoreNew,
+composition, keyframes, repeat, auto-reverse, custom animation, and custom interpolation.
+
+## Platform status and limitations
+
+Windows remains the primary runtime target. Android touch integration is experimental and requires
+device/emulator validation for frame pacing, background/foreground transitions, multi-touch
+rendering, and orientation changes. Native reduced-motion discovery is not yet automatic.
+Visual-state layout metrics switch immediately rather than interpolate, incompatible Brush
+structures switch discretely, ripple currently uses oldest-first eviction, and complex
+interaction-effect collections remain code-first in the Designer.
+
+See [UI animations](animations.md) and the
+[composable-animation ADR](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md).

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -42,6 +42,12 @@ dotnet run
 
 ## ControlGallery
 
+The **Animations and Interaction Effects** page demonstrates pointer- and center-origin ripple,
+rapid bounded waves, press scale, hover/focus/disabled transitions, sequence, parallel, timeline,
+keyframes, repeat, auto-reverse, custom definitions and interpolators, cancellation, replacement
+policies, reduced motion, animations disabled, and scheduler/ripple diagnostics. It is opt-in and
+restores the animation policy when unloaded.
+
 The `MarkdownEditor` page demonstrates Editor, Preview, and Split modes, the public command
 toolbar, Ctrl+K, hosted link and image request dialogs built only from ModernFormsNext controls,
 preview link forwarding, and optional proportional scroll synchronization. Its source includes

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -21,6 +21,7 @@ namespace ControlGallery
 
             tree.Items.Add ("Button", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Animations", ImageLoader.Get ("swatches.png"));
+            tree.Items.Add ("Animations and Interaction Effects", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("CheckBox", ImageLoader.Get ("button.png"));
             tree.Items.Add ("CheckedListBox", ImageLoader.Get ("button.png"));
             tree.Items.Add ("ComboBox", ImageLoader.Get ("button.png"));
@@ -104,6 +105,8 @@ namespace ControlGallery
             switch (text) {
                 case "Animations":
                     return new AnimationSchedulerPanel ();
+                case "Animations and Interaction Effects":
+                    return new AnimationsAndInteractionEffectsPanel ();
                 case "Button":
                     return new ButtonPanel ();
                 case "CheckBox":

--- a/samples/ControlGallery/Panels/AnimationsAndInteractionEffectsPanel.cs
+++ b/samples/ControlGallery/Panels/AnimationsAndInteractionEffectsPanel.cs
@@ -1,0 +1,500 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using ModernFormsNext;
+using ModernFormsNext.Animations;
+using SkiaSharp;
+
+namespace ControlGallery.Panels;
+
+/// <summary>
+/// Provides manual demonstrations for composable animations, visual-state transitions,
+/// and scheduler-backed interaction effects.
+/// </summary>
+public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
+{
+    private readonly AnimationScheduler scheduler = AnimationScheduler.Default;
+    private readonly List<AnimationRun> runs = [];
+    private readonly RippleDemoButton pointerRipple;
+    private readonly RippleDemoButton centerRipple;
+    private readonly RippleDemoButton rapidRipple;
+    private readonly Button transitionButton;
+    private readonly Panel animationTarget;
+    private readonly Label diagnosticsLabel;
+    private readonly Button animationsButton;
+    private readonly Button reducedMotionButton;
+    private readonly bool originalAnimationsEnabled;
+    private readonly bool originalReducedMotion;
+    private readonly double originalDurationScale;
+    private bool alternate;
+    private bool unloaded;
+
+    /// <summary>Initializes the opt-in animation and interaction-effects gallery page.</summary>
+    public AnimationsAndInteractionEffectsPanel()
+    {
+        AutoScroll = true;
+        originalAnimationsEnabled = scheduler.Policy.AnimationsEnabled;
+        originalReducedMotion = scheduler.Policy.ReducedMotion;
+        originalDurationScale = scheduler.Policy.DurationScale;
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 18,
+            Width = 820,
+            Height = 30,
+            Text = "Animations and Interaction Effects",
+            Font = new ModernFormsNext.Font("Segoe UI", 16)
+        });
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 52,
+            Width = 820,
+            Height = 42,
+            Multiline = true,
+            Text = "All demos share AnimationScheduler.Default. Hover, focus, click, resize, cancel, and rapidly repeat actions while watching active work return to idle."
+        });
+
+        pointerRipple = AddEffectButton(24, 108, "Pointer ripple", startFromPointer: true);
+        centerRipple = AddEffectButton(218, 108, "Center ripple", startFromPointer: false);
+        rapidRipple = AddEffectButton(412, 108, "Rapid ripple target", startFromPointer: true);
+        rapidRipple.Ripple!.MaxConcurrentRipples = 4;
+
+        transitionButton = AddEffectButton(606, 108, "Hover / focus / press", startFromPointer: true);
+        transitionButton.PressEffect = new PressScaleEffect();
+        transitionButton.Style.BackgroundColor = SKColors.SlateBlue;
+        transitionButton.Style.ForegroundColor = SKColors.White;
+        transitionButton.StyleHover.BackgroundColor = SKColors.MediumPurple;
+        transitionButton.StyleHover.ScaleX = 1.04f;
+        transitionButton.StyleHover.ScaleY = 1.04f;
+        transitionButton.StyleFocused.Border.Color = SKColors.Gold;
+        transitionButton.StyleFocused.Border.Width = 2;
+        transitionButton.StylePressed.BackgroundColor = SKColors.DarkSlateBlue;
+        transitionButton.StyleDisabled.Opacity = 0.45f;
+        AddStateTransition(transitionButton, VisualState.Normal, VisualState.Hover);
+        AddStateTransition(transitionButton, VisualState.Hover, VisualState.Normal);
+        AddStateTransition(transitionButton, VisualState.Normal, VisualState.Focused);
+        AddStateTransition(transitionButton, VisualState.Focused, VisualState.Normal);
+        AddStateTransition(transitionButton, VisualState.Hover, VisualState.Pressed);
+        AddStateTransition(transitionButton, VisualState.Pressed, VisualState.Hover);
+
+        animationTarget = Controls.Add(new Panel
+        {
+            Left = 24,
+            Top = 202,
+            Width = 150,
+            Height = 72,
+            BackColor = SKColors.CornflowerBlue
+        });
+        animationTarget.Style.Border.Width = 1;
+        animationTarget.Style.Border.Color = Theme.BorderMidColor;
+        animationTarget.Controls.Add(new Label
+        {
+            Dock = DockStyle.Fill,
+            Text = "Animation target",
+            TextAlign = ModernFormsNext.ContentAlignment.MiddleCenter
+        });
+
+        AddButton(194, 202, 110, "Sequence", RunSequence);
+        AddButton(312, 202, 110, "Parallel", RunParallel);
+        AddButton(430, 202, 110, "Timeline", RunTimeline);
+        AddButton(548, 202, 110, "Keyframes", RunKeyframes);
+        AddButton(666, 202, 110, "Repeat", RunRepeat);
+
+        AddButton(194, 244, 110, "Auto-reverse", RunAutoReverse);
+        AddButton(312, 244, 110, "Shake", RunShake);
+        AddButton(430, 244, 110, "Pulse", RunPulse);
+        AddButton(548, 244, 110, "Interpolator", RunCustomInterpolator);
+        AddButton(666, 244, 110, "Disabled state", ToggleTransitionDisabled);
+
+        AddButton(24, 304, 110, "Start", RunSequence);
+        AddButton(142, 304, 110, "Cancel", CancelAll);
+        AddButton(260, 304, 110, "Rapid x5", RunRapidRipples);
+        AddButton(378, 304, 110, "Replace", RunReplace);
+        AddButton(496, 304, 110, "IgnoreNew", RunIgnoreNew);
+        reducedMotionButton = AddButton(614, 304, 164, string.Empty, ToggleReducedMotion);
+
+        animationsButton = AddButton(24, 346, 180, string.Empty, ToggleAnimations);
+        AddButton(212, 346, 180, "Refresh diagnostics", UpdateDiagnostics);
+        AddButton(400, 346, 180, "Reset transforms", ResetTarget);
+        AddButton(588, 346, 190, "Resize ripple targets", ResizeRippleTargets);
+
+        diagnosticsLabel = Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 402,
+            Width = 754,
+            Height = 68,
+            Multiline = true
+        });
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 480,
+            Width = 754,
+            Height = 94,
+            Multiline = true,
+            Text = "Manual checklist: pointer and keyboard activation, focus ring order, rapid ripple eviction, resize during a wave, leave/re-enter, disabled state, cancel, Replace, IgnoreNew, reduced motion, animations disabled, and diagnostics returning to Active 0 / Tick source stopped."
+        });
+
+        UpdatePolicyButtons();
+        UpdateDiagnostics();
+    }
+
+    /// <inheritdoc/>
+    public override void UnloadPanel()
+    {
+        if (unloaded)
+            return;
+        unloaded = true;
+        CancelAll();
+        scheduler.Policy.AnimationsEnabled = originalAnimationsEnabled;
+        scheduler.Policy.ReducedMotion = originalReducedMotion;
+        scheduler.Policy.DurationScale = originalDurationScale;
+        base.UnloadPanel();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            UnloadPanel();
+        base.Dispose(disposing);
+    }
+
+    private RippleDemoButton AddEffectButton(
+        int left,
+        int top,
+        string text,
+        bool startFromPointer)
+    {
+        var button = Controls.Add(new RippleDemoButton
+        {
+            Left = left,
+            Top = top,
+            Width = 176,
+            Height = 58,
+            Text = text,
+            Ripple = new RippleEffect
+            {
+                Color = Color.FromArgb(105, 255, 255, 255),
+                Duration = TimeSpan.FromMilliseconds(500),
+                StartFromPointer = startFromPointer,
+                RadiusMode = RippleRadiusMode.CoverControl,
+                Layer = RippleLayer.AboveBackgroundBelowContent,
+                MaxConcurrentRipples = 4
+            }
+        });
+        button.Style.BackgroundColor = SKColors.Teal;
+        button.Style.ForegroundColor = SKColors.White;
+        button.Style.Border.Radius = 12;
+        return button;
+    }
+
+    private Button AddButton(int left, int top, int width, string text, Action action)
+    {
+        var button = Controls.Add(new Button
+        {
+            Left = left,
+            Top = top,
+            Width = width,
+            Height = 32,
+            Text = text
+        });
+        button.Click += (_, _) => action();
+        return button;
+    }
+
+    private void RunSequence()
+    {
+        ResetTarget();
+        AnimationDefinition animation = Animation.Sequence(
+            animationTarget.FadeTo(0.35f, Options(220)),
+            animationTarget.ScaleTo(1.18f, Options(220)),
+            Animation.Parallel(
+                animationTarget.FadeTo(1f, Options(220)),
+                animationTarget.ScaleTo(1f, Options(220))));
+        Track(animation.Start(scheduler));
+    }
+
+    private void RunParallel()
+    {
+        alternate = !alternate;
+        float direction = alternate ? 1f : -1f;
+        Track(Animation.Parallel(
+            animationTarget.TranslateTo(120f * direction, 22f, Options(650)),
+            animationTarget.RotateTo(18f * direction, Options(650)),
+            animationTarget.FadeTo(0.55f, Options(650)))
+            .Start(scheduler));
+    }
+
+    private void RunTimeline()
+    {
+        var timeline = new AnimationTimeline()
+            .At(TimeSpan.Zero, animationTarget.FadeTo(0.35f, Options(300)))
+            .At(TimeSpan.FromMilliseconds(120), animationTarget.ScaleTo(1.2f, Options(300)))
+            .At(TimeSpan.FromMilliseconds(300), Animation.Parallel(
+                animationTarget.FadeTo(1f, Options(300)),
+                animationTarget.ScaleTo(1f, Options(300)),
+                animationTarget.TranslateTo(0f, 0f, Options(300))));
+        Track(timeline.Start(scheduler));
+    }
+
+    private void RunKeyframes()
+    {
+        var keyframes = KeyframeAnimation<float>
+            .Create(
+                animationTarget,
+                value =>
+                {
+                    animationTarget.ScaleX = value;
+                    animationTarget.ScaleY = value;
+                })
+            .Keyframe(0f, 1f)
+            .Keyframe(0.4f, 1.25f, Easings.CubicOut)
+            .Keyframe(0.72f, 0.94f, Easings.CubicOut)
+            .Keyframe(1f, 1f, Easings.BounceOut);
+        keyframes.Duration = TimeSpan.FromMilliseconds(800);
+        Track(keyframes.Start(scheduler));
+    }
+
+    private void RunRepeat()
+    {
+        AnimationDefinition animation = animationTarget
+            .TranslateTo(70f, 0f, Options(220))
+            .Repeat(3);
+        Track(animation.Start(scheduler));
+    }
+
+    private void RunAutoReverse()
+    {
+        AnimationDefinition animation = animationTarget
+            .RotateTo(16f, Options(260))
+            .Repeat(2)
+            .AutoReverse();
+        Track(animation.Start(scheduler));
+    }
+
+    private void RunShake()
+    {
+        var shake = new ShakeAnimation
+        {
+            Duration = TimeSpan.FromMilliseconds(700),
+            Distance = 14f,
+            Oscillations = 5
+        };
+        Track(shake.Start(animationTarget, scheduler));
+    }
+
+    private void RunPulse()
+    {
+        var pulse = KeyframeAnimation<float>
+            .Create(
+                animationTarget,
+                value =>
+                {
+                    animationTarget.ScaleX = value;
+                    animationTarget.ScaleY = value;
+                })
+            .Keyframe(0f, 1f)
+            .Keyframe(0.5f, 1.14f, Easings.CubicOut)
+            .Keyframe(1f, 1f, Easings.CubicOut);
+        pulse.Duration = TimeSpan.FromMilliseconds(400);
+        pulse.Repeat(3);
+        Track(pulse.Start(scheduler));
+    }
+
+    private void RunCustomInterpolator()
+    {
+        var animation = new PropertyAnimation<float>(
+            animationTarget,
+            "Gallery.CustomInterpolator",
+            animationTarget.TranslationY,
+            animationTarget.TranslationY < 35f ? 70f : 0f,
+            new OvershootInterpolator(),
+            value => animationTarget.TranslationY = value)
+        {
+            Duration = TimeSpan.FromMilliseconds(700),
+            Easing = Easings.CubicOut
+        };
+        Track(animation.Start(scheduler));
+    }
+
+    private void RunReplace()
+    {
+        var first = animationTarget.RotateTo(180f, new AnimationOptions
+        {
+            Duration = TimeSpan.FromSeconds(2),
+            Easing = Easings.Linear,
+            ReplacementMode = AnimationReplacementMode.Replace
+        });
+        var replacement = animationTarget.RotateTo(0f, Options(500));
+        Track(first.Start(scheduler));
+        Track(replacement.Start(scheduler));
+    }
+
+    private void RunIgnoreNew()
+    {
+        var options = new AnimationOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(1200),
+            Easing = Easings.CubicOut,
+            ReplacementMode = AnimationReplacementMode.IgnoreNew
+        };
+        Track(animationTarget.RotateTo(120f, options).Start(scheduler));
+        Track(animationTarget.RotateTo(-120f, options).Start(scheduler));
+    }
+
+    private void RunRapidRipples()
+    {
+        for (int index = 0; index < 5; index++)
+            rapidRipple.TriggerRipple(18 + (index * 28), 16 + ((index % 2) * 18), index + 1);
+        UpdateDiagnostics();
+    }
+
+    private void ToggleTransitionDisabled()
+        => transitionButton.Enabled = !transitionButton.Enabled;
+
+    private void ToggleAnimations()
+    {
+        scheduler.Policy.AnimationsEnabled = !scheduler.Policy.AnimationsEnabled;
+        UpdatePolicyButtons();
+        UpdateDiagnostics();
+    }
+
+    private void ToggleReducedMotion()
+    {
+        scheduler.Policy.ReducedMotion = !scheduler.Policy.ReducedMotion;
+        UpdatePolicyButtons();
+        UpdateDiagnostics();
+    }
+
+    private void ResizeRippleTargets()
+    {
+        int height = pointerRipple.Height < 70 ? 78 : 58;
+        pointerRipple.Height = height;
+        centerRipple.Height = height;
+        rapidRipple.Height = height;
+    }
+
+    private void ResetTarget()
+    {
+        animationTarget.Opacity = 1f;
+        animationTarget.TranslationX = 0f;
+        animationTarget.TranslationY = 0f;
+        animationTarget.ScaleX = 1f;
+        animationTarget.ScaleY = 1f;
+        animationTarget.Rotation = 0f;
+        UpdateDiagnostics();
+    }
+
+    private void CancelAll()
+    {
+        foreach (AnimationRun run in runs)
+            run.Cancel();
+        runs.Clear();
+        scheduler.CancelAll(animationTarget);
+        CancelRipples(pointerRipple, centerRipple, rapidRipple, transitionButton);
+        UpdateDiagnostics();
+    }
+
+    private void Track(AnimationRun run)
+    {
+        runs.RemoveAll(static item => item.State is
+            AnimationState.Completed or AnimationState.Canceled or AnimationState.Faulted);
+        runs.Add(run);
+        UpdateDiagnostics();
+    }
+
+    private void UpdatePolicyButtons()
+    {
+        animationsButton.Text = scheduler.Policy.AnimationsEnabled
+            ? "Animations: enabled"
+            : "Animations: disabled";
+        reducedMotionButton.Text = scheduler.Policy.ReducedMotion
+            ? "Reduced motion: on"
+            : "Reduced motion: off";
+    }
+
+    private void UpdateDiagnostics()
+    {
+        AnimationSchedulerDiagnostics diagnostics = scheduler.GetDiagnostics();
+        int activeRipples =
+            (pointerRipple?.Ripple?.ActiveRippleCount ?? 0) +
+            (centerRipple?.Ripple?.ActiveRippleCount ?? 0) +
+            (rapidRipple?.Ripple?.ActiveRippleCount ?? 0) +
+            (transitionButton?.Ripple?.ActiveRippleCount ?? 0);
+        diagnosticsLabel.Text =
+            $"Active: {diagnostics.ActiveAnimationCount} | completed: {diagnostics.CompletedCount} | canceled: {diagnostics.CanceledCount} | faulted: {diagnostics.FaultedCount} | active ripples: {activeRipples}\n" +
+            $"Ticks: {diagnostics.TickCount} | tick source: {(diagnostics.IsTickSourceRunning ? "running" : "stopped")} | policy: {(scheduler.Policy.AnimationsEnabled ? "enabled" : "disabled")}, reduced motion {(scheduler.Policy.ReducedMotion ? "on" : "off")}";
+    }
+
+    private static void CancelRipples(params Button[] buttons)
+    {
+        foreach (Button button in buttons)
+        {
+            if (button.Ripple is not { } ripple)
+                continue;
+            ripple.Enabled = false;
+            ripple.Enabled = true;
+        }
+    }
+
+    private static void AddStateTransition(Button button, VisualState from, VisualState to)
+        => button.StyleTransitions.Add(
+            from,
+            to,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(150),
+                Easing = Easings.CubicOut
+            });
+
+    private static AnimationOptions Options(int milliseconds)
+        => new()
+        {
+            Duration = TimeSpan.FromMilliseconds(milliseconds),
+            Easing = Easings.CubicOut
+        };
+
+    private sealed class RippleDemoButton : Button
+    {
+        public void TriggerRipple(int x, int y, int pointerId)
+        {
+            var args = new MouseEventArgs(
+                MouseButtons.Left,
+                1,
+                x,
+                y,
+                Point.Empty,
+                pointerId: pointerId,
+                pointerKind: PointerDeviceKind.Touch);
+            OnMouseDown(args);
+            OnMouseUp(args);
+        }
+    }
+
+    private sealed class ShakeAnimation : AnimationDefinition
+    {
+        public float Distance { get; init; } = 8f;
+        public int Oscillations { get; init; } = 4;
+
+        protected override void Update(AnimationContext context, float progress)
+        {
+            context.Target.TranslationX =
+                MathF.Sin(progress * MathF.PI * 2f * Oscillations)
+                * Distance
+                * (1f - progress);
+        }
+    }
+
+    private sealed class OvershootInterpolator : IAnimationInterpolator<float>
+    {
+        public float Interpolate(float from, float to, float progress)
+        {
+            float overshoot = MathF.Sin(progress * MathF.PI) * 0.18f;
+            return from + ((to - from) * (progress + overshoot));
+        }
+    }
+}

--- a/samples/ControlGallery/Panels/AnimationsAndInteractionEffectsPanel.cs
+++ b/samples/ControlGallery/Panels/AnimationsAndInteractionEffectsPanel.cs
@@ -468,8 +468,11 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
                 x,
                 y,
                 Point.Empty,
-                pointerId: pointerId,
-                pointerKind: PointerDeviceKind.Touch);
+                null,
+                null,
+                Keys.None,
+                pointerId,
+                PointerDeviceKind.Touch);
             OnMouseDown(args);
             OnMouseUp(args);
         }


### PR DESCRIPTION
## Summary

Adds a complete public, scheduler-backed composition layer for animations and reusable interaction effects. The implementation reuses the existing `AnimationScheduler`, typed interpolators, owner/key replacement, reduced-motion policy, brush interpolation, lifecycle handling, and per-window repaint batching. It does not add another scheduler, timer, animation loop, or background worker.

## Architecture

- `AnimationDefinition`, `AnimationRun`, and `AnimationContext` provide reusable definitions and per-run ownership.
- Typed `PropertyAnimation<T>` and `Control.AnimateAsync<T>` support built-in and custom interpolators.
- `Animation.Sequence`, `Animation.Parallel`, `AnimationTimeline`, and scheduler-backed `Delay` compose definitions without blocking the UI thread.
- `KeyframeAnimation<T>` provides bounded keyframes, explicit duplicate-position policy, per-segment easing, exact endpoints, finite-value validation, and deterministic `Sample`/`Seek`.
- Finite repeat, cancellation-bound repeat-forever, and auto-reverse reuse one scheduler execution path and return the scheduler to idle.
- Replacement remains owner/key based (`Replace`, `IgnoreNew`, parallel channels); stale handles cannot cancel newer work and nested groups use isolated child keys.
- Property start values and all updates are captured/executed through the scheduler UI callback. User callbacks are never invoked while the scheduler lock is held.
- Scheduler entries release owners, callbacks, and context targets before terminal completion becomes observable.

The architecture and lifetime contracts are documented in `docs/architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md`.

## Public API and compatibility

- Adds the requested typed `AnimateAsync` API and custom `AnimationDefinition` extension point.
- Keeps existing `FadeToAsync`, `TranslateToAsync`, `ScaleToAsync`, and `RotateToAsync` source-compatible; they delegate to the new run model.
- Adds composable `FadeTo`, `TranslateTo`, `ScaleTo`, and `RotateTo` factories.
- Adds public visual states, directional transitions, interaction-effect collection, ripple, press scale, clipping abstraction, pointer device kind/ID, diagnostics, and documented configuration types.
- New public and protected APIs include XML documentation; the packed XML docs were checked for the principal new types.

## Visual-state transitions

- Resolves `Disabled > Pressed > Hover > Focused > Normal`.
- Supports directional transitions with latest-state-wins replacement.
- Interpolates compatible background/foreground/border colors and brushes plus opacity, scale, translation, and rotation.
- Layout metrics switch immediately; animation ticks request visual invalidation only.
- State styles inherit brushes and transforms they do not override.
- Theme changes cancel stale transitions and resolve the currently active state again.
- Active state brushes use the existing weak, reference-counted `Brush.Changed` invalidation subscription, so in-place mutations repaint without another pointer/focus event.

## Interaction effects

- Effects support attach/detach, target ownership, input callbacks, a shared render hook, scheduler cancellation, disposal, reduced motion, and Designer-safe immediate behavior.
- `RippleEffect` supports pointer/touch origin or center origin, keyboard activation, cover-control/fixed radius, alpha fade, resize-aware geometry, gradient-backed controls, bounded concurrent waves, and explicit eviction.
- `PressScaleEffect` composes with control and visual-state transforms and releases on pointer/touch/keyboard up, cancel, disable, focus loss, detach, reparent, or disposal.
- Nullable pointer IDs preserve independent multi-touch cancellation.
- Rendering order is shared across controls: background, effects below content, content, effects above content, focus overlay.
- `IInteractionEffectClip` and the rounded control-bounds implementation keep clipping extensible for future shape/geometry support.

## Reduced motion, lifecycle, Designer, and platforms

- Reduced motion and disabled animations collapse finite work deterministically; decorative ripple is skipped and repeat-forever cannot spin synchronously.
- Pause/resume remains based on the scheduler monotonic clock, so timelines do not jump after lifecycle pauses.
- Effect render contexts are reused per attached effect and documented as borrowed frame-scoped objects.
- Designer mode does not start runtime ticking or platform services, including for custom effects.
- Windows mouse, keyboard, focus, disabled, resize, multiple-window batching, and scheduler-idle behavior are covered by deterministic tests.
- Android remains experimental. Pointer ID, multi-touch cancellation, down/up/cancel plumbing, resize-aware ripple, reduced-motion fallback, disposal, and no-host behavior are covered by shared/backend tests and Android builds. Runtime success is not claimed because no device/emulator was connected.

## Performance

- No per-effect or per-ripple timers and no additional animation loop.
- One scheduler tick-wide invalidation batch coalesces repaint per window.
- Animation/effect frames do not request full layout.
- Ripple work is explicitly bounded; eviction is linear in the small configured bound, with no unbounded history.
- Render contexts and brush interpolator working instances are reused where practical.
- Completed/canceled/faulted runs release target and callback references; disposal cancels owner-scoped work.
- No `Thread.Sleep` or wall-clock delays were added to deterministic tests.

## ControlGallery and documentation

Adds `Animations and Interaction Effects` with pointer/center/rapid ripple, press scale, hover/focus/disabled transitions, sequence, parallel, timeline, keyframes, repeat, auto-reverse, shake, pulse, custom interpolation, cancellation, Replace, IgnoreNew, reduced motion, disabled animations, and opt-in diagnostics.

Documentation includes overview/getting started, custom definitions, composition, timeline, keyframes and seeking, repeat/auto-reverse, state transitions, ripple/press, custom interpolators, cancellation/replacement, reduced motion, Designer, Windows, experimental Android, performance/lifecycle, limitations, helper migration, gallery guidance, ADR, and version-neutral draft release notes. `ModernFormsNext.DemoApp` was not changed.

## Validation

- `dotnet restore ModernFormsNext.slnx --force --no-cache`: passed.
- Full Debug build (`--no-restore --verbosity normal -m:1 /p:UseSharedCompilation=false`): passed.
- Full Release build with the same deterministic settings: passed.
- Debug tests: **705/705** passed:
  - ModernFormsNext.Tests: 594
  - Android backend tests: 52
  - Designer tests: 43
  - Cross-platform sample tests: 16
- Release tests: **705/705** passed with the same split.
- Focused animation/state/effect regression run: **70/70** passed.
- Explicit Release project builds passed for core, Windows backend, Android backend, Android smoke host, Designer, Visual Studio extension, and VSIX.
- Generated artifacts checked: signed/unsigned Android smoke APK and `ModernFormsNextDesigner.vsix`.
- ControlGallery Release startup smoke: passed (window remained alive for 8 seconds without startup failure).
- DemoApp Release compatibility startup smoke: passed; no DemoApp changes.
- Local pack: passed; **8 `.nupkg` + 7 `.snupkg`**, all 15 ZIP archives opened successfully and the core package target assemblies/XML docs were validated.
- Packages, VSIX, tags, and releases were not published.
- Final tracked worktree status and `git diff --check`: clean.

## Warnings

No new warnings were observed from the added animation/effect source files. The solution retains pre-existing warnings, principally:

- Visual Studio extension: 25 NuGet warnings on the explicit project build: 11 `MessagePack 2.5.192` vulnerability advisories (`NU1902`/`NU1903`) and 14 .NET Framework compatibility warnings for Visual Studio SDK packages (`NU1701`).
- Existing nullable and obsolete Skia API compiler warnings in pre-existing framework/renderer files during a clean solution build.

This PR intentionally does not update dependencies or package versions.

## Manual checklist

Completed:

- ControlGallery and DemoApp startup smoke.
- Deterministic coverage for pointer/center/rapid ripple, resize-aware radius, keyboard, disabled, press, hover/focus/all visual states, sequence/parallel/timeline/keyframes/repeat/auto-reverse, cancellation, Replace/IgnoreNew, reduced motion, animations disabled, leave/focus-loss cancellation, active count returning to zero, stopped tick source, Designer behavior, multi-window repaint batching, Android pointer IDs/multi-touch/cancel, and disposal/leak behavior.

Still requires interactive human/runtime validation:

- Visual inspection of ripple/press/state transitions in ControlGallery, including high DPI, minimize/restore, rapid user input, leave/re-enter, and resizing while a wave is visibly active.
- Visual Studio Experimental Instance property-grid/serialization interaction.
- Android foreground/background, orientation, and on-device rendering/touch behavior; no emulator/device was connected (`adb devices -l` returned no devices).

## Known limitations

- Android interaction effects remain experimental and are not claimed as runtime-validated here.
- Layout-affecting state metrics intentionally switch immediately instead of being animated.
- Built-in clipping covers control bounds and rounded corners; arbitrary future shapes plug in through `IInteractionEffectClip` but are not included in this PR.
- Custom interpolators/definitions must remain finite, lightweight, UI-thread safe, and avoid retaining the borrowed animation/render contexts.

This pull request is intentionally left as **Draft**. It must not be marked ready or merged until the remaining interactive validation is completed.