### PR TITLE
Polish animation platform integration and Designer support

### DIFF
--- a/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
+++ b/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
@@ -312,11 +312,11 @@ public sealed class CSharpDesignerGenerator
                 + $"Color = System.Drawing.Color.FromArgb({color >> 24}, {(color >> 16) & 0xFF}, {(color >> 8) & 0xFF}, {color & 0xFF}), "
                 + $"Duration = System.TimeSpan.FromMilliseconds({ReadDoubleLiteral(properties, "DurationMilliseconds", 450d)}), "
                 + $"StartFromPointer = {ReadBoolLiteral(properties, "StartFromPointer", true)}, "
-                + $"RadiusMode = {ReadValue(properties, "RadiusMode", "ModernFormsNext.Animations.RippleRadiusMode.CoverControl")}, "
+                + $"RadiusMode = {ReadEnumLiteral(properties, "RadiusMode", "ModernFormsNext.Animations.RippleRadiusMode", "CoverControl", "CoverControl", "Fixed")}, "
                 + $"FixedRadius = {ReadFloatLiteral(properties, "FixedRadius", 48d)}, "
-                + $"Layer = {ReadValue(properties, "Layer", "ModernFormsNext.Animations.RippleLayer.AboveBackgroundBelowContent")}, "
+                + $"Layer = {ReadEnumLiteral(properties, "Layer", "ModernFormsNext.Animations.RippleLayer", "AboveBackgroundBelowContent", "AboveBackgroundBelowContent", "AboveContent")}, "
                 + $"MaxConcurrentRipples = {ReadInt(properties, "MaxConcurrentRipples", 4)}, "
-                + $"OverflowPolicy = {ReadValue(properties, "OverflowPolicy", "ModernFormsNext.Animations.RippleOverflowPolicy.RemoveOldest")} "
+                + $"OverflowPolicy = {ReadEnumLiteral(properties, "OverflowPolicy", "ModernFormsNext.Animations.RippleOverflowPolicy", "RemoveOldest", "RemoveOldest", "RemoveNewest", "IgnoreNew", "ReplaceAll")} "
                 + "}";
         }
 
@@ -347,24 +347,38 @@ public sealed class CSharpDesignerGenerator
 
     private static bool IsEffectType(string typeName, string shortName)
         => string.Equals(typeName, shortName, StringComparison.Ordinal)
-        || typeName.EndsWith("." + shortName, StringComparison.Ordinal);
+        || string.Equals(typeName, "ModernFormsNext.Animations." + shortName, StringComparison.Ordinal);
 
     private static int ReadInt(
         IReadOnlyDictionary<string, DesignPropertyValue> properties,
         string name,
         int fallback)
-        => properties.TryGetValue(name, out DesignPropertyValue? value)
-            ? Convert.ToInt32(value.Value, CultureInfo.InvariantCulture)
-            : fallback;
+    {
+        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
+            return fallback;
+        if (value.Kind != DesignPropertyValueKind.Int32 || value.Value is not int result)
+            throw new FormatException($"Property '{name}' must be a 32-bit integer.");
+        return result;
+    }
 
     private static string ReadDoubleLiteral(
         IReadOnlyDictionary<string, DesignPropertyValue> properties,
         string name,
         double fallback)
     {
-        double result = properties.TryGetValue(name, out DesignPropertyValue? value)
-            ? Convert.ToDouble(value.Value, CultureInfo.InvariantCulture)
-            : fallback;
+        double result;
+        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
+        {
+            result = fallback;
+        }
+        else if (value.Kind is DesignPropertyValueKind.Double or DesignPropertyValueKind.Int32)
+        {
+            result = Convert.ToDouble(value.Value, CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            throw new FormatException($"Property '{name}' must be numeric.");
+        }
         if (!double.IsFinite(result))
             throw new FormatException($"Property '{name}' must be finite.");
         return result.ToString("R", CultureInfo.InvariantCulture);
@@ -387,17 +401,34 @@ public sealed class CSharpDesignerGenerator
         IReadOnlyDictionary<string, DesignPropertyValue> properties,
         string name,
         bool fallback)
-        => properties.TryGetValue(name, out DesignPropertyValue? value)
-            ? CSharpLiteralWriter.WriteValue(value)
-            : fallback ? "true" : "false";
+    {
+        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
+            return fallback ? "true" : "false";
+        if (value.Kind != DesignPropertyValueKind.Boolean || value.Value is not bool result)
+            throw new FormatException($"Property '{name}' must be a Boolean.");
+        return result ? "true" : "false";
+    }
 
-    private static string ReadValue(
+    private static string ReadEnumLiteral(
         IReadOnlyDictionary<string, DesignPropertyValue> properties,
         string name,
-        string fallback)
-        => properties.TryGetValue(name, out DesignPropertyValue? value)
-            ? CSharpLiteralWriter.WriteValue(value)
-            : fallback;
+        string enumTypeName,
+        string fallbackMember,
+        params string[] supportedMembers)
+    {
+        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
+            return enumTypeName + "." + fallbackMember;
+        string shortTypeName = enumTypeName.Split('.').Last();
+        string member = value.GetString();
+        if (value.Kind != DesignPropertyValueKind.Enum
+            || (!string.Equals(value.EnumTypeName, enumTypeName, StringComparison.Ordinal)
+                && !string.Equals(value.EnumTypeName, shortTypeName, StringComparison.Ordinal))
+            || !supportedMembers.Contains(member, StringComparer.Ordinal))
+        {
+            throw new FormatException($"Property '{name}' is not a supported {shortTypeName} value.");
+        }
+        return enumTypeName + "." + member;
+    }
 
     private static void WritePropertyAssignment(
         CodeWriter writer,

--- a/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
+++ b/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using ModernFormsNext.CodeGeneration.Utilities;
 using ModernFormsNext.Designing;
@@ -250,11 +251,153 @@ public sealed class CSharpDesignerGenerator
             if (GeneratedControlProperties.Contains(property.Key) || DesignerOnlyProperties.Contains(property.Key))
                 continue;
 
+            if (string.Equals(property.Key, InteractionEffectDesignValue.PropertyName, StringComparison.Ordinal))
+            {
+                WriteInteractionEffects(writer, controlExpression, property.Value, control.Name, validation);
+                continue;
+            }
+
             WritePropertyAssignment(writer, controlExpression, property.Key, property.Value, control.Name, validation);
         }
 
         writer.WriteLine();
     }
+
+    private static void WriteInteractionEffects(
+        CodeWriter writer,
+        string targetExpression,
+        DesignPropertyValue value,
+        string ownerName,
+        DesignDocumentValidationResult validation)
+    {
+        if (!InteractionEffectDesignValue.TryRead(value, out IReadOnlyList<DesignPropertyValue> effects, out string? error))
+        {
+            validation.AddWarning($"InteractionEffects on '{ownerName}' was skipped: {error}");
+            return;
+        }
+
+        for (int index = 0; index < effects.Count; index++)
+        {
+            try
+            {
+                string expression = WriteInteractionEffect(effects[index]);
+                writer.WriteLine($"        {targetExpression}.InteractionEffects.Add({expression});");
+            }
+            catch (Exception exception) when (exception is NotSupportedException
+                or FormatException
+                or InvalidCastException
+                or OverflowException)
+            {
+                validation.AddWarning(
+                    $"InteractionEffects.Item{index} on '{ownerName}' was skipped: {exception.Message}");
+            }
+        }
+    }
+
+    private static string WriteInteractionEffect(DesignPropertyValue effect)
+    {
+        IReadOnlyDictionary<string, DesignPropertyValue> properties = effect.ObjectProperties
+            ?? throw new FormatException("The effect description does not contain properties.");
+        string typeName = effect.ObjectTypeName ?? string.Empty;
+
+        if (IsEffectType(typeName, "RippleEffect"))
+        {
+            ValidateEffectProperties(properties,
+                "Enabled", "ColorArgb", "DurationMilliseconds", "StartFromPointer", "RadiusMode",
+                "FixedRadius", "Layer", "MaxConcurrentRipples", "OverflowPolicy");
+            int argb = ReadInt(properties, "ColorArgb", unchecked((int)0x5AFFFFFF));
+            uint color = unchecked((uint)argb);
+            return "new ModernFormsNext.Animations.RippleEffect { "
+                + $"Enabled = {ReadBoolLiteral(properties, "Enabled", true)}, "
+                + $"Color = System.Drawing.Color.FromArgb({color >> 24}, {(color >> 16) & 0xFF}, {(color >> 8) & 0xFF}, {color & 0xFF}), "
+                + $"Duration = System.TimeSpan.FromMilliseconds({ReadDoubleLiteral(properties, "DurationMilliseconds", 450d)}), "
+                + $"StartFromPointer = {ReadBoolLiteral(properties, "StartFromPointer", true)}, "
+                + $"RadiusMode = {ReadValue(properties, "RadiusMode", "ModernFormsNext.Animations.RippleRadiusMode.CoverControl")}, "
+                + $"FixedRadius = {ReadFloatLiteral(properties, "FixedRadius", 48d)}, "
+                + $"Layer = {ReadValue(properties, "Layer", "ModernFormsNext.Animations.RippleLayer.AboveBackgroundBelowContent")}, "
+                + $"MaxConcurrentRipples = {ReadInt(properties, "MaxConcurrentRipples", 4)}, "
+                + $"OverflowPolicy = {ReadValue(properties, "OverflowPolicy", "ModernFormsNext.Animations.RippleOverflowPolicy.RemoveOldest")} "
+                + "}";
+        }
+
+        if (IsEffectType(typeName, "PressScaleEffect"))
+        {
+            ValidateEffectProperties(properties,
+                "Enabled", "PressedScale", "PressDurationMilliseconds", "ReleaseDurationMilliseconds");
+            return "new ModernFormsNext.Animations.PressScaleEffect { "
+                + $"Enabled = {ReadBoolLiteral(properties, "Enabled", true)}, "
+                + $"PressedScale = {ReadFloatLiteral(properties, "PressedScale", 0.97d)}, "
+                + $"PressDuration = System.TimeSpan.FromMilliseconds({ReadDoubleLiteral(properties, "PressDurationMilliseconds", 80d)}), "
+                + $"ReleaseDuration = System.TimeSpan.FromMilliseconds({ReadDoubleLiteral(properties, "ReleaseDurationMilliseconds", 120d)}) "
+                + "}";
+        }
+
+        throw new NotSupportedException($"Interaction effect type '{typeName}' is not registered for code generation.");
+    }
+
+    private static void ValidateEffectProperties(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        params string[] supportedNames)
+    {
+        var supported = supportedNames.ToHashSet(StringComparer.Ordinal);
+        string? unsupported = properties.Keys.FirstOrDefault(name => !supported.Contains(name));
+        if (unsupported is not null)
+            throw new NotSupportedException($"Property '{unsupported}' is not supported for this interaction effect.");
+    }
+
+    private static bool IsEffectType(string typeName, string shortName)
+        => string.Equals(typeName, shortName, StringComparison.Ordinal)
+        || typeName.EndsWith("." + shortName, StringComparison.Ordinal);
+
+    private static int ReadInt(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name,
+        int fallback)
+        => properties.TryGetValue(name, out DesignPropertyValue? value)
+            ? Convert.ToInt32(value.Value, CultureInfo.InvariantCulture)
+            : fallback;
+
+    private static string ReadDoubleLiteral(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name,
+        double fallback)
+    {
+        double result = properties.TryGetValue(name, out DesignPropertyValue? value)
+            ? Convert.ToDouble(value.Value, CultureInfo.InvariantCulture)
+            : fallback;
+        if (!double.IsFinite(result))
+            throw new FormatException($"Property '{name}' must be finite.");
+        return result.ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    private static string ReadFloatLiteral(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name,
+        double fallback)
+    {
+        float result = (float)double.Parse(
+            ReadDoubleLiteral(properties, name, fallback),
+            CultureInfo.InvariantCulture);
+        if (!float.IsFinite(result))
+            throw new FormatException($"Property '{name}' must fit in a finite single-precision value.");
+        return result.ToString("R", CultureInfo.InvariantCulture) + "f";
+    }
+
+    private static string ReadBoolLiteral(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name,
+        bool fallback)
+        => properties.TryGetValue(name, out DesignPropertyValue? value)
+            ? CSharpLiteralWriter.WriteValue(value)
+            : fallback ? "true" : "false";
+
+    private static string ReadValue(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name,
+        string fallback)
+        => properties.TryGetValue(name, out DesignPropertyValue? value)
+            ? CSharpLiteralWriter.WriteValue(value)
+            : fallback;
 
     private static void WritePropertyAssignment(
         CodeWriter writer,

--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
@@ -241,6 +241,9 @@ public sealed class CSharpDesignerParser
 
     private void ProcessInvocation(InvocationExpressionSyntax invocation)
     {
+        if (TryProcessInteractionEffectAdd(invocation))
+            return;
+
         if (TryReadControlsAdd(invocation, out var parentName, out var childName))
         {
             addOperations.Add(new ControlAddOperation(parentName, childName, invocation));
@@ -248,6 +251,149 @@ public sealed class CSharpDesignerParser
         }
 
         AddUnsupported(invocation, "Unsupported method call in InitializeComponent.");
+    }
+
+    private bool TryProcessInteractionEffectAdd(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax addAccess
+            || !string.Equals(addAccess.Name.Identifier.ValueText, "Add", StringComparison.Ordinal)
+            || addAccess.Expression is not MemberAccessExpressionSyntax effectsAccess
+            || !string.Equals(effectsAccess.Name.Identifier.ValueText, InteractionEffectDesignValue.PropertyName, StringComparison.Ordinal)
+            || invocation.ArgumentList.Arguments.Count != 1)
+        {
+            return false;
+        }
+
+        string? ownerName = syntaxReader.GetObjectReferenceName(effectsAccess.Expression);
+        if (string.IsNullOrWhiteSpace(ownerName)
+            || !TryGetNode(ownerName, invocation, out DesignControlNode node))
+        {
+            return true;
+        }
+
+        if (!TryReadInteractionEffect(invocation.ArgumentList.Arguments[0].Expression, out DesignPropertyValue effect))
+        {
+            AddUnsupported(invocation, $"Unsupported interaction effect initializer for '{ownerName}'.");
+            return true;
+        }
+
+        node.Properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? existing);
+        if (!InteractionEffectDesignValue.TryRead(existing, out IReadOnlyList<DesignPropertyValue> effects, out string? error))
+        {
+            AddUnsupported(invocation, $"Cannot append interaction effect for '{ownerName}': {error}");
+            return true;
+        }
+
+        node.Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create(effects.Append(effect));
+        return true;
+    }
+
+    private static bool TryReadInteractionEffect(ExpressionSyntax expression, out DesignPropertyValue effect)
+    {
+        effect = null!;
+        if (expression is not ObjectCreationExpressionSyntax objectCreation
+            || objectCreation.Initializer is null)
+        {
+            return false;
+        }
+
+        string typeName = objectCreation.Type.ToString();
+        bool isRipple = IsType(typeName, "RippleEffect");
+        bool isPressScale = IsType(typeName, "PressScaleEffect");
+        if (!isRipple && !isPressScale)
+            return false;
+
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        foreach (ExpressionSyntax initializer in objectCreation.Initializer.Expressions)
+        {
+            if (initializer is not AssignmentExpressionSyntax assignment
+                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                return false;
+            }
+
+            string propertyName = assignment.Left switch
+            {
+                IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+                MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+                _ => string.Empty
+            };
+            if (string.IsNullOrWhiteSpace(propertyName))
+                return false;
+
+            if (string.Equals(propertyName, "Color", StringComparison.Ordinal))
+            {
+                if (!TryReadColorArgb(assignment.Right, out int argb))
+                    return false;
+                properties["ColorArgb"] = DesignPropertyValue.FromInt32(argb);
+                continue;
+            }
+
+            string? durationProperty = propertyName switch
+            {
+                "Duration" when isRipple => "DurationMilliseconds",
+                "PressDuration" when isPressScale => "PressDurationMilliseconds",
+                "ReleaseDuration" when isPressScale => "ReleaseDurationMilliseconds",
+                _ => null
+            };
+            if (durationProperty is not null)
+            {
+                if (!TryReadTimeSpanMilliseconds(assignment.Right, out double milliseconds))
+                    return false;
+                properties[durationProperty] = DesignPropertyValue.FromDouble(milliseconds);
+                continue;
+            }
+
+            if (!TryReadDesignerValue(assignment.Right, out DesignPropertyValue value))
+                return false;
+            properties[propertyName] = value;
+        }
+
+        effect = DesignPropertyValue.FromStructuredObject(typeName, properties);
+        return true;
+    }
+
+    private static bool TryReadTimeSpanMilliseconds(ExpressionSyntax expression, out double milliseconds)
+    {
+        milliseconds = 0d;
+        return expression is InvocationExpressionSyntax invocation
+            && invocation.Expression is MemberAccessExpressionSyntax member
+            && string.Equals(member.Name.Identifier.ValueText, "FromMilliseconds", StringComparison.Ordinal)
+            && member.Expression.ToString().EndsWith("TimeSpan", StringComparison.Ordinal)
+            && invocation.ArgumentList.Arguments.Count == 1
+            && TryReadDouble(invocation.ArgumentList.Arguments[0].Expression, out milliseconds)
+            && double.IsFinite(milliseconds)
+            && milliseconds >= 0d;
+    }
+
+    private static bool TryReadColorArgb(ExpressionSyntax expression, out int argb)
+    {
+        argb = 0;
+        if (expression is not InvocationExpressionSyntax invocation
+            || invocation.Expression is not MemberAccessExpressionSyntax member
+            || !string.Equals(member.Name.Identifier.ValueText, "FromArgb", StringComparison.Ordinal)
+            || !member.Expression.ToString().EndsWith("Color", StringComparison.Ordinal)
+            || invocation.ArgumentList.Arguments.Count != 4)
+        {
+            return false;
+        }
+
+        var channels = new int[4];
+        for (int index = 0; index < channels.Length; index++)
+        {
+            if (!TryReadInt32(invocation.ArgumentList.Arguments[index].Expression, out channels[index])
+                || channels[index] is < 0 or > 255)
+            {
+                return false;
+            }
+        }
+
+        argb = unchecked((int)(((uint)channels[0] << 24)
+            | ((uint)channels[1] << 16)
+            | ((uint)channels[2] << 8)
+            | (uint)channels[3]));
+        return true;
     }
 
     private void ProcessPropertyAssignment(

--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
@@ -299,10 +299,14 @@ public sealed class CSharpDesignerParser
         }
 
         string typeName = objectCreation.Type.ToString();
-        bool isRipple = IsType(typeName, "RippleEffect");
-        bool isPressScale = IsType(typeName, "PressScaleEffect");
+        bool isRipple = IsInteractionEffectType(typeName, "RippleEffect");
+        bool isPressScale = IsInteractionEffectType(typeName, "PressScaleEffect");
         if (!isRipple && !isPressScale)
             return false;
+
+        string[] supportedProperties = isRipple
+            ? ["Enabled", "Color", "Duration", "StartFromPointer", "RadiusMode", "FixedRadius", "Layer", "MaxConcurrentRipples", "OverflowPolicy"]
+            : ["Enabled", "PressedScale", "PressDuration", "ReleaseDuration"];
 
         var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
         foreach (ExpressionSyntax initializer in objectCreation.Initializer.Expressions)
@@ -319,14 +323,16 @@ public sealed class CSharpDesignerParser
                 MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
                 _ => string.Empty
             };
-            if (string.IsNullOrWhiteSpace(propertyName))
+            if (string.IsNullOrWhiteSpace(propertyName)
+                || !supportedProperties.Contains(propertyName, StringComparer.Ordinal))
                 return false;
 
             if (string.Equals(propertyName, "Color", StringComparison.Ordinal))
             {
                 if (!TryReadColorArgb(assignment.Right, out int argb))
                     return false;
-                properties["ColorArgb"] = DesignPropertyValue.FromInt32(argb);
+                if (!properties.TryAdd("ColorArgb", DesignPropertyValue.FromInt32(argb)))
+                    return false;
                 continue;
             }
 
@@ -341,18 +347,24 @@ public sealed class CSharpDesignerParser
             {
                 if (!TryReadTimeSpanMilliseconds(assignment.Right, out double milliseconds))
                     return false;
-                properties[durationProperty] = DesignPropertyValue.FromDouble(milliseconds);
+                if (!properties.TryAdd(durationProperty, DesignPropertyValue.FromDouble(milliseconds)))
+                    return false;
                 continue;
             }
 
             if (!TryReadDesignerValue(assignment.Right, out DesignPropertyValue value))
                 return false;
-            properties[propertyName] = value;
+            if (!properties.TryAdd(propertyName, value))
+                return false;
         }
 
         effect = DesignPropertyValue.FromStructuredObject(typeName, properties);
         return true;
     }
