### PR TITLE
Fix editor pointer input regression after animation polish

### DIFF
--- a/ModernFormsNext.Tests/AnimationOptInDefaultsTests.cs
+++ b/ModernFormsNext.Tests/AnimationOptInDefaultsTests.cs
@@ -108,10 +108,10 @@ public sealed class AnimationOptInDefaultsTests
             => OnMouseLeave(EventArgs.Empty);
 
         public void DownForTest()
-            => OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
+            => RaiseMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
 
         public void UpForTest()
-            => OnMouseUp(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
+            => RaiseMouseUp(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
 
         public void FocusForTest() => OnGotFocus(EventArgs.Empty);
     }

--- a/ModernFormsNext.Tests/EditorPointerInputRegressionTests.cs
+++ b/ModernFormsNext.Tests/EditorPointerInputRegressionTests.cs
@@ -1,0 +1,360 @@
+using System.Drawing;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Documents;
+using Topten.RichTextKit;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+[Collection(DefaultAnimationSchedulerCollection.Name)]
+public sealed class EditorPointerInputRegressionTests
+{
+    [Fact]
+    public void TextBoxClickPlacesCaretAtExactUtf16Index()
+    {
+        using var textBox = CreateTextBox<TextBox>("alpha beta gamma");
+
+        Click(textBox, PointForIndex(textBox, 6));
+
+        Assert.Equal(6, textBox.document.CursorIndex);
+        Assert.Equal(-1, textBox.SelectionStart);
+    }
+
+    [Fact]
+    public void RichTextBoxClickPlacesCaretAtExactUtf16Index()
+    {
+        using var textBox = CreateTextBox<RichTextBox>("alpha beta gamma");
+
+        Click(textBox, PointForIndex(textBox, 11));
+
+        Assert.Equal(11, textBox.document.CursorIndex);
+        Assert.Equal(0, textBox.SelectionLength);
+    }
+
+    [Fact]
+    public void MarkdownEditorSourceClickPlacesCaretAtExactUtf16Index()
+    {
+        using var editor = CreateMarkdownEditor("# alpha beta gamma");
+
+        Click(editor.EditorSurface, PointForIndex(editor.EditorSurface, 8));
+
+        Assert.Equal(8, editor.EditorSurface.document.CursorIndex);
+        Assert.Equal(8, editor.SelectionStart);
+        Assert.Equal(0, editor.SelectionLength);
+    }
+
+    [Fact]
+    public void TypingAfterClickInsertsAtClickedIndex()
+    {
+        using var textBox = CreateTextBox<TextBox>("alpha beta");
+        using var surface = new SkiaControlSurface(textBox);
+        surface.Resize(textBox.Width, textBox.Height);
+        var point = PointForIndex(textBox, 6);
+
+        surface.ProcessPointer(7, ControlSurfacePointerAction.Down, point.X, point.Y);
+        surface.ProcessPointer(7, ControlSurfacePointerAction.Up, point.X, point.Y);
+        surface.CommitText("123");
+
+        Assert.Equal("alpha 123beta", textBox.Text);
+        Assert.Equal(9, textBox.document.CursorIndex);
+    }
+
+    [Fact]
+    public void DragSelectionUsesCapturedTextEditorUntilMouseUp()
+    {
+        using var textBox = CreateTextBox<TextBox>("alpha beta gamma");
+        using var surface = new SkiaControlSurface(textBox) { PointerDragThreshold = 1000 };
+        surface.Resize(textBox.Width, textBox.Height);
+        var start = PointForIndex(textBox, 2);
+        var end = PointForIndex(textBox, 10);
+
+        surface.ProcessPointer(9, ControlSurfacePointerAction.Down, start.X, start.Y);
+        surface.ProcessPointer(9, ControlSurfacePointerAction.Move, end.X, end.Y);
+        surface.ProcessPointer(9, ControlSurfacePointerAction.Up, end.X, end.Y);
+
+        Assert.Equal(2, textBox.SelectionStart);
+        Assert.Equal(10, textBox.SelectionEnd);
+        Assert.False(textBox.Capture);
+        Assert.Equal(0, surface.ActivePointerCount);
+    }
+
+    [Fact]
+    public void ShiftClickExtendsSelectionFromExistingCaret()
+    {
+        using var textBox = CreateTextBox<TextBox>("alpha beta gamma");
+        textBox.document.SetImeSelection(2, 2);
+        var end = PointForIndex(textBox, 10);
+
+        textBox.RaiseMouseDown(Mouse(end, Keys.Shift));
+        textBox.RaiseMouseUp(Mouse(end, Keys.Shift));
+
+        Assert.Equal(2, textBox.SelectionStart);
+        Assert.Equal(10, textBox.SelectionEnd);
+    }
+
+    [Fact]
+    public void MarkdownEditorDoubleClickSelectsWord()
+    {
+        using var editor = CreateMarkdownEditor("alpha beta gamma");
+        var point = PointForIndex(editor.EditorSurface, 7);
+
+        editor.EditorSurface.RaiseDoubleClick(Mouse(point, clicks: 2));
+
+        Assert.Equal("beta", editor.SelectedText);
+        Assert.Equal(6, editor.SelectionStart);
+        Assert.Equal(4, editor.SelectionLength);
+    }
+
+    [Fact]
+    public void PreviewInputDoesNotChangeSourceCaretOrSelection()
+    {
+        using var editor = CreateMarkdownEditor("- [ ] task\n[link](https://example.com)", MarkdownEditorViewMode.Split);
+        editor.Select(2, 5);
+        editor.PreviewViewer.PerformLayout();
+        var checkBox = Assert.Single(
+            editor.PreviewViewer.GetDocumentLayout().Elements.OfType<DocumentTaskCheckBoxLayoutElement>());
+        var point = new Point(checkBox.Bounds.Left + 2, checkBox.Bounds.Top + 2);
+
+        editor.PreviewViewer.RaiseMouseDown(Mouse(point));
+        editor.PreviewViewer.RaiseMouseUp(Mouse(point));
+
+        var link = Assert.Single(editor.PreviewViewer.GetDocumentLayout().Links);
+        var linkPoint = PointInsideCodePoint(link.Element, link.Start);
+        editor.PreviewViewer.RaiseMouseDown(Mouse(linkPoint));
+        editor.PreviewViewer.RaiseMouseUp(Mouse(linkPoint));
+
+        Assert.Equal(2, editor.SelectionStart);
+        Assert.Equal(5, editor.SelectionLength);
+    }
+
+    [Fact]
+    public void ParentPanelEffectDoesNotRunForChildTextEditorInput()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = new VisiblePanel
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(360, 80),
+            Ripple = CreateRipple()
+        };
+        var textBox = CreateTextBox<TextBox>("alpha beta");
+        textBox.Bounds = new Rectangle(20, 15, 300, 40);
+        textBox.AnimationSchedulerOverride = harness.Scheduler;
+        panel.Controls.Add(textBox);
+        var local = PointForIndex(textBox, 6);
+        var panelPoint = new Point(textBox.Left + local.X, textBox.Top + local.Y);
+
+        panel.RaiseMouseDown(Mouse(panelPoint));
+        panel.RaiseMouseUp(Mouse(panelPoint));
+
+        Assert.Equal(6, textBox.document.CursorIndex);
+        Assert.Equal(0, panel.Ripple.ActiveRippleCount);
+        Assert.Equal(VisualState.Normal, panel.VisualState);
+    }
+
+    [Fact]
+    public void DataGridEditingControlReceivesInputWithoutGridEffect()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var grid = new VisibleDataGridView
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(320, 140),
+            Ripple = CreateRipple()
+        };
+        grid.Columns.Add("First", 220);
+        grid.Rows.Add("alpha beta");
+        grid.BeginEdit(0, 0);
+        var editor = Assert.Single(grid.Controls.GetAllControls(true).OfType<TextBox>());
+        editor.AnimationSchedulerOverride = harness.Scheduler;
+        var local = PointForIndex(editor, 6);
+        var gridPoint = new Point(editor.ScaledLeft + local.X, editor.ScaledTop + local.Y);
+
+        grid.RaiseMouseDown(Mouse(gridPoint));
+        grid.RaiseMouseUp(Mouse(gridPoint));
+
+        Assert.Equal(6, editor.document.CursorIndex);
+        Assert.Equal(0, grid.Ripple.ActiveRippleCount);
+        Assert.NotEqual(VisualState.Pressed, grid.VisualState);
+    }
+
+    [Fact]
+    public void ExplicitRippleRunsAfterCaretPlacementWithoutChangingSelection()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var textBox = CreateTextBox<TextBox>("alpha beta");
+        textBox.AnimationSchedulerOverride = harness.Scheduler;
+        textBox.Ripple = CreateRipple();
+        var effect = new CaretProbeEffect(() => textBox.document.CursorIndex);
+        textBox.InteractionEffects.Add(effect);
+
+        Click(textBox, PointForIndex(textBox, 6));
+
+        Assert.Equal(6, textBox.document.CursorIndex);
+        Assert.Equal(6, effect.CursorAtPointerDown);
+        Assert.Equal(1, textBox.Ripple.ActiveRippleCount);
+        Assert.Equal(-1, textBox.SelectionStart);
+    }
+
+    [Fact]
+    public void PointerCancelReleasesCaptureAndStopsDragSelection()
+    {
+        using var textBox = CreateTextBox<PointerTextBox>("alpha beta gamma");
+        var start = PointForIndex(textBox, 2);
+        var end = PointForIndex(textBox, 10);
+        textBox.RaiseMouseDown(Mouse(start, pointerId: 12));
+
+        textBox.CancelPointerForTest(12);
+        textBox.MoveForTest(Mouse(end, pointerId: 12));
+
+        Assert.False(textBox.Capture);
+        Assert.Equal(2, textBox.document.CursorIndex);
+        Assert.Equal(-1, textBox.SelectionStart);
+    }
+
+    [Fact]
+    public void FocusLossReleasesCaptureAndStopsDragSelection()
+    {
+        using var textBox = CreateTextBox<PointerTextBox>("alpha beta gamma");
+        using var surface = new SkiaControlSurface(textBox) { PointerDragThreshold = 1000 };
+        surface.Resize(textBox.Width, textBox.Height);
+        var start = PointForIndex(textBox, 2);
+        var end = PointForIndex(textBox, 10);
+        surface.ProcessPointer(13, ControlSurfacePointerAction.Down, start.X, start.Y);
+
+        textBox.LoseFocusForTest();
+        surface.ProcessPointer(13, ControlSurfacePointerAction.Move, end.X, end.Y);
+
+        Assert.False(textBox.Capture);
+        Assert.Equal(0, surface.ActivePointerCount);
+        Assert.Equal(2, textBox.document.CursorIndex);
+        Assert.Equal(-1, textBox.SelectionStart);
+    }
+
+    [Fact]
+    public void RemovingCapturedEditorClearsPointerOwner()
+    {
+        using var root = new VisiblePanel { Size = new Size(360, 80) };
+        var textBox = CreateTextBox<TextBox>("alpha beta");
+        textBox.Bounds = new Rectangle(20, 15, 300, 40);
+        root.Controls.Add(textBox);
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(root.Width, root.Height);
+        var local = PointForIndex(textBox, 2);
+        var location = new Point(textBox.Left + local.X, textBox.Top + local.Y);
+        surface.ProcessPointer(14, ControlSurfacePointerAction.Down, location.X, location.Y);
+
+        root.Controls.Remove(textBox);
+
+        Assert.False(textBox.Capture);
+        Assert.False(root.Capture);
+        Assert.Equal(0, surface.ActivePointerCount);
+    }
+
+    private static T CreateTextBox<T>(string text)
+        where T : TextBox, new()
+        => new()
+        {
+            Text = text,
+            Size = new Size(340, 48)
+        };
+
+    private static MarkdownEditor CreateMarkdownEditor(
+        string markdown,
+        MarkdownEditorViewMode viewMode = MarkdownEditorViewMode.Editor)
+    {
+        var editor = new MarkdownEditor
+        {
+            Markdown = markdown,
+            ViewMode = viewMode,
+            ShowToolbar = false,
+            Size = new Size(700, 260)
+        };
+        editor.PerformLayout();
+        editor.EditorSurface.PerformLayout();
+        return editor;
+    }
+
+    private static Point PointForIndex(TextBox textBox, int utf16Index)
+    {
+        var block = textBox.document.GetTextBlock();
+        var codePointIndex = textBox.document.GetLayoutCodePointIndex(utf16Index);
+        var caret = block.GetCaretInfo(new CaretPosition(codePointIndex));
+        return new Point(
+            textBox.TextOrigin.X + (int)MathF.Round(caret.CaretXCoord),
+            textBox.TextOrigin.Y + (int)MathF.Round(caret.CaretRectangle.MidY));
+    }
+
+    private static Point PointInsideCodePoint(DocumentTextLayoutElement element, int codePointIndex)
+    {
+        var start = element.TextBlock.GetCaretInfo(new CaretPosition(codePointIndex)).CaretRectangle;
+        var end = element.TextBlock.GetCaretInfo(new CaretPosition(codePointIndex + 1)).CaretRectangle;
+        var glyphWidth = end.Top == start.Top ? end.Left - start.Left : Math.Max(2f, start.Height * 0.5f);
+        return new Point(
+            element.TextOrigin.X + (int)MathF.Round(start.Left + (Math.Max(2f, glyphWidth) * 0.35f)),
+            element.TextOrigin.Y + (int)MathF.Round(start.Top + (start.Height / 2f)));
+    }
+
+    private static void Click(TextBox textBox, Point point)
+    {
+        textBox.RaiseMouseDown(Mouse(point));
+        textBox.RaiseMouseUp(Mouse(point));
+    }
+
+    private static MouseEventArgs Mouse(
+        Point point,
+        Keys modifiers = Keys.None,
+        int clicks = 1,
+        int pointerId = 0)
+        => new(
+            MouseButtons.Left,
+            clicks,
+            point.X,
+            point.Y,
+            Point.Empty,
+            null,
+            null,
+            modifiers,
+            pointerId,
+            PointerDeviceKind.Mouse);
+
+    private static RippleEffect CreateRipple()
+        => new()
+        {
+            Duration = TimeSpan.FromMilliseconds(100),
+            Easing = Easings.Linear
+        };
+
+    private sealed class CaretProbeEffect(Func<int> getCursor) : InteractionEffect
+    {
+        public int CursorAtPointerDown { get; private set; } = -1;
+
+        protected override void OnPointerDown(MouseEventArgs e)
+            => CursorAtPointerDown = getCursor();
+    }
+
+    private sealed class PointerTextBox : TextBox
+    {
+        public void CancelPointerForTest(int pointerId) => CancelPointerInteraction(pointerId);
+        public void LoseFocusForTest() => OnLostFocus(EventArgs.Empty);
+        public void MoveForTest(MouseEventArgs e) => OnMouseMove(e);
+    }
+
+    private sealed class VisiblePanel : Panel
+    {
+        public override bool Visible
+        {
+            get => true;
+            set => base.Visible = value;
+        }
+    }
+
+    private sealed class VisibleDataGridView : DataGridView
+    {
+        public override bool Visible
+        {
+            get => true;
+            set => base.Visible = value;
+        }
+    }
+}