+
+    private static bool IsInteractionEffectType(string typeName, string shortName)
+        => string.Equals(typeName, shortName, StringComparison.Ordinal)
+        || string.Equals(typeName, "ModernFormsNext.Animations." + shortName, StringComparison.Ordinal);
 
     private static bool TryReadTimeSpanMilliseconds(ExpressionSyntax expression, out double milliseconds)
     {

--- a/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
@@ -1,0 +1,212 @@
+using System.ComponentModel;
+using Microsoft.CodeAnalysis.CSharp;
+using ModernFormsNext.Animations;
+using ModernFormsNext.CodeGeneration.CSharp;
+using ModernFormsNext.CodeGeneration.Reverse;
+using ModernFormsNext.Designer.Properties;
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designing;
+using Xunit;
+
+namespace ModernFormsNext.Designer.Tests;
+
+public sealed class InteractionEffectDesignerTests
+{
+    [Fact]
+    public void RegistryOffersOnlyBuiltInSafeEffectTypes()
+    {
+        Assert.Equal(
+            [
+                InteractionEffectDesignerRegistry.RippleTypeName,
+                InteractionEffectDesignerRegistry.PressScaleTypeName
+            ],
+            InteractionEffectDesignerRegistry.SupportedTypeNames);
+    }
+
+    [Fact]
+    public void AddRemoveAndOrderProduceDeterministicCollectionValue()
+    {
+        var entries = new List<DesignerInteractionEffectEntry>
+        {
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName),
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.PressScaleTypeName)
+        };
+
+        DesignPropertyValue value = InteractionEffectDesignerRegistry.WriteCollection(entries);
+        Assert.True(InteractionEffectDesignerRegistry.TryReadCollection(value, out var restored, out var error), error);
+        Assert.Equal(InteractionEffectDesignerRegistry.RippleTypeName, restored[0].TypeName);
+        Assert.Equal(InteractionEffectDesignerRegistry.PressScaleTypeName, restored[1].TypeName);
+
+        entries.RemoveAt(0);
+        value = InteractionEffectDesignerRegistry.WriteCollection(entries);
+        Assert.True(InteractionEffectDesignValue.TryRead(value, out var remaining, out error), error);
+        Assert.Single(remaining);
+        Assert.Equal(InteractionEffectDesignerRegistry.PressScaleTypeName, remaining[0].ObjectTypeName);
+    }
+
+    [Fact]
+    public void PropertyMutationGeneratesStableRuntimeInitializer()
+    {
+        DesignerInteractionEffectEntry ripple =
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName);
+        string edited = InteractionEffectDesignerRegistry.FormatEditorText(ripple)
+            .Replace("DurationMilliseconds=450", "DurationMilliseconds=275", StringComparison.Ordinal)
+            .Replace("OverflowPolicy=RemoveOldest", "OverflowPolicy=IgnoreNew", StringComparison.Ordinal)
+            .Replace("ColorArgb=#5AFFFFFF", "ColorArgb=#7F102030", StringComparison.Ordinal);
+        Assert.True(InteractionEffectDesignerRegistry.TryApplyEditorText(ripple, edited, out var error), error);
+        DesignDocument document = CreateDocument(ripple);
+
+        var generated = new CSharpDesignerGenerator().Generate(document);
+
+        Assert.True(generated.Succeeded, string.Join(Environment.NewLine, generated.Validation.Errors));
+        Assert.Contains("Duration = System.TimeSpan.FromMilliseconds(275)", generated.Code, StringComparison.Ordinal);
+        Assert.Contains("Color = System.Drawing.Color.FromArgb(127, 16, 32, 48)", generated.Code, StringComparison.Ordinal);
+        Assert.Contains("RippleOverflowPolicy.IgnoreNew", generated.Code, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            CSharpSyntaxTree.ParseText(generated.Code).GetDiagnostics(),
+            diagnostic => diagnostic.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void GeneratedCodeRoundTripPreservesOrderAndDoesNotDuplicateEffects()
+    {
+        DesignerInteractionEffectEntry ripple =
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName);
+        DesignerInteractionEffectEntry press =
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.PressScaleTypeName);
+        DesignDocument document = CreateDocument(ripple, press);
+        var generator = new CSharpDesignerGenerator();
+
+        string firstCode = generator.Generate(document).Code;
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(firstCode);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+        DesignDocument reopened = Assert.IsType<DesignDocument>(parsed.Document);
+        DesignPropertyValue value = Assert.Single(reopened.Controls).Properties[InteractionEffectDesignValue.PropertyName];
+        Assert.True(InteractionEffectDesignValue.TryRead(value, out var effects, out var error), error);
+        Assert.Equal(2, effects.Count);
+        Assert.EndsWith("RippleEffect", effects[0].ObjectTypeName, StringComparison.Ordinal);
+        Assert.EndsWith("PressScaleEffect", effects[1].ObjectTypeName, StringComparison.Ordinal);
+
+        string secondCode = generator.Generate(reopened).Code;
+        Assert.Equal(firstCode, secondCode);
+        Assert.Equal(2, CountOccurrences(secondCode, ".InteractionEffects.Add("));
+    }
+
+    [Fact]
+    public void MfdesignSaveReloadAndCloneKeepOneOrderedCollection()
+    {
+        DesignDocument document = CreateDocument(
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.PressScaleTypeName),
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName));
+        string json = DesignDocumentSerializer.Default.Serialize(document);
+
+        DesignDocument reopened = DesignDocumentSerializer.Default.Deserialize(json);
+        DesignDocument cloned = DesignDocumentSerializer.Default.Deserialize(
+            DesignDocumentSerializer.Default.Serialize(reopened));
+        DesignPropertyValue value = Assert.Single(cloned.Controls).Properties[InteractionEffectDesignValue.PropertyName];
+
+        Assert.True(InteractionEffectDesignValue.TryRead(value, out var effects, out var error), error);
+        Assert.Equal(2, effects.Count);
+        Assert.EndsWith("PressScaleEffect", effects[0].ObjectTypeName, StringComparison.Ordinal);
+        Assert.EndsWith("RippleEffect", effects[1].ObjectTypeName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnsupportedEffectTypeIsRejectedWithoutMutation()
+    {
+        DesignPropertyValue unsupported = DesignPropertyValue.FromStructuredObject(
+            "Example.UnsafeEffect",
+            new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal));
+        DesignPropertyValue value = InteractionEffectDesignValue.Create([unsupported]);
+
+        bool success = InteractionEffectDesignerRegistry.TryReadCollection(value, out var entries, out var error);
+
+        Assert.False(success);
+        Assert.Empty(entries);
+        Assert.Contains("not supported", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DesignerModelCreatesNoRuntimeEffectsOrSchedulerHandles()
+    {
+        int activeBefore = AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount;
+
+        DesignerInteractionEffectEntry entry =
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName);
+        DesignPropertyValue value = InteractionEffectDesignerRegistry.WriteCollection([entry]);
+        Assert.True(InteractionEffectDesignerRegistry.TryReadCollection(value, out var entries, out var error), error);
+
+        Assert.All(entries, item => Assert.False((object)item is InteractionEffect));
+        Assert.Equal(activeBefore, AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void RuntimeCollectionMetadataUsesContentSerialization()
+    {
+        PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(Control))[nameof(Control.InteractionEffects)]!;
+
+        Assert.True(property.IsBrowsable);
+        Assert.Equal(
+            DesignerSerializationVisibility.Content,
+            property.SerializationVisibility);
+    }
+
+    [Fact]
+    public void PropertyGridExposesDesignerOnlyCollectionDialog()
+    {
+        int activeBefore = AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount;
+        DesignDocument document = CreateDocument(
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName));
+        var session = new DesignerSession();
+        session.LoadDocument(document);
+        session.Host.Selection.Select(Assert.Single(document.Controls));
+        var state = new DesignerPropertyGridState(session);
+
+        DesignerPropertyDescriptor descriptor = Assert.Single(
+            state.Properties,
+            property => property.Name == InteractionEffectDesignValue.PropertyName);
+
+        Assert.True(descriptor.HasDialogEditor);
+        Assert.NotNull(descriptor.DialogEditor);
+        Assert.Equal("1 effect", descriptor.GetValue());
+        Assert.Equal(activeBefore, AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void RemovingLastEffectRemovesGeneratedAddCall()
+    {
+        DesignDocument document = CreateDocument(
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName));
+        DesignControlNode control = Assert.Single(document.Controls);
+        control.Properties.Remove(InteractionEffectDesignValue.PropertyName);
+
+        string code = new CSharpDesignerGenerator().Generate(document).Code;
+
+        Assert.DoesNotContain(".InteractionEffects.Add(", code, StringComparison.Ordinal);
+    }
+
+    private static DesignDocument CreateDocument(params DesignerInteractionEffectEntry[] effects)
+    {
+        var document = new DesignDocument
+        {
+            Namespace = "Example",
+            ClassName = "MainForm",
+            FormName = "MainForm",
+            Size = new DesignSize(640, 480)
+        };
+        var control = new DesignControlNode
+        {
+            TypeName = "Button",
+            Name = "button1",
+            Bounds = new DesignBounds(10, 10, 120, 36),
+            MemberVisibility = DesignerMemberVisibility.Private
+        };
+        control.Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignerRegistry.WriteCollection(effects);
+        document.Controls.Add(control);
+        return document;
+    }
+
+    private static int CountOccurrences(string text, string value)
+        => text.Split(value, StringSplitOptions.None).Length - 1;
+}

--- a/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
@@ -127,6 +127,52 @@ public sealed class InteractionEffectDesignerTests
     }
 
     [Fact]
+    public void GeneratorRejectsForeignTypeWithBuiltInShortName()
+    {
+        DesignDocument document = CreateDocument();
+        DesignControlNode control = Assert.Single(document.Controls);
+        DesignPropertyValue foreign = DesignPropertyValue.FromStructuredObject(
+            "Example.RippleEffect",
+            new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal));
+        control.Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create([foreign]);
+
+        var generated = new CSharpDesignerGenerator().Generate(document);
+
+        Assert.DoesNotContain(".InteractionEffects.Add(", generated.Code, StringComparison.Ordinal);
+        Assert.Contains(
+            generated.Validation.Warnings,
+            warning => warning.Contains("not registered", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ReverseParserRejectsForeignTypeAndUnsupportedPropertyWithoutMutation()
+    {
+        DesignDocument document = CreateDocument(
+            InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName));
+        string code = new CSharpDesignerGenerator().Generate(document).Code;
+        string[] unsupportedVariants =
+        [
+            code.Replace(
+                "ModernFormsNext.Animations.RippleEffect",
+                "Example.RippleEffect",
+                StringComparison.Ordinal),
+            code.Replace("Enabled = true", "Unsupported = true", StringComparison.Ordinal)
+        ];
+
+        foreach (string unsupportedCode in unsupportedVariants)
+        {
+            CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(unsupportedCode);
+            DesignControlNode control = Assert.Single(Assert.IsType<DesignDocument>(parsed.Document).Controls);
+
+            Assert.Contains(
+                parsed.Diagnostics,
+                diagnostic => diagnostic.Message.Contains("Unsupported interaction effect initializer", StringComparison.Ordinal));
+            Assert.False(control.Properties.ContainsKey(InteractionEffectDesignValue.PropertyName));
+        }
+    }
+
+    [Fact]
     public void DesignerModelCreatesNoRuntimeEffectsOrSchedulerHandles()
     {
         int activeBefore = AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount;

--- a/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
@@ -198,6 +198,19 @@ public sealed class InteractionEffectDesignerTests
     }
 
     [Fact]
+    public void EmptyRuntimeCollectionIsNotMarkedForSerialization()
+    {
+        using var button = new Button();
+        PropertyDescriptor property = TypeDescriptor.GetProperties(button)[nameof(Control.InteractionEffects)]!;
+
+        Assert.False(property.ShouldSerializeValue(button));
+
+        button.InteractionEffects.Add(new RippleEffect());
+
+        Assert.True(property.ShouldSerializeValue(button));
+    }
+
+    [Fact]
     public void PropertyGridExposesDesignerOnlyCollectionDialog()
     {
         int activeBefore = AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount;
@@ -215,6 +228,51 @@ public sealed class InteractionEffectDesignerTests
         Assert.True(descriptor.HasDialogEditor);
         Assert.NotNull(descriptor.DialogEditor);
         Assert.Equal("1 effect", descriptor.GetValue());
+        Assert.Equal(activeBefore, AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void NewButtonKeepsEmptyEffectsOutOfSaveCodeGenerationAndReverseSync()
+    {
+        DesignDocument document = CreateDocument();
+        DesignControlNode button = Assert.Single(document.Controls);
+        var generator = new CSharpDesignerGenerator();
+
+        Assert.False(button.Properties.ContainsKey(InteractionEffectDesignValue.PropertyName));
+
+        string json = DesignDocumentSerializer.Default.Serialize(document);
+        Assert.DoesNotContain(InteractionEffectDesignValue.PropertyName, json, StringComparison.Ordinal);
+
+        DesignDocument reopened = DesignDocumentSerializer.Default.Deserialize(json);
+        Assert.False(Assert.Single(reopened.Controls).Properties.ContainsKey(InteractionEffectDesignValue.PropertyName));
+
+        string code = generator.Generate(reopened).Code;
+        Assert.DoesNotContain(".InteractionEffects.Add(", code, StringComparison.Ordinal);
+        Assert.DoesNotContain(".StyleTransitions.Add(", code, StringComparison.Ordinal);
+
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(code);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+        Assert.False(
+            Assert.Single(Assert.IsType<DesignDocument>(parsed.Document).Controls)
+                .Properties.ContainsKey(InteractionEffectDesignValue.PropertyName));
+    }
+
+    [Fact]
+    public void NewButtonPropertyGridShowsEmptyCollectionWithoutStartingRuntimeWork()
+    {
+        int activeBefore = AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount;
+        DesignDocument document = CreateDocument();
+        var session = new DesignerSession();
+        session.LoadDocument(document);
+        session.Host.Selection.Select(Assert.Single(document.Controls));
+        var state = new DesignerPropertyGridState(session);
+
+        DesignerPropertyDescriptor descriptor = Assert.Single(
+            state.Properties,
+            property => property.Name == InteractionEffectDesignValue.PropertyName);
+
+        Assert.True(descriptor.HasDialogEditor);
+        Assert.Equal("0 effects", descriptor.GetValue());
         Assert.Equal(activeBefore, AnimationScheduler.Default.GetDiagnostics().ActiveAnimationCount);
     }
 
@@ -247,8 +305,11 @@ public sealed class InteractionEffectDesignerTests
             Bounds = new DesignBounds(10, 10, 120, 36),
             MemberVisibility = DesignerMemberVisibility.Private
         };
-        control.Properties[InteractionEffectDesignValue.PropertyName] =
-            InteractionEffectDesignerRegistry.WriteCollection(effects);
+        if (effects.Length > 0)
+        {
+            control.Properties[InteractionEffectDesignValue.PropertyName] =
+                InteractionEffectDesignerRegistry.WriteCollection(effects);
+        }
         document.Controls.Add(control);
         return document;
     }

--- a/ModernFormsNext.Designer/Properties/DesignerInteractionEffectCollectionDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerInteractionEffectCollectionDialog.cs
@@ -1,0 +1,176 @@
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designing;
+
+namespace ModernFormsNext.Designer.Properties;
+
+internal sealed class DesignerInteractionEffectCollectionDialog : Form
+{
+    private readonly DesignerSession session;
+    private readonly DesignControlNode control;
+    private readonly List<DesignerInteractionEffectEntry> entries;
+    private readonly ListBox effectList;
+    private readonly TextBox propertyEditor;
+    private readonly Label errorLabel;
+    private int loadedIndex = -1;
+    private bool changingSelection;
+
+    public DesignerInteractionEffectCollectionDialog(DesignerSession session, DesignControlNode control)
+    {
+        this.session = session ?? throw new ArgumentNullException(nameof(session));
+        this.control = control ?? throw new ArgumentNullException(nameof(control));
+
+        control.Properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? stored);
+        if (!InteractionEffectDesignerRegistry.TryReadCollection(stored, out entries, out string? error))
+            throw new InvalidOperationException(error);
+
+        Text = "Interaction Effects Collection Editor";
+        Name = "DesignerInteractionEffectCollectionDialog";
+        Size = new System.Drawing.Size(760, 520);
+        StartPosition = FormStartPosition.CenterParent;
+
+        Controls.Add(new Label { Left = 18, Top = 16, Width = 240, Height = 22, Text = "Members (runtime order)" });
+        effectList = Controls.Add(new ListBox { Left = 18, Top = 42, Width = 250, Height = 330 });
+
+        var addRipple = Controls.Add(new Button { Left = 18, Top = 382, Width = 116, Height = 30, Text = "Add Ripple" });
+        var addPress = Controls.Add(new Button { Left = 142, Top = 382, Width = 126, Height = 30, Text = "Add PressScale" });
+        var remove = Controls.Add(new Button { Left = 18, Top = 418, Width = 78, Height = 30, Text = "Remove" });
+        var up = Controls.Add(new Button { Left = 104, Top = 418, Width = 48, Height = 30, Text = "Up" });
+        var down = Controls.Add(new Button { Left = 160, Top = 418, Width = 56, Height = 30, Text = "Down" });
+
+        Controls.Add(new Label { Left = 292, Top = 16, Width = 420, Height = 22, Text = "Selected effect properties (Property=Value)" });
+        propertyEditor = Controls.Add(new TextBox
+        {
+            Left = 292,
+            Top = 42,
+            Width = 430,
+            Height = 300,
+            MultiLine = true
+        });
+        Controls.Add(new Label
+        {
+            Left = 292,
+            Top = 350,
+            Width = 430,
+            Height = 42,
+            Text = "Enums use member names. Colors use #AARRGGBB. Durations are milliseconds."
+        });
+        errorLabel = Controls.Add(new Label { Left = 292, Top = 396, Width = 430, Height = 44, Text = string.Empty });
+
+        var apply = Controls.Add(new Button { Left = 450, Top = 446, Width = 80, Height = 30, Text = "Apply" });
+        var ok = Controls.Add(new Button { Left = 546, Top = 446, Width = 80, Height = 30, Text = "OK" });
+        var cancel = Controls.Add(new Button { Left = 642, Top = 446, Width = 80, Height = 30, Text = "Cancel" });
+
+        effectList.SelectedIndexChanged += (_, _) => ChangeSelection();
+        addRipple.Click += (_, _) => Add(InteractionEffectDesignerRegistry.RippleTypeName);
+        addPress.Click += (_, _) => Add(InteractionEffectDesignerRegistry.PressScaleTypeName);
+        remove.Click += (_, _) => RemoveSelected();
+        up.Click += (_, _) => MoveSelected(-1);
+        down.Click += (_, _) => MoveSelected(1);
+        apply.Click += (_, _) => TryApplyLoaded();
+        ok.Click += (_, _) => Commit();
+        cancel.Click += (_, _) => DialogResult = DialogResult.Cancel;
+
+        RefreshList(selectIndex: entries.Count > 0 ? 0 : -1);
+    }
+
+    private void Add(string typeName)
+    {
+        if (!TryApplyLoaded())
+            return;
+        entries.Add(InteractionEffectDesignerRegistry.Create(typeName));
+        RefreshList(entries.Count - 1);
+    }
+
+    private void RemoveSelected()
+    {
+        int index = effectList.SelectedIndex;
+        if (index < 0 || index >= entries.Count)
+            return;
+        entries.RemoveAt(index);
+        loadedIndex = -1;
+        RefreshList(Math.Min(index, entries.Count - 1));
+    }
+
+    private void MoveSelected(int delta)
+    {
+        if (!TryApplyLoaded())
+            return;
+        int oldIndex = effectList.SelectedIndex;
+        int newIndex = oldIndex + delta;
+        if (oldIndex < 0 || newIndex < 0 || newIndex >= entries.Count)
+            return;
+        DesignerInteractionEffectEntry entry = entries[oldIndex];
+        entries.RemoveAt(oldIndex);
+        entries.Insert(newIndex, entry);
+        loadedIndex = -1;
+        RefreshList(newIndex);
+    }
+
+    private void ChangeSelection()
+    {
+        if (changingSelection)
+            return;
+        int selected = effectList.SelectedIndex;
+        if (selected == loadedIndex)
+            return;
+        if (!TryApplyLoaded())
+        {
+            changingSelection = true;
+            effectList.SelectedIndex = loadedIndex;
+            changingSelection = false;
+            return;
+        }
+        loadedIndex = selected;
+        propertyEditor.Text = selected >= 0 && selected < entries.Count
+            ? InteractionEffectDesignerRegistry.FormatEditorText(entries[selected])
+            : string.Empty;
+        errorLabel.Text = string.Empty;
+    }
+
+    private bool TryApplyLoaded()
+    {
+        if (loadedIndex < 0 || loadedIndex >= entries.Count)
+            return true;
+        if (InteractionEffectDesignerRegistry.TryApplyEditorText(
+            entries[loadedIndex],
+            propertyEditor.Text,
+            out string? error))
+        {
+            errorLabel.Text = string.Empty;
+            return true;
+        }
+        ShowError(error ?? "The selected effect properties are invalid.");
+        return false;
+    }
+
+    private void Commit()
+    {
+        if (!TryApplyLoaded())
+            return;
+
+        if (entries.Count == 0)
+            control.Properties.Remove(InteractionEffectDesignValue.PropertyName);
+        else
+            control.Properties[InteractionEffectDesignValue.PropertyName] =
+                InteractionEffectDesignerRegistry.WriteCollection(entries);
+        DialogResult = DialogResult.OK;
+    }
+
+    private void RefreshList(int selectIndex)
+    {
+        changingSelection = true;
+        effectList.Items.Clear();
+        foreach (DesignerInteractionEffectEntry entry in entries)
+            effectList.Items.Add(entry);
+        effectList.SelectedIndex = entries.Count == 0 ? -1 : Math.Clamp(selectIndex, 0, entries.Count - 1);
+        changingSelection = false;
+        loadedIndex = -1;
+        ChangeSelection();
+    }
+
+    private void ShowError(string message)
+    {
+        errorLabel.Text = message;
+        session.Log($"Interaction effect editor: {message}");
+    }
+}

--- a/ModernFormsNext.Designer/Properties/DesignerInteractionEffectModel.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerInteractionEffectModel.cs
@@ -1,0 +1,356 @@
+using System.Globalization;
+using ModernFormsNext.Designing;
+
+namespace ModernFormsNext.Designer.Properties;
+
+internal sealed class DesignerInteractionEffectEntry
+{
+    public DesignerInteractionEffectEntry(
+        string typeName,
+        IReadOnlyDictionary<string, DesignPropertyValue> properties)
+    {
+        TypeName = typeName;
+        Properties = new SortedDictionary<string, DesignPropertyValue>(
+            properties.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal),
+            StringComparer.Ordinal);
+    }
+
+    public string TypeName { get; }
+
+    public SortedDictionary<string, DesignPropertyValue> Properties { get; private set; }
+
+    public void ReplaceProperties(IReadOnlyDictionary<string, DesignPropertyValue> properties)
+        => Properties = new SortedDictionary<string, DesignPropertyValue>(
+            properties.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal),
+            StringComparer.Ordinal);
+
+    public DesignPropertyValue ToDesignValue()
+        => DesignPropertyValue.FromStructuredObject(TypeName, Properties);
+
+    public override string ToString()
+        => TypeName.Split('.').Last();
+}
+
+internal static class InteractionEffectDesignerRegistry
+{
+    internal const string RippleTypeName = "ModernFormsNext.Animations.RippleEffect";
+    internal const string PressScaleTypeName = "ModernFormsNext.Animations.PressScaleEffect";
+
+    private static readonly EffectPropertyDefinition[] RippleProperties =
+    [
+        EffectPropertyDefinition.Boolean("Enabled", true),
+        EffectPropertyDefinition.ColorArgb("ColorArgb", unchecked((int)0x5AFFFFFF)),
+        EffectPropertyDefinition.Number("DurationMilliseconds", 450d, 0d, double.MaxValue),
+        EffectPropertyDefinition.Boolean("StartFromPointer", true),
+        EffectPropertyDefinition.Enum(
+            "RadiusMode",
+            "ModernFormsNext.Animations.RippleRadiusMode",
+            "CoverControl",
+            "CoverControl",
+            "Fixed"),
+        EffectPropertyDefinition.Number("FixedRadius", 48d, 0d, float.MaxValue),
+        EffectPropertyDefinition.Enum(
+            "Layer",
+            "ModernFormsNext.Animations.RippleLayer",
+            "AboveBackgroundBelowContent",
+            "AboveBackgroundBelowContent",
+            "AboveContent"),
+        EffectPropertyDefinition.Integer("MaxConcurrentRipples", 4, 1, 32),
+        EffectPropertyDefinition.Enum(
+            "OverflowPolicy",
+            "ModernFormsNext.Animations.RippleOverflowPolicy",
+            "RemoveOldest",
+            "RemoveOldest",
+            "RemoveNewest",
+            "IgnoreNew",
+            "ReplaceAll")
+    ];
+
+    private static readonly EffectPropertyDefinition[] PressScaleProperties =
+    [
+        EffectPropertyDefinition.Boolean("Enabled", true),
+        EffectPropertyDefinition.Number("PressedScale", 0.97d, double.Epsilon, float.MaxValue),
+        EffectPropertyDefinition.Number("PressDurationMilliseconds", 80d, 0d, double.MaxValue),
+        EffectPropertyDefinition.Number("ReleaseDurationMilliseconds", 120d, 0d, double.MaxValue)
+    ];
+
+    public static IReadOnlyList<string> SupportedTypeNames { get; } =
+        [RippleTypeName, PressScaleTypeName];
+
+    public static DesignerInteractionEffectEntry Create(string typeName)
+    {
+        EffectPropertyDefinition[] definitions = GetDefinitions(typeName)
+            ?? throw new NotSupportedException($"Interaction effect type '{typeName}' is not supported by the Designer.");
+        return new DesignerInteractionEffectEntry(
+            typeName,
+            definitions.ToDictionary(item => item.Name, item => item.DefaultValue, StringComparer.Ordinal));
+    }
+
+    public static bool TryReadCollection(
+        DesignPropertyValue? value,
+        out List<DesignerInteractionEffectEntry> entries,
+        out string? error)
+    {
+        entries = [];
+        if (!InteractionEffectDesignValue.TryRead(value, out IReadOnlyList<DesignPropertyValue> effects, out error))
+            return false;
+
+        foreach (DesignPropertyValue effect in effects)
+        {
+            string typeName = NormalizeTypeName(effect.ObjectTypeName);
+            EffectPropertyDefinition[]? definitions = GetDefinitions(typeName);
+            if (definitions is null)
+            {
+                error = $"Interaction effect type '{effect.ObjectTypeName}' is not supported by the Designer.";
+                entries.Clear();
+                return false;
+            }
+            if (!TryNormalizeProperties(definitions, effect.ObjectProperties!, out var properties, out error))
+            {
+                entries.Clear();
+                return false;
+            }
+            entries.Add(new DesignerInteractionEffectEntry(typeName, properties));
+        }
+        return true;
+    }
+
+    public static DesignPropertyValue WriteCollection(IEnumerable<DesignerInteractionEffectEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        return InteractionEffectDesignValue.Create(entries.Select(entry => entry.ToDesignValue()));
+    }
+
+    public static string FormatEditorText(DesignerInteractionEffectEntry entry)
+    {
+        EffectPropertyDefinition[] definitions = GetDefinitions(entry.TypeName)!;
+        return string.Join(
+            Environment.NewLine,
+            definitions.Select(definition =>
+                $"{definition.Name}={definition.Format(entry.Properties[definition.Name])}"));
+    }
+
+    public static bool TryApplyEditorText(
+        DesignerInteractionEffectEntry entry,
+        string text,
+        out string? error)
+    {
+        EffectPropertyDefinition[] definitions = GetDefinitions(entry.TypeName)!;
+        var byName = definitions.ToDictionary(item => item.Name, StringComparer.Ordinal);
+        var parsed = definitions.ToDictionary(item => item.Name, item => item.DefaultValue, StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (string rawLine in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+                continue;
+            int separator = line.IndexOf('=');
+            if (separator <= 0)
+            {
+                error = $"'{line}' must use Property=Value syntax.";
+                return false;
+            }
+            string name = line[..separator].Trim();
+            string value = line[(separator + 1)..].Trim();
+            if (!byName.TryGetValue(name, out EffectPropertyDefinition? definition))
+            {
+                error = $"Property '{name}' is not supported for {entry}.";
+                return false;
+            }
+            if (!seen.Add(name))
+            {
+                error = $"Property '{name}' is duplicated.";
+                return false;
+            }
+            if (!definition.TryParse(value, out DesignPropertyValue parsedValue, out error))
+                return false;
+            parsed[name] = parsedValue;
+        }
+
+        entry.ReplaceProperties(parsed);
+        error = null;
+        return true;
+    }
+
+    private static bool TryNormalizeProperties(
+        EffectPropertyDefinition[] definitions,
+        IReadOnlyDictionary<string, DesignPropertyValue> source,
+        out IReadOnlyDictionary<string, DesignPropertyValue> normalized,
+        out string? error)
+    {
+        var supported = definitions.ToDictionary(item => item.Name, StringComparer.Ordinal);
+        foreach (string name in source.Keys)
+        {
+            if (!supported.ContainsKey(name))
+            {
+                normalized = new Dictionary<string, DesignPropertyValue>();
+                error = $"Property '{name}' is not supported for this interaction effect.";
+                return false;
+            }
+        }
+
+        var result = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        foreach (EffectPropertyDefinition definition in definitions)
+        {
+            DesignPropertyValue value = source.TryGetValue(definition.Name, out DesignPropertyValue? stored)
+                ? stored
+                : definition.DefaultValue;
+            if (!definition.TryParse(definition.Format(value), out DesignPropertyValue normalizedValue, out error))
+            {
+                normalized = new Dictionary<string, DesignPropertyValue>();
+                return false;
+            }
+            result[definition.Name] = normalizedValue;
+        }
+
+        normalized = result;
+        error = null;
+        return true;
+    }
+
+    private static string NormalizeTypeName(string? typeName)
+        => typeName switch
+        {
+            "RippleEffect" => RippleTypeName,
+            "PressScaleEffect" => PressScaleTypeName,
+            _ => typeName ?? string.Empty
+        };
+
+    private static EffectPropertyDefinition[]? GetDefinitions(string typeName)
+        => NormalizeTypeName(typeName) switch
+        {
+            RippleTypeName => RippleProperties,
+            PressScaleTypeName => PressScaleProperties,
+            _ => null
+        };
+
+    private enum EffectPropertyKind
+    {
+        Boolean,
+        Integer,
+        Number,
+        Enum,
+        ColorArgb
+    }
+
+    private sealed class EffectPropertyDefinition
+    {
+        private EffectPropertyDefinition(
+            string name,
+            EffectPropertyKind kind,
+            DesignPropertyValue defaultValue,
+            double minimum = double.MinValue,
+            double maximum = double.MaxValue,
+            string? enumTypeName = null,
+            string[]? enumMembers = null)
+        {
+            Name = name;
+            Kind = kind;
+            DefaultValue = defaultValue;
+            Minimum = minimum;
+            Maximum = maximum;
+            EnumTypeName = enumTypeName;
+            EnumMembers = enumMembers ?? [];
+        }
+
+        public string Name { get; }
+        public EffectPropertyKind Kind { get; }
+        public DesignPropertyValue DefaultValue { get; }
+        public double Minimum { get; }
+        public double Maximum { get; }
+        public string? EnumTypeName { get; }
+        public IReadOnlyList<string> EnumMembers { get; }
+
+        public static EffectPropertyDefinition Boolean(string name, bool defaultValue)
+            => new(name, EffectPropertyKind.Boolean, DesignPropertyValue.FromBoolean(defaultValue));
+
+        public static EffectPropertyDefinition Integer(string name, int defaultValue, int minimum, int maximum)
+            => new(name, EffectPropertyKind.Integer, DesignPropertyValue.FromInt32(defaultValue), minimum, maximum);
+
+        public static EffectPropertyDefinition Number(string name, double defaultValue, double minimum, double maximum)
+            => new(name, EffectPropertyKind.Number, DesignPropertyValue.FromDouble(defaultValue), minimum, maximum);
+
+        public static EffectPropertyDefinition ColorArgb(string name, int defaultValue)
+            => new(name, EffectPropertyKind.ColorArgb, DesignPropertyValue.FromInt32(defaultValue));
+
+        public static EffectPropertyDefinition Enum(
+            string name,
+            string enumTypeName,
+            string defaultMember,
+            params string[] members)
+            => new(
+                name,
+                EffectPropertyKind.Enum,
+                DesignPropertyValue.FromEnum(enumTypeName, defaultMember),
+                enumTypeName: enumTypeName,
+                enumMembers: members);
+
+        public string Format(DesignPropertyValue value)
+            => Kind switch
+            {
+                EffectPropertyKind.Boolean => value.Value is bool boolValue && boolValue ? "true" : "false",
+                EffectPropertyKind.Integer => Convert.ToInt32(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                EffectPropertyKind.Number => Convert.ToDouble(value.Value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
+                EffectPropertyKind.Enum => value.GetString(),
+                EffectPropertyKind.ColorArgb => $"#{unchecked((uint)Convert.ToInt32(value.Value, CultureInfo.InvariantCulture)):X8}",
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+        public bool TryParse(string text, out DesignPropertyValue value, out string? error)
+        {
+            switch (Kind)
+            {
+                case EffectPropertyKind.Boolean:
+                    if (bool.TryParse(text, out bool boolValue))
+                    {
+                        value = DesignPropertyValue.FromBoolean(boolValue);
+                        error = null;
+                        return true;
+                    }
+                    break;
+                case EffectPropertyKind.Integer:
+                    if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int intValue)
+                        && intValue >= Minimum && intValue <= Maximum)
+                    {
+                        value = DesignPropertyValue.FromInt32(intValue);
+                        error = null;
+                        return true;
+                    }
+                    break;
+                case EffectPropertyKind.Number:
+                    if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double number)
+                        && double.IsFinite(number)
+                        && number >= Minimum && number <= Maximum)
+                    {
+                        value = DesignPropertyValue.FromDouble(number);
+                        error = null;
+                        return true;
+                    }
+                    break;
+                case EffectPropertyKind.Enum:
+                    if (EnumMembers.Contains(text, StringComparer.Ordinal))
+                    {
+                        value = DesignPropertyValue.FromEnum(EnumTypeName!, text);
+                        error = null;
+                        return true;
+                    }
+                    break;
+                case EffectPropertyKind.ColorArgb:
+                    if (text.Length == 9
+                        && text[0] == '#'
+                        && uint.TryParse(text.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint argb))
+                    {
+                        value = DesignPropertyValue.FromInt32(unchecked((int)argb));
+                        error = null;
+                        return true;
+                    }
+                    break;
+            }
+
+            value = DesignPropertyValue.FromNull();
+            error = $"Value '{text}' is not valid for {Name}.";
+            return false;
+        }
+    }
+}

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyDialogEditors.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyDialogEditors.cs
@@ -104,6 +104,13 @@ internal static class DesignerPropertyDialogEditors
             return await dialog.ShowDialog(context.Owner) == DialogResult.OK;
         };
 
+    public static Func<DesignerPropertyDialogContext, Task<bool>> InteractionEffects(DesignControlNode control)
+        => async context =>
+        {
+            var dialog = new DesignerInteractionEffectCollectionDialog(context.Session, control);
+            return await dialog.ShowDialog(context.Owner) == DialogResult.OK;
+        };
+
     private static string? GetStoredString(DesignControlNode node, string propertyName)
         => node.Properties.TryGetValue(propertyName, out var value)
             ? value.Value?.ToString()

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
@@ -651,6 +651,8 @@ internal sealed class DesignerPropertyGridState
 
     private void AddSpecialContainerDescriptors(List<DesignerPropertyDescriptor> descriptors, DesignControlNode node)
     {
+        descriptors.Add(InteractionEffectsProperty(node));
+
         if (DesignerSpecialContainers.IsTabControl(node))
             descriptors.Add(TabPagesProperty(node));
 
@@ -688,6 +690,26 @@ internal sealed class DesignerPropertyGridState
                 minimumValue: 1));
         }
     }
+
+    private static DesignerPropertyDescriptor InteractionEffectsProperty(DesignControlNode control)
+        => new()
+        {
+            Name = InteractionEffectDesignValue.PropertyName,
+            DisplayName = "InteractionEffects",
+            Category = "Behavior",
+            Description = "Edits the ordered RippleEffect and PressScaleEffect collection without running effects in the Designer.",
+            ValueType = typeof(string),
+            IsReadOnly = true,
+            HasDialogEditor = true,
+            DialogEditor = DesignerPropertyDialogEditors.InteractionEffects(control),
+            GetValue = () =>
+            {
+                control.Properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? value);
+                return InteractionEffectDesignValue.TryRead(value, out IReadOnlyList<DesignPropertyValue> effects, out _)
+                    ? $"{effects.Count} effect{(effects.Count == 1 ? string.Empty : "s")}"
+                    : "(invalid)";
+            }
+        };
 
     private static DesignerPropertyDescriptor TabPagesProperty(DesignControlNode tabControl)
         => new()

--- a/ModernFormsNext.Designing/Properties/InteractionEffectDesignValue.cs
+++ b/ModernFormsNext.Designing/Properties/InteractionEffectDesignValue.cs
@@ -1,0 +1,102 @@
+namespace ModernFormsNext.Designing;
+
+/// <summary>
+/// Encodes an ordered interaction-effect collection inside one deterministic designer value.
+/// </summary>
+/// <remarks>
+/// The value uses a structured object with a <c>Count</c> member and zero-based <c>ItemN</c>
+/// members. Each item is another structured value whose type name identifies the effect and whose
+/// properties contain only designer-safe primitive values. This representation does not construct
+/// runtime effects or start animations.
+/// </remarks>
+public static class InteractionEffectDesignValue
+{
+    /// <summary>Gets the design-document property name used for the collection.</summary>
+    public const string PropertyName = "InteractionEffects";
+
+    /// <summary>Gets the structured type discriminator used for the collection value.</summary>
+    public const string CollectionTypeName = "ModernFormsNext.Animations.InteractionEffectCollection";
+
+    /// <summary>Creates an ordered collection value from detached effect descriptions.</summary>
+    /// <param name="effects">Structured effect descriptions in runtime attachment order.</param>
+    /// <returns>A deterministic collection value.</returns>
+    /// <exception cref="ArgumentException">An item is not a structured value with a type name.</exception>
+    public static DesignPropertyValue Create(IEnumerable<DesignPropertyValue> effects)
+    {
+        ArgumentNullException.ThrowIfNull(effects);
+        DesignPropertyValue[] items = effects.ToArray();
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["Count"] = DesignPropertyValue.FromInt32(items.Length)
+        };
+
+        for (int index = 0; index < items.Length; index++)
+        {
+            DesignPropertyValue item = items[index]
+                ?? throw new ArgumentException("Interaction effect descriptions cannot contain null.", nameof(effects));
+            if (item.Kind != DesignPropertyValueKind.Object
+                || string.IsNullOrWhiteSpace(item.ObjectTypeName))
+            {
+                throw new ArgumentException(
+                    "Every interaction effect description must be a structured value with a type name.",
+                    nameof(effects));
+            }
+            properties[$"Item{index}"] = item;
+        }
+
+        return DesignPropertyValue.FromStructuredObject(CollectionTypeName, properties);
+    }
+
+    /// <summary>Reads ordered detached effect descriptions from a collection value.</summary>
+    /// <param name="value">The collection value to read.</param>
+    /// <param name="effects">The ordered effect descriptions when successful.</param>
+    /// <param name="error">A validation error when the value is malformed.</param>
+    /// <returns><see langword="true"/> when the collection is valid; otherwise <see langword="false"/>.</returns>
+    public static bool TryRead(
+        DesignPropertyValue? value,
+        out IReadOnlyList<DesignPropertyValue> effects,
+        out string? error)
+    {
+        effects = [];
+        error = null;
+
+        if (value is null)
+            return true;
+        if (value.Kind != DesignPropertyValueKind.Object
+            || !IsCollectionType(value.ObjectTypeName)
+            || value.ObjectProperties is null)
+        {
+            error = "InteractionEffects must be a structured interaction-effect collection value.";
+            return false;
+        }
+        if (!value.ObjectProperties.TryGetValue("Count", out DesignPropertyValue? countValue)
+            || countValue.Kind != DesignPropertyValueKind.Int32
+            || countValue.Value is not int count
+            || count is < 0 or > 64)
+        {
+            error = "InteractionEffects.Count must be an integer from 0 through 64.";
+            return false;
+        }
+
+        var result = new List<DesignPropertyValue>(count);
+        for (int index = 0; index < count; index++)
+        {
+            if (!value.ObjectProperties.TryGetValue($"Item{index}", out DesignPropertyValue? item)
+                || item.Kind != DesignPropertyValueKind.Object
+                || string.IsNullOrWhiteSpace(item.ObjectTypeName)
+                || item.ObjectProperties is null)
+            {
+                error = $"InteractionEffects.Item{index} is missing or malformed.";
+                return false;
+            }
+            result.Add(item);
+        }
+
+        effects = result;
+        return true;
+    }
+
+    private static bool IsCollectionType(string? typeName)
+        => string.Equals(typeName, CollectionTypeName, StringComparison.Ordinal)
+        || string.Equals(typeName, "InteractionEffectCollection", StringComparison.Ordinal);
+}

--- a/ModernFormsNext.Tests/AnimationOptInDefaultsTests.cs
+++ b/ModernFormsNext.Tests/AnimationOptInDefaultsTests.cs
@@ -1,0 +1,118 @@
+using ModernFormsNext.Animations;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+[Collection(DefaultAnimationSchedulerCollection.Name)]
+public sealed class AnimationOptInDefaultsTests
+{
+    [Fact]
+    public void NewControlsHaveIndependentEmptyEffectAndTransitionCollections()
+    {
+        Control[] controls = [new Control(), new Button(), new TextBox(), new Switch()];
+        try
+        {
+            foreach (Control control in controls)
+            {
+                Assert.Empty(control.InteractionEffects);
+                Assert.Equal(0, control.StyleTransitions.Count);
+                Assert.Null(control.Ripple);
+                Assert.Null(control.PressEffect);
+            }
+
+            Assert.All(
+                controls.Skip(1),
+                control => Assert.NotSame(controls[0].InteractionEffects, control.InteractionEffects));
+            Assert.All(
+                controls.Skip(1),
+                control => Assert.NotSame(controls[0].StyleTransitions, control.StyleTransitions));
+        }
+        finally
+        {
+            foreach (Control control in controls)
+                control.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ExplicitConfigurationOnOneControlDoesNotAffectAnother()
+    {
+        using var first = new Button();
+        using var second = new Button();
+
+        first.InteractionEffects.Add(new RippleEffect());
+        first.StyleTransitions.Add(
+            VisualState.Normal,
+            VisualState.Hover,
+            new VisualStateTransition());
+
+        Assert.Single(first.InteractionEffects);
+        Assert.Equal(1, first.StyleTransitions.Count);
+        Assert.Empty(second.InteractionEffects);
+        Assert.Equal(0, second.StyleTransitions.Count);
+        Assert.Null(second.Ripple);
+        Assert.Null(second.PressEffect);
+    }
+
+    [Fact]
+    public void DefaultVisualStatesApplyImmediatelyWithoutSchedulerTicksOrLayout()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        control.Style.BackgroundColor = SKColors.Black;
+        control.StyleHover.BackgroundColor = SKColors.Blue;
+        control.StylePressed.BackgroundColor = SKColors.Red;
+        control.StyleFocused.BackgroundColor = SKColors.Green;
+        control.StyleDisabled.BackgroundColor = SKColors.Gray;
+        int layouts = 0;
+        control.Layout += (_, _) => layouts++;
+
+        control.EnterForTest();
+        AssertState(control, VisualState.Hover, control.StyleHover, SKColors.Blue);
+        control.DownForTest();
+        AssertState(control, VisualState.Pressed, control.StylePressed, SKColors.Red);
+        control.UpForTest();
+        AssertState(control, VisualState.Hover, control.StyleHover, SKColors.Blue);
+        control.LeaveForTest();
+        AssertState(control, VisualState.Normal, control.Style, SKColors.Black);
+        control.FocusForTest();
+        AssertState(control, VisualState.Focused, control.StyleFocused, SKColors.Green);
+        control.Enabled = false;
+        AssertState(control, VisualState.Disabled, control.StyleDisabled, SKColors.Gray);
+
+        Assert.Empty(control.InteractionEffects);
+        Assert.Empty(control.StyleTransitions);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, layouts);
+    }
+
+    private static void AssertState(
+        TestButton control,
+        VisualState state,
+        ControlStyle style,
+        SKColor background)
+    {
+        Assert.Equal(state, control.VisualState);
+        Assert.Same(style, control.CurrentStyle);
+        Assert.Equal(background, control.CurrentStyle.GetBackgroundColor());
+    }
+
+    private sealed class TestButton : Button
+    {
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, System.Drawing.Point.Empty));
+
+        public void LeaveForTest()
+            => OnMouseLeave(EventArgs.Empty);
+
+        public void DownForTest()
+            => OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
+
+        public void UpForTest()
+            => OnMouseUp(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
+
+        public void FocusForTest() => OnGotFocus(EventArgs.Empty);
+    }
+}

--- a/ModernFormsNext.Tests/AnimationPlatformPolicyTests.cs
+++ b/ModernFormsNext.Tests/AnimationPlatformPolicyTests.cs
@@ -1,0 +1,178 @@
+using ModernFormsNext.Animations;
+using ModernFormsNext.WindowKit.Backend;
+using ModernFormsNext.WindowKit.Backend.Lifecycle;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class AnimationPlatformPolicyTests
+{
+    [Fact]
+    public void StartupSnapshotUpdatesEffectiveReducedMotion()
+    {
+        var provider = new TestPlatformAnimationSettings(reducedMotion: true, animationsEnabled: false);
+
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+
+        Assert.True(harness.Policy.ReducedMotion);
+        Assert.Equal(1, provider.SubscriberCount);
+        Assert.Equal("Deterministic test provider", harness.Scheduler.GetPlatformDiagnostics().Source);
+    }
+
+    [Fact]
+    public void LivePlatformChangeCompletesActiveAnimationAndReturnsSchedulerToIdle()
+    {
+        var provider = new TestPlatformAnimationSettings();
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+        float value = 0f;
+        AnimationHandle handle = harness.Scheduler.Start(
+            new object(),
+            "PlatformPolicy",
+            progress => value = progress,
+            new AnimationOptions { Duration = TimeSpan.FromSeconds(1) });
+
+        provider.Set(reducedMotion: true, animationsEnabled: false);
+
+        Assert.Equal(AnimationState.Completed, handle.State);
+        Assert.Equal(1f, value);
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void RepeatedRefreshAndStartsDoNotDuplicateProviderSubscription()
+    {
+        var provider = new TestPlatformAnimationSettings();
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+
+        harness.Scheduler.RefreshPlatformPolicy();
+        harness.Scheduler.RefreshPlatformPolicy();
+        AnimationHandle handle = harness.Scheduler.Start(
+            new object(),
+            "OneSubscription",
+            _ => { },
+            new AnimationOptions { Duration = TimeSpan.FromSeconds(1) });
+
+        Assert.Equal(1, provider.SubscriberCount);
+        handle.Cancel();
+    }
+
+    [Fact]
+    public void ShutdownRemovesProviderSubscription()
+    {
+        var provider = new TestPlatformAnimationSettings();
+        var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+
+        harness.Dispose();
+
+        Assert.Equal(0, provider.SubscriberCount);
+    }
+
+    [Fact]
+    public void MissingProviderUsesSafeEnabledFallback()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+
+        AnimationPlatformDiagnostics diagnostics = harness.Scheduler.GetPlatformDiagnostics();
+
+        Assert.False(harness.Policy.ReducedMotion);
+        Assert.True(diagnostics.AnimationsEnabled);
+        Assert.True(diagnostics.FallbackUsed);
+        Assert.Equal(PlatformAnimationProviderState.Unavailable, diagnostics.ProviderState);
+    }
+
+    [Fact]
+    public void DesignerModeHasNoProviderSubscriptionOrRefreshSideEffects()
+    {
+        var provider = new TestPlatformAnimationSettings(reducedMotion: true, animationsEnabled: false);
+        using var harness = new AnimationSchedulerTestHarness(
+            animationSettings: provider,
+            isDesignMode: static () => true);
+
+        harness.Scheduler.RefreshPlatformPolicy();
+        AnimationPlatformDiagnostics diagnostics = harness.Scheduler.GetPlatformDiagnostics();
+
+        Assert.Equal(0, provider.SubscriberCount);
+        Assert.Equal(0, provider.RefreshCount);
+        Assert.False(harness.Policy.ReducedMotion);
+        Assert.Equal(PlatformAnimationProviderState.Disabled, diagnostics.ProviderState);
+    }
+
+    [Fact]
+    public void PlatformChangeIsAppliedThroughUiDispatcher()
+    {
+        var dispatcher = new QueuedAnimationDispatcher();
+        var provider = new TestPlatformAnimationSettings();
+        using var harness = new AnimationSchedulerTestHarness(dispatcher, animationSettings: provider);
+        dispatcher.Drain();
+
+        var worker = new Thread(() => provider.Set(reducedMotion: true, animationsEnabled: false));
+        worker.Start();
+        worker.Join();
+
+        Assert.False(harness.Policy.ReducedMotion);
+        Assert.Equal(1, dispatcher.PendingCount);
+        dispatcher.Drain();
+        Assert.True(harness.Policy.ReducedMotion);
+        Assert.Equal(Environment.CurrentManagedThreadId, dispatcher.ThreadId);
+    }
+
+    [Fact]
+    public void ProviderInvokesCallbacksOutsideItsLock()
+    {
+        var provider = new TestPlatformAnimationSettings();
+        bool? lockHeld = null;
+        provider.Changed += (_, _) => lockHeld = provider.IsLockHeldByCurrentThread;
+
+        provider.Set(reducedMotion: true, animationsEnabled: false);
+
+        Assert.False(lockHeld);
+    }
+
+    [Fact]
+    public void ForegroundTransitionRefreshesProviderAndAppliesLatestSnapshot()
+    {
+        var lifecycle = new TestPlatformApplicationLifecycle(PlatformApplicationLifecycleState.Background);
+        var provider = new TestPlatformAnimationSettings();
+        provider.SetOnNextRefresh(reducedMotion: true, animationsEnabled: false);
+        using var harness = new AnimationSchedulerTestHarness(
+            lifecycle: lifecycle,
+            animationSettings: provider);
+
+        lifecycle.SetState(PlatformApplicationLifecycleState.Foreground);
+
+        Assert.Equal(1, provider.RefreshCount);
+        Assert.True(harness.Policy.ReducedMotion);
+    }
+
+    [Fact]
+    public void DiagnosticsExposeFallbackStateAndError()
+    {
+        var provider = new TestPlatformAnimationSettings(
+            providerState: PlatformAnimationProviderState.Fallback,
+            fallbackUsed: true,
+            lastError: "Native setting unavailable");
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+
+        AnimationPlatformDiagnostics diagnostics = harness.Scheduler.GetPlatformDiagnostics();
+
+        Assert.True(diagnostics.FallbackUsed);
+        Assert.Equal(PlatformAnimationProviderState.Fallback, diagnostics.ProviderState);
+        Assert.Equal("Native setting unavailable", diagnostics.LastError);
+        Assert.Equal(DateTimeOffset.UnixEpoch, diagnostics.LastPlatformUpdate);
+    }
+
+    [Fact]
+    public void ApplicationAndPlatformReducedMotionPreferencesAreCombined()
+    {
+        var provider = new TestPlatformAnimationSettings(reducedMotion: true, animationsEnabled: false);
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+
+        harness.Policy.ReducedMotion = false;
+        Assert.True(harness.Policy.ReducedMotion);
+
+        harness.Policy.ReducedMotion = true;
+        provider.Set(reducedMotion: false, animationsEnabled: true);
+        Assert.True(harness.Policy.ReducedMotion);
+    }
+}

--- a/ModernFormsNext.Tests/AnimationPlatformPolicyTests.cs
+++ b/ModernFormsNext.Tests/AnimationPlatformPolicyTests.cs
@@ -170,8 +170,10 @@ public sealed class AnimationPlatformPolicyTests
 
         harness.Policy.ReducedMotion = false;
         Assert.True(harness.Policy.ReducedMotion);
+        Assert.False(harness.Policy.ApplicationReducedMotion);
 
         harness.Policy.ReducedMotion = true;
+        Assert.True(harness.Policy.ApplicationReducedMotion);
         provider.Set(reducedMotion: false, animationsEnabled: true);
         Assert.True(harness.Policy.ReducedMotion);
     }

--- a/ModernFormsNext.Tests/AnimationSchedulerTestInfrastructure.cs
+++ b/ModernFormsNext.Tests/AnimationSchedulerTestInfrastructure.cs
@@ -1,4 +1,5 @@
 using ModernFormsNext.Animations;
+using ModernFormsNext.WindowKit.Backend;
 using ModernFormsNext.WindowKit.Backend.Lifecycle;
 
 namespace ModernFormsNext.Tests;
@@ -7,13 +8,22 @@ internal sealed class AnimationSchedulerTestHarness : IDisposable
 {
     public AnimationSchedulerTestHarness(
         IAnimationDispatcher? dispatcher = null,
-        IPlatformApplicationLifecycle? lifecycle = null)
+        IPlatformApplicationLifecycle? lifecycle = null,
+        IPlatformAnimationSettings? animationSettings = null,
+        Func<bool>? isDesignMode = null)
     {
         Clock = new ManualAnimationClock();
         Dispatcher = dispatcher ?? new ImmediateAnimationDispatcher();
         TickSource = new ManualAnimationTickSource();
         Policy = new AnimationPolicy();
-        Scheduler = new AnimationScheduler(Clock, Dispatcher, TickSource, Policy, lifecycle);
+        Scheduler = new AnimationScheduler(
+            Clock,
+            Dispatcher,
+            TickSource,
+            Policy,
+            lifecycle,
+            animationSettings,
+            isDesignMode);
     }
 
     public ManualAnimationClock Clock { get; }
@@ -33,6 +43,142 @@ internal sealed class AnimationSchedulerTestHarness : IDisposable
     }
 
     public void Dispose() => Scheduler.Dispose();