--- a/ModernFormsNext.Tests/EditorPointerInputRegressionTests.cs
+++ b/ModernFormsNext.Tests/EditorPointerInputRegressionTests.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using System.Text;
 using ModernFormsNext.Animations;
 using ModernFormsNext.Documents;
 using Topten.RichTextKit;
@@ -41,6 +42,114 @@ public sealed class EditorPointerInputRegressionTests
         Assert.Equal(8, editor.EditorSurface.document.CursorIndex);
         Assert.Equal(8, editor.SelectionStart);
         Assert.Equal(0, editor.SelectionLength);
+    }
+
+    [Fact]
+    public void TextBoxCrLfClickMapsRenderedCaretToExactUtf16Index()
+    {
+        const string text = "first\r\nsecond\r\nthird";
+        using var textBox = CreateTextBox<TextBox>(text);
+        var expected = text.IndexOf("third", StringComparison.Ordinal) + 2;
+
+        Click(textBox, PointForRenderedIndex(textBox, expected));
+
+        Assert.Equal(expected, textBox.document.CursorIndex);
+        Assert.Equal(-1, textBox.SelectionStart);
+    }
+
+    [Fact]
+    public void MarkdownEditorCrLfClickThroughNestedTreeInsertsAtRenderedIndex()
+    {
+        const string markdown = "# Header\r\n\r\nEdit **bold** text.\r\n\r\n> Preview target\r\n\r\n- item";
+        using var root = CreateMarkdownEditorRoot(markdown, out var editor);
+        var expected = markdown.IndexOf("target", StringComparison.Ordinal) + 3;
+        var local = PointForRenderedIndex(editor.EditorSurface, expected);
+        var routed = PointInAncestor(editor.EditorSurface, root, local);
+        Point? observedLocation = null;
+        editor.EditorSurface.MouseDown += (_, e) => observedLocation = e.Location;
+
+        Click(root, routed);
+        Assert.Equal(local, observedLocation);
+        editor.EditorSurface.RaiseKeyPress(new KeyPressEventArgs("123"));
+
+        Assert.Equal(markdown.Insert(expected, "123"), editor.Markdown);
+        Assert.Equal(expected + 3, editor.SelectionStart);
+        Assert.Equal(0, editor.SelectionLength);
+    }
+
+    [Fact]
+    public void MarkdownEditorCrLfDoubleClickThroughNestedTreeSelectsRenderedWord()
+    {
+        const string markdown = "# Header\r\n\r\nEdit **bold** text.\r\n\r\n> Preview target";
+        using var root = CreateMarkdownEditorRoot(markdown, out var editor);
+        var target = markdown.IndexOf("target", StringComparison.Ordinal) + 2;
+        var local = PointForRenderedIndex(editor.EditorSurface, target);
+        var routed = PointInAncestor(editor.EditorSurface, root, local);
+
+        root.RaiseDoubleClick(Mouse(routed, clicks: 2));
+
+        Assert.Equal("target", editor.SelectedText);
+    }
+
+    [Fact]
+    public void MarkdownEditorCrLfDragSelectionUsesRenderedUtf16Boundaries()
+    {
+        const string markdown = "# Header\r\n\r\nEdit **bold** text.\r\n\r\n> Preview target";
+        using var root = CreateMarkdownEditorRoot(markdown, out var editor);
+        var start = markdown.IndexOf("bold", StringComparison.Ordinal) + 1;
+        var end = markdown.IndexOf("target", StringComparison.Ordinal) + "target".Length;
+        var startPoint = PointInAncestor(
+            editor.EditorSurface,
+            root,
+            PointForRenderedIndex(editor.EditorSurface, start));
+        var endPoint = PointInAncestor(
+            editor.EditorSurface,
+            root,
+            PointForRenderedIndex(editor.EditorSurface, end));
+
+        root.RaiseMouseDown(Mouse(startPoint));
+        root.RaiseMouseMove(Mouse(endPoint));
+        root.RaiseMouseUp(Mouse(endPoint));
+
+        Assert.Equal(start, editor.SelectionStart);
+        Assert.Equal(end - start, editor.SelectionLength);
+        Assert.False(editor.EditorSurface.Capture);
+    }
+
+    [Fact]
+    public void MarkdownEditorCrLfShiftClickExtendsFromUtf16Caret()
+    {
+        const string markdown = "# Header\r\n\r\nEdit **bold** text.\r\n\r\n> Preview target";
+        using var root = CreateMarkdownEditorRoot(markdown, out var editor);
+        var start = markdown.IndexOf("bold", StringComparison.Ordinal);
+        var end = markdown.IndexOf("target", StringComparison.Ordinal) + "target".Length;
+        editor.Select(start, 0);
+        var endPoint = PointInAncestor(
+            editor.EditorSurface,
+            root,
+            PointForRenderedIndex(editor.EditorSurface, end));
+
+        root.RaiseMouseDown(Mouse(endPoint, Keys.Shift));
+        root.RaiseMouseUp(Mouse(endPoint, Keys.Shift));
+
+        Assert.Equal(start, editor.SelectionStart);
+        Assert.Equal(end - start, editor.SelectionLength);
+    }
+
+    [Fact]
+    public void RichTextBoxFormattedRunClickUsesRenderedTextBlock()
+    {
+        const string text = "WIDE prefix target suffix";
+        using var textBox = CreateTextBox<RichTextBox>(text);
+        textBox.Select(0, "WIDE prefix".Length);
+        textBox.SelectionFont = new Font("Segoe UI", 28, FontStyle.Bold);
+        textBox.DeselectAll();
+        var expected = text.IndexOf("target", StringComparison.Ordinal) + 3;
+
+        Click(textBox, PointForRenderedIndex(textBox, expected));
+
+        Assert.Equal(expected, textBox.document.CursorIndex);
+        Assert.Equal(0, textBox.SelectionLength);
     }
 
     [Fact]
@@ -271,8 +380,29 @@ public sealed class EditorPointerInputRegressionTests
             Size = new Size(700, 260)
         };
         editor.PerformLayout();
+        foreach (var control in editor.Controls.GetAllControls(true).ToArray())
+            control.PerformLayout();
         editor.EditorSurface.PerformLayout();
         return editor;
+    }
+
+    private static VisiblePanel CreateMarkdownEditorRoot(string markdown, out MarkdownEditor editor)
+    {
+        var root = new VisiblePanel { Size = new Size(740, 300) };
+        editor = new MarkdownEditor
+        {
+            Markdown = markdown,
+            ViewMode = MarkdownEditorViewMode.Split,
+            ShowToolbar = false,
+            Bounds = new Rectangle(10, 10, 700, 260)
+        };
+        root.Controls.Add(editor);
+        root.PerformLayout();
+        editor.PerformLayout();
+        foreach (var control in editor.Controls.GetAllControls(true).ToArray())
+            control.PerformLayout();
+        editor.EditorSurface.PerformLayout();
+        return root;
     }
 
     private static Point PointForIndex(TextBox textBox, int utf16Index)
@@ -283,6 +413,38 @@ public sealed class EditorPointerInputRegressionTests
         return new Point(
             textBox.TextOrigin.X + (int)MathF.Round(caret.CaretXCoord),
             textBox.TextOrigin.Y + (int)MathF.Round(caret.CaretRectangle.MidY));