+}
+
+internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
+{
+    private readonly object sync = new();
+    private EventHandler<PlatformAnimationSettingsChangedEventArgs>? changed;
+    private PlatformAnimationSettingsSnapshot current;
+    private PlatformAnimationSettingsSnapshot? nextRefresh;
+
+    public TestPlatformAnimationSettings(
+        bool reducedMotion = false,
+        bool animationsEnabled = true,
+        PlatformAnimationProviderState providerState = PlatformAnimationProviderState.Ready,
+        bool fallbackUsed = false,
+        string? lastError = null)
+    {
+        current = CreateSnapshot(
+            reducedMotion,
+            animationsEnabled,
+            providerState,
+            fallbackUsed,
+            lastError);
+    }
+
+    public PlatformAnimationSettingsSnapshot Current
+    {
+        get
+        {
+            lock (sync)
+                return current;
+        }
+    }
+
+    public int SubscriberCount { get; private set; }
+
+    public int RefreshCount { get; private set; }
+
+    public bool IsLockHeldByCurrentThread => Monitor.IsEntered(sync);
+
+    public event EventHandler<PlatformAnimationSettingsChangedEventArgs>? Changed
+    {
+        add
+        {
+            lock (sync)
+            {
+                changed += value;
+                SubscriberCount++;
+            }
+        }
+        remove
+        {
+            lock (sync)
+            {
+                changed -= value;
+                SubscriberCount--;
+            }
+        }
+    }
+
+    public PlatformAnimationSettingsSnapshot Refresh()
+    {
+        PlatformAnimationSettingsSnapshot? refresh;
+        lock (sync)
+        {
+            RefreshCount++;
+            refresh = nextRefresh;
+            nextRefresh = null;
+        }
+
+        if (refresh is not null)
+            Publish(refresh);
+        return Current;
+    }
+
+    public void Set(
+        bool reducedMotion,
+        bool animationsEnabled = true,
+        PlatformAnimationProviderState providerState = PlatformAnimationProviderState.Ready,
+        bool fallbackUsed = false,
+        string? lastError = null)
+    {
+        PlatformAnimationSettingsSnapshot next = CreateSnapshot(
+            reducedMotion,
+            animationsEnabled,
+            providerState,
+            fallbackUsed,
+            lastError);
+        Publish(next);
+    }
+
+    public void SetOnNextRefresh(
+        bool reducedMotion,
+        bool animationsEnabled = true,
+        PlatformAnimationProviderState providerState = PlatformAnimationProviderState.Ready,
+        bool fallbackUsed = false,
+        string? lastError = null)
+    {
+        lock (sync)
+        {
+            nextRefresh = CreateSnapshot(
+                reducedMotion,
+                animationsEnabled,
+                providerState,
+                fallbackUsed,
+                lastError);
+        }
+    }
+
+    private void Publish(PlatformAnimationSettingsSnapshot next)
+    {
+        PlatformAnimationSettingsSnapshot previous;
+        EventHandler<PlatformAnimationSettingsChangedEventArgs>? handlers;
+        lock (sync)
+        {
+            previous = current;
+            current = next;
+            handlers = changed;
+        }
+
+        handlers?.Invoke(this, new PlatformAnimationSettingsChangedEventArgs(previous, next));
+    }
+
+    private static PlatformAnimationSettingsSnapshot CreateSnapshot(
+        bool reducedMotion,
+        bool animationsEnabled,
+        PlatformAnimationProviderState providerState,
+        bool fallbackUsed,
+        string? lastError)
+        => new(
+            "Deterministic test provider",
+            reducedMotion,
+            animationsEnabled,
+            DateTimeOffset.UnixEpoch,
+            fallbackUsed,
+            providerState,
+            lastError);
 }
 
 internal sealed class TestPlatformApplicationLifecycle : IPlatformApplicationLifecycle

--- a/ModernFormsNext.Tests/InteractionEffectScopeTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectScopeTests.cs
@@ -1,0 +1,280 @@
+using System.Drawing;
+using ModernFormsNext.Animations;
+using ModernFormsNext.WindowKit.Platform;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+[Collection(DefaultAnimationSchedulerCollection.Name)]
+public sealed class InteractionEffectScopeTests
+{
+    [Fact]
+    public void PanelWithoutEffectsDoesNotEnterPressedStateOrStartRipple()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = new VisiblePanel
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(160, 80)
+        };
+
+        panel.RaiseMouseDown(Mouse(30, 20));
+
+        Assert.Equal(VisualState.Normal, panel.VisualState);
+        Assert.Empty(panel.InteractionEffects);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void ExplicitPanelRippleRunsAndRemainsClippedToPanel()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = new VisiblePanel
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(100, 50),
+            Ripple = new RippleEffect
+            {
+                Color = Color.FromArgb(160, 20, 80, 160),
+                Duration = TimeSpan.FromMilliseconds(100),
+                Easing = Easings.Linear
+            }
+        };
+        panel.Style.Border.Radius = 16;
+
+        panel.RaiseMouseDown(Mouse(50, 25));
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        using SKBitmap bitmap = RenderEffect(panel);
+
+        Assert.Equal(1, panel.Ripple.ActiveRippleCount);
+        Assert.Equal(VisualState.Normal, panel.VisualState);
+        Assert.NotEqual(0, bitmap.GetPixel(50, 25).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void ChildClickRunsOnlyChildRippleAndDoesNotBubbleToParent()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = new VisiblePanel
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(200, 100),
+            Ripple = CreateRipple()
+        };
+        var button = new Button
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Bounds = new Rectangle(20, 20, 100, 40),
+            Ripple = CreateRipple()
+        };
+        panel.Controls.Add(button);
+        int panelDown = 0;
+        int buttonDown = 0;
+        panel.MouseDown += (_, _) => panelDown++;
+        button.MouseDown += (_, _) => buttonDown++;
+        Assert.True(button.ScaledBounds.Contains(new Point(40, 35)));
+
+        panel.RaiseMouseDown(Mouse(40, 35));
+
+        Assert.Equal(0, panelDown);
+        Assert.Equal(1, buttonDown);
+        Assert.Equal(0, panel.Ripple.ActiveRippleCount);
+        Assert.Equal(1, button.Ripple.ActiveRippleCount);
+        Assert.Equal(VisualState.Normal, panel.VisualState);
+        Assert.Equal(VisualState.Pressed, button.VisualState);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void ExplicitPressedTransitionOptsNonHoverableControlIntoVisualStateAnimation()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = new Panel
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(100, 50)
+        };
+        panel.StylePressed.BackgroundColor = SKColors.Red;
+        panel.StyleTransitions.Add(
+            VisualState.Normal,
+            VisualState.Pressed,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                Easing = Easings.Linear
+            });
+
+        panel.RaiseMouseDown(Mouse(20, 20));
+
+        Assert.Equal(VisualState.Pressed, panel.VisualState);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.True(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void DataGridViewWithoutEffectsKeepsCellHeaderAndDragInputAnimationFree()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using DataGridView grid = CreateGrid(harness);
+        Rectangle first = grid.GetCellBounds(0, 0);
+        Rectangle second = grid.GetCellBounds(1, 1);
+
+        grid.RaiseMouseDown(Mouse(first.Left + 5, first.Top + 5));
+        AssertGridIdle(grid, harness);
+        grid.RaiseMouseUp(Mouse(first.Left + 5, first.Top + 5));
+
+        grid.RaiseMouseDown(Mouse(first.Left + 5, 5));
+        AssertGridIdle(grid, harness);
+        grid.RaiseMouseUp(Mouse(first.Left + 5, 5));
+
+        grid.RaiseMouseDown(Mouse(first.Left + 5, first.Top + 5));
+        AssertGridIdle(grid, harness);
+        grid.RaiseMouseMove(Mouse(second.Left + 5, second.Top + 5));
+        grid.RaiseMouseUp(Mouse(second.Left + 5, second.Top + 5));
+        AssertGridIdle(grid, harness);
+    }
+
+    [Fact]
+    public void DataGridViewScrollbarInputDoesNotStartControlOrScrollbarEffect()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using DataGridView grid = CreateGrid(harness);
+        VerticalScrollBar scrollbar = Assert.Single(
+            grid.Controls.GetAllControls(true).OfType<VerticalScrollBar>());
+        scrollbar.Visible = true;
+        scrollbar.Bounds = new Rectangle(grid.Width - 15, 0, 15, grid.Height);
+        scrollbar.AnimationSchedulerOverride = harness.Scheduler;
+        Point location = new(
+            scrollbar.ScaledBounds.Left + (scrollbar.ScaledBounds.Width / 2),
+            scrollbar.ScaledBounds.Top + Math.Max(1, scrollbar.ScaledBounds.Height / 2));
+
+        grid.RaiseMouseDown(Mouse(location.X, location.Y));
+
+        Assert.Equal(VisualState.Normal, grid.VisualState);
+        Assert.NotEqual(VisualState.Pressed, scrollbar.VisualState);
+        Assert.Empty(grid.InteractionEffects);
+        Assert.Empty(scrollbar.InteractionEffects);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void RapidClicksAcrossDataGridViewCellsNeverCreateGlobalWaves()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using DataGridView grid = CreateGrid(harness);
+
+        for (int index = 0; index < 20; index++)
+        {
+            Rectangle cell = grid.GetCellBounds(index % 10, index % 2);
+            grid.RaiseMouseDown(Mouse(cell.Left + 4, cell.Top + 4, index));
+            AssertGridIdle(grid, harness);
+            grid.RaiseMouseUp(Mouse(cell.Left + 4, cell.Top + 4, index));
+        }
+
+        AssertGridIdle(grid, harness);
+    }
+
+    [Fact]
+    public void EditingChildEffectDoesNotAlsoRunExplicitGridEffect()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using DataGridView grid = CreateGrid(harness);
+        grid.Ripple = CreateRipple();
+        grid.BeginEdit(0, 0);
+        TextBox editor = Assert.Single(
+            grid.Controls.GetAllControls(true).OfType<TextBox>());
+        editor.AnimationSchedulerOverride = harness.Scheduler;
+        editor.Ripple = CreateRipple();
+        int gridDown = 0;
+        int editorDown = 0;
+        grid.MouseDown += (_, _) => gridDown++;
+        editor.MouseDown += (_, _) => editorDown++;
+        Point location = new(
+            editor.ScaledBounds.Left + Math.Max(1, editor.ScaledBounds.Width / 2),
+            editor.ScaledBounds.Top + Math.Max(1, editor.ScaledBounds.Height / 2));
+
+        grid.RaiseMouseDown(Mouse(location.X, location.Y));
+
+        Assert.Equal(0, gridDown);
+        Assert.Equal(1, editorDown);
+        Assert.Equal(0, grid.Ripple.ActiveRippleCount);
+        Assert.Equal(1, editor.Ripple.ActiveRippleCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    private static DataGridView CreateGrid(AnimationSchedulerTestHarness harness)
+    {
+        var grid = new VisibleDataGridView
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(220, 120)
+        };
+        grid.Columns.Add("First", 120);
+        grid.Columns.Add("Second", 120);
+        for (int index = 0; index < 20; index++)
+            grid.Rows.Add($"A{index}", $"B{index}");
+        return grid;
+    }
+
+    private static void AssertGridIdle(DataGridView grid, AnimationSchedulerTestHarness harness)
+    {
+        Assert.NotEqual(VisualState.Pressed, grid.VisualState);
+        Assert.Empty(grid.InteractionEffects);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    private static RippleEffect CreateRipple()
+        => new()
+        {
+            Duration = TimeSpan.FromMilliseconds(100),
+            Easing = Easings.Linear
+        };
+
+    private static MouseEventArgs Mouse(int x, int y, int pointerId = 0)
+        => new(
+            MouseButtons.Left,
+            1,
+            x,
+            y,
+            Point.Empty,
+            null,
+            null,
+            Keys.None,
+            pointerId,
+            PointerDeviceKind.Mouse);
+
+    private static SKBitmap RenderEffect(Control control)
+    {
+        var bitmap = new SKBitmap(control.Width, control.Height);
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+        control.RenderInteractionEffects(
+            InteractionEffectLayer.AboveBackgroundBelowContent,
+            new PaintEventArgs(bitmap.Info, canvas, 1d));
+        canvas.Flush();
+        return bitmap;
+    }
+
+    private sealed class VisiblePanel : Panel
+    {
+        public override bool Visible
+        {
+            get => true;
+            set => base.Visible = value;
+        }
+    }
+
+    private sealed class VisibleDataGridView : DataGridView
+    {
+        public override bool Visible
+        {
+            get => true;
+            set => base.Visible = value;
+        }
+    }
+}

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -109,6 +109,194 @@ public sealed class InteractionEffectTests
         Assert.False(harness.TickSource.IsRunning);
     }
 
+    [Theory]
+    [InlineData(RippleOverflowPolicy.RemoveOldest, 1)]
+    [InlineData(RippleOverflowPolicy.RemoveNewest, 2)]
+    public void RemovalPoliciesEvictTheDeterministicWave(
+        RippleOverflowPolicy policy,
+        int evictedPointerId)
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Ripple = new RippleEffect
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                MaxConcurrentRipples = 2,
+                OverflowPolicy = policy
+            }
+        };
+
+        control.DownForTest(Mouse(1, 1, 1, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(2, 1, 2, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(3, 1, 3, PointerDeviceKind.Touch));
+
+        Assert.Equal(2, control.Ripple.ActiveRippleCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().CanceledCount);
+        control.CancelPointerForTest(evictedPointerId);
+        Assert.Equal(2, control.Ripple.ActiveRippleCount);
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(0, control.Ripple.ActiveRippleCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void IgnoreNewCreatesNoWaveOrSchedulerHandle()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Ripple = new RippleEffect
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                MaxConcurrentRipples = 2,
+                OverflowPolicy = RippleOverflowPolicy.IgnoreNew
+            }
+        };
+
+        control.DownForTest(Mouse(1, 1, 1, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(2, 1, 2, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(3, 1, 3, PointerDeviceKind.Touch));
+
+        Assert.Equal(2, control.Ripple.ActiveRippleCount);
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().CanceledCount);
+        control.CancelPointerForTest(3);
+        Assert.Equal(2, control.Ripple.ActiveRippleCount);
+    }
+
+    [Fact]
+    public void ReplaceAllCancelsEveryWaveAndStartsOnlyTheNewWave()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Ripple = new RippleEffect
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                MaxConcurrentRipples = 2,
+                OverflowPolicy = RippleOverflowPolicy.ReplaceAll
+            }
+        };
+
+        control.DownForTest(Mouse(1, 1, 1, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(2, 1, 2, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(3, 1, 3, PointerDeviceKind.Touch));
+
+        Assert.Equal(1, control.Ripple.ActiveRippleCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().CanceledCount);
+        control.CancelPointerForTest(1);
+        control.CancelPointerForTest(2);
+        Assert.Equal(1, control.Ripple.ActiveRippleCount);
+    }
+
+    [Theory]
+    [InlineData(RippleOverflowPolicy.RemoveOldest)]
+    [InlineData(RippleOverflowPolicy.RemoveNewest)]
+    [InlineData(RippleOverflowPolicy.IgnoreNew)]
+    [InlineData(RippleOverflowPolicy.ReplaceAll)]
+    public void LimitOneRemainsBoundedForEveryOverflowPolicy(RippleOverflowPolicy policy)
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Ripple = new RippleEffect
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                MaxConcurrentRipples = 1,
+                OverflowPolicy = policy
+            }
+        };
+
+        control.DownForTest(Mouse(1, 1, 1, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(2, 1, 2, PointerDeviceKind.Touch));
+
+        Assert.Equal(1, control.Ripple.ActiveRippleCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Theory]
+    [InlineData(RippleOverflowPolicy.RemoveOldest)]
+    [InlineData(RippleOverflowPolicy.RemoveNewest)]
+    [InlineData(RippleOverflowPolicy.IgnoreNew)]
+    [InlineData(RippleOverflowPolicy.ReplaceAll)]
+    public void RapidInputLeavesNoHandlesAndSchedulerReturnsToIdle(RippleOverflowPolicy policy)
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Ripple = new RippleEffect
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                MaxConcurrentRipples = 4,
+                OverflowPolicy = policy
+            }
+        };
+
+        for (int pointerId = 0; pointerId < 100; pointerId++)
+            control.DownForTest(Mouse(pointerId, 1, pointerId, PointerDeviceKind.Touch));
+
+        Assert.InRange(control.Ripple.ActiveRippleCount, 1, 4);
+        Assert.Equal(
+            control.Ripple.ActiveRippleCount,
+            harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(0, control.Ripple.ActiveRippleCount);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Theory]
+    [InlineData(RippleOverflowPolicy.RemoveOldest)]
+    [InlineData(RippleOverflowPolicy.RemoveNewest)]
+    [InlineData(RippleOverflowPolicy.IgnoreNew)]
+    [InlineData(RippleOverflowPolicy.ReplaceAll)]
+    public void ReducedMotionSkipsEveryOverflowPolicy(RippleOverflowPolicy policy)
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        harness.Policy.ReducedMotion = true;
+        var control = new TestButton
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Ripple = new RippleEffect { OverflowPolicy = policy }
+        };
+
+        control.DownForTest(Mouse(1, 1, 1, PointerDeviceKind.Touch));
+
+        Assert.Equal(0, control.Ripple.ActiveRippleCount);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void DisposingRippleCancelsAllOverflowPolicyHandles()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        var ripple = new RippleEffect
+        {
+            MaxConcurrentRipples = 4,
+            OverflowPolicy = RippleOverflowPolicy.RemoveNewest
+        };
+        control.Ripple = ripple;
+        control.DownForTest(Mouse(1, 1, 1, PointerDeviceKind.Touch));
+        control.DownForTest(Mouse(2, 1, 2, PointerDeviceKind.Touch));
+
+        ripple.Dispose();
+
+        Assert.Equal(0, ripple.ActiveRippleCount);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
     [Fact]
     public void RippleRejectsUndefinedRadiusAndEvictionPolicies()
     {
@@ -118,6 +306,23 @@ public sealed class InteractionEffectTests
             () => ripple.RadiusMode = (RippleRadiusMode)int.MaxValue);
         Assert.Throws<ArgumentOutOfRangeException>(
             () => ripple.EvictionPolicy = (RippleEvictionPolicy)int.MaxValue);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ripple.OverflowPolicy = (RippleOverflowPolicy)int.MaxValue);
+    }
+
+    [Theory]
+    [InlineData(RippleEvictionPolicy.Oldest, RippleOverflowPolicy.RemoveOldest)]
+    [InlineData(RippleEvictionPolicy.Newest, RippleOverflowPolicy.RemoveNewest)]
+    [InlineData(RippleEvictionPolicy.IgnoreNew, RippleOverflowPolicy.IgnoreNew)]
+    [InlineData(RippleEvictionPolicy.ReplaceAll, RippleOverflowPolicy.ReplaceAll)]
+    public void LegacyEvictionPolicyMapsWithoutBreakingBehavior(
+        RippleEvictionPolicy legacy,
+        RippleOverflowPolicy expected)
+    {
+        var ripple = new RippleEffect { EvictionPolicy = legacy };
+
+        Assert.Equal(expected, ripple.OverflowPolicy);
+        Assert.Equal(legacy, ripple.EvictionPolicy);
     }
 
     [Fact]