+    }
+
+    private static Point PointForRenderedIndex(TextBox textBox, int utf16Index)
+    {
+        var block = textBox is RichTextBox richTextBox
+            ? richTextBox.GetRichTextBlock()
+            : textBox.document.GetTextBlock();
+        var caret = block.GetCaretInfo(new CaretPosition(GetRichTextKitCodePointIndex(textBox.Text, utf16Index)));
+        var origin = textBox.GetTextOrigin(block);
+        return new Point(
+            origin.X + (int)MathF.Round(caret.CaretXCoord),
+            origin.Y + (int)MathF.Round(caret.CaretRectangle.MidY));
+    }
+
+    private static int GetRichTextKitCodePointIndex(string text, int utf16Index)
+    {
+        var normalizedPrefix = text[..utf16Index].Replace("\r\n", "\n", StringComparison.Ordinal);
+        var codePointIndex = 0;
+        foreach (Rune _ in normalizedPrefix.EnumerateRunes())
+            codePointIndex++;
+        return codePointIndex;
+    }
+
+    private static Point PointInAncestor(Control control, Control ancestor, Point point)
+    {
+        for (var current = control; !ReferenceEquals(current, ancestor); current = current.Parent
+            ?? throw new InvalidOperationException("The requested control is not parented to the ancestor."))
+        {
+            point.Offset(current.ScaledLeft, current.ScaledTop);
+        }
+
+        return point;
     }
 
     private static Point PointInsideCodePoint(DocumentTextLayoutElement element, int codePointIndex)
@@ -299,6 +461,12 @@ public sealed class EditorPointerInputRegressionTests
     {
         textBox.RaiseMouseDown(Mouse(point));
         textBox.RaiseMouseUp(Mouse(point));
+    }
+
+    private static void Click(Control control, Point point)
+    {
+        control.RaiseMouseDown(Mouse(point));
+        control.RaiseMouseUp(Mouse(point));
     }
 
     private static MouseEventArgs Mouse(

--- a/ModernFormsNext.Tests/InteractionEffectTests.cs
+++ b/ModernFormsNext.Tests/InteractionEffectTests.cs
@@ -778,10 +778,10 @@ public sealed class InteractionEffectTests
 
     private class TestButton : Button
     {
-        public void DownForTest(MouseEventArgs e) => OnMouseDown(e);
-        public void UpForTest(MouseEventArgs e) => OnMouseUp(e);
-        public void KeyDownForTest(Keys key) => OnKeyDown(new KeyEventArgs(key));
-        public void KeyUpForTest(Keys key) => OnKeyUp(new KeyEventArgs(key));
+        public void DownForTest(MouseEventArgs e) => RaiseMouseDown(e);
+        public void UpForTest(MouseEventArgs e) => RaiseMouseUp(e);
+        public void KeyDownForTest(Keys key) => RaiseKeyDown(new KeyEventArgs(key));
+        public void KeyUpForTest(Keys key) => RaiseKeyUp(new KeyEventArgs(key));
         public void LostFocusForTest() => OnLostFocus(EventArgs.Empty);
         public void CancelPointerForTest(int? pointerId = null) => CancelPointerInteraction(pointerId);
     }

--- a/ModernFormsNext.Tests/SkiaControlSurfaceTests.cs
+++ b/ModernFormsNext.Tests/SkiaControlSurfaceTests.cs
@@ -359,6 +359,7 @@ public sealed class SkiaControlSurfaceTests
 
         adapter.ProcessPointer(3, ControlSurfacePointerAction.Down, 10, 10);
         adapter.ProcessPointer(7, ControlSurfacePointerAction.Down, 130, 10);
+        Assert.True(first.Capture);
         adapter.ProcessPointer(7, ControlSurfacePointerAction.Up, 130, 10);
         Assert.Equal(1, adapter.ActivePointerCount);
         adapter.ProcessPointer(3, ControlSurfacePointerAction.Up, 10, 10);

--- a/ModernFormsNext.Tests/TextBoxUnicodeEditingTests.cs
+++ b/ModernFormsNext.Tests/TextBoxUnicodeEditingTests.cs
@@ -21,6 +21,29 @@ public sealed class TextBoxUnicodeEditingTests
     }
 
     [Fact]
+    public void CrLfLayoutIndexMapsWholePairToUtf16Boundary()
+    {
+        const string text = "a\r\nb";
+        var textBox = new TextBox { Width = 200, Height = 80, MultiLine = true, Text = text };
+
+        Assert.Equal(2, textBox.document.GetLayoutCodePointIndex(3));
+        Assert.Equal(3, textBox.document.GetUtf16IndexFromLayoutCodePointIndex(2));
+    }
+
+    [Fact]
+    public void ArrowNavigationTreatsCrLfAsSingleCaretStep()
+    {
+        const string text = "a\r\nb";
+        var textBox = new TextBox { Width = 200, Height = 80, MultiLine = true, Text = text };
+        textBox.document.SetImeSelection(3, 3);
+
+        Assert.True(textBox.document.MoveCursor(ArrowDirection.Left, select: false, wholeWord: false, end: false));
+        Assert.Equal(1, textBox.document.CursorIndex);
+        Assert.True(textBox.document.MoveCursor(ArrowDirection.Right, select: false, wholeWord: false, end: false));
+        Assert.Equal(3, textBox.document.CursorIndex);
+    }
+
+    [Fact]
     public void HitTestingAfterEmojiReturnsUtf16Index()
     {
         const string text = "emoji 👋🏽 and composition: 你妇";

--- a/ModernFormsNext.Tests/Theming/ThemeVisualRefreshTests.cs
+++ b/ModernFormsNext.Tests/Theming/ThemeVisualRefreshTests.cs
@@ -65,7 +65,7 @@ public sealed class ThemeVisualRefreshTests
         pressed.CreateControl();
         focused.CreateControl();
         disabled.CreateControl();
-        pressed.PressThumb();
+        pressed.SetThumbPressedForThemeTest();
         focused.Select();
         disabled.Enabled = false;
         SKColor focusedBefore = focused.CurrentStyle.GetBackgroundColor();
@@ -410,7 +410,9 @@ public sealed class ThemeVisualRefreshTests
         public int ThemeChanges { get; private set; }
         public int Invalidations { get; private set; }
 
-        public void PressThumb()
+        public void SetThumbPressedForThemeTest()
+            // This test needs simultaneous active states on independent controls. Invoke the
+            // Switch state handler directly instead of moving real focus/capture between them.
             => OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, Point.Empty));
 
         public void ResetObservations()

--- a/ModernFormsNext.Tests/VisualStateTransitionTests.cs
+++ b/ModernFormsNext.Tests/VisualStateTransitionTests.cs
@@ -279,7 +279,7 @@ public sealed class VisualStateTransitionTests
             => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, System.Drawing.Point.Empty));
 
         public void DownForTest()
-            => OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
+            => RaiseMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, System.Drawing.Point.Empty));
 
         public void FocusForTest() => OnGotFocus(EventArgs.Empty);
 

--- a/ModernFormsNext/Control.InteractionEffects.cs
+++ b/ModernFormsNext/Control.InteractionEffects.cs
@@ -23,6 +23,8 @@ public partial class Control
     /// Each control starts with its own empty collection. Effects run only after an effect is
     /// explicitly added in code or through generated Designer code. Target-local input is sent
     /// only to that collection; child input does not bubble an effect into a parent collection.
+    /// Standard focus, capture, hit testing, caret, selection, and keyboard handling always run
+    /// independently and complete before an attached effect observes the input transition.
     /// </para>
     /// <para>
     /// The custom Designer edits detached descriptions and emits ordered <c>Add</c> calls. It does

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -41,6 +41,7 @@ namespace ModernFormsNext
         private bool is_captured;
 
         // Property store keys for properties.
+        private static readonly int s_focusLossPointerPreservationProperty = PropertyStore.CreateKey ();
         private static readonly int s_controlsCollectionProperty = PropertyStore.CreateKey ();
         private static readonly int s_contextMenuProperty = PropertyStore.CreateKey ();
         private static readonly int s_cursorProperty = PropertyStore.CreateKey ();
@@ -88,6 +89,11 @@ namespace ModernFormsNext
             var old_visible = Visible;
 
             Control? previousParent = parent;
+
+            // Capture belongs to the current routed input tree. End the gesture while the old
+            // parent is still attached so clearing Capture can propagate through every ancestor.
+            if (previousParent is not null && value is null)
+                CancelCapturedPointerInteractionsInSubtree();
 
             // Update the parent
             parent = value;
@@ -659,10 +665,23 @@ namespace ModernFormsNext
         /// <summary>
         /// Removes focus from the control.
         /// </summary>
-        internal void Deselect ()
+        internal void Deselect (bool preservePointerInteraction = false)
         {
             Selected = false;
-            OnDeselected (EventArgs.Empty);
+            int preservationDepth = Properties.GetInteger(s_focusLossPointerPreservationProperty);
+            if (preservePointerInteraction)
+                Properties.SetInteger(s_focusLossPointerPreservationProperty, preservationDepth + 1);
+            try {
+                OnDeselected (EventArgs.Empty);
+            }
+            finally {
+                if (preservePointerInteraction) {
+                    if (preservationDepth == 0)
+                        Properties.RemoveInteger(s_focusLossPointerPreservationProperty);
+                    else
+                        Properties.SetInteger(s_focusLossPointerPreservationProperty, preservationDepth);
+                }
+            }
 
             Invalidate ();
         }