--- a/ModernFormsNext.Tests/Theming/ThemeManagerApplyAndTransitionTests.cs
+++ b/ModernFormsNext.Tests/Theming/ThemeManagerApplyAndTransitionTests.cs
@@ -11,6 +11,29 @@ namespace ModernFormsNext.Tests;
 public sealed class ThemeManagerApplyAndTransitionTests
 {
     [Fact]
+    public void DefaultApplyOptionsKeepThemeTransitionsOptIn()
+    {
+        var options = new ThemeApplyOptions();
+
+        Assert.False(options.Transition.Enabled);
+    }
+
+    [Fact]
+    public void ApplyWithoutOptionsCommitsImmediatelyAndLeavesSchedulerIdle()
+    {
+        using var harness = new ThemeManagerTestHarness();
+
+        ThemeApplyResult result = harness.Manager.Apply(Theme("apply.default.immediate", Color.Red));
+
+        Assert.True(result.Success);
+        Assert.Null(result.Transition);
+        Assert.Equal(Color.Red.ToArgb(), ResourceColor(harness, ThemeTokens.Colors.Background.ResourceKey).ToArgb());
+        Assert.Equal(ThemeTransitionStatus.None, harness.Manager.GetDiagnostics().TransitionState);
+        Assert.Equal(0, harness.SchedulerHarness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.SchedulerHarness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public void ImmediateApplyCommitsAtomicallyAndRaisesDocumentedEventOrder()
     {
         using var harness = new ThemeManagerTestHarness();

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAnimationScaleEvaluatorTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAnimationScaleEvaluatorTests.cs
@@ -1,0 +1,81 @@
+using ModernFormsNext.WindowKit.Backend;
+using ModernFormsNext.WindowKit.Backend.Android;
+using Xunit;
+
+namespace ModernFormsNext.WindowKit.Backend.Android.Tests;
+
+public sealed class AndroidAnimationScaleEvaluatorTests
+{
+    [Theory]
+    [InlineData(0f, 1f)]
+    [InlineData(1f, 0f)]
+    [InlineData(0f, 0f)]
+    public void ZeroAnimationScaleRequestsReducedMotion(float animatorScale, float transitionScale)
+    {
+        PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
+            animatorScale,
+            transitionScale,
+            DateTimeOffset.UnixEpoch);
+
+        Assert.True(snapshot.ReducedMotion);
+        Assert.False(snapshot.AnimationsEnabled);
+        Assert.False(snapshot.FallbackUsed);
+        Assert.Equal(PlatformAnimationProviderState.Ready, snapshot.ProviderState);
+    }
+
+    [Fact]
+    public void PositiveAnimationScalesKeepAnimationsEnabled()
+    {
+        PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
+            0.5f,
+            2f,
+            DateTimeOffset.UnixEpoch);
+
+        Assert.False(snapshot.ReducedMotion);
+        Assert.True(snapshot.AnimationsEnabled);
+        Assert.Equal(PlatformAnimationProviderState.Ready, snapshot.ProviderState);
+    }
+
+    [Theory]
+    [InlineData(null, 1f)]
+    [InlineData(1f, null)]
+    [InlineData(-1f, 1f)]
+    [InlineData(1f, -1f)]
+    public void MissingOrInvalidScaleUsesSafeFallback(float? animatorScale, float? transitionScale)
+    {
+        PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
+            animatorScale,
+            transitionScale,
+            DateTimeOffset.UnixEpoch);
+
+        Assert.False(snapshot.ReducedMotion);
+        Assert.True(snapshot.AnimationsEnabled);
+        Assert.True(snapshot.FallbackUsed);
+        Assert.Equal(PlatformAnimationProviderState.Fallback, snapshot.ProviderState);
+    }
+
+    [Fact]
+    public void NonFiniteScaleUsesSafeFallback()
+    {
+        PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
+            float.NaN,
+            float.PositiveInfinity,
+            DateTimeOffset.UnixEpoch);
+
+        Assert.True(snapshot.FallbackUsed);
+        Assert.Equal(PlatformAnimationProviderState.Fallback, snapshot.ProviderState);
+    }
+
+    [Fact]
+    public void ContextOrPlatformErrorIsPreservedInDiagnostics()
+    {
+        PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
+            null,
+            null,
+            DateTimeOffset.UnixEpoch,
+            "Context unavailable");
+
+        Assert.Equal("Context unavailable", snapshot.LastError);
+        Assert.Equal(AndroidAnimationScaleEvaluator.SourceName, snapshot.Source);
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/AndroidAnimationScaleEvaluator.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/AndroidAnimationScaleEvaluator.cs
@@ -1,0 +1,43 @@
+using ModernFormsNext.WindowKit.Backend;
+
+namespace ModernFormsNext.WindowKit.Backend.Android;
+
+internal static class AndroidAnimationScaleEvaluator
+{
+    internal const string SourceName = "Android Settings.Global animation scales";
+
+    public static PlatformAnimationSettingsSnapshot CreateSnapshot(
+        float? animatorDurationScale,
+        float? transitionAnimationScale,
+        DateTimeOffset lastUpdate,
+        string? error = null)
+    {
+        if (error is not null ||
+            animatorDurationScale is not { } animator ||
+            transitionAnimationScale is not { } transition ||
+            !float.IsFinite(animator) ||
+            !float.IsFinite(transition) ||
+            animator < 0f ||
+            transition < 0f)
+        {
+            return new PlatformAnimationSettingsSnapshot(
+                SourceName,
+                reducedMotion: false,
+                animationsEnabled: true,
+                lastUpdate,
+                fallbackUsed: true,
+                PlatformAnimationProviderState.Fallback,
+                error ?? "Android animation scales are unavailable or invalid.");
+        }
+
+        bool enabled = animator > 0f && transition > 0f;
+        return new PlatformAnimationSettingsSnapshot(
+            SourceName,
+            reducedMotion: !enabled,
+            animationsEnabled: enabled,
+            lastUpdate,
+            fallbackUsed: false,
+            PlatformAnimationProviderState.Ready,
+            lastError: null);
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidPlatformAnimationSettings.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidPlatformAnimationSettings.cs
@@ -1,0 +1,106 @@
+using Android.Content;
+using Android.Provider;
+using ModernFormsNext.WindowKit.Backend;
+
+namespace ModernFormsNext.WindowKit.Backend.Android;
+
+internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSettings
+{
+    private readonly object sync = new();
+    private readonly Context? applicationContext;
+    private EventHandler<PlatformAnimationSettingsChangedEventArgs>? changed;
+    private PlatformAnimationSettingsSnapshot current;
+
+    public AndroidPlatformAnimationSettings(Context? applicationContext)
+    {
+        this.applicationContext = applicationContext;
+        current = AndroidAnimationScaleEvaluator.CreateSnapshot(
+            null,
+            null,
+            DateTimeOffset.UtcNow,
+            "Android application context is unavailable.");
+        Refresh();
+    }
+
+    public PlatformAnimationSettingsSnapshot Current
+    {
+        get
+        {
+            lock (sync)
+                return current;
+        }
+    }
+
+    public event EventHandler<PlatformAnimationSettingsChangedEventArgs>? Changed
+    {
+        add
+        {
+            lock (sync)
+                changed += value;
+        }
+        remove
+        {
+            lock (sync)
+                changed -= value;
+        }
+    }
+
+    public PlatformAnimationSettingsSnapshot Refresh()
+    {
+        DateTimeOffset update = DateTimeOffset.UtcNow;
+        PlatformAnimationSettingsSnapshot next;
+        try
+        {
+            ContentResolver? resolver = applicationContext?.ContentResolver;
+            if (resolver is null)
+            {
+                next = AndroidAnimationScaleEvaluator.CreateSnapshot(
+                    null,
+                    null,
+                    update,
+                    "Android application context is unavailable.");
+            }
+            else
+            {
+                float animatorScale = Settings.Global.GetFloat(
+                    resolver,
+                    Settings.Global.AnimatorDurationScale,
+                    1f);
+                float transitionScale = Settings.Global.GetFloat(
+                    resolver,
+                    Settings.Global.TransitionAnimationScale,
+                    1f);
+                next = AndroidAnimationScaleEvaluator.CreateSnapshot(
+                    animatorScale,
+                    transitionScale,
+                    update);
+            }
+        }
+        catch (Exception exception)
+        {
+            next = AndroidAnimationScaleEvaluator.CreateSnapshot(
+                null,
+                null,
+                update,
+                exception.Message);
+        }
+
+        EventHandler<PlatformAnimationSettingsChangedEventArgs>? handlers;
+        PlatformAnimationSettingsSnapshot previous;
+        bool meaningfulChange;
+        lock (sync)
+        {
+            previous = current;
+            current = next;
+            meaningfulChange = previous.ReducedMotion != next.ReducedMotion
+                || previous.AnimationsEnabled != next.AnimationsEnabled
+                || previous.FallbackUsed != next.FallbackUsed
+                || previous.ProviderState != next.ProviderState
+                || !string.Equals(previous.LastError, next.LastError, StringComparison.Ordinal);
+            handlers = meaningfulChange ? changed : null;
+        }
+
+        handlers?.Invoke(this, new PlatformAnimationSettingsChangedEventArgs(previous, next));
+        return next;
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidWindowKitBackend.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidWindowKitBackend.cs
@@ -96,6 +96,8 @@ public sealed class AndroidWindowKitBackend : IWindowKitBackend
             // IWindowingPlatform or clipboard registration until Android UI/rendering support exists.
             PlatformServiceRegistry.Register<IPlatformDispatcher>(Dispatcher);
             PlatformServiceRegistry.Register<IPlatformApplicationLifecycle>(ActivityTracker);
+            PlatformServiceRegistry.Register<IPlatformAnimationSettings>(
+                new AndroidPlatformAnimationSettings(ApplicationContext.Context));
             PlatformServiceRegistry.Register<IPermissionService>(Permissions);
 
             IsInitialized = true;

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/ModernFormsNext.WindowKit.Backend.Windows.Tests.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/ModernFormsNext.WindowKit.Backend.Windows.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ModernFormsNext.WindowKit.Backend.Windows\ModernFormsNext.WindowKit.Backend.Windows.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsPlatformAnimationSettingsTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsPlatformAnimationSettingsTests.cs
@@ -1,0 +1,131 @@
+using ModernFormsNext.WindowKit.Backend;
+using ModernFormsNext.WindowKit.Backend.Windows;
+using Xunit;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows.Tests;
+
+public sealed class WindowsPlatformAnimationSettingsTests
+{
+    [Fact]
+    public void ConstructorReadsNativePreferenceAtStartup()
+    {
+        var reader = new TestReader(new WindowsAnimationPreferenceReadResult(true, false, null));
+
+        var provider = CreateProvider(reader);
+
+        Assert.Equal(1, reader.ReadCount);
+        Assert.True(provider.Current.ReducedMotion);
+        Assert.False(provider.Current.AnimationsEnabled);
+        Assert.Equal(PlatformAnimationProviderState.Ready, provider.Current.ProviderState);
+        Assert.False(provider.Current.FallbackUsed);
+    }
+
+    [Fact]
+    public void SystemSettingsChangePublishesMeaningfulLiveUpdate()
+    {
+        var reader = new TestReader(
+            new(true, true, null),
+            new(true, false, null));
+        var provider = CreateProvider(reader);
+        PlatformAnimationSettingsChangedEventArgs? observed = null;
+        provider.Changed += (_, args) => observed = args;
+
+        provider.NotifySystemSettingsChanged();
+
+        Assert.NotNull(observed);
+        Assert.True(observed.Current.ReducedMotion);
+        Assert.False(observed.Current.AnimationsEnabled);
+        Assert.Equal(2, reader.ReadCount);
+    }
+
+    [Fact]
+    public void EquivalentRefreshDoesNotPublishDuplicateChange()
+    {
+        var reader = new TestReader(
+            new(true, true, null),
+            new(true, true, null));
+        var provider = CreateProvider(reader);
+        int changes = 0;
+        provider.Changed += (_, _) => changes++;
+
+        provider.Refresh();
+
+        Assert.Equal(0, changes);
+        Assert.Equal(2, reader.ReadCount);
+    }
+
+    [Fact]
+    public void CallbackRunsOutsideProviderLock()
+    {
+        var reader = new TestReader(
+            new(true, true, null),
+            new(true, false, null));
+        var provider = CreateProvider(reader);
+        bool? lockHeld = null;
+        provider.Changed += (_, _) => lockHeld = provider.IsLockHeldByCurrentThread;
+
+        provider.Refresh();
+
+        Assert.False(lockHeld);
+    }
+
+    [Fact]
+    public void FailedNativeReadUsesSafeEnabledFallback()
+    {
+        var reader = new TestReader(new WindowsAnimationPreferenceReadResult(false, true, "SPI failed"));
+
+        var provider = CreateProvider(reader);
+
+        Assert.False(provider.Current.ReducedMotion);
+        Assert.True(provider.Current.AnimationsEnabled);
+        Assert.True(provider.Current.FallbackUsed);
+        Assert.Equal(PlatformAnimationProviderState.Fallback, provider.Current.ProviderState);
+        Assert.Equal("SPI failed", provider.Current.LastError);
+    }
+
+    [Fact]
+    public void ReaderExceptionCannotCrashProvider()
+    {
+        var provider = CreateProvider(new ThrowingReader());
+
+        Assert.Equal(PlatformAnimationProviderState.Fallback, provider.Current.ProviderState);
+        Assert.Contains("Native read failed", provider.Current.LastError, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EventAccessorsTrackSubscriptionsWithoutDuplication()
+    {
+        var provider = CreateProvider(new TestReader(
+            new WindowsAnimationPreferenceReadResult(true, true, null)));
+        EventHandler<PlatformAnimationSettingsChangedEventArgs> handler = (_, _) => { };
+
+        provider.Changed += handler;
+        Assert.Equal(1, provider.SubscriberCount);
+        provider.Changed -= handler;
+
+        Assert.Equal(0, provider.SubscriberCount);
+    }
+
+    private static WindowsPlatformAnimationSettings CreateProvider(IWindowsAnimationPreferenceReader reader)
+        => new(reader, static () => DateTimeOffset.UnixEpoch);
+
+    private sealed class TestReader(params WindowsAnimationPreferenceReadResult[] results)
+        : IWindowsAnimationPreferenceReader
+    {
+        private readonly Queue<WindowsAnimationPreferenceReadResult> results = new(results);
+
+        public int ReadCount { get; private set; }
+
+        public WindowsAnimationPreferenceReadResult Read()
+        {
+            ReadCount++;
+            return results.Count > 1 ? results.Dequeue() : results.Peek();
+        }
+    }
+
+    private sealed class ThrowingReader : IWindowsAnimationPreferenceReader
+    {
+        public WindowsAnimationPreferenceReadResult Read()
+            => throw new InvalidOperationException("Native read failed");
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/Win32Platform.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/Win32Platform.cs
@@ -116,6 +116,8 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
         internal IntPtr Handle => _hwnd;
 
+        internal WindowsPlatformAnimationSettings? AnimationSettings { get; set; }
+
         /// <summary>
         /// Gets the actual WindowsVersion. Same as the info returned from RtlGetVersion.
         /// </summary>
@@ -197,6 +199,9 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
             if (msg == (uint)WindowsMessage.WM_SETTINGCHANGE 
                 && PlatformSettings is Win32PlatformSettings win32PlatformSettings)
             {
+                // Microsoft documents that lParam does not reliably identify the exact system
+                // parameter. Re-read the one accessibility preference used by the framework.
+                AnimationSettings?.NotifySystemSettingsChanged();
                 var changedSetting = Marshal.PtrToStringAuto(lParam);
                 if (changedSetting == "ImmersiveColorSet" // dark/light mode
                     || changedSetting == "WindowsThemeElement") // high contrast mode

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/Win32Platform.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/Win32Platform.cs
@@ -196,17 +196,20 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
                 }
             }
             
-            if (msg == (uint)WindowsMessage.WM_SETTINGCHANGE 
-                && PlatformSettings is Win32PlatformSettings win32PlatformSettings)
+            if (msg == (uint)WindowsMessage.WM_SETTINGCHANGE)
             {
                 // Microsoft documents that lParam does not reliably identify the exact system
                 // parameter. Re-read the one accessibility preference used by the framework.
                 AnimationSettings?.NotifySystemSettingsChanged();
-                var changedSetting = Marshal.PtrToStringAuto(lParam);
-                if (changedSetting == "ImmersiveColorSet" // dark/light mode
-                    || changedSetting == "WindowsThemeElement") // high contrast mode
+
+                if (PlatformSettings is Win32PlatformSettings win32PlatformSettings)
                 {
-                    win32PlatformSettings.OnColorValuesChanged();   
+                    var changedSetting = Marshal.PtrToStringAuto(lParam);
+                    if (changedSetting == "ImmersiveColorSet" // dark/light mode
+                        || changedSetting == "WindowsThemeElement") // high contrast mode
+                    {
+                        win32PlatformSettings.OnColorValuesChanged();
+                    }
                 }
             }
             

--- a/ModernFormsNext.WindowKit.Backend.Windows/Properties/AssemblyInfo.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ModernFormsNext.WindowKit.Backend.Windows.Tests")]

--- a/ModernFormsNext.WindowKit.Backend.Windows/WindowsPlatformAnimationSettings.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/WindowsPlatformAnimationSettings.cs
@@ -1,0 +1,176 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using ModernFormsNext.WindowKit.Backend;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows;
+
+internal readonly record struct WindowsAnimationPreferenceReadResult(
+    bool Succeeded,
+    bool AnimationsEnabled,
+    string? Error);
+
+internal interface IWindowsAnimationPreferenceReader
+{
+    WindowsAnimationPreferenceReadResult Read();
+}
+
+internal sealed class WindowsAnimationPreferenceReader : IWindowsAnimationPreferenceReader
+{
+    private const uint SpiGetClientAreaAnimation = 0x1042;
+
+    public WindowsAnimationPreferenceReadResult Read()
+    {
+        if (!OperatingSystem.IsWindows())
+            return new(false, true, "Windows client-area animation settings are unavailable on this platform.");
+
+        try
+        {
+            if (SystemParametersInfo(SpiGetClientAreaAnimation, 0, out bool enabled, 0))
+                return new(true, enabled, null);
+
+            return new(false, true, new Win32Exception(Marshal.GetLastWin32Error()).Message);
+        }
+        catch (Exception exception) when (exception is DllNotFoundException or EntryPointNotFoundException)
+        {
+            return new(false, true, exception.Message);
+        }
+    }
+
+    [DllImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SystemParametersInfo(
+        uint action,
+        uint parameter,
+        [MarshalAs(UnmanagedType.Bool)] out bool value,
+        uint updateFlags);
+}
+
+/// <summary>
+/// Reads and publishes the Windows client-area animation accessibility preference.
+/// </summary>
+/// <remarks>
+/// The provider creates no native handles. The existing backend message window calls
+/// <see cref="NotifySystemSettingsChanged"/> for <c>WM_SETTINGCHANGE</c>.
+/// </remarks>
+internal sealed class WindowsPlatformAnimationSettings : IPlatformAnimationSettings
+{
+    internal const string SourceName = "Windows SPI_GETCLIENTAREAANIMATION";
+
+    private readonly object sync = new();
+    private readonly IWindowsAnimationPreferenceReader reader;
+    private readonly Func<DateTimeOffset> utcNow;
+    private EventHandler<PlatformAnimationSettingsChangedEventArgs>? changed;
+    private PlatformAnimationSettingsSnapshot current;
+
+    public WindowsPlatformAnimationSettings()
+        : this(new WindowsAnimationPreferenceReader(), static () => DateTimeOffset.UtcNow)
+    {
+    }
+
+    internal WindowsPlatformAnimationSettings(
+        IWindowsAnimationPreferenceReader reader,
+        Func<DateTimeOffset> utcNow)
+    {
+        this.reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        this.utcNow = utcNow ?? throw new ArgumentNullException(nameof(utcNow));
+        current = CreateFallback(lastError: null, lastUpdate: null);
+        Refresh();
+    }
+
+    public PlatformAnimationSettingsSnapshot Current
+    {
+        get
+        {
+            lock (sync)
+                return current;
+        }
+    }
+
+    public event EventHandler<PlatformAnimationSettingsChangedEventArgs>? Changed
+    {
+        add
+        {
+            lock (sync)
+                changed += value;
+        }
+        remove
+        {
+            lock (sync)
+                changed -= value;
+        }
+    }
+
+    internal int SubscriberCount
+    {
+        get
+        {
+            lock (sync)
+                return changed?.GetInvocationList().Length ?? 0;
+        }
+    }
+
+    internal bool IsLockHeldByCurrentThread => Monitor.IsEntered(sync);
+
+    public PlatformAnimationSettingsSnapshot Refresh()
+    {
+        WindowsAnimationPreferenceReadResult result;
+        try
+        {
+            result = reader.Read();
+        }
+        catch (Exception exception)
+        {
+            result = new WindowsAnimationPreferenceReadResult(false, true, exception.Message);
+        }
+
+        DateTimeOffset update = utcNow();
+        PlatformAnimationSettingsSnapshot next = result.Succeeded
+            ? new PlatformAnimationSettingsSnapshot(
+                SourceName,
+                reducedMotion: !result.AnimationsEnabled,
+                animationsEnabled: result.AnimationsEnabled,
+                update,
+                fallbackUsed: false,
+                PlatformAnimationProviderState.Ready,
+                lastError: null)
+            : CreateFallback(result.Error, update);
+
+        EventHandler<PlatformAnimationSettingsChangedEventArgs>? handlers;
+        PlatformAnimationSettingsSnapshot previous;
+        bool meaningfulChange;
+        lock (sync)
+        {
+            previous = current;
+            current = next;
+            meaningfulChange = !IsMeaningfullyEquivalent(previous, next);
+            handlers = meaningfulChange ? changed : null;
+        }
+
+        handlers?.Invoke(this, new PlatformAnimationSettingsChangedEventArgs(previous, next));
+        return next;
+    }
+
+    internal void NotifySystemSettingsChanged()
+        => Refresh();
+
+    private static PlatformAnimationSettingsSnapshot CreateFallback(
+        string? lastError,
+        DateTimeOffset? lastUpdate)
+        => new(
+            SourceName,
+            reducedMotion: false,
+            animationsEnabled: true,
+            lastUpdate,
+            fallbackUsed: true,
+            PlatformAnimationProviderState.Fallback,
+            lastError);
+
+    private static bool IsMeaningfullyEquivalent(
+        PlatformAnimationSettingsSnapshot left,
+        PlatformAnimationSettingsSnapshot right)
+        => left.ReducedMotion == right.ReducedMotion
+        && left.AnimationsEnabled == right.AnimationsEnabled
+        && left.FallbackUsed == right.FallbackUsed
+        && left.ProviderState == right.ProviderState
+        && string.Equals(left.LastError, right.LastError, StringComparison.Ordinal);
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows/WindowsPlatformBootstrap.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/WindowsPlatformBootstrap.cs
@@ -44,7 +44,10 @@ public static class WindowsPlatformBootstrap
             AvaloniaGlobals.AddService<IPlatformFontDialogService>(new WindowsFontDialogService());
             AvaloniaGlobals.AddService<IPlatformPrintDialogService>(new WindowsPrintDialogService());
             AvaloniaGlobals.AddService<IPlatformTrayManager>(new WindowsTrayManager());
-            PlatformServiceRegistry.Register<IPlatformThemeSettings>(new WindowsPlatformThemeSettings());
+            var animationSettings = new WindowsPlatformAnimationSettings();
+            Win32Platform.Instance.AnimationSettings = animationSettings;
+            PlatformServiceRegistry.Register<IPlatformAnimationSettings>(animationSettings);
+            PlatformServiceRegistry.Register<IPlatformThemeSettings>(new WindowsPlatformThemeSettings(animationSettings));
 
             initialized = true;
         }

--- a/ModernFormsNext.WindowKit.Backend.Windows/WindowsPlatformThemeSettings.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/WindowsPlatformThemeSettings.cs
@@ -9,7 +9,10 @@ internal sealed class WindowsPlatformThemeSettings : IPlatformThemeSettings
 {
     private const string PersonalizeKey =
         @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
-    private const uint SpiGetClientAreaAnimation = 0x1042;
+    private readonly WindowsPlatformAnimationSettings animationSettings;
+
+    public WindowsPlatformThemeSettings(WindowsPlatformAnimationSettings animationSettings)
+        => this.animationSettings = animationSettings ?? throw new ArgumentNullException(nameof(animationSettings));
 
     public PlatformColorScheme GetPreferredVariant()
     {
@@ -31,26 +34,7 @@ internal sealed class WindowsPlatformThemeSettings : IPlatformThemeSettings
 
     public bool? GetReducedMotion()
     {
-        if (!OperatingSystem.IsWindows())
-            return null;
-
-        try
-        {
-            return SystemParametersInfo(SpiGetClientAreaAnimation, 0, out bool enabled, 0)
-                ? !enabled
-                : null;
-        }
-        catch (Exception exception) when (exception is DllNotFoundException or EntryPointNotFoundException)
-        {
-            return null;
-        }
+        PlatformAnimationSettingsSnapshot snapshot = animationSettings.Current;
+        return snapshot.FallbackUsed ? null : snapshot.ReducedMotion;
     }
-
-    [DllImport("user32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SystemParametersInfo(
-        uint action,
-        uint parameter,
-        [MarshalAs(UnmanagedType.Bool)] out bool value,
-        uint updateFlags);
 }

--- a/ModernFormsNext.WindowKit.Backend/PlatformAnimationSettings.cs
+++ b/ModernFormsNext.WindowKit.Backend/PlatformAnimationSettings.cs
@@ -1,0 +1,121 @@
+namespace ModernFormsNext.WindowKit.Backend;
+
+/// <summary>
+/// Identifies the current health of a native animation-settings provider.
+/// </summary>
+public enum PlatformAnimationProviderState
+{
+    /// <summary>No platform provider is available.</summary>
+    Unavailable,
+
+    /// <summary>The provider returned a native platform value.</summary>
+    Ready,
+
+    /// <summary>The provider used the compatibility fallback after a native read failed.</summary>
+    Fallback,
+
+    /// <summary>Platform integration is disabled for a design-time environment.</summary>
+    Disabled
+}
+
+/// <summary>
+/// Represents an immutable platform animation-preference snapshot.
+/// </summary>
+public sealed class PlatformAnimationSettingsSnapshot
+{
+    /// <summary>
+    /// Initializes a platform animation-preference snapshot.
+    /// </summary>
+    /// <param name="source">A stable human-readable source identifier.</param>
+    /// <param name="reducedMotion">Whether the platform requests reduced motion.</param>
+    /// <param name="animationsEnabled">Whether the platform permits UI animations.</param>
+    /// <param name="lastPlatformUpdate">The last native read attempt, in UTC.</param>
+    /// <param name="fallbackUsed">Whether compatibility defaults were used.</param>
+    /// <param name="providerState">The provider health state.</param>
+    /// <param name="lastError">The last non-sensitive native error, if any.</param>
+    public PlatformAnimationSettingsSnapshot(
+        string source,
+        bool reducedMotion,
+        bool animationsEnabled,
+        DateTimeOffset? lastPlatformUpdate,
+        bool fallbackUsed,
+        PlatformAnimationProviderState providerState,
+        string? lastError)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+        Source = source;
+        ReducedMotion = reducedMotion;
+        AnimationsEnabled = animationsEnabled;
+        LastPlatformUpdate = lastPlatformUpdate;
+        FallbackUsed = fallbackUsed;
+        ProviderState = providerState;
+        LastError = lastError;
+    }
+
+    /// <summary>Gets the platform source identifier.</summary>
+    public string Source { get; }
+
+    /// <summary>Gets whether the platform requests reduced motion.</summary>
+    public bool ReducedMotion { get; }
+
+    /// <summary>Gets whether the platform permits UI animations.</summary>
+    public bool AnimationsEnabled { get; }
+
+    /// <summary>Gets the last native read attempt, in UTC.</summary>
+    public DateTimeOffset? LastPlatformUpdate { get; }
+
+    /// <summary>Gets whether compatibility defaults were used.</summary>
+    public bool FallbackUsed { get; }
+
+    /// <summary>Gets the provider health state.</summary>
+    public PlatformAnimationProviderState ProviderState { get; }
+
+    /// <summary>Gets the last non-sensitive native error, if any.</summary>
+    public string? LastError { get; }
+}
+
+/// <summary>
+/// Provides data for a native animation-preference change.
+/// </summary>
+public sealed class PlatformAnimationSettingsChangedEventArgs : EventArgs
+{
+    /// <summary>Initializes change data for two immutable snapshots.</summary>
+    /// <param name="previous">The previous provider snapshot.</param>
+    /// <param name="current">The current provider snapshot.</param>
+    public PlatformAnimationSettingsChangedEventArgs(
+        PlatformAnimationSettingsSnapshot previous,
+        PlatformAnimationSettingsSnapshot current)
+    {
+        Previous = previous ?? throw new ArgumentNullException(nameof(previous));
+        Current = current ?? throw new ArgumentNullException(nameof(current));
+    }
+
+    /// <summary>Gets the previous provider snapshot.</summary>
+    public PlatformAnimationSettingsSnapshot Previous { get; }
+
+    /// <summary>Gets the current provider snapshot.</summary>
+    public PlatformAnimationSettingsSnapshot Current { get; }
+}
+
+/// <summary>
+/// Provides observable native animation and reduced-motion preferences.
+/// </summary>
+/// <remarks>
+/// Implementations must be safe without an active window or activity. They must not invoke
+/// <see cref="Changed"/> handlers while holding an implementation lock. Consumers are responsible
+/// for marshaling policy mutations to their UI dispatcher.
+/// </remarks>
+public interface IPlatformAnimationSettings
+{
+    /// <summary>Gets the most recent immutable provider snapshot.</summary>
+    PlatformAnimationSettingsSnapshot Current { get; }
+
+    /// <summary>Occurs after a meaningful native animation preference changes.</summary>
+    event EventHandler<PlatformAnimationSettingsChangedEventArgs>? Changed;
+
+    /// <summary>
+    /// Reads the current platform preference and returns the resulting snapshot.
+    /// </summary>
+    /// <returns>The refreshed immutable snapshot.</returns>
+    PlatformAnimationSettingsSnapshot Refresh();
+}

--- a/ModernFormsNext.slnx
+++ b/ModernFormsNext.slnx
@@ -16,6 +16,7 @@
     <Project Path="ModernFormsNext.CrossPlatform.Sample.Tests/ModernFormsNext.CrossPlatform.Sample.Tests.csproj" />
     <Project Path="ModernFormsNext.Designer.Tests/ModernFormsNext.Designer.Tests.csproj" />
     <Project Path="ModernFormsNext.WindowKit.Backend.Android.Tests/ModernFormsNext.WindowKit.Backend.Android.Tests.csproj" />
+    <Project Path="ModernFormsNext.WindowKit.Backend.Windows.Tests/ModernFormsNext.WindowKit.Backend.Windows.Tests.csproj" />
     <Project Path="ModernFormsNext.Tests/ModernFormsNext.Tests.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/ModernFormsNext/Animations/AnimationPlatformDiagnostics.cs
+++ b/ModernFormsNext/Animations/AnimationPlatformDiagnostics.cs
@@ -1,0 +1,48 @@
+using ModernFormsNext.WindowKit.Backend;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Represents a read-only snapshot of native animation-policy integration.
+/// </summary>
+public sealed class AnimationPlatformDiagnostics
+{
+    internal AnimationPlatformDiagnostics(
+        string source,
+        bool reducedMotion,
+        bool animationsEnabled,
+        DateTimeOffset? lastPlatformUpdate,
+        bool fallbackUsed,
+        PlatformAnimationProviderState providerState,
+        string? lastError)
+    {
+        Source = source;
+        ReducedMotion = reducedMotion;
+        AnimationsEnabled = animationsEnabled;
+        LastPlatformUpdate = lastPlatformUpdate;
+        FallbackUsed = fallbackUsed;
+        ProviderState = providerState;
+        LastError = lastError;
+    }
+
+    /// <summary>Gets the native or fallback source name.</summary>
+    public string Source { get; }
+
+    /// <summary>Gets the effective reduced-motion state used by the scheduler.</summary>
+    public bool ReducedMotion { get; }
+
+    /// <summary>Gets whether animations are effectively enabled.</summary>
+    public bool AnimationsEnabled { get; }
+
+    /// <summary>Gets the last native provider read attempt, in UTC.</summary>
+    public DateTimeOffset? LastPlatformUpdate { get; }
+
+    /// <summary>Gets whether the native provider used compatibility defaults.</summary>
+    public bool FallbackUsed { get; }
+
+    /// <summary>Gets the current provider health state.</summary>
+    public PlatformAnimationProviderState ProviderState { get; }
+
+    /// <summary>Gets the last non-sensitive provider error, if any.</summary>
+    public string? LastError { get; }
+}

--- a/ModernFormsNext/Animations/AnimationPolicy.cs
+++ b/ModernFormsNext/Animations/AnimationPolicy.cs
@@ -7,13 +7,15 @@ namespace ModernFormsNext.Animations;
 /// The policy is shared by one <see cref="AnimationScheduler"/>. Properties are thread-safe.
 /// Disabling animations, enabling reduced motion, or setting <see cref="DurationScale"/> to zero
 /// completes active animations at their final value on the UI thread and prevents timer ticks.
-/// Native operating-system reduced-motion discovery is not yet automatic.
+/// Native operating-system reduced-motion discovery is applied independently from the explicit
+/// application preference. Either source can request immediate completion.
 /// </remarks>
 public sealed class AnimationPolicy
 {
     private readonly object sync = new();
     private bool animationsEnabled = true;
     private bool reducedMotion;
+    private bool platformReducedMotion;
     private double durationScale = 1d;
 
     /// <summary>
@@ -34,21 +36,34 @@ public sealed class AnimationPolicy
     }
 
     /// <summary>
-    /// Gets or sets whether reduced motion is requested by the application.
+    /// Gets whether reduced motion is effectively requested and sets the application preference.
     /// </summary>
     /// <remarks>
-    /// Reduced motion currently has the same scheduling behavior as disabling animations: final
-    /// values are applied immediately. A future backend integration may initialize this value from
-    /// the platform accessibility preference.
+    /// Reduced motion has the same scheduling behavior as disabling animations: final values are
+    /// applied immediately. The getter combines this explicit application preference with the
+    /// current native platform preference. Setting this property does not override a platform
+    /// reduced-motion request.
     /// </remarks>
     public bool ReducedMotion
     {
         get
         {
             lock (sync)
-                return reducedMotion;
+                return reducedMotion || platformReducedMotion;
         }
-        set => SetValue(ref reducedMotion, value);
+        set
+        {
+            bool changed;
+            lock (sync)
+            {
+                bool previous = reducedMotion || platformReducedMotion;
+                reducedMotion = value;
+                changed = previous != (reducedMotion || platformReducedMotion);
+            }
+
+            if (changed)
+                Changed?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     /// <summary>
@@ -89,8 +104,22 @@ public sealed class AnimationPolicy
         get
         {
             lock (sync)
-                return !animationsEnabled || reducedMotion || durationScale == 0d;
+                return !animationsEnabled || reducedMotion || platformReducedMotion || durationScale == 0d;
         }
+    }
+
+    internal void SetPlatformReducedMotion(bool value)
+    {
+        bool changed;
+        lock (sync)
+        {
+            bool previous = reducedMotion || platformReducedMotion;
+            platformReducedMotion = value;
+            changed = previous != (reducedMotion || platformReducedMotion);
+        }
+
+        if (changed)
+            Changed?.Invoke(this, EventArgs.Empty);
     }
 
     internal event EventHandler? Changed;

--- a/ModernFormsNext/Animations/AnimationPolicy.cs
+++ b/ModernFormsNext/Animations/AnimationPolicy.cs
@@ -108,6 +108,21 @@ public sealed class AnimationPolicy
         }
     }
 
+    /// <summary>Gets whether reduced motion was explicitly requested by application code.</summary>
+    /// <remarks>
+    /// Use this read-only value when a settings UI must preserve the application preference
+    /// independently from the effective <see cref="ReducedMotion"/> value contributed by the
+    /// operating system.
+    /// </remarks>
+    public bool ApplicationReducedMotion
+    {
+        get
+        {
+            lock (sync)
+                return reducedMotion;
+        }
+    }
+
     internal void SetPlatformReducedMotion(bool value)
     {
         bool changed;

--- a/ModernFormsNext/Animations/AnimationScheduler.Lifecycle.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.Lifecycle.cs
@@ -58,7 +58,10 @@ public sealed partial class AnimationScheduler
     private void ApplyPlatformLifecycleState(PlatformApplicationLifecycleState state)
     {
         if (state == PlatformApplicationLifecycleState.Foreground)
+        {
+            RefreshPlatformPolicyAfterForeground();
             Resume();
+        }
         else if (state is PlatformApplicationLifecycleState.Background or PlatformApplicationLifecycleState.NoHost)
             Pause();
     }

--- a/ModernFormsNext/Animations/AnimationScheduler.PlatformPolicy.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.PlatformPolicy.cs
@@ -1,0 +1,182 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using ModernFormsNext.WindowKit.Backend;
+
+namespace ModernFormsNext.Animations;
+
+public sealed partial class AnimationScheduler
+{
+    private readonly Func<bool> isDesignMode;
+    private IPlatformAnimationSettings? platformAnimationSettings;
+    private PlatformAnimationSettingsSnapshot platformAnimationSnapshot = CreateUnavailableSnapshot();
+
+    /// <summary>
+    /// Refreshes native reduced-motion settings and schedules policy mutation on the UI thread.
+    /// </summary>
+    /// <remarks>
+    /// This method is safe to call from any thread. In Designer mode it has no platform side
+    /// effects. A posted policy update can complete active animations at their final value through
+    /// the existing visual-invalidation batch; it does not request layout.
+    /// </remarks>
+    public void RefreshPlatformPolicy()
+    {
+        BindPlatformAnimationSettingsIfAvailable();
+
+        bool designMode = isDesignMode();
+        IPlatformAnimationSettings? provider;
+        lock (sync)
+        {
+            if (isShutdown || designMode)
+                return;
+            provider = platformAnimationSettings;
+        }
+
+        if (provider is not null)
+            ApplyPlatformAnimationSnapshot(provider, provider.Refresh());
+    }
+
+    /// <summary>Returns a thread-safe snapshot of native reduced-motion diagnostics.</summary>
+    public AnimationPlatformDiagnostics GetPlatformDiagnostics()
+    {
+        BindPlatformAnimationSettingsIfAvailable();
+
+        PlatformAnimationSettingsSnapshot snapshot;
+        lock (sync)
+            snapshot = platformAnimationSnapshot;
+
+        bool reducedMotion = Policy.ReducedMotion;
+        return new AnimationPlatformDiagnostics(
+            snapshot.Source,
+            reducedMotion,
+            Policy.AnimationsEnabled && snapshot.AnimationsEnabled && !reducedMotion,
+            snapshot.LastPlatformUpdate,
+            snapshot.FallbackUsed,
+            snapshot.ProviderState,
+            snapshot.LastError);
+    }
+
+    private void BindPlatformAnimationSettingsIfAvailable()
+    {
+        bool designMode = isDesignMode();
+        lock (sync)
+        {
+            if (platformAnimationSettings is not null || isShutdown || designMode)
+            {
+                if (designMode)
+                    platformAnimationSnapshot = CreateDesignerSnapshot();
+                return;
+            }
+        }
+
+        IPlatformAnimationSettings? provider = PlatformServiceRegistry.GetService<IPlatformAnimationSettings>();
+        if (provider is not null)
+            BindPlatformAnimationSettings(provider);
+    }
+
+    private void BindPlatformAnimationSettings(IPlatformAnimationSettings provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        bool designMode = isDesignMode();
+
+        lock (sync)
+        {
+            if (platformAnimationSettings is not null || isShutdown || designMode)
+            {
+                if (designMode)
+                    platformAnimationSnapshot = CreateDesignerSnapshot();
+                return;
+            }
+
+            platformAnimationSettings = provider;
+            provider.Changed += HandlePlatformAnimationSettingsChanged;
+        }
+
+        ApplyPlatformAnimationSnapshot(provider, provider.Current);
+    }
+
+    private void HandlePlatformAnimationSettingsChanged(
+        object? sender,
+        PlatformAnimationSettingsChangedEventArgs e)
+    {
+        if (sender is IPlatformAnimationSettings provider)
+            ApplyPlatformAnimationSnapshot(provider, e.Current);
+    }
+
+    private void ApplyPlatformAnimationSnapshot(
+        IPlatformAnimationSettings provider,
+        PlatformAnimationSettingsSnapshot snapshot)
+    {
+        lock (sync)
+        {
+            if (isShutdown || !ReferenceEquals(platformAnimationSettings, provider))
+                return;
+            if (ReferenceEquals(platformAnimationSnapshot, snapshot))
+                return;
+            platformAnimationSnapshot = snapshot;
+        }
+
+        void ApplyPolicy()
+        {
+            lock (sync)
+            {
+                if (isShutdown || !ReferenceEquals(platformAnimationSettings, provider))
+                    return;
+            }
+
+            Policy.SetPlatformReducedMotion(snapshot.ReducedMotion || !snapshot.AnimationsEnabled);
+        }
+
+        try
+        {
+            if (dispatcher.CheckAccess())
+                ApplyPolicy();
+            else
+                dispatcher.Post(ApplyPolicy);
+        }
+        catch (Exception exception)
+        {
+            // A backend notification must never tear down its native message or lifecycle callback.
+            // The next explicit refresh or animation start retries binding and policy application.
+            Trace.TraceError($"Failed to dispatch the platform animation policy update: {exception}");
+        }
+    }
+
+    private void RefreshPlatformPolicyAfterForeground()
+        => RefreshPlatformPolicy();
+
+    private void UnbindPlatformAnimationSettings()
+    {
+        IPlatformAnimationSettings? provider;
+        lock (sync)
+        {
+            provider = platformAnimationSettings;
+            platformAnimationSettings = null;
+        }
+
+        if (provider is not null)
+            provider.Changed -= HandlePlatformAnimationSettingsChanged;
+    }
+
+    private static bool IsProcessInDesignMode()
+        => LicenseManager.UsageMode == LicenseUsageMode.Designtime;
+
+    private static PlatformAnimationSettingsSnapshot CreateUnavailableSnapshot()
+        => new(
+            "No platform animation provider",
+            reducedMotion: false,
+            animationsEnabled: true,
+            lastPlatformUpdate: null,
+            fallbackUsed: true,
+            PlatformAnimationProviderState.Unavailable,
+            lastError: null);
+
+    private static PlatformAnimationSettingsSnapshot CreateDesignerSnapshot()
+        => new(
+            "Designer (platform integration disabled)",
+            reducedMotion: false,
+            animationsEnabled: true,
+            lastPlatformUpdate: null,
+            fallbackUsed: false,
+            PlatformAnimationProviderState.Disabled,
+            lastError: null);
+}

--- a/ModernFormsNext/Animations/AnimationScheduler.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using ModernFormsNext.WindowKit.Backend;
 using ModernFormsNext.WindowKit.Backend.Lifecycle;
 
 namespace ModernFormsNext.Animations;
@@ -71,13 +72,18 @@ public sealed partial class AnimationScheduler : IDisposable
         IAnimationDispatcher dispatcher,
         IAnimationTickSource tickSource,
         AnimationPolicy policy,
-        IPlatformApplicationLifecycle? platformLifecycle = null)
+        IPlatformApplicationLifecycle? platformLifecycle = null,
+        IPlatformAnimationSettings? platformAnimationSettings = null,
+        Func<bool>? isDesignMode = null)
     {
         this.clock = clock ?? throw new ArgumentNullException(nameof(clock));
         this.dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         this.tickSource = tickSource ?? throw new ArgumentNullException(nameof(tickSource));
+        this.isDesignMode = isDesignMode ?? IsProcessInDesignMode;
         Policy = policy ?? throw new ArgumentNullException(nameof(policy));
         Policy.Changed += HandlePolicyChanged;
+        if (platformAnimationSettings is not null)
+            BindPlatformAnimationSettings(platformAnimationSettings);
         if (platformLifecycle is not null)
             BindPlatformLifecycle(platformLifecycle);
     }
@@ -137,6 +143,7 @@ public sealed partial class AnimationScheduler : IDisposable
         ArgumentNullException.ThrowIfNull(update);
 
         BindPlatformLifecycleIfAvailable();
+        BindPlatformAnimationSettingsIfAvailable();
         AnimationOptionsSnapshot snapshot = (options ?? new AnimationOptions()).CreateSnapshot(Policy);
         if (owner is IComponent { Site.DesignMode: true } ||
             owner is InteractionEffect { Target.Site.DesignMode: true })
@@ -435,6 +442,7 @@ public sealed partial class AnimationScheduler : IDisposable
             entry.FinishTerminal(signalCancellation: true);
 
         Policy.Changed -= HandlePolicyChanged;
+        UnbindPlatformAnimationSettings();
         UnbindPlatformLifecycle();
         tickSource.Dispose();
     }

--- a/ModernFormsNext/Animations/RippleEffect.cs
+++ b/ModernFormsNext/Animations/RippleEffect.cs
@@ -17,7 +17,7 @@ public sealed class RippleEffect : InteractionEffect
     private long nextId;
     private RippleLayer layer = RippleLayer.AboveBackgroundBelowContent;
     private RippleRadiusMode radiusMode = RippleRadiusMode.CoverControl;
-    private RippleEvictionPolicy evictionPolicy = RippleEvictionPolicy.Oldest;
+    private RippleOverflowPolicy overflowPolicy = RippleOverflowPolicy.RemoveOldest;
 
     /// <summary>Gets or sets the wave color including its initial alpha.</summary>
     public Color Color { get; set; } = Color.FromArgb(90, 255, 255, 255);
@@ -95,20 +95,57 @@ public sealed class RippleEffect : InteractionEffect
             if (value is < 1 or > 32)
                 throw new ArgumentOutOfRangeException(nameof(value), value, "Concurrent ripple count must be from 1 through 32.");
             maxConcurrentRipples = value;
-            EvictOverflow();
+            if (EvictOverflow())
+                InvalidateTarget();
         }
     }
 
-    /// <summary>Gets or sets the explicit bounded-wave eviction policy.</summary>
-    [DefaultValue(RippleEvictionPolicy.Oldest)]
-    public RippleEvictionPolicy EvictionPolicy
+    /// <summary>Gets or sets how a new wave is handled when the active-wave limit is reached.</summary>
+    /// <remarks>
+    /// The default is <see cref="RippleOverflowPolicy.RemoveOldest"/>, preserving the original
+    /// bounded-ripple behavior. <see cref="RippleOverflowPolicy.IgnoreNew"/> does not allocate a
+    /// ripple instance or scheduler handle.
+    /// </remarks>
+    [DefaultValue(RippleOverflowPolicy.RemoveOldest)]
+    public RippleOverflowPolicy OverflowPolicy
     {
-        get => evictionPolicy;
+        get => overflowPolicy;
         set
         {
             if (!Enum.IsDefined(value))
                 throw new ArgumentOutOfRangeException(nameof(value));
-            evictionPolicy = value;
+            overflowPolicy = value;
+        }
+    }
+
+    /// <summary>Gets or sets the compatibility alias for <see cref="OverflowPolicy"/>.</summary>
+    /// <remarks>
+    /// This property preserves source compatibility with the original single-policy API. New code
+    /// should use <see cref="OverflowPolicy"/>.
+    /// </remarks>
+    [DefaultValue(RippleEvictionPolicy.Oldest)]
+    public RippleEvictionPolicy EvictionPolicy
+    {
+        get => OverflowPolicy switch
+        {
+            RippleOverflowPolicy.RemoveOldest => RippleEvictionPolicy.Oldest,
+            RippleOverflowPolicy.RemoveNewest => RippleEvictionPolicy.Newest,
+            RippleOverflowPolicy.IgnoreNew => RippleEvictionPolicy.IgnoreNew,
+            RippleOverflowPolicy.ReplaceAll => RippleEvictionPolicy.ReplaceAll,
+            _ => throw new InvalidOperationException("The ripple overflow policy is invalid.")
+        };
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value));
+            OverflowPolicy = value switch
+            {
+                RippleEvictionPolicy.Oldest => RippleOverflowPolicy.RemoveOldest,
+                RippleEvictionPolicy.Newest => RippleOverflowPolicy.RemoveNewest,
+                RippleEvictionPolicy.IgnoreNew => RippleOverflowPolicy.IgnoreNew,
+                RippleEvictionPolicy.ReplaceAll => RippleOverflowPolicy.ReplaceAll,
+                _ => throw new ArgumentOutOfRangeException(nameof(value))
+            };
         }
     }
 
@@ -201,8 +238,8 @@ public sealed class RippleEffect : InteractionEffect
             Scheduler.Policy.ShouldCompleteImmediately)
             return;
 
-        while (ripples.Count >= MaxConcurrentRipples)
-            EvictOne();
+        if (!PrepareForNewRipple())
+            return;
 
         var ripple = new RippleInstance(++nextId, pointerId, origin);
         ripples.Add(ripple);
@@ -249,23 +286,62 @@ public sealed class RippleEffect : InteractionEffect
         InvalidateTarget();
     }
 
-    private void EvictOverflow()
+    private bool EvictOverflow()
     {
+        bool removed = false;
+        if (OverflowPolicy == RippleOverflowPolicy.ReplaceAll && ripples.Count > MaxConcurrentRipples)
+        {
+            CancelAllRipples();
+            return true;
+        }
+
         while (ripples.Count > MaxConcurrentRipples)
-            EvictOne();
+        {
+            bool removeNewest = OverflowPolicy is RippleOverflowPolicy.RemoveNewest
+                or RippleOverflowPolicy.IgnoreNew;
+            EvictOne(removeNewest);
+            removed = true;
+        }
+        return removed;
     }
 
-    private void EvictOne()
+    private bool PrepareForNewRipple()
+    {
+        if (ripples.Count < MaxConcurrentRipples)
+            return true;
+
+        switch (OverflowPolicy)
+        {
+            case RippleOverflowPolicy.RemoveOldest:
+                EvictOne(removeNewest: false);
+                return true;
+            case RippleOverflowPolicy.RemoveNewest:
+                EvictOne(removeNewest: true);
+                return true;
+            case RippleOverflowPolicy.IgnoreNew:
+                return false;
+            case RippleOverflowPolicy.ReplaceAll:
+                CancelAllRipples();
+                return true;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(OverflowPolicy));
+        }
+    }
+
+    private void EvictOne(bool removeNewest)
     {
         if (ripples.Count == 0)
             return;
-        RippleInstance ripple = EvictionPolicy switch
-        {
-            RippleEvictionPolicy.Oldest => ripples[0],
-            _ => throw new ArgumentOutOfRangeException(nameof(EvictionPolicy))
-        };
+        RippleInstance ripple = removeNewest ? ripples[^1] : ripples[0];
         ripples.Remove(ripple);
         ripple.Handle?.Cancel();
+    }
+
+    private void CancelAllRipples()
+    {
+        foreach (RippleInstance ripple in ripples.ToArray())
+            ripple.Handle?.Cancel();
+        ripples.Clear();
     }
 
     private float ResolveRadius(PointF origin, Control target)

--- a/ModernFormsNext/Animations/RippleEffectOptions.cs
+++ b/ModernFormsNext/Animations/RippleEffectOptions.cs
@@ -20,9 +20,41 @@ public enum RippleLayer
     AboveContent
 }
 
-/// <summary>Specifies which active wave is evicted when a ripple limit is reached.</summary>
+/// <summary>Specifies how a new ripple is handled when the active-wave limit is reached.</summary>
+public enum RippleOverflowPolicy
+{
+    /// <summary>Cancel the oldest active wave and start the new wave.</summary>
+    RemoveOldest,
+
+    /// <summary>Cancel the newest active wave and start the new wave.</summary>
+    RemoveNewest,
+
+    /// <summary>Keep every active wave and do not create a wave or scheduler handle.</summary>
+    IgnoreNew,
+
+    /// <summary>Cancel every active wave and start only the new wave.</summary>
+    ReplaceAll
+}
+
+/// <summary>
+/// Specifies which active wave is evicted when a ripple limit is reached.
+/// </summary>
+/// <remarks>
+/// This compatibility surface maps to <see cref="RippleEffect.OverflowPolicy"/>. New code should
+/// prefer <see cref="RippleOverflowPolicy"/>, whose member names describe complete overflow
+/// behavior.
+/// </remarks>
 public enum RippleEvictionPolicy
 {
     /// <summary>Cancel and remove the oldest active wave.</summary>
-    Oldest
+    Oldest,
+
+    /// <summary>Cancel and remove the newest active wave.</summary>
+    Newest,
+
+    /// <summary>Keep active waves and ignore the new wave.</summary>
+    IgnoreNew,
+
+    /// <summary>Cancel all active waves before starting the new wave.</summary>
+    ReplaceAll
 }

--- a/ModernFormsNext/Animations/VisualStateTransitionCollection.cs
+++ b/ModernFormsNext/Animations/VisualStateTransitionCollection.cs
@@ -41,6 +41,9 @@ public sealed class VisualStateTransitionCollection : IEnumerable<VisualStateTra
     internal bool TryGet(VisualState from, VisualState to, out VisualStateTransition? transition)
         => transitions.TryGetValue((from, to), out transition);
 