@@ -1363,10 +1382,17 @@ namespace ModernFormsNext
         protected virtual void OnLostFocus(EventArgs e)
         {
             keyboardPressed = false;
-            // A control can lose focus before the matching activation-key release reaches it.
-            // Treat that as cancellation so keyboard-driven press effects cannot stay held.
-            ClearPointerVisualPressed();
-            NotifyInteractionPointerCanceled();
+            // Focus can move before the matching pointer or activation-key release reaches this
+            // control. Cancel the complete gesture through the virtual hook so text-selection and
+            // other control-owned input state is cleared together with capture and optional visuals.
+            if (Properties.GetInteger(s_focusLossPointerPreservationProperty) == 0) {
+                if (Capture)
+                    CancelPointerInteraction();
+                else {
+                    ClearPointerVisualPressed();
+                    NotifyInteractionPointerCanceled();
+                }
+            }
             SetVisualFocus (false);
             (Events[s_lostFocusEvent] as EventHandler)?.Invoke(this, e);
             NotifyAccessibilityClients(AccessibleEvents.StateChange);
@@ -1375,11 +1401,13 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the KeyDown event.
         /// </summary>
+        /// <remarks>
+        /// Framework routing invokes this standard input handler before observing the key for
+        /// optional pressed visuals or interaction effects. Overrides should call the base
+        /// implementation when the public event must be raised.
+        /// </remarks>
         protected virtual void OnKeyDown (KeyEventArgs e)
-        {
-            NotifyInteractionKeyDown (e);
-            (Events[s_keyDownEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
-        }
+            => (Events[s_keyDownEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
 
         /// <summary>
         /// Raises the KeyPress event.
@@ -1393,11 +1421,13 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the KeyUp event.
         /// </summary>
+        /// <remarks>
+        /// Framework routing invokes this standard input handler before releasing optional
+        /// keyboard-driven visuals or interaction effects. Overrides should call the base
+        /// implementation when the public event must be raised.
+        /// </remarks>
         protected virtual void OnKeyUp (KeyEventArgs e)
-        {
-            NotifyInteractionKeyUp (e);
-            (Events[s_keyUpEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
-        }
+            => (Events[s_keyUpEvent] as EventHandler<KeyEventArgs>)?.Invoke (this, e);
 
         /// <summary>
         /// Raises the LocationChanged event.
@@ -1416,13 +1446,14 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the MouseDown event.
         /// </summary>
+        /// <remarks>
+        /// Focus and capture are established before this handler runs. Framework routing waits for
+        /// this handler to finish caret placement, selection, or other control-specific input, then
+        /// applies any opted-in pressed visual and notifies attached interaction effects. Overrides
+        /// should call the base implementation when the public event must be raised.
+        /// </remarks>
         protected virtual void OnMouseDown (MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Left)
-                SetPointerVisualPressed(true, e.PointerId);
-            NotifyInteractionPointerDown (e);
-            (Events[s_mouseDownEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
-        }
+            => (Events[s_mouseDownEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
 
         /// <summary>
         /// Raises the MouseEnter event.
@@ -1462,13 +1493,13 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the MouseUp event.
         /// </summary>
+        /// <remarks>
+        /// Framework routing invokes this standard input handler before releasing optional
+        /// pressed visuals and interaction effects. Overrides should call the base implementation
+        /// when the public event must be raised.
+        /// </remarks>
         protected virtual void OnMouseUp (MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Left)
-                SetPointerVisualPressed(false, e.PointerId);
-            NotifyInteractionPointerUp (e);
-            (Events[s_mouseUpEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
-        }
+            => (Events[s_mouseUpEvent] as EventHandler<MouseEventArgs>)?.Invoke (this, e);
 
         /// <summary>
         /// Raises the MouseWheel event.
@@ -1857,11 +1888,10 @@ namespace ModernFormsNext
                 int previousNotifiedDepth = interactionKeyDownNotifiedDepth;
                 interactionKeyDownRouteDepth++;
                 try {
-                    // Route interaction state before virtual dispatch. Some established controls
-                    // consume activation keys without calling base, but their press visuals and
-                    // attached effects must still receive the matching down/up pair.
-                    NotifyInteractionKeyDown (e);
                     OnKeyDown (e);
+                    // Keyboard handling owns the standard input contract. Optional visuals and
+                    // effects observe the completed handler and cannot suppress text/navigation.
+                    NotifyInteractionKeyDown (e);
                 }
                 finally {
                     interactionKeyDownNotifiedDepth = previousNotifiedDepth;
@@ -1918,6 +1948,11 @@ namespace ModernFormsNext
                     Select ();
                     Capture = true;
                     OnMouseDown (e);
+                    // Focus, capture, caret placement, selection, and control-specific input have
+                    // completed. Pressed visuals and attached effects are optional consequences.
+                    if (e.Button == MouseButtons.Left)
+                        SetPointerVisualPressed(true, e.PointerId);
+                    NotifyInteractionPointerDown (e);
                 }
             }
         }
@@ -1935,8 +1970,8 @@ namespace ModernFormsNext
             int previousNotifiedDepth = interactionKeyUpNotifiedDepth;
             interactionKeyUpRouteDepth++;
             try {
-                NotifyInteractionKeyUp (e);
                 OnKeyUp (e);
+                NotifyInteractionKeyUp (e);
             }
             finally {
                 interactionKeyUpNotifiedDepth = previousNotifiedDepth;
@@ -2028,6 +2063,9 @@ namespace ModernFormsNext
                 if (Enabled) {
                     Capture = false;
                     OnMouseUp (e);
+                    if (e.Button == MouseButtons.Left)
+                        SetPointerVisualPressed(false, e.PointerId);
+                    NotifyInteractionPointerUp (e);
                 }
             }
         }
@@ -2043,6 +2081,18 @@ namespace ModernFormsNext
             NotifyInteractionPointerCanceled (pointerId);
             OnMouseLeave (EventArgs.Empty);
             Invalidate ();
+        }
+
+        private void CancelCapturedPointerInteractionsInSubtree()
+        {
+            // Capture is stored on the leaf and propagated to its ancestors. Clear every actual
+            // owner before detaching the subtree; assigning Parent first would strand the old
+            // ancestor chain in a captured state until unrelated input happens to reset it.
+            foreach (var captured in Controls.GetAllControls(true).Where(control => control.is_captured).ToArray())
+                captured.CancelPointerInteraction();
+
+            if (is_captured)
+                CancelPointerInteraction();
         }
 
         /// <summary>

--- a/ModernFormsNext/RichTextBox.cs
+++ b/ModernFormsNext/RichTextBox.cs
@@ -82,6 +82,21 @@ namespace ModernFormsNext
             VerticalScrollBar.ValueChanged += (_, _) => OnVScroll(EventArgs.Empty);
         }
 
+        /// <inheritdoc/>
+        protected override int GetTextIndexFromPosition(Point location)
+        {
+            if (Text.Length == 0)
+                return 0;
+
+            // Pointer hit testing must use the same styled block and origin as rendering. The
+            // plain TextBoxDocument block can wrap at different positions when a RichTextBox run
+            // changes font family, size, weight, or other glyph metrics.
+            var block = GetRichTextBlock();
+            var origin = GetTextOrigin(block);
+            var hit = block.HitTest(location.X - origin.X, location.Y - origin.Y);
+            return document.GetUtf16IndexFromLayoutCodePointIndex(hit.ClosestCodePointIndex);
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether the TAB key inserts a tab character.
         /// </summary>

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -20,6 +20,7 @@ public sealed class SkiaControlSurface : IDisposable
     private readonly SurfaceRootControl surfaceRoot = new();
     private readonly Action<string>? pointerDiagnosticSink;
     private int pointerDragThreshold = 8;
+    private int pointerDownRouteDepth;
     private bool disposed;
 
     /// <summary>
@@ -160,9 +161,17 @@ public sealed class SkiaControlSurface : IDisposable
                 if (pointers.Remove(pointerId, out var replaced))
                     CancelPointer(replaced);
 
-                FinishComposingText();
-                foreach (var control in observedControls.Where(control => control.Selected).ToArray())
-                    control.Deselect();
+                pointerDownRouteDepth++;
+                try
+                {
+                    FinishComposingText();
+                    foreach (var control in observedControls.Where(control => control.Selected).ToArray())
+                        control.Deselect(preservePointerInteraction: IsPointerOwnedBy(control));
+                }
+                finally
+                {
+                    pointerDownRouteDepth--;
+                }
 
                 var target = hit?.Control;
                 var scrollCandidate = FindScrollableAncestor(target);
@@ -503,6 +512,7 @@ public sealed class SkiaControlSurface : IDisposable
         control.Invalidated += OnControlInvalidated;
         control.ControlAdded += OnControlAdded;
         control.ControlRemoved += OnControlRemoved;
+        control.LostFocus += OnControlLostFocus;
         foreach (var child in control.Controls.GetAllControls())
             ObserveTree(child);
     }
@@ -512,6 +522,7 @@ public sealed class SkiaControlSurface : IDisposable
         control.Invalidated -= OnControlInvalidated;
         control.ControlAdded -= OnControlAdded;
         control.ControlRemoved -= OnControlRemoved;
+        control.LostFocus -= OnControlLostFocus;
         observedControls.Remove(control);
     }
 
@@ -523,19 +534,43 @@ public sealed class SkiaControlSurface : IDisposable
 
     private void OnControlRemoved(object? sender, EventArgs<Control> e)
     {
-        foreach (var pointer in pointers.Values.Where(pointer =>
-                     IsSelfOrDescendant(pointer.CapturedControl, e.Value) ||
-                     IsSelfOrDescendant(pointer.GestureOwner, e.Value) ||
-                     IsSelfOrDescendant(pointer.ScrollCandidate, e.Value)).ToArray())
-        {
-            pointers.Remove(pointer.PointerId);
-            CancelPointer(pointer);
-        }
+        CancelPointersOwnedBy(e.Value);
 
         if (e.Value is TextBox textBox)
             textBox.document.FinishComposition();
         UnobserveTree(e.Value);
     }
+
+    private void OnControlLostFocus(object? sender, EventArgs e)
+    {
+        // Starting another touch pointer deselects the previously focused control, but does not
+        // terminate that control's independent pointer sequence. External focus loss remains a
+        // terminal condition and clears the corresponding router ownership below.
+        if (pointerDownRouteDepth > 0)
+            return;
+
+        if (sender is Control control)
+            CancelPointersOwnedBy(control);
+    }
+
+    private void CancelPointersOwnedBy(Control control)
+    {
+        // Focus loss and detach are terminal for a control-owned gesture. Remove the router entry
+        // as well as clearing Control.Capture so a later move/up cannot reach a stale text editor.
+        foreach (var pointer in pointers.Values.Where(pointer =>
+                     IsSelfOrDescendant(pointer.CapturedControl, control) ||
+                     IsSelfOrDescendant(pointer.GestureOwner, control) ||
+                     IsSelfOrDescendant(pointer.ScrollCandidate, control)).ToArray())
+        {
+            pointers.Remove(pointer.PointerId);
+            CancelPointer(pointer);
+        }
+    }
+
+    private bool IsPointerOwnedBy(Control control)
+        => pointers.Values.Any(pointer =>
+            IsSelfOrDescendant(pointer.CapturedControl, control) ||
+            IsSelfOrDescendant(pointer.GestureOwner, control));
 
     private void CancelAllPointers(bool invalidate = true)
     {

--- a/ModernFormsNext/TextBox.cs
+++ b/ModernFormsNext/TextBox.cs
@@ -341,10 +341,12 @@ namespace ModernFormsNext
             if (e.Button != MouseButtons.Left)
                 return;
 
+            var anchor = GetPointerSelectionAnchor();
             SetCursorToCharIndex (GetTextIndexFromPosition (e.Location));
 
             is_highlighting = true;
-            selection_anchor = document.CursorIndex;
+            selection_anchor = e.Shift ? anchor : document.CursorIndex;
+            UpdatePointerSelection();
 
             Invalidate ();
         }
@@ -356,14 +358,7 @@ namespace ModernFormsNext
 
             if (is_highlighting) {
                 SetCursorToCharIndex (GetTextIndexFromPosition (e.Location));
-
-                if (document.CursorIndex == selection_anchor) {
-                    document.SelectionStart = -1;
-                    document.SelectionEnd = -1;
-                } else {
-                    document.SelectionStart = selection_anchor;
-                    document.SelectionEnd = document.CursorIndex;
-                }
+                UpdatePointerSelection();
 
                 Invalidate ();
             }
@@ -380,7 +375,25 @@ namespace ModernFormsNext
             SetCursorToCharIndex (GetTextIndexFromPosition (e.Location));
 
             is_highlighting = false;
+            UpdatePointerSelection();
 
+            Invalidate ();
+        }
+
+        private int GetPointerSelectionAnchor()
+        {
+            if (document.SelectionStart < 0 || document.SelectionEnd < 0)
+                return document.CursorIndex;
+
+            // The cursor is the active edge. Shift+click extends from the opposite logical edge,
+            // including reverse selections whose anchor is numerically greater than the cursor.
+            return document.CursorIndex == document.SelectionStart
+                ? document.SelectionEnd
+                : document.SelectionStart;
+        }
+
+        private void UpdatePointerSelection()
+        {
             if (document.CursorIndex == selection_anchor) {
                 document.SelectionStart = -1;
                 document.SelectionEnd = -1;
@@ -388,8 +401,6 @@ namespace ModernFormsNext
                 document.SelectionStart = selection_anchor;
                 document.SelectionEnd = document.CursorIndex;
             }
-
-            Invalidate ();
         }
 
         internal override void CancelPointerInteraction (int? pointerId = null)

--- a/ModernFormsNext/TextBox.cs
+++ b/ModernFormsNext/TextBox.cs
@@ -92,8 +92,10 @@ namespace ModernFormsNext
         /// <remarks>
         /// Derived source editors use this hook for gestures such as word selection while the
         /// shared text document remains responsible for hit testing and DPI-aware text layout.
+        /// Overrides that render a separate styled text block must hit-test that same block and
+        /// convert its layout code-point index back to the control's UTF-16 document index.
         /// </remarks>
-        protected int GetTextIndexFromPosition (Point location)
+        protected virtual int GetTextIndexFromPosition (Point location)
         {
             if (!document.Text.HasValue ())
                 return 0;

--- a/ModernFormsNext/TextBoxDocument.cs
+++ b/ModernFormsNext/TextBoxDocument.cs
@@ -658,8 +658,23 @@ namespace ModernFormsNext
 
             var offsets = new List<int> { 0 };
             var utf16Offset = 0;
-            foreach (var rune in text.EnumerateRunes ()) {
-                utf16Offset += rune.Utf16SequenceLength;
+
+            while (utf16Offset < text.Length) {
+                // RichTextKit normalizes a Windows CRLF pair to one layout code point. Keep the
+                // document-side offset table aligned with that layout while preserving both UTF-16
+                // units in Text, SelectionStart, SelectionLength, and all public editing APIs.
+                if (text[utf16Offset] == '\r'
+                    && utf16Offset + 1 < text.Length
+                    && text[utf16Offset + 1] == '\n') {
+                    utf16Offset += 2;
+                } else if (char.IsHighSurrogate(text[utf16Offset])
+                    && utf16Offset + 1 < text.Length
+                    && char.IsLowSurrogate(text[utf16Offset + 1])) {
+                    utf16Offset += 2;
+                } else {
+                    utf16Offset++;
+                }
+
                 offsets.Add (utf16Offset);
             }
 

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -417,6 +417,13 @@ Containers and data surfaces also do not enter the shared Pressed visual state m
 receive a left click. Built-in clickable controls opt in through their existing hover behavior;
 other controls can opt in by configuring `StylePressed` or a transition involving `Pressed`.
 
+Standard input is independent of both layers. The leaf control first receives focus and capture and
+finishes its pointer or keyboard handler, including caret placement and selection. Only then can an
+opted-in `Pressed` presentation be resolved and an explicitly attached effect observe the input.
+Missing effects or pressed styles therefore never suppress hit testing, text editing, selection, or
+capture. Focus loss, pointer cancellation, detach, and disposal terminate control-owned capture and
+remove the corresponding platform pointer owner without waiting for another move or release.
+
 `DataGridView` currently has no cell/row interaction-effect target contract. Its default is
 therefore no effect, including for cell selection, headers, resizing, dragging, and scrollbars.
 Applications that need a cell-, row-, or action-cell-bounded ripple should not attach a generic

--- a/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
+++ b/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
@@ -125,6 +125,13 @@ an explicitly configured pressed style/transition. This keeps panels, layout sur
 allowing any control to opt into a per-control effect. Cell/row/action-cell targeting is not
 modeled by the current grid architecture and remains a separate API design step.
 
+The opt-in boundary changes presentation only. Focus, capture, leaf hit testing, control-specific
+pointer handling, caret placement, selection, and keyboard input remain unconditional. The routed
+control handler completes first; the pipeline then resolves an optional Pressed presentation and
+finally notifies the target's explicit effect collection. Focus loss, cancellation, detach, and
+disposal clear both control capture and platform pointer ownership. Starting another independent
+touch pointer may move keyboard focus but does not cancel the earlier touch sequence.
+
 ## Known limitations
 
 - Android refreshes on foreground instead of observing the global setting continuously.

--- a/docs/markdown-editor.md
+++ b/docs/markdown-editor.md
@@ -23,7 +23,10 @@ editor.PreviewLinkClicked += (_, e) => HandleLink(e.Destination);
 
 `Text` is an exact alias of `Markdown`. Assigning either property programmatically clears undo
 history and resets `Modified`. Source offsets (`SelectionStart` and `SelectionLength`) are UTF-16
-indexes, matching normal .NET string indexing.
+indexes, matching normal .NET string indexing. Windows `CRLF` remains two UTF-16 units in the
+source even though RichTextKit shapes the pair as one visual line break; pointer hit testing,
+caret movement, drag selection, Shift+click, and double-click translate that visual boundary back
+to the exact source index.
 
 ## Editing core
 
@@ -31,6 +34,10 @@ The private editing surface derives from `RichTextBox`, so Markdown editing shar
 caret, selection, keyboard, mouse, clipboard, scrolling, focus, and backend IME path. Double-click
 selects a word or a complete surrogate pair. `ReadOnly` still permits selection and copying but
 blocks typing, cut, paste, undo/redo, and formatting commands.
+
+Pointer hit testing uses the same syntax-highlighted RichTextKit block that is painted. Formatting
+runs can therefore change font metrics or wrapping without moving the logical insertion point away
+from the glyph selected by the user.
 
 Text is Unicode and arrives through the platform `TextInput`/IME path rather than being inferred
 from physical keys. This preserves dead keys, composed text, emoji, and international layouts.

--- a/docs/richtextbox.md
+++ b/docs/richtextbox.md
@@ -21,6 +21,11 @@ editor.DeselectAll();
 
 Formatting is stored independently from the plain `Text` value. Assigning `Text` replaces the document with plain text and clears explicit run formatting. Editing operations keep formatting attached to the original character ranges as text is inserted or removed.
 
+Pointer hit testing uses the same styled RichTextKit block and text origin as rendering. A run that
+changes font family, size, weight, or wrapping therefore does not shift the caret away from the
+clicked glyph. Public caret and selection offsets remain UTF-16 indexes; `CRLF` is preserved as two
+UTF-16 units while being treated as one visual line-break boundary.
+
 Supported formatting members include:
 
 - `SelectionFont`


### PR DESCRIPTION
## Summary

PR #19 was merged before the editor input regression fix in `db93cb5`. This Draft follow-up restores the standard pointer-input contract without reintroducing implicit click animations on panels, data surfaces, or other non-opted-in controls.

The original regression came from the ordering inside the shared input path: optional `Pressed` state and `InteractionEffects` work was interleaved with the virtual base `OnMouseDown` handler. Text controls call that base handler as part of their caret and selection path, so presentation behavior could run before control-specific pointer processing had completed.

The follow-up recording exposed a second, independent cause of inaccurate caret placement. RichTextKit shapes a Windows `CRLF` pair as one layout code point, while `TextBoxDocument` counted `CR` and `LF` separately when translating layout positions back to public UTF-16 indices. The insertion point therefore drifted left by one UTF-16 unit for every preceding `CRLF`. `RichTextBox` and `MarkdownEditor` also inherited plain-text hit testing even though they render a separately styled RichTextKit block, allowing font metrics and wrapping to diverge from the block used for the pointer lookup.

The corrected routing contract remains:

1. hit testing;
2. focus and pointer capture;
3. complete control-specific input handling;
4. optional `Pressed` visual-state resolution;
5. explicitly configured `InteractionEffects` notification.

Neither a missing pressed style nor an empty effect collection can suppress or alter normal input.

## Fixes

- keeps base mouse/pointer dispatch, focus, capture, and hit testing independent from visual state and effects;
- maps RichTextKit layout code points to exact UTF-16 source offsets while treating `CRLF` as one visual boundary;
- hit-tests `RichTextBox` and the `MarkdownEditor` source surface against the same styled block and origin used for rendering;
- restores exact caret placement and text insertion after any number of Windows line endings;
- preserves drag selection, Shift+click extension, and double-click word selection across `CRLF` boundaries;
- keeps preview input independent from the source editor selection;
- clears control capture and platform pointer ownership on mouse/pointer cancellation, focus loss, detach, and removal;
- preserves editor input inside `Panel` and `DataGridView` without triggering effects on the parent/container;
- keeps explicitly configured effects target-local and runs them only after standard input processing;
- preserves independent multi-touch pointer ownership;
- documents UTF-16/CRLF behavior and rendered-block hit testing.

## Validation

- Debug tests: **822/822 passed**;
- Release tests: **822/822 passed**;
- focused editor/pointer and Unicode tests: **31/31 passed**;
- full Debug build: passed;
- full Release build: passed;
- no new warning families were introduced;
- `ControlGallery` and `ModernFormsNext.DemoApp` launch and close successfully;
- the recorded `CRLF` scenario was reproduced in `ControlGallery`: typing after a click landed at the clicked visual position, and drag selection followed the pointer.

Full human manual validation is still required before this PR can be marked Ready for review. In particular: repeat the exact click-and-type scenario, Shift+click, native double-click, preview checkboxes/links, and returning to the source editor.

This PR intentionally remains Draft and contains only the post-PR #19 input regression fixes, their regression tests, and related documentation.