+    internal bool Contains(VisualState state)
+        => transitions.Keys.Any(pair => pair.From == state || pair.To == state);
+
     private static void ValidateState(VisualState value, string parameterName)
     {
         if (!Enum.IsDefined(value))

--- a/ModernFormsNext/Application.cs
+++ b/ModernFormsNext/Application.cs
@@ -289,10 +289,11 @@ namespace ModernFormsNext
         public static void Run(Form mainForm)
         {
             FrameworkBootstrap.EnsureInitialized();
+            Animations.AnimationScheduler.Default.RefreshPlatformPolicy();
             AvaloniaSynchronizationContext.InstallIfNeeded();
 
             mainForm.Show();
-            Run((ICloseable)mainForm);
+            RunMainLoop(mainForm);
         }
 
         /// <summary>
@@ -317,6 +318,13 @@ namespace ModernFormsNext
         public static void Run(ICloseable closable)
         {
             FrameworkBootstrap.EnsureInitialized();
+            Animations.AnimationScheduler.Default.RefreshPlatformPolicy();
+            RunMainLoop(closable);
+        }
+
+        private static void RunMainLoop(ICloseable closable)
+        {
+            ArgumentNullException.ThrowIfNull(closable);
 
             if (_mainLoopCancellationTokenSource != null)
                 throw new InvalidOperationException("Run should only be called once");

--- a/ModernFormsNext/Control.InteractionEffects.cs
+++ b/ModernFormsNext/Control.InteractionEffects.cs
@@ -19,9 +19,15 @@ public partial class Control
 
     /// <summary>Gets the effects attached to this control.</summary>
     /// <remarks>
+    /// <para>
+    /// Each control starts with its own empty collection. Effects run only after an effect is
+    /// explicitly added in code or through generated Designer code.
+    /// </para>
+    /// <para>
     /// The custom Designer edits detached descriptions and emits ordered <c>Add</c> calls. It does
     /// not attach these runtime objects while the form is being designed. Easing delegates and
     /// custom effect types that are not registered by the Designer remain code-only.
+    /// </para>
     /// </remarks>
     [Browsable(true)]
     [Category("Behavior")]
@@ -39,6 +45,7 @@ public partial class Control
     }
 
     /// <summary>Gets or sets the convenience ripple effect attached to this control.</summary>
+    [DefaultValue(null)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
     public RippleEffect? Ripple
     {
@@ -47,6 +54,7 @@ public partial class Control
     }
 
     /// <summary>Gets or sets the convenience press-scale effect attached to this control.</summary>
+    [DefaultValue(null)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
     public PressScaleEffect? PressEffect
     {
@@ -177,6 +185,9 @@ public partial class Control
         if (value is not null)
             InteractionEffects.Add(value);
     }
+
+    private bool ShouldSerializeInteractionEffects()
+        => Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection { Count: > 0 };
 
     private void RecalculateInteractionScale(Dictionary<InteractionEffect, float> scales)
     {

--- a/ModernFormsNext/Control.InteractionEffects.cs
+++ b/ModernFormsNext/Control.InteractionEffects.cs
@@ -21,7 +21,8 @@ public partial class Control
     /// <remarks>
     /// <para>
     /// Each control starts with its own empty collection. Effects run only after an effect is
-    /// explicitly added in code or through generated Designer code.
+    /// explicitly added in code or through generated Designer code. Target-local input is sent
+    /// only to that collection; child input does not bubble an effect into a parent collection.
     /// </para>
     /// <para>
     /// The custom Designer edits detached descriptions and emits ordered <c>Add</c> calls. It does

--- a/ModernFormsNext/Control.InteractionEffects.cs
+++ b/ModernFormsNext/Control.InteractionEffects.cs
@@ -19,11 +19,13 @@ public partial class Control
 
     /// <summary>Gets the effects attached to this control.</summary>
     /// <remarks>
-    /// Effects are code-first objects that can contain easing delegates and runtime state, so the
-    /// collection is intentionally hidden from ordinary designer serialization.
+    /// The custom Designer edits detached descriptions and emits ordered <c>Add</c> calls. It does
+    /// not attach these runtime objects while the form is being designed. Easing delegates and
+    /// custom effect types that are not registered by the Designer remain code-only.
     /// </remarks>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Browsable(true)]
+    [Category("Behavior")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
     public InteractionEffectCollection InteractionEffects
     {
         get

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -66,6 +66,8 @@ public partial class Control
     /// <para>
     /// Each control starts with its own empty collection. Without a matching explicitly added
     /// transition, state changes apply the target style immediately and only invalidate rendering.
+    /// Container and data-surface controls do not enter the Pressed state merely because they
+    /// receive pointer input; they must opt in through a pressed style or transition.
     /// </para>
     /// <para>
     /// Delegate-valued easing functions are code-first configuration, so the collection is hidden
@@ -110,6 +112,8 @@ public partial class Control
 
     internal void SetPointerVisualPressed(bool value, int pointerId = 0)
     {
+        if (value && !ShouldTrackActivationVisualState())
+            return;
         bool wasPressed = pointerPressed;
         if (value)
             (pressedPointerIds ??= []).Add(pointerId);
@@ -137,6 +141,8 @@ public partial class Control
 
     internal void SetKeyboardVisualPressed(bool value)
     {
+        if (value && !ShouldTrackActivationVisualState())
+            return;
         if (keyboardPressed == value)
             return;
         keyboardPressed = value;
@@ -221,6 +227,27 @@ public partial class Control
         if (hasVisualFocus || Focused)
             return VisualState.Focused;
         return VisualState.Normal;
+    }
+
+    private bool ShouldTrackActivationVisualState()
+    {
+        // Pointer routing is shared by buttons, containers, scrollbars, and data surfaces. Do not
+        // turn every leaf that receives a click into a pressed visual: container state styles can
+        // cover the entire viewport and look like an implicit whole-control interaction effect.
+        if (GetControlBehavior(ControlBehaviors.Hoverable) ||
+            Properties.GetObject(s_stylePressedProperty) is ControlStyle)
+        {
+            return true;
+        }
+
+        if (Properties.GetObject(s_interactionEffectsProperty) is InteractionEffectCollection effects &&
+            effects.Any(static effect => effect is PressScaleEffect))
+        {
+            return true;
+        }
+
+        return Properties.GetObject(s_styleTransitionsProperty) is VisualStateTransitionCollection transitions &&
+            transitions.Contains(VisualState.Pressed);
     }
 
     private AnimationScheduler EffectiveAnimationScheduler

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -63,9 +63,15 @@ public partial class Control
 
     /// <summary>Gets directional visual-state transitions for this control.</summary>
     /// <remarks>
+    /// <para>
+    /// Each control starts with its own empty collection. Without a matching explicitly added
+    /// transition, state changes apply the target style immediately and only invalidate rendering.
+    /// </para>
+    /// <para>
     /// Delegate-valued easing functions are code-first configuration, so the collection is hidden
     /// from ordinary designer serialization. Design-time playback completes immediately through
     /// the existing scheduler policy and does not create a separate timer.
+    /// </para>
     /// </remarks>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]

--- a/ModernFormsNext/Theming/ThemeApplyContracts.cs
+++ b/ModernFormsNext/Theming/ThemeApplyContracts.cs
@@ -28,7 +28,7 @@ public enum ThemeTransitionStatus
     Failed
 }
 
-/// <summary>Configures an animated theme transition.</summary>
+/// <summary>Configures an optional animated theme transition.</summary>
 public sealed class ThemeTransitionOptions
 {
     private TimeSpan duration = TimeSpan.FromMilliseconds(250);
@@ -36,7 +36,11 @@ public sealed class ThemeTransitionOptions
     private AnimationReplacementMode replacementMode = AnimationReplacementMode.Replace;
 
     /// <summary>Gets or sets whether compatible values should animate.</summary>
-    public bool Enabled { get; set; } = true;
+    /// <remarks>
+    /// The default is <see langword="false"/>. Set this property explicitly to opt into an
+    /// animated theme transition; otherwise the theme is committed and repainted immediately.
+    /// </remarks>
+    public bool Enabled { get; set; }
 
     /// <summary>Gets or sets the unscaled transition duration.</summary>
     public TimeSpan Duration
@@ -100,6 +104,10 @@ public sealed class ThemeApplyOptions
     private ThemeVariant systemFallbackVariant = ThemeVariant.Light;
 
     /// <summary>Gets or sets transition behavior.</summary>
+    /// <remarks>
+    /// The default options keep animation disabled, so an apply request without explicit
+    /// transition configuration completes immediately.
+    /// </remarks>
     public ThemeTransitionOptions Transition { get; set; } = new();
 
     /// <summary>Gets or sets the explicit fallback when platform theme detection is unavailable.</summary>

--- a/ModernFormsNext/Theming/ThemeManager.cs
+++ b/ModernFormsNext/Theming/ThemeManager.cs
@@ -27,6 +27,7 @@ namespace ModernFormsNext;
 ///     {
 ///         Transition = new ThemeTransitionOptions
 ///         {
+///             Enabled = true,
 ///             Duration = TimeSpan.FromMilliseconds(200)
 ///         }
 ///     });
@@ -206,7 +207,10 @@ public sealed class ThemeManager
 
     /// <summary>Applies a theme and blocks until the UI-thread commit has completed.</summary>
     /// <param name="theme">The mutable authoring definition, which is copied immediately.</param>
-    /// <param name="options">Optional transition and System fallback behavior.</param>
+    /// <param name="options">
+    /// Optional transition and System fallback behavior. Omitting this value applies the theme
+    /// immediately without starting an animation.
+    /// </param>
     /// <returns>The commit result. An animation may still be running.</returns>
     /// <remarks>
     /// Calling this method from a background thread waits for the dispatcher. Prefer
@@ -217,7 +221,10 @@ public sealed class ThemeManager
 
     /// <summary>Validates on the caller thread and atomically commits on the UI thread.</summary>
     /// <param name="theme">The mutable authoring definition, which is copied immediately.</param>
-    /// <param name="options">Optional transition and System fallback behavior.</param>
+    /// <param name="options">
+    /// Optional transition and System fallback behavior. Omitting this value applies the theme
+    /// immediately without starting an animation.
+    /// </param>
     /// <param name="cancellationToken">Cancels the request before commit.</param>
     /// <returns>The commit result. Observe <see cref="ThemeApplyResult.Transition"/> for animation completion.</returns>
     public async Task<ThemeApplyResult> ApplyAsync(

--- a/docs/1.9.0-theme-system-draft.md
+++ b/docs/1.9.0-theme-system-draft.md
@@ -13,7 +13,7 @@
 - atomic UI-thread commit, rollback, documented events, counters, and safe diagnostics;
 - version 1 strict JSON string/stream/file load/save with Brush converters and security limits;
 - animated color, custom numeric, solid, and compatible gradient transitions through the shared
-  animation scheduler;
+  animation scheduler when explicitly enabled; theme application is immediate by default;
 - Windows light/dark and reduced-motion preference provider;
 - built-in ModernFormsNext Light/Dark definitions with semantic colors and Brush examples;
 - ThemeManager ControlGallery page and deterministic headless coverage.

--- a/docs/android-backend.md
+++ b/docs/android-backend.md
@@ -47,6 +47,22 @@ automatic.
 An optional `ActivityProvider` exists for hosts with their own lifecycle integration. It is invoked
 on demand; the delegate must not keep destroyed activities alive.
 
+### Experimental platform animation preference
+
+The backend registers `AndroidPlatformAnimationSettings` through the shared backend service
+registry. When an application context exists, it reads
+`Settings.Global.ANIMATOR_DURATION_SCALE` and `TRANSITION_ANIMATION_SCALE`; a zero value in either
+setting requests reduced motion. The animation scheduler combines that snapshot with application
+policy on the UI dispatcher.
+
+The provider refreshes during startup, on foreground entry, and when application code calls
+`AnimationScheduler.RefreshPlatformPolicy()`. It deliberately does not register a process-lifetime
+`ContentObserver` in this experimental stage. A missing application context or failed settings
+read uses compatibility defaults, records a fallback diagnostic, and does not fail application
+startup.
+The settings evaluator and lifecycle refresh path have deterministic host-side tests, but runtime
+behavior still requires device/emulator validation.
+
 ## Dispatcher
 
 `AndroidMainThreadDispatcher` uses `Looper.MainLooper` and `Handler`. It provides:

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -404,8 +404,10 @@ button.InteractionEffects.Add(new PressScaleEffect());
 An effect has one target at a time, receives shared pointer/keyboard and render hooks, owns its
 scheduler channels, and cancels them on removal or disposal. Adding the same instance to the same
 collection is idempotent; attaching it to a different control while still attached throws.
-`InteractionEffects` is hidden from ordinary Designer serialization. Convenience properties
-support the common cases:
+At runtime the collection keeps its normal control-owned lifetime. The ModernFormsNext Designer
+exposes a detached collection editor for the built-in `RippleEffect` and `PressScaleEffect`; it
+does not instantiate effects, start the scheduler, or mutate a live preview control while the
+dialog is open. Convenience properties support the common cases:
 
 ```csharp
 button.Ripple = new RippleEffect
@@ -416,7 +418,7 @@ button.Ripple = new RippleEffect
     RadiusMode = RippleRadiusMode.CoverControl,
     Layer = RippleLayer.AboveBackgroundBelowContent,
     MaxConcurrentRipples = 4,
-    EvictionPolicy = RippleEvictionPolicy.Oldest
+    OverflowPolicy = RippleOverflowPolicy.RemoveOldest
 };
 
 button.PressEffect = new PressScaleEffect
@@ -436,10 +438,17 @@ while radius uses the configured easing.
 
 Waves are clipped to control bounds and the current corner radius. `AboveBackgroundBelowContent`
 keeps content legible; `AboveContent` is available for stronger feedback. Active waves are bounded
-from 1 through 32 and `Oldest` explicitly cancels the oldest wave when the limit is reached.
-Disabled controls do not start waves. A touch cancel removes waves for that pointer ID; global
-cancel, removal, disable, detach, and disposal clear all effect-owned work. Decorative ripple is
-omitted under reduced motion.
+from 1 through 32. `OverflowPolicy` deterministically chooses what happens at the limit:
+
+- `RemoveOldest` cancels the oldest active wave and starts the new wave;
+- `RemoveNewest` cancels the newest active wave and starts the new wave;
+- `IgnoreNew` keeps the active waves and allocates neither a wave nor a scheduler handle;
+- `ReplaceAll` cancels every active wave and starts only the new wave.
+
+The existing `EvictionPolicy` property remains source-compatible and maps all four behaviors to
+`OverflowPolicy`. Disabled controls do not start waves. A touch cancel removes waves for that
+pointer ID; global cancel, removal, disable, detach, and disposal clear all effect-owned work.
+Decorative ripple is omitted under reduced motion.
 
 ### Press, hover, and focus
 
@@ -500,12 +509,21 @@ policy.ReducedMotion = false;
 policy.DurationScale = 0.5; // Half the configured duration for newly started animations.
 ```
 
-When animations are disabled, reduced motion is enabled, or the duration scale is zero, the final
-value is posted once on the UI thread and completion reports `Completed`; no tick source starts.
-Changing to one of those modes while animations are active completes them through the same
+`ReducedMotion` is the effective value: its setter changes the application preference, while its
+getter also includes the platform preference. `ApplicationReducedMotion` exposes the application
+part read-only so a settings UI can preserve it without accidentally copying a native override.
+Application code cannot turn motion back on while the operating system asks for reduced motion.
+
+When animations are disabled, reduced motion is effective, or the duration scale is zero, the
+final value is posted once on the UI thread and completion reports `Completed`; no tick source
+starts. Changing to one of those modes while animations are active completes them through the same
 final-value path. Positive duration scale is captured when each animation starts.
 
-ModernFormsNext does not yet read the operating system reduced-motion preference automatically.
+Windows reads `SPI_GETCLIENTAREAANIMATION` during framework startup and refreshes it from the
+existing WindowKit message-only window on `WM_SETTINGCHANGE`. This adds no polling loop, timer, or
+native handle. The experimental Android backend reads `Settings.Global.ANIMATOR_DURATION_SCALE`
+and `TRANSITION_ANIMATION_SCALE` when a usable Activity context exists and refreshes on foreground
+entry. Android intentionally has no live settings observer in this stage.
 
 ## Diagnostics and faults
 
@@ -517,13 +535,40 @@ If easing, interpolation, or an update callback throws, only that animation move
 The exception is available through `AnimationHandle.Exception`, a trace error is written, and other
 animations continue.
 
+`RefreshPlatformPolicy()` requests an explicit native refresh. `GetPlatformDiagnostics()` reports
+the source, provider state, effective animation/reduced-motion values, last refresh time, fallback
+use, and a non-sensitive last error:
+
+```csharp
+AnimationScheduler scheduler = AnimationScheduler.Default;
+scheduler.RefreshPlatformPolicy();
+AnimationPlatformDiagnostics platform = scheduler.GetPlatformDiagnostics();
+```
+
+Native read failure keeps the framework usable with compatibility defaults and changes the
+provider state to `Fallback`; it does not crash startup. Native notifications are marshaled to the
+UI dispatcher before policy mutation. Provider event callbacks are invoked outside provider and
+scheduler locks.
+
 ## Designer behavior
 
 Animations started for an `IComponent` whose `Site.DesignMode` is true apply their final value on
 the designer dispatcher without starting periodic ticks. Runtime animation state is not serialized
 into `.Designer.cs` or `.mfdesign` files. Ripple does not start in the Designer. Press preview
-applies deterministic endpoints, and complex transition/effect collections stay hidden from the
-ordinary property grid.
+applies deterministic endpoints.
+
+The `InteractionEffects` Property Grid entry opens a collection editor over detached descriptions.
+Add, remove, reorder, and property changes are committed atomically only after **OK**; **Cancel**
+leaves the document unchanged. `.mfdesign` stores a deterministic `Count` plus ordered `ItemN`
+structure containing only validated primitive values. Generated code uses stable ordered
+`control.InteractionEffects.Add(new RippleEffect { ... })` and
+`control.InteractionEffects.Add(new PressScaleEffect { ... })` calls. Reload parses only this
+conservative generated shape and never executes project code or reflects arbitrary effect types.
+
+The current Designer has dirty/save support but no transaction-based undo/redo stack. Therefore a
+successful collection commit participates in normal save/reload and code regeneration, but it does
+not claim undo/redo integration. Custom interaction-effect types and custom easing delegates remain
+code-first.
 
 ## Windows and experimental Android
 
@@ -533,9 +578,10 @@ and scheduler paths.
 
 Android remains experimental. `SkiaControlSurface` forwards touch down/up/cancel, pointer IDs, and
 multi-touch sequences to the same control/effect pipeline. Lifecycle background/foreground pauses
-monotonic scheduler time. Orientation and resize use current control geometry. Native
-reduced-motion discovery and device-specific frame pacing are not yet validated; do not infer
-runtime parity from a successful Android build.
+monotonic scheduler time and refreshes the platform animation snapshot on foreground entry.
+Orientation and resize use current control geometry. The global animation-scale read has
+deterministic host-side coverage, but device-specific reduced-motion behavior and frame pacing still
+require runtime validation; do not infer runtime parity from a successful Android build.
 
 ## Performance and repaint batching
 
@@ -551,20 +597,21 @@ stops when no runnable work remains.
 
 ## Current limitations
 
-- There is no automatic native reduced-motion preference adapter yet.
 - There is no general animated-layout subsystem. Updating bounds or spacing uses the existing
   setters and can be more expensive than render-only transforms.
 - Brush interpolation requires matching built-in concrete types and equal gradient stop counts.
 - Visual-state layout metrics switch discretely rather than interpolate.
-- Ripple has one bounded eviction policy, `Oldest`; additional policies can be added without
-  changing effect attachment or rendering APIs.
-- Complex effect collections are code-first and do not yet have a dedicated Designer collection
-  editor.
+- The Designer collection editor supports the built-in `RippleEffect` and `PressScaleEffect` only;
+  custom effects and easing delegates remain code-first, and Designer undo/redo is not available.
+- Android platform preference refresh occurs on startup/foreground or explicit refresh; there is no
+  live `ContentObserver` in this experimental stage.
 - Android is experimental; physical-device frame pacing, multi-touch rendering,
-  background/foreground, and orientation changes still require manual validation.
+  platform settings changes, background/foreground, and orientation changes still require manual
+  validation.
 
 See [the scheduler architecture](architecture/ui-animation-scheduler.md), the
 [scheduler architecture decision](architecture/decisions/ADR-UI-Animation-Scheduler.md), the
 [composable-animation architecture decision](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md),
+the [animation platform polish decision](architecture/decisions/ADR-Animation-Platform-Polish.md),
 and **Animations and Interaction Effects** in `samples/ControlGallery` for implementation rationale
 and interactive checks.

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -365,6 +365,11 @@ Controls resolve one of `Normal`, `Hover`, `Pressed`, `Focused`, or `Disabled` w
 Disabled > Pressed > Hover > Focused > Normal
 ```
 
+Every new control owns an empty `StyleTransitions` collection. With no matching entry, the active
+state style is resolved immediately and rendering is invalidated without scheduling frames or
+requesting layout. Animated state changes begin only after an application explicitly adds a
+directional transition.
+
 Add directional transitions without creating another hover or focus state machine:
 
 ```csharp
@@ -400,6 +405,11 @@ Effects are reusable objects attached through one control-owned collection:
 button.InteractionEffects.Add(new RippleEffect());
 button.InteractionEffects.Add(new PressScaleEffect());
 ```
+
+Every new `Control`, `Button`, `TextBox`, and `Switch` starts with an independent empty collection;
+`Ripple` and `PressEffect` are `null`. Pointer, keyboard, hover, and focus routing does not create
+effects or scheduler handles. Adding an effect, assigning a convenience property, or generating an
+explicit Designer `Add` call is the opt-in boundary.
 
 An effect has one target at a time, receives shared pointer/keyboard and render hooks, owns its
 scheduler channels, and cancels them on removal or disposal. Adding the same instance to the same

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -411,6 +411,17 @@ Every new `Control`, `Button`, `TextBox`, and `Switch` starts with an independen
 effects or scheduler handles. Adding an effect, assigning a convenience property, or generating an
 explicit Designer `Add` call is the opt-in boundary.
 
+Pointer dispatch is target-local and leaf-first. A child click does not bubble an interaction
+effect into its parent, even when that parent has its own explicitly configured collection.
+Containers and data surfaces also do not enter the shared Pressed visual state merely because they
+receive a left click. Built-in clickable controls opt in through their existing hover behavior;
+other controls can opt in by configuring `StylePressed` or a transition involving `Pressed`.
+
+`DataGridView` currently has no cell/row interaction-effect target contract. Its default is
+therefore no effect, including for cell selection, headers, resizing, dragging, and scrollbars.
+Applications that need a cell-, row-, or action-cell-bounded ripple should not attach a generic
+whole-control ripple to the grid; that scoped target model is a separate future API step.
+
 An effect has one target at a time, receives shared pointer/keyboard and render hooks, owns its
 scheduler channels, and cancels them on removal or disposal. Adding the same instance to the same
 collection is idempotent; attaching it to a different control while still attached throws.

--- a/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
+++ b/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
@@ -1,0 +1,132 @@
+# ADR: Animation platform policy, ripple overflow, and Designer effects
+
+Status: Accepted for the animation platform polish draft
+
+## Context
+
+ModernFormsNext already has one monotonic, idle-aware `AnimationScheduler`, an
+`AnimationPolicy`, platform lifecycle services, and scheduler-backed interaction effects. The
+remaining platform gaps are native reduced-motion discovery, explicit ripple overflow semantics,
+and deterministic editing of interaction effects in the ModernFormsNext Designer.
+
+The implementation must extend those systems. It must not introduce a second scheduler, polling
+loop, per-ripple timer, platform type in shared UI APIs, or a Designer dependency in the runtime
+framework.
+
+## Decision
+
+### Platform animation settings
+
+`ModernFormsNext.WindowKit.Backend` defines an observable, platform-neutral animation-settings
+provider. A provider publishes immutable snapshots containing:
+
+- a stable source name;
+- whether reduced motion is requested;
+- whether animations are enabled by the platform;
+- the last successful or attempted platform update;
+- whether a fallback was used;
+- provider state;
+- the last non-sensitive error message.
+
+Providers support an explicit refresh and a change event. Events are copied under the provider
+lock and invoked after the lock is released. `AnimationScheduler` subscribes at most once,
+unsubscribes during shutdown, and marshals policy updates through its existing UI dispatcher.
+The scheduler exposes a read-only diagnostics snapshot and an explicit refresh method. No native
+provider is queried or subscribed when the scheduler is operating in Designer mode.
+
+The application-level `AnimationPolicy.AnimationsEnabled` remains an independent application
+switch. Effective animation availability is the conjunction of that switch and the platform
+snapshot. A platform reduced-motion request completes active animations at their final value by
+using the existing policy-change path. It does not add a new repaint or layout mechanism.
+
+### Windows source
+
+Windows reads `SPI_GETCLIENTAREAANIMATION` with `SystemParametersInfoW`. A false client-area
+animation preference means reduced motion. The existing Win32 message-only infrastructure
+observes `WM_SETTINGCHANGE` and tells the single provider to refresh. This follows the Windows
+recommendation to reload used system parameters because `lParam` does not reliably identify the
+specific setting. No additional HWND, hook, timer, or per-window subscription is created.
+
+If the API is unavailable or fails, the provider reports animations enabled, reduced motion
+false, `FallbackUsed = true`, and the error in diagnostics. That fallback preserves historical
+ModernFormsNext behavior.
+
+### Experimental Android source
+
+The Android provider reads `Settings.Global.ANIMATOR_DURATION_SCALE`. A finite scale less than or
+equal to zero requests reduced motion; a positive scale permits animations. The application
+context is sufficient, so no foreground `Activity` is required.
+
+Android live observation is intentionally limited in this experimental backend. The scheduler
+refreshes the provider when the shared lifecycle reports `Foreground`. This avoids a permanent
+`ContentObserver` and its `Handler` ownership while still reflecting changes after resume. Missing
+context, inaccessible settings, malformed values, and platform exceptions use the same safe
+fallback as Windows. Device/emulator runtime behavior must not be claimed from compile-time or
+abstraction tests alone.
+
+### Threading and lifetime
+
+Native reads may occur on the notifying thread. Policy mutation and completion callbacks occur on
+the scheduler UI dispatcher. Provider and scheduler locks never cover external callbacks. The
+scheduler owns only its event subscription, not the process-wide platform provider. Shutdown
+removes provider and lifecycle subscriptions, cancels scheduler work, and leaves the tick source
+idle.
+
+### Ripple overflow policies
+
+`RippleOverflowPolicy` defines four deterministic behaviors when
+`MaxConcurrentRipples` is reached:
+
+- `RemoveOldest` cancels the first active wave and starts the new wave;
+- `RemoveNewest` cancels the last active wave and starts the new wave;
+- `IgnoreNew` leaves existing waves unchanged and creates no wave or handle;
+- `ReplaceAll` cancels every active wave and starts only the new wave.
+
+The default is `RemoveOldest`, preserving the behavior shipped with composable animations. The
+legacy `RippleEvictionPolicy` surface remains as a compatibility bridge. All waves still use the
+shared scheduler; disposal and cancellation clear their handles and visual state.
+
+### Designer collection editor and serialization
+
+The runtime `InteractionEffectCollection` remains the owner-attached collection. Designer-only
+editing lives in `ModernFormsNext.Designer` and supports the built-in `RippleEffect` and
+`PressScaleEffect`. Unsupported effect types are not offered and are rejected when imported.
+
+The `.mfdesign` value is a deterministic structured object containing `Count` and ordered `ItemN`
+entries. Each entry stores a type discriminator and supported serializable properties. Generated
+C# emits ordered `control.InteractionEffects.Add(new ... { ... });` calls. Removing an entry
+removes its corresponding call; reopening and code reverse-sync rebuild one ordered collection
+without appending duplicates.
+
+The editor works on detached descriptions. It never attaches effects, starts animations, queries
+platform settings, or creates scheduler handles. Generated runtime code performs the normal
+single attach when `InteractionEffects.Add` executes. The current Designer has no transaction or
+undo/redo service, so collection edits participate in its existing dirty/save workflow but cannot
+offer transactional undo until that infrastructure exists.
+
+## Serialization compatibility
+
+Runtime public APIs remain code-first. Existing `Ripple` and `PressEffect` convenience properties
+continue to work. Existing `.mfdesign` documents without `InteractionEffects` deserialize as an
+empty collection. Unknown future effect entries are rejected with a Designer diagnostic rather
+than instantiated through arbitrary reflection.
+
+## Known limitations
+
+- Android refreshes on foreground instead of observing the global setting continuously.
+- Android runtime behavior requires a device or emulator for confirmation.
+- The Designer initially supports only `RippleEffect` and `PressScaleEffect` and their safe,
+  deterministic properties; arbitrary easing delegates and custom clip implementations are not
+  serialized.
+- Designer undo/redo remains unavailable because the existing Designer session has no command
+  transaction stack.
+- This work does not add animated layout, gradient-stop morphing, Shapes/Geometry, new large
+  effects, or broader Android runtime stabilization.
+
+## Consequences
+
+Native accessibility changes flow through one provider subscription and the existing scheduler
+policy path. Ripple overflow is explicit and testable without extra timers. Designer-generated
+effect code is stable and runtime-compatible while keeping all editing UI outside the core
+framework. Tests use deterministic providers, lifecycle objects, dispatchers, and clocks; they do
+not use timing sleeps.

--- a/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
+++ b/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
@@ -53,9 +53,10 @@ ModernFormsNext behavior.
 
 ### Experimental Android source
 
-The Android provider reads `Settings.Global.ANIMATOR_DURATION_SCALE`. A finite scale less than or
-equal to zero requests reduced motion; a positive scale permits animations. The application
-context is sufficient, so no foreground `Activity` is required.
+The Android provider reads `Settings.Global.ANIMATOR_DURATION_SCALE` and
+`TRANSITION_ANIMATION_SCALE`. A finite zero value in either setting requests reduced motion; both
+values must be positive to permit animations. The application context is sufficient, so no
+foreground `Activity` is required.
 
 Android live observation is intentionally limited in this experimental backend. The scheduler
 refreshes the provider when the shared lifecycle reports `Foreground`. This avoids a permanent

--- a/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
+++ b/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
@@ -112,6 +112,12 @@ continue to work. Existing `.mfdesign` documents without `InteractionEffects` de
 empty collection. Unknown future effect entries are rejected with a Designer diagnostic rather
 than instantiated through arbitrary reflection.
 
+Animation and interaction decoration remain opt-in. New controls own independent empty
+`InteractionEffects` and `StyleTransitions` collections, and the Designer neither persists empty
+collections nor emits initializer calls for them. Theme application is immediate unless callers
+explicitly enable `ThemeTransitionOptions.Enabled`; built-in animation tokens never activate a
+transition by themselves.
+
 ## Known limitations
 
 - Android refreshes on foreground instead of observing the global setting continuously.

--- a/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
+++ b/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
@@ -118,6 +118,13 @@ collections nor emits initializer calls for them. Theme application is immediate
 explicitly enable `ThemeTransitionOptions.Enabled`; built-in animation tokens never activate a
 transition by themselves.
 
+The shared pointer pipeline resolves one leaf control and does not bubble interaction effects to
+containers. It tracks the Pressed visual state only for controls with built-in hover interaction or
+an explicitly configured pressed style/transition. This keeps panels, layout surfaces,
+`DataGridView`, headers, and scrollbars on their pre-animation presentation by default while still
+allowing any control to opt into a per-control effect. Cell/row/action-cell targeting is not
+modeled by the current grid architecture and remains a separate API design step.
+
 ## Known limitations
 
 - Android refreshes on foreground instead of observing the global setting continuously.

--- a/docs/architecture/ui-animation-scheduler.md
+++ b/docs/architecture/ui-animation-scheduler.md
@@ -199,11 +199,25 @@ invalidation rather than the render-only control transform path.
 
 ## Reduced motion
 
-`AnimationPolicy` is central and platform-neutral. When animations are disabled, reduced motion is
-requested, or duration scale is zero, newly started animations apply their final value once on the
-UI thread and complete without a timer. Disabling motion while animations are active completes
-them through the same final-value path. A positive duration scale is captured when an entry starts;
-for example, 0.5 halves its duration and 2 doubles it. Native OS preference discovery is deferred.
+`AnimationPolicy` is central and platform-neutral. Its effective reduced-motion value is the OR of
+the application preference and the latest immutable platform snapshot, so application code cannot
+override an operating-system accessibility request. `ApplicationReducedMotion` exposes the
+application part independently for settings surfaces.
+
+`IPlatformAnimationSettings` is registered through the existing backend service registry. The
+scheduler subscribes once, marshals provider changes through its UI dispatcher, applies policy, and
+then releases provider and scheduler locks before user-visible completion callbacks can run.
+Startup and foreground entry explicitly refresh the snapshot. Windows additionally refreshes from
+the existing message-only WindowKit window on `WM_SETTINGCHANGE`; no poller, timer, or native handle
+is introduced. Experimental Android reads its global animator/transition scales when a usable
+Activity context exists and refreshes on foreground entry rather than using a live observer.
+
+When animations are disabled, reduced motion is requested, or duration scale is zero, newly started
+animations apply their final value once on the UI thread and complete without a timer. Disabling
+motion while animations are active completes them through the same final-value path. A positive
+duration scale is captured when an entry starts; for example, 0.5 halves its duration and 2 doubles
+it. Native read failures retain compatibility defaults and are visible through
+`GetPlatformDiagnostics()` instead of failing application startup.
 
 ## Performance and memory risks
 

--- a/docs/composable-animations-draft.md
+++ b/docs/composable-animations-draft.md
@@ -17,6 +17,12 @@ does not authorize publication.
   latest-state-wins transitions for compatible colors, Brushes, opacity, and render transforms.
 - Reusable interaction effects add bounded ripple and press-scale feedback for mouse, keyboard,
   and experimental Android touch input.
+- Ripple overflow is explicit and deterministic: remove oldest, remove newest, ignore the new wave,
+  or replace all active waves. The existing eviction property remains source-compatible.
+- Windows observes the native client-area animation preference without polling. Experimental
+  Android reads the global animator and transition scales on startup/foreground entry.
+- The Designer Property Grid has a detached, scheduler-free collection editor for ordered built-in
+  ripple and press-scale effects with stable `.mfdesign` and generated-code round trips.
 - The common render order is background, effects below content, content, effects above content,
   then the focus ring. Built-in clipping respects control bounds and corner radius.
 - One application visual-invalidation batch wraps every scheduler tick, coalescing repaint per
@@ -32,17 +38,20 @@ refresh, ripple/press input, clipping, resize, multi-touch, Designer behavior, d
 ordering, multiple windows, repaint batching, and absence of layout during visual frames.
 
 The new **Animations and Interaction Effects** ControlGallery page provides manual controls for
-Start, Cancel, Rapid x5, reduced motion, animations disabled, diagnostics, Replace, IgnoreNew,
-composition, keyframes, repeat, auto-reverse, custom animation, and custom interpolation.
+Start, Cancel, rapid animation replacement, application and native reduced motion, animations
+disabled, platform diagnostics, all ripple overflow policies, composition, keyframes, repeat,
+auto-reverse, custom animation, and custom interpolation.
 
 ## Platform status and limitations
 
 Windows remains the primary runtime target. Android touch integration is experimental and requires
 device/emulator validation for frame pacing, background/foreground transitions, multi-touch
-rendering, and orientation changes. Native reduced-motion discovery is not yet automatic.
-Visual-state layout metrics switch immediately rather than interpolate, incompatible Brush
-structures switch discretely, ripple currently uses oldest-first eviction, and complex
-interaction-effect collections remain code-first in the Designer.
+rendering, platform setting changes, and orientation changes. Android refreshes platform animation
+scales on foreground entry rather than maintaining a live settings observer. Visual-state layout
+metrics switch immediately rather than interpolate and incompatible Brush structures switch
+discretely. The Designer editor currently supports only the built-in ripple and press-scale effect
+descriptions; custom effects and easing remain code-first, and the Designer has no undo/redo stack.
 
 See [UI animations](animations.md) and the
-[composable-animation ADR](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md).
+[composable-animation ADR](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md),
+plus the [animation platform polish ADR](architecture/decisions/ADR-Animation-Platform-Polish.md).

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -14,6 +14,12 @@ does not introduce XAML or a second control/property model.
 background caller can use `ApplyAsync`; validation can occur on that caller, while the commit and
 events are dispatched to the UI thread.
 
+Theme transitions are opt-in. `Apply(theme)`, `ApplyAsync(theme)`, and a new `ThemeApplyOptions`
+commit and repaint immediately without starting the scheduler. Set
+`ThemeTransitionOptions.Enabled = true` explicitly to animate compatible values. The built-in
+`ThemeTransition` animation token describes reusable motion settings; it does not activate a
+transition by itself.
+
 ```csharp
 ThemeApplyResult result = ThemeManager.Current.Apply(
     BuiltInThemes.Dark,

--- a/samples/ControlGallery/Panels/AnimationsAndInteractionEffectsPanel.cs
+++ b/samples/ControlGallery/Panels/AnimationsAndInteractionEffectsPanel.cs
@@ -23,6 +23,7 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
     private readonly Label diagnosticsLabel;
     private readonly Button animationsButton;
     private readonly Button reducedMotionButton;
+    private readonly ComboBox ripplePolicyCombo;
     private readonly bool originalAnimationsEnabled;
     private readonly bool originalReducedMotion;
     private readonly double originalDurationScale;
@@ -34,7 +35,7 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
     {
         AutoScroll = true;
         originalAnimationsEnabled = scheduler.Policy.AnimationsEnabled;
-        originalReducedMotion = scheduler.Policy.ReducedMotion;
+        originalReducedMotion = scheduler.Policy.ApplicationReducedMotion;
         originalDurationScale = scheduler.Policy.DurationScale;
 
         Controls.Add(new Label
@@ -116,28 +117,50 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
         reducedMotionButton = AddButton(614, 304, 164, string.Empty, ToggleReducedMotion);
 
         animationsButton = AddButton(24, 346, 180, string.Empty, ToggleAnimations);
-        AddButton(212, 346, 180, "Refresh diagnostics", UpdateDiagnostics);
+        AddButton(212, 346, 180, "Refresh platform policy", RefreshPlatformPolicy);
         AddButton(400, 346, 180, "Reset transforms", ResetTarget);
         AddButton(588, 346, 190, "Resize ripple targets", ResizeRippleTargets);
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 396,
+            Width = 164,
+            Height = 28,
+            Text = "Rapid ripple overflow:"
+        });
+        ripplePolicyCombo = Controls.Add(new ComboBox
+        {
+            Left = 194,
+            Top = 392,
+            Width = 190,
+            Height = 32
+        });
+        foreach (string policy in Enum.GetNames<RippleOverflowPolicy>())
+            ripplePolicyCombo.Items.Add(policy);
+        ripplePolicyCombo.SelectedIndexChanged += (_, _) => ApplyRipplePolicy();
+        AddButton(400, 392, 180, "Rapid input x20", RunRapidRipples20);
+        AddButton(588, 392, 190, "Refresh diagnostics", UpdateDiagnostics);
 
         diagnosticsLabel = Controls.Add(new Label
         {
             Left = 24,
-            Top = 402,
+            Top = 442,
             Width = 754,
-            Height = 68,
+            Height = 96,
             Multiline = true
         });
         Controls.Add(new Label
         {
             Left = 24,
-            Top = 480,
+            Top = 548,
             Width = 754,
-            Height = 94,
+            Height = 118,
             Multiline = true,
-            Text = "Manual checklist: pointer and keyboard activation, focus ring order, rapid ripple eviction, resize during a wave, leave/re-enter, disabled state, cancel, Replace, IgnoreNew, reduced motion, animations disabled, and diagnostics returning to Active 0 / Tick source stopped."
+            Text = "Manual checklist: change Windows animation preference while this page is open; verify immediate reduced-motion behavior and return to enabled; select each ripple overflow policy and run rapid input; resize during a wave; test pointer/keyboard activation, disabled state, cancel, Designer save/reload, and diagnostics returning to Active 0 / Tick source stopped."
         });
 
+        ripplePolicyCombo.SelectedIndex = 0;
         UpdatePolicyButtons();
         UpdateDiagnostics();
     }
@@ -353,6 +376,26 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
         UpdateDiagnostics();
     }
 
+    private void RunRapidRipples20()
+    {
+        for (int index = 0; index < 20; index++)
+            rapidRipple.TriggerRipple(12 + ((index * 17) % Math.Max(1, rapidRipple.Width - 24)), 12 + ((index % 2) * 22), index + 100);
+        UpdateDiagnostics();
+    }
+
+    private void ApplyRipplePolicy()
+    {
+        if (rapidRipple?.Ripple is null
+            || ripplePolicyCombo.SelectedItem is not { } selected
+            || !Enum.TryParse(selected.ToString(), out RippleOverflowPolicy policy))
+        {
+            return;
+        }
+
+        rapidRipple.Ripple.OverflowPolicy = policy;
+        UpdateDiagnostics();
+    }
+
     private void ToggleTransitionDisabled()
         => transitionButton.Enabled = !transitionButton.Enabled;
 
@@ -365,7 +408,14 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
 
     private void ToggleReducedMotion()
     {
-        scheduler.Policy.ReducedMotion = !scheduler.Policy.ReducedMotion;
+        scheduler.Policy.ReducedMotion = !scheduler.Policy.ApplicationReducedMotion;
+        UpdatePolicyButtons();
+        UpdateDiagnostics();
+    }
+
+    private void RefreshPlatformPolicy()
+    {
+        scheduler.RefreshPlatformPolicy();
         UpdatePolicyButtons();
         UpdateDiagnostics();
     }
@@ -413,13 +463,14 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
             ? "Animations: enabled"
             : "Animations: disabled";
         reducedMotionButton.Text = scheduler.Policy.ReducedMotion
-            ? "Reduced motion: on"
+            ? $"Reduced motion: on{(scheduler.Policy.ApplicationReducedMotion ? " (app)" : " (platform)")}"
             : "Reduced motion: off";
     }
 
     private void UpdateDiagnostics()
     {
         AnimationSchedulerDiagnostics diagnostics = scheduler.GetDiagnostics();
+        AnimationPlatformDiagnostics platform = scheduler.GetPlatformDiagnostics();
         int activeRipples =
             (pointerRipple?.Ripple?.ActiveRippleCount ?? 0) +
             (centerRipple?.Ripple?.ActiveRippleCount ?? 0) +
@@ -427,7 +478,9 @@ public sealed class AnimationsAndInteractionEffectsPanel : BasePanel
             (transitionButton?.Ripple?.ActiveRippleCount ?? 0);
         diagnosticsLabel.Text =
             $"Active: {diagnostics.ActiveAnimationCount} | completed: {diagnostics.CompletedCount} | canceled: {diagnostics.CanceledCount} | faulted: {diagnostics.FaultedCount} | active ripples: {activeRipples}\n" +
-            $"Ticks: {diagnostics.TickCount} | tick source: {(diagnostics.IsTickSourceRunning ? "running" : "stopped")} | policy: {(scheduler.Policy.AnimationsEnabled ? "enabled" : "disabled")}, reduced motion {(scheduler.Policy.ReducedMotion ? "on" : "off")}";
+            $"Ticks: {diagnostics.TickCount} | tick source: {(diagnostics.IsTickSourceRunning ? "running" : "stopped")} | policy: {(scheduler.Policy.AnimationsEnabled ? "enabled" : "disabled")}, reduced motion {(scheduler.Policy.ReducedMotion ? "on" : "off")}\n" +
+            $"Platform: {platform.Source} | state: {platform.ProviderState} | animations: {(platform.AnimationsEnabled ? "enabled" : "disabled")} | fallback: {platform.FallbackUsed} | last update: {platform.LastPlatformUpdate?.ToString("O") ?? "never"}" +
+            (string.IsNullOrWhiteSpace(platform.LastError) ? string.Empty : $" | error: {platform.LastError}");
     }
 
     private static void CancelRipples(params Button[] buttons)


### PR DESCRIPTION
## Summary  This draft closes the three platform-polish gaps in the shared animation system:  - native reduced-motion integration for Windows and the experimental Android backend; - deterministic ripple overflow policies; - a safe Designer collection editor for built-in interaction effects.  The implementation extends the existing AnimationScheduler, backend registry, lifecycle, interaction-effect pipeline, invalidation batching, and Designer document/code-generation systems. It adds no second scheduler, polling loop, per-ripple timer, or platform type to shared control APIs.  ## Native reduced motion  - Adds immutable platform animation snapshots and an observable IPlatformAnimationSettings contract. - Combines the application preference with the platform preference so application code cannot override an operating-system reduced-motion request. - Applies native changes through the scheduler UI dispatcher. - Keeps provider and scheduler locks out of callbacks. - Subscribes once, unsubscribes on scheduler shutdown, and disables integration in Designer mode. - Exposes read-only source, effective policy, last update, fallback, provider state, and last error diagnostics. - Completes active animations through the existing immediate-final-value path and leaves the shared tick source idle.  ### Windows  - Reads SPI_GETCLIENTAREAANIMATION at startup. - Reuses the existing WindowKit message-only window for WM_SETTINGCHANGE. - Re-reads the setting without polling, extra HWNDs, hooks, or per-window subscriptions. - Uses compatibility defaults and diagnostics when native reads fail. - Keeps animation refresh independent from a concrete theme-settings implementation.  ### Experimental Android  - Reads Settings.Global animator-duration and transition-animation scales from the application context. - Is safe with no host/context and falls back without crashing. - Refreshes on startup, foreground entry, and explicit refresh. - Deliberately does not keep a live ContentObserver in this experimental stage. - Has compile-time and deterministic abstraction coverage; runtime device success is not claimed.  ## Ripple overflow  Adds RippleOverflowPolicy with:  - RemoveOldest; - RemoveNewest; - IgnoreNew, which creates neither a wave nor a scheduler handle; - ReplaceAll.  RemoveOldest remains the default. The existing RippleEvictionPolicy surface remains source-compatible and maps to the new behavior. Limit changes, rapid input, cancellation, reduced motion, disposal, deterministic ordering, handle cleanup, and scheduler idle behavior have regression coverage.  ## Designer and serialization  - Adds an InteractionEffects Property Grid collection dialog for RippleEffect and PressScaleEffect. - Edits detached, validated descriptions only; it does not attach runtime effects, query platform settings, or create scheduler handles. - Supports add, remove, reorder, property mutation, OK/Cancel atomicity, save/reload, and deterministic code regeneration. - Stores one ordered Count plus ItemN structure in .mfdesign. - Emits stable ordered InteractionEffects.Add calls. - Reverse sync accepts only the two registered ModernFormsNext effect types and their supported properties. - Foreign namespace lookalikes and unsupported properties are rejected with stable diagnostics. - Removing the final effect removes the generated call and reload does not duplicate entries. - Designer undo/redo is not claimed because the current Designer session has no transaction stack.  ## ControlGallery and documentation  The existing Animations and Interaction Effects page now shows the platform policy source/state, application-versus-platform reduced motion, explicit refresh, active ripples, all overflow policies, rapid input x20, and an expanded manual checklist. The ADR, animation architecture, Android backend guide, public XML docs, known limitations, and version-neutral draft release notes are updated.  ## Validation  - dotnet restore ModernFormsNext.slnx --force --no-cache: passed. - Full Debug solution build: passed, 204 warnings, 0 errors. - Full Release solution build: passed, 198 warnings, 0 errors. - Debug tests: 784 passed, 0 failed, 0 skipped. - Release tests: 784 passed, 0 failed, 0 skipped. - Per configuration: core 644, Android 62, Designer 55, cross-platform sample 16, Windows 7. - Release solution build produced the Windows backend, experimental Android backend and both Android sample APKs, Designer/host, VS extension, VSIX, ControlGallery, and DemoApp. - Local pack passed: 8 nupkg and 7 snupkg files inspected; package libraries and XML documentation are present. - Release artifacts include ModernFormsNextDesigner.vsix and signed APKs for the Android smoke host and cross-platform sample. - ControlGallery, Designer Playground, and DemoApp compatibility smoke each created a real desktop window and closed cleanly. - git diff --check passed and the worktree is clean.  No warning points at changed source. The observed warning families predate this work: MessagePack advisories and legacy Visual Studio package compatibility in the VS extension, existing nullable/XML/unused/SkiaSharp diagnostics, and Android XA0141 for HarfBuzzSharp 16 KB page-size compatibility.  ## Known limitations and remaining manual checks  - No Android device or emulator was connected, so foreground/background and native animation-scale behavior remain unverified at runtime. - Android refreshes on foreground rather than using a live settings observer. - Designer supports the two built-in effects only; custom effects/easing remain code-first. - Designer undo/redo remains unavailable. - A human interactive pass is still requested for live Windows setting changes, immediate animation policy response and return to enabled, each rapid-ripple policy plus idle diagnostics, Designer add/save/reload/run without duplicates, and Android lifecycle when a device is available.  No package or assembly version was changed. Nothing was published, tagged, released, merged, or marked Ready for review. ## Follow-up: opt-in animation defaults  Commit `dcc5c43` makes the new interaction and transition surfaces opt-in by default.  ### Root cause and fix  - `ThemeApplyOptions` always created a `ThemeTransitionOptions`, whose `Enabled` property previously defaulted to `true`. Consequently `ThemeManager.Apply(theme)` and `ApplyAsync(theme)` could create a transition and scheduler handle without explicit animation configuration. - `ThemeTransitionOptions.Enabled` now defaults to `false`; callers must set `Enabled = true` to animate. Immediate apply still uses the same atomic UI-thread commit, dynamic-resource notifications, batched visual refresh, and repaint path. - Built-in animation tokens remain declarative resources and do not activate transitions by themselves. - The audit confirmed that `InteractionEffects` and `StyleTransitions` were already lazy, empty, independent per-control collections. This contract is now documented and protected by regression tests for `Control`, `Button`, `TextBox`, and `Switch`. - With no matching `StyleTransitions` entry, Normal, Hover, Pressed, Focused, and Disabled styles resolve immediately, request render invalidation only, and leave the scheduler idle. Explicitly added transitions and effects retain their existing behavior. - Empty interaction-effect collections are not serialized. `Ripple` and `PressEffect` have null default metadata, and Designer save/reload, code generation, reverse sync, and Property Grid tests verify that a new Button remains at zero effects without emitted `Add` calls. - ControlGallery opts in only on `AnimationsAndInteractionEffectsPanel`; the remaining samples and the template/reference DemoApp contain no effect or state-transition initialization.  ### Follow-up validation  - Restore: passed. - Full Debug solution build: passed, 0 errors. - Full Release solution build: passed, 0 errors. - Debug tests: 792 passed, 0 failed, 0 skipped. - Release tests: 792 passed, 0 failed, 0 skipped. - Per configuration: core 649, Designer 58, Android backend 62, Windows backend 7, cross-platform sample 16. - Explicit theme-transition tests still pass with `Enabled = true`; default apply returns no transition and leaves the tick source idle. - Runtime and Designer regression tests cover independent empty collections, immediate active-state resolution, no layout, no scheduler work, empty serialization, code generation, and reverse sync. - Debug and Release builds include Windows/Android backends, Designer/host, VS extension, validated VSIX, ControlGallery, DemoApp, and Android samples. - All eight packable projects passed pack validation; the main and Designer packages contain the expected assemblies and XML documentation, and the template package contents remain unchanged. - ControlGallery, DemoApp, and DesignerPlayground each opened a responsive Windows desktop window and closed cleanly. - `git diff --check` passed and the worktree is clean after commit.  No new warning points to changed source. Existing VS SDK/MessagePack, nullable, SkiaSharp, and backend warnings remain unchanged in scope. No version was changed and nothing was published, tagged, released, merged, or marked Ready for review. 
 
## Clarification: target-local interaction effects

Commit `be526a9` addresses the direct cause of the whole-panel and whole-grid click visual.

### Direct cause and propagation fix

- The shared `Control.OnMouseDown` path called `SetPointerVisualPressed` for every leaf control receiving a left click. Because `StylePressed` inherits the hover style, generic container and data-surface styling could be resolved across the entire control bounds and appear as an implicit ripple/click animation.
- No runtime path was auto-constructing `RippleEffect`; empty `InteractionEffects` collections were already no-ops. The defect was the too-broad activation of the shared Pressed visual state at the base-control input stage.
- Activation-state tracking now runs only for built-in interactive controls or explicit opt-ins: `StylePressed`, a transition involving `Pressed`, or `PressScaleEffect`.
- Interaction-effect dispatch remains leaf-first and target-local. A child click does not start an effect on its parent, even when both controls have explicitly configured collections.
- A plain Panel and an unconfigured DataGridView remain animation-free. An explicitly configured Panel ripple still runs and is clipped to the Panel bounds.
- DataGridView currently has no safe cell/row/action-cell effect-target abstraction. The default is therefore `none`; cell selection, headers, drag selection, scrollbars, and rapid clicks create no wave or scheduler work. A cell/row/action-cell target API and its scoped clipping tests are intentionally deferred as a separate design step instead of adding a premature public API.

### Clarification validation

- Full Debug and Release solution builds passed with 0 errors.
- Debug tests: 800 passed, 0 failed, 0 skipped.
- Release tests: 800 passed, 0 failed, 0 skipped.
- Per configuration: core 657, Designer 58, Android backend 62, Windows backend 7, cross-platform sample 16.
- New regression coverage verifies an unconfigured Panel, an explicit clipped Panel ripple, child-versus-parent ownership, explicit Pressed transitions, unconfigured DataGridView cells and headers, drag selection, scrollbars, rapid cross-cell clicks, and an editing child control with an explicit effect.
- ControlGallery, DemoApp, and DesignerPlayground each opened a responsive Windows window and closed cleanly.
- Restore, package targets, package XML documentation, Debug/Release VSIX artifacts, `git diff --check`, and final worktree hygiene passed.

The visible-state change remains render-only: it does not request layout per input event or animation frame, and empty/default controls leave the animation scheduler idle.

PR #19 remains Draft. It has not been marked Ready, merged, tagged, released, or published.