### PR TITLE
Fix Designer dock and Z-order consistency

### DIFF
--- a/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
+++ b/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
@@ -14,8 +14,11 @@ namespace ModernFormsNext.CodeGeneration.CSharp;
 /// <c>Dock</c>, <c>Name</c>, <c>Text</c>, and <c>Size</c>. It emits an explicit
 /// <c>DockStyle.None</c> when the design document has no dock value so runtime
 /// constructor defaults on specialized controls do not change designer-authored
-/// layout. It does not depend on Visual Studio SDK services and is deterministic
-/// for a given document and option set.
+/// layout. Child collections are mapped from persisted front-to-back order to the runtime
+/// collection's last-index-is-front representation. Sequential flow, table, and tab containers
+/// retain authored order because their collection order also defines their content sequence.
+/// It does not depend on Visual Studio SDK services and is deterministic for a
+/// given document and option set.
 /// </remarks>
 public sealed class CSharpDesignerGenerator
 {
@@ -188,7 +191,7 @@ public sealed class CSharpDesignerGenerator
     }
 
     private static void ValidatePropertyNames(
-        IEnumerable<DesignControlNode> controls,
+        IReadOnlyList<DesignControlNode> controls,
         DesignDocumentValidationResult validation)
     {
         foreach (var control in controls)
@@ -479,12 +482,16 @@ public sealed class CSharpDesignerGenerator
 
     private static void WriteControlAdds(
         CodeWriter writer,
-        IEnumerable<DesignControlNode> controls,
+        IReadOnlyList<DesignControlNode> controls,
         string parentExpression,
         DesignControlNode? parentNode,
         IReadOnlyDictionary<DesignControlNode, string> controlExpressions)
     {
-        foreach (var control in controls)
+        // Runtime ControlCollection uses its last index as the visual/docking front, whereas the
+        // document stores the front-most node at index zero. Map that Z-order explicitly for
+        // ordinary containers. Flow/table/tab collections are sequential content models, so their
+        // authored order must stay forward and must not be affected by a global reversal.
+        foreach (var control in EnumerateControlAddOrder(controls, parentNode))
         {
             if (IsSplitPanel(control))
             {
@@ -500,6 +507,27 @@ public sealed class CSharpDesignerGenerator
             WriteControlAdds(writer, control.Children, controlExpression, control, controlExpressions);
         }
     }
+
+    private static IEnumerable<DesignControlNode> EnumerateControlAddOrder(
+        IReadOnlyList<DesignControlNode> controls,
+        DesignControlNode? parentNode)
+    {
+        if (parentNode is not null && PreservesSequentialChildOrder(parentNode))
+        {
+            for (var index = 0; index < controls.Count; index++)
+                yield return controls[index];
+
+            yield break;
+        }
+
+        for (var index = controls.Count - 1; index >= 0; index--)
+            yield return controls[index];
+    }
+
+    private static bool PreservesSequentialChildOrder(DesignControlNode node)
+        => IsType(node, "FlowLayoutPanel")
+        || IsType(node, "TableLayoutPanel")
+        || IsType(node, "TabControl");
 
     private static void WriteTableLayoutAssignments(
         CodeWriter writer,

--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
@@ -595,6 +595,9 @@ public sealed class CSharpDesignerParser
         document.Controls.Clear();
         var added = new HashSet<string>(StringComparer.Ordinal);
 
+        // Runtime Controls.Add appends at the visual front. Ordinary generated containers therefore
+        // emit back-to-front and are inserted at document index zero to recover canonical
+        // front-to-back order. Sequential flow/table/tab collections preserve invocation order.
         foreach (var operation in addOperations)
         {
             if (!nodes.TryGetValue(operation.ChildName, out var child))
@@ -617,7 +620,7 @@ public sealed class CSharpDesignerParser
 
             if (operation.ParentName is null)
             {
-                document.Controls.Add(child);
+                document.Controls.Insert(0, child);
                 continue;
             }
 
@@ -641,7 +644,10 @@ public sealed class CSharpDesignerParser
                 continue;
             }
 
-            parent.Children.Add(child);
+            if (PreservesSequentialChildOrder(parent))
+                parent.Children.Add(child);
+            else
+                parent.Children.Insert(0, child);
         }
 
         foreach (var name in nodeOrder)
@@ -656,6 +662,11 @@ public sealed class CSharpDesignerParser
             document.Controls.Add(nodes[name]);
         }
     }
+
+    private static bool PreservesSequentialChildOrder(DesignControlNode node)
+        => IsType(node.TypeName, "FlowLayoutPanel")
+        || IsType(node.TypeName, "TableLayoutPanel")
+        || IsType(node.TypeName, "TabControl");
 
     private static bool ContainsDescendant(DesignControlNode root, DesignControlNode candidate)
     {

--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParserExamples.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParserExamples.cs
@@ -82,8 +82,8 @@ public static class CSharpDesignerParserExamples
                    this.button1.Enabled = true;
                    this.button1.Visible = true;
 
-                   this.panel1.Controls.Add(this.label1);
                    this.panel1.Controls.Add(this.button1);
+                   this.panel1.Controls.Add(this.label1);
                    this.Controls.Add(this.panel1);
 
                    this.Name = "MainForm";

--- a/ModernFormsNext.Designer.Tests/DesignerChildOrderTests.cs
+++ b/ModernFormsNext.Designer.Tests/DesignerChildOrderTests.cs
@@ -1,0 +1,387 @@
+using System.Drawing;
+using ModernFormsNext.CodeGeneration.CSharp;
+using ModernFormsNext.CodeGeneration.Reverse;
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designer.Surface;
+using ModernFormsNext.Designing;
+using Xunit;
+
+namespace ModernFormsNext.Designer.Tests;
+
+public sealed class DesignerChildOrderTests
+{
+    [Fact]
+    public void ThreeTopDockedPanelsWithFillLabelsMatchPreviewAndRuntime()
+    {
+        var document = CreateThreePanelDocument(DockStyle.Top);
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(new DesignBounds(0, 0, 600, 120), PreviewBounds(document, "panel1"));
+        Assert.Equal(new DesignBounds(0, 120, 600, 120), PreviewBounds(document, "panel2"));
+        Assert.Equal(new DesignBounds(0, 240, 600, 120), PreviewBounds(document, "panel21"));
+        Assert.Equal(PreviewBounds(document, "panel1"), PreviewBounds(document, "label1"));
+        Assert.Equal(PreviewBounds(document, "panel2"), PreviewBounds(document, "label2"));
+        Assert.Equal(PreviewBounds(document, "panel21"), PreviewBounds(document, "label3"));
+    }
+
+    [Theory]
+    [InlineData(DockStyle.Bottom)]
+    [InlineData(DockStyle.Left)]
+    [InlineData(DockStyle.Right)]
+    public void RepeatedEdgeDockingMatchesPreviewAndRuntime(DockStyle dock)
+    {
+        var document = CreateThreePanelDocument(dock);
+
+        AssertPreviewAndRuntimeMatch(document);
+
+        var first = PreviewBounds(document, "panel1");
+        var second = PreviewBounds(document, "panel2");
+        var third = PreviewBounds(document, "panel21");
+        if (dock == DockStyle.Bottom)
+            Assert.True(first.Y > second.Y && second.Y > third.Y);
+        else if (dock == DockStyle.Left)
+            Assert.True(first.X < second.X && second.X < third.X);
+        else
+            Assert.True(first.X > second.X && second.X > third.X);
+    }
+
+    [Theory]
+    [MemberData(nameof(MixedDockCases))]
+    public void MixedDockingMatchesPreviewAndRuntime(DockStyle[] docks)
+    {
+        var document = CreateDocument(docks);
+
+        AssertPreviewAndRuntimeMatch(document);
+    }
+
+    [Fact]
+    public void DockedControlLocationIsIgnoredButAuthoredThicknessIsPreserved()
+    {
+        var document = CreateDocument([DockStyle.Top, DockStyle.Fill]);
+        document.Controls[0].Bounds = new DesignBounds(777, 888, 321, 120);
+        document.Controls[1].Bounds = new DesignBounds(-200, -300, 444, 555);
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(new DesignBounds(0, 0, 600, 120), PreviewBounds(document, "panel1"));
+        Assert.Equal(new DesignBounds(0, 120, 600, 480), PreviewBounds(document, "panel2"));
+    }
+
+    [Fact]
+    public void NestedContainerUsesTheSameFrontToBackOrder()
+    {
+        var document = CreateDocument([DockStyle.Fill]);
+        var container = document.Controls[0];
+        container.Name = "container";
+        container.Children.Clear();
+        container.Children.Add(CreatePanel("nested1", DockStyle.Top, 120));
+        container.Children.Add(CreatePanel("nested2", DockStyle.Top, 120));
+        container.Children.Add(CreatePanel("nested3", DockStyle.Top, 120));
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(new DesignBounds(0, 0, 600, 120), PreviewBounds(document, "nested1"));
+        Assert.Equal(new DesignBounds(0, 120, 600, 120), PreviewBounds(document, "nested2"));
+        Assert.Equal(new DesignBounds(0, 240, 600, 120), PreviewBounds(document, "nested3"));
+    }
+
+    [Fact]
+    public void OverlappingControlsTreatTheFirstDocumentChildAsFrontMost()
+    {
+        var document = CreateDocument([DockStyle.None, DockStyle.None, DockStyle.None]);
+        foreach (var child in document.Controls)
+            child.Bounds = new DesignBounds(20, 20, 200, 100);
+
+        var hit = new DesignerHost(document).HitTest(30, 30);
+
+        Assert.Same(document.Controls[0], hit.Node);
+    }
+
+    [Fact]
+    public void SaveReloadGenerateAndReverseSyncPreserveChildOrder()
+    {
+        var original = CreateThreePanelDocument(DockStyle.Top);
+        var serializer = DesignDocumentSerializer.Default;
+        var reloaded = serializer.Deserialize(serializer.Serialize(original));
+        var generator = new CSharpDesignerGenerator();
+        var firstGeneration = generator.Generate(reloaded);
+        var secondGeneration = generator.Generate(reloaded);
+
+        Assert.True(firstGeneration.Succeeded, string.Join(Environment.NewLine, firstGeneration.Validation.Errors));
+        Assert.Equal(firstGeneration.Code, secondGeneration.Code);
+        Assert.Equal(["panel1", "panel2", "panel21"], reloaded.Controls.Select(node => node.Name));
+        AssertInOrder(
+            firstGeneration.Code,
+            "this.Controls.Add(this.panel21);",
+            "this.Controls.Add(this.panel2);",
+            "this.Controls.Add(this.panel1);");
+
+        var parsed = new CSharpDesignerParser().Parse(firstGeneration.Code);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        var reversed = Assert.IsType<DesignDocument>(parsed.Document);
+        Assert.Equal(["panel1", "panel2", "panel21"], reversed.Controls.Select(node => node.Name));
+        Assert.Equal(["label1"], reversed.Controls[0].Children.Select(node => node.Name));
+        Assert.Equal(["label2"], reversed.Controls[1].Children.Select(node => node.Name));
+        Assert.Equal(["label3"], reversed.Controls[2].Children.Select(node => node.Name));
+    }
+
+    [Fact]
+    public void OutlineMoveUpAndDownChangesPreviewAndGeneratedRuntimeOrder()
+    {
+        var document = CreateThreePanelDocument(DockStyle.Top);
+        var session = new DesignerSession();
+        session.LoadDocument(document);
+        session.SelectNode(document.Controls[1]);
+
+        Assert.True(session.MoveSelectedNodeUp());
+        Assert.Equal(["panel2", "panel1", "panel21"], document.Controls.Select(node => node.Name));
+        Assert.Equal(new DesignBounds(0, 0, 600, 120), PreviewBounds(document, "panel2"));
+        AssertGeneratedRootOrder(document, "panel21", "panel1", "panel2");
+
+        Assert.True(session.MoveSelectedNodeDown());
+        Assert.Equal(["panel1", "panel2", "panel21"], document.Controls.Select(node => node.Name));
+        Assert.Equal(new DesignBounds(0, 0, 600, 120), PreviewBounds(document, "panel1"));
+        AssertGeneratedRootOrder(document, "panel21", "panel2", "panel1");
+    }
+
+    [Fact]
+    public void FlowAndTableContainersKeepTheirAuthoredChildSequence()
+    {
+        foreach (var typeName in new[] { "FlowLayoutPanel", "TableLayoutPanel" })
+        {
+            var document = CreateDocument([DockStyle.Fill]);
+            var container = document.Controls[0];
+            container.TypeName = typeName;
+            container.Children.Clear();
+            container.Children.Add(CreatePanel("first", DockStyle.None, 40));
+            container.Children.Add(CreatePanel("second", DockStyle.None, 40));
+            container.Children.Add(CreatePanel("third", DockStyle.None, 40));
+
+            var generated = new CSharpDesignerGenerator().Generate(document);
+            Assert.True(generated.Succeeded, string.Join(Environment.NewLine, generated.Validation.Errors));
+            AssertInOrder(
+                generated.Code,
+                "this.panel1.Controls.Add(this.first);",
+                "this.panel1.Controls.Add(this.second);",
+                "this.panel1.Controls.Add(this.third);");
+            var parsed = new CSharpDesignerParser().Parse(generated.Code);
+            Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(diagnostic => diagnostic.Message)));
+            var parsedContainer = Assert.Single(Assert.IsType<DesignDocument>(parsed.Document).Controls);
+
+            Assert.Equal(["first", "second", "third"], parsedContainer.Children.Select(node => node.Name));
+            Assert.Same(container.Children[2], new DesignerHost(document).HitTest(55, 65).Node);
+        }
+    }
+
+    [Fact]
+    public void RuntimeBringToFrontAndSendToBackUseLastCollectionIndexAsFront()
+    {
+        using var root = new Panel();
+        var first = new Panel { Name = "first" };
+        var second = new Panel { Name = "second" };
+        var third = new Panel { Name = "third" };
+        root.Controls.AddRange(first, second, third);
+
+        first.BringToFront();
+        Assert.Equal(["second", "third", "first"], root.Controls.Select(control => control.Name));
+
+        first.SendToBack();
+        Assert.Equal(["first", "second", "third"], root.Controls.Select(control => control.Name));
+    }
+
+    [Fact]
+    public void FrontAndBackDocumentReorderingSurvivesSerializationAndReverseSync()
+    {
+        var document = CreateDocument([DockStyle.None, DockStyle.None, DockStyle.None]);
+        var front = document.Controls[0];
+        document.Controls.RemoveAt(0);
+        document.Controls.Add(front);
+        AssertRoundTripOrder(document, "panel2", "panel21", "panel1");
+
+        document.Controls.RemoveAt(document.Controls.Count - 1);
+        document.Controls.Insert(0, front);
+        AssertRoundTripOrder(document, "panel1", "panel2", "panel21");
+    }
+
+    public static TheoryData<DockStyle[]> MixedDockCases => new()
+    {
+        new[] { DockStyle.Top, DockStyle.Fill },
+        new[] { DockStyle.Top, DockStyle.Bottom, DockStyle.Fill }
+    };
+
+    private static DesignDocument CreateThreePanelDocument(DockStyle dock)
+        => CreateDocument([dock, dock, dock]);
+
+    private static DesignDocument CreateDocument(IReadOnlyList<DockStyle> docks)
+    {
+        var document = new DesignDocument
+        {
+            Namespace = "DockOrderReproduction",
+            ClassName = "MainForm",
+            FormName = "MainForm",
+            Size = new DesignSize(600, 600)
+        };
+        var names = new[] { "panel1", "panel2", "panel21" };
+
+        for (var index = 0; index < docks.Count; index++)
+        {
+            var panel = CreatePanel(names[index], docks[index], 120);
+            panel.Bounds = new DesignBounds(50 + (index * 20), 60 + (index * 20), 120, 120);
+            panel.Children.Add(new DesignControlNode
+            {
+                TypeName = "Label",
+                Name = $"label{index + 1}",
+                Bounds = new DesignBounds(19, 23, 75, 23),
+                Properties =
+                {
+                    ["Dock"] = DesignPropertyValue.FromObject(DockStyle.Fill),
+                    ["Text"] = DesignPropertyValue.FromString($"TestPanel{index + 1}")
+                }
+            });
+            document.Controls.Add(panel);
+        }
+
+        return document;
+    }
+
+    private static DesignControlNode CreatePanel(string name, DockStyle dock, int thickness)
+        => new()
+        {
+            TypeName = "Panel",
+            Name = name,
+            Bounds = new DesignBounds(0, 0, thickness, thickness),
+            Properties =
+            {
+                ["Dock"] = DesignPropertyValue.FromObject(dock)
+            }
+        };
+
+    private static void AssertPreviewAndRuntimeMatch(DesignDocument document)
+    {
+        var preview = new DesignerLayoutEngine().Layout(document);
+        using var root = BuildRuntimeTree(document, out var runtimeControls);
+
+        foreach (var node in Enumerate(document.Controls))
+        {
+            var expected = preview.GetEffectiveBounds(node);
+            var actual = GetAbsoluteBounds(runtimeControls[node.Name]);
+            Assert.Equal(new Rectangle(expected.X, expected.Y, expected.Width, expected.Height), actual);
+        }
+    }
+
+    private static Panel BuildRuntimeTree(
+        DesignDocument document,
+        out Dictionary<string, Control> controls)
+    {
+        controls = new Dictionary<string, Control>(StringComparer.Ordinal);
+        var root = new Panel { Size = new Size(document.Size.Width, document.Size.Height) };
+        root.SuspendLayout();
+        for (var index = document.Controls.Count - 1; index >= 0; index--)
+        {
+            var node = document.Controls[index];
+            root.Controls.Add(CreateRuntimeControl(node, controls));
+        }
+        root.ResumeLayout(true);
+        PerformLayoutRecursively(root);
+        return root;
+    }
+
+    private static Control CreateRuntimeControl(
+        DesignControlNode node,
+        IDictionary<string, Control> controls)
+    {
+        Control control = node.TypeName switch
+        {
+            "Label" => new Label(),
+            "FlowLayoutPanel" => new FlowLayoutPanel(),
+            "TableLayoutPanel" => new TableLayoutPanel(),
+            _ => new Panel()
+        };
+        control.Name = node.Name;
+        control.Bounds = new Rectangle(node.Bounds.X, node.Bounds.Y, node.Bounds.Width, node.Bounds.Height);
+        control.Dock = GetDock(node);
+        controls.Add(node.Name, control);
+        control.SuspendLayout();
+        if (PreservesSequentialChildOrder(node))
+        {
+            foreach (var child in node.Children)
+                control.Controls.Add(CreateRuntimeControl(child, controls));
+        }
+        else
+        {
+            for (var index = node.Children.Count - 1; index >= 0; index--)
+                control.Controls.Add(CreateRuntimeControl(node.Children[index], controls));
+        }
+        control.ResumeLayout(true);
+        return control;
+    }
+
+    private static bool PreservesSequentialChildOrder(DesignControlNode node)
+        => node.TypeName is "FlowLayoutPanel" or "TableLayoutPanel" or "TabControl";
+
+    private static void PerformLayoutRecursively(Control control)
+    {
+        control.PerformLayout();
+        foreach (var child in control.Controls)
+            PerformLayoutRecursively(child);
+    }
+
+    private static Rectangle GetAbsoluteBounds(Control control)
+    {
+        var bounds = control.Bounds;
+        for (var parent = control.Parent; parent?.Parent is not null; parent = parent.Parent)
+            bounds.Offset(parent.Left, parent.Top);
+        return bounds;
+    }
+
+    private static DockStyle GetDock(DesignControlNode node)
+        => node.Properties.TryGetValue("Dock", out var value)
+            && Enum.TryParse(value.GetString(), out DockStyle dock)
+                ? dock
+                : DockStyle.None;
+
+    private static DesignBounds PreviewBounds(DesignDocument document, string name)
+    {
+        var node = Enumerate(document.Controls).Single(candidate => candidate.Name == name);
+        return new DesignerLayoutEngine().Layout(document).GetEffectiveBounds(node);
+    }
+
+    private static IEnumerable<DesignControlNode> Enumerate(IEnumerable<DesignControlNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            yield return node;
+            foreach (var child in Enumerate(node.Children))
+                yield return child;
+        }
+    }
+
+    private static void AssertGeneratedRootOrder(DesignDocument document, params string[] names)
+    {
+        var result = new CSharpDesignerGenerator().Generate(document);
+        Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Validation.Errors));
+        AssertInOrder(result.Code, names.Select(name => $"this.Controls.Add(this.{name});").ToArray());
+    }
+
+    private static void AssertRoundTripOrder(DesignDocument document, params string[] names)
+    {
+        var serializer = DesignDocumentSerializer.Default;
+        var reloaded = serializer.Deserialize(serializer.Serialize(document));
+        Assert.Equal(names, reloaded.Controls.Select(node => node.Name));
+
+        var generated = new CSharpDesignerGenerator().Generate(reloaded);
+        Assert.True(generated.Succeeded, string.Join(Environment.NewLine, generated.Validation.Errors));
+        var parsed = new CSharpDesignerParser().Parse(generated.Code);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        Assert.Equal(names, Assert.IsType<DesignDocument>(parsed.Document).Controls.Select(node => node.Name));
+    }
+
+    private static void AssertInOrder(string text, params string[] values)
+    {
+        var previous = -1;
+        foreach (var value in values)
+        {
+            var current = text.IndexOf(value, StringComparison.Ordinal);
+            Assert.True(current > previous, $"'{value}' was not emitted after the previous child add.");
+            previous = current;
+        }
+    }
+}

--- a/ModernFormsNext.Designer/Services/DesignerSession.cs
+++ b/ModernFormsNext.Designer/Services/DesignerSession.cs
@@ -452,6 +452,11 @@ public sealed class DesignerSession
     /// <summary>
     /// Moves the selected control one position earlier inside its current parent collection.
     /// </summary>
+    /// <remarks>
+    /// For ordinary containers, an earlier collection index moves the control toward the front of
+    /// the Z-order. For flow, table, and tab containers, it moves the control earlier in the
+    /// container's authored sequence.
+    /// </remarks>
     /// <returns><see langword="true"/> when the selected control was moved; otherwise, <see langword="false"/>.</returns>
     public bool MoveSelectedNodeUp()
         => MoveSelectedNodeWithinCurrentContainer(delta: -1);
@@ -459,6 +464,11 @@ public sealed class DesignerSession
     /// <summary>
     /// Moves the selected control one position later inside its current parent collection.
     /// </summary>
+    /// <remarks>
+    /// For ordinary containers, a later collection index moves the control toward the back of the
+    /// Z-order. For flow, table, and tab containers, it moves the control later in the container's
+    /// authored sequence.
+    /// </remarks>
     /// <returns><see langword="true"/> when the selected control was moved; otherwise, <see langword="false"/>.</returns>
     public bool MoveSelectedNodeDown()
         => MoveSelectedNodeWithinCurrentContainer(delta: 1);
@@ -595,7 +605,7 @@ public sealed class DesignerSession
             return false;
 
         var layout = new DesignerLayoutEngine().Layout(Document);
-        var targetParent = FindDeepestContainerAtPoint(Document.Controls, layout, node, documentPoint, new DesignBounds(0, 0, Document.Size.Width, Document.Size.Height));
+        var targetParent = FindDeepestContainerAtPoint(Document.Controls, parentNode: null, layout, node, documentPoint, new DesignBounds(0, 0, Document.Size.Width, Document.Size.Height));
 
         if (ReferenceEquals(currentParent, targetParent))
             return false;
@@ -1073,14 +1083,13 @@ public sealed class DesignerSession
 
     private DesignControlNode? FindDeepestContainerAtPoint(
         DesignControlCollection nodes,
+        DesignControlNode? parentNode,
         DesignerLayoutResult layout,
         DesignControlNode draggedNode,
         DesignPoint point,
         DesignBounds clip)
     {
-        DesignControlNode? result = null;
-
-        for (var index = nodes.Count - 1; index >= 0; index--)
+        foreach (var index in GetFrontToBackIndices(nodes.Count, parentNode))
         {
             var node = nodes[index];
 
@@ -1093,17 +1102,36 @@ public sealed class DesignerSession
             if (!visible.Contains(point.X, point.Y))
                 continue;
 
-            var childResult = FindDeepestContainerAtPoint(node.Children, layout, draggedNode, point, visible);
+            var childResult = FindDeepestContainerAtPoint(node.Children, node, layout, draggedNode, point, visible);
 
             if (childResult is not null)
                 return childResult;
 
             if (IsContainerNode(node))
-                result = node;
+                return node;
         }
 
-        return result;
+        return null;
     }
+
+    private static IEnumerable<int> GetFrontToBackIndices(int count, DesignControlNode? parentNode)
+    {
+        if (parentNode is not null && PreservesSequentialChildOrder(parentNode))
+        {
+            for (var index = count - 1; index >= 0; index--)
+                yield return index;
+
+            yield break;
+        }
+
+        for (var index = 0; index < count; index++)
+            yield return index;
+    }
+
+    private static bool PreservesSequentialChildOrder(DesignControlNode node)
+        => DesignerSpecialContainers.IsFlowLayoutPanel(node)
+        || DesignerSpecialContainers.IsTableLayoutPanel(node)
+        || DesignerSpecialContainers.IsTabControl(node);
 
     private static DesignBounds Intersect(DesignBounds first, DesignBounds second)
     {

--- a/ModernFormsNext.Designer/Surface/DesignerHitTestService.cs
+++ b/ModernFormsNext.Designer/Surface/DesignerHitTestService.cs
@@ -21,7 +21,7 @@ internal sealed class DesignerHitTestService
         var layout = layoutEngine.Layout(state.Document);
         var documentClip = new DesignBounds(0, 0, Math.Max(1, state.Document.Size.Width), Math.Max(1, state.Document.Size.Height));
 
-        return HitTestControls(state.Document.Controls, layout, documentClip, documentPoint)
+        return HitTestControls(state.Document.Controls, parentNode: null, layout, documentClip, documentPoint)
             ?? DesignerHitTestResult.Empty;
     }
 
@@ -30,7 +30,7 @@ internal sealed class DesignerHitTestService
         var layout = layoutEngine.Layout(state.Document);
         var documentClip = new DesignBounds(0, 0, Math.Max(1, state.Document.Size.Width), Math.Max(1, state.Document.Size.Height));
 
-        return HitTestSplitters(state.Document.Controls, layout, documentClip, documentPoint);
+        return HitTestSplitters(state.Document.Controls, parentNode: null, layout, documentClip, documentPoint);
     }
 
     public DesignControlNode? HitTestTabHeader(DesignerSession state, DesignPoint documentPoint, out int tabIndex)
@@ -38,7 +38,7 @@ internal sealed class DesignerHitTestService
         var layout = layoutEngine.Layout(state.Document);
         var documentClip = new DesignBounds(0, 0, Math.Max(1, state.Document.Size.Width), Math.Max(1, state.Document.Size.Height));
 
-        return HitTestTabHeaders(state.Document.Controls, layout, documentClip, documentPoint, out tabIndex);
+        return HitTestTabHeaders(state.Document.Controls, parentNode: null, layout, documentClip, documentPoint, out tabIndex);
     }
 
     public DesignerResizeHandle HitTestResizeHandle(
@@ -133,13 +133,14 @@ internal sealed class DesignerHitTestService
 
     private static DesignerHitTestResult? HitTestControls(
         IEnumerable<DesignControlNode> controls,
+        DesignControlNode? parentNode,
         DesignerLayoutResult layout,
         DesignBounds parentClip,
         DesignPoint point)
     {
         var orderedControls = new List<DesignControlNode>(controls);
 
-        for (var index = orderedControls.Count - 1; index >= 0; index--)
+        foreach (var index in GetFrontToBackIndices(orderedControls.Count, parentNode))
         {
             var control = orderedControls[index];
             var absoluteBounds = layout.GetEffectiveBounds(control);
@@ -148,7 +149,7 @@ internal sealed class DesignerHitTestService
             if (!visibleBounds.Contains(point.X, point.Y))
                 continue;
 
-            var childHit = HitTestControls(GetHitTestChildren(control), layout, visibleBounds, point);
+            var childHit = HitTestControls(GetHitTestChildren(control), control, layout, visibleBounds, point);
 
             if (childHit is not null)
                 return childHit;
@@ -176,13 +177,14 @@ internal sealed class DesignerHitTestService
 
     private static DesignControlNode? HitTestSplitters(
         IEnumerable<DesignControlNode> controls,
+        DesignControlNode? parentNode,
         DesignerLayoutResult layout,
         DesignBounds parentClip,
         DesignPoint point)
     {
         var orderedControls = new List<DesignControlNode>(controls);
 
-        for (var index = orderedControls.Count - 1; index >= 0; index--)
+        foreach (var index in GetFrontToBackIndices(orderedControls.Count, parentNode))
         {
             var control = orderedControls[index];
             var absoluteBounds = layout.GetEffectiveBounds(control);
@@ -197,7 +199,7 @@ internal sealed class DesignerHitTestService
                 return control;
             }
 
-            var childHit = HitTestSplitters(GetHitTestChildren(control), layout, visibleBounds, point);
+            var childHit = HitTestSplitters(GetHitTestChildren(control), control, layout, visibleBounds, point);
 
             if (childHit is not null)
                 return childHit;
@@ -208,6 +210,7 @@ internal sealed class DesignerHitTestService
 
     private static DesignControlNode? HitTestTabHeaders(
         IEnumerable<DesignControlNode> controls,
+        DesignControlNode? parentNode,
         DesignerLayoutResult layout,
         DesignBounds parentClip,
         DesignPoint point,
@@ -215,7 +218,7 @@ internal sealed class DesignerHitTestService
     {
         var orderedControls = new List<DesignControlNode>(controls);
 
-        for (var index = orderedControls.Count - 1; index >= 0; index--)
+        foreach (var index in GetFrontToBackIndices(orderedControls.Count, parentNode))
         {
             var control = orderedControls[index];
             var absoluteBounds = layout.GetEffectiveBounds(control);
@@ -230,7 +233,7 @@ internal sealed class DesignerHitTestService
                 return control;
             }
 
-            var childHit = HitTestTabHeaders(GetHitTestChildren(control), layout, visibleBounds, point, out tabIndex);
+            var childHit = HitTestTabHeaders(GetHitTestChildren(control), control, layout, visibleBounds, point, out tabIndex);
 
             if (childHit is not null)
                 return childHit;
@@ -239,6 +242,25 @@ internal sealed class DesignerHitTestService
         tabIndex = -1;
         return null;
     }
+
+    private static IEnumerable<int> GetFrontToBackIndices(int count, DesignControlNode? parentNode)
+    {
+        if (parentNode is not null && PreservesSequentialChildOrder(parentNode))
+        {
+            for (var index = count - 1; index >= 0; index--)
+                yield return index;
+
+            yield break;
+        }
+
+        for (var index = 0; index < count; index++)
+            yield return index;
+    }
+
+    private static bool PreservesSequentialChildOrder(DesignControlNode node)
+        => DesignerSpecialContainers.IsFlowLayoutPanel(node)
+        || DesignerSpecialContainers.IsTableLayoutPanel(node)
+        || DesignerSpecialContainers.IsTabControl(node);
 
     private static bool TryHitTabHeader(
         DesignControlNode tabControl,

--- a/ModernFormsNext.Designer/Surface/DesignerSurfaceRenderer.cs
+++ b/ModernFormsNext.Designer/Surface/DesignerSurfaceRenderer.cs
@@ -42,8 +42,7 @@ internal sealed class DesignerSurfaceRenderer
         e.Canvas.Save();
         e.Canvas.ClipRect(clientBounds.ToSKRect());
 
-        foreach (var node in state.Document.Controls)
-            DrawNode(e, previewPaintArgs, state, layout, node, view);
+        DrawNodesInPaintOrder(e, previewPaintArgs, state, layout, state.Document.Controls, parentNode: null, view);
 
         e.Canvas.Restore();
 
@@ -144,8 +143,15 @@ internal sealed class DesignerSurfaceRenderer
             surfacePaintArgs.Canvas.Save();
             surfacePaintArgs.Canvas.ClipRect(GetChildClipBounds(bounds).ToSKRect());
 
-            foreach (var child in GetRenderableChildren(node))
-                DrawNode(surfacePaintArgs, previewPaintArgs, state, layout, child, view);
+            if (DesignerSpecialContainers.IsTabControl(node))
+            {
+                if (DesignerSpecialContainers.GetSelectedTabPage(node) is { } page)
+                    DrawNode(surfacePaintArgs, previewPaintArgs, state, layout, page, view);
+            }
+            else
+            {
+                DrawNodesInPaintOrder(surfacePaintArgs, previewPaintArgs, state, layout, node.Children, node, view);
+            }
 
             surfacePaintArgs.Canvas.Restore();
         }
@@ -224,19 +230,34 @@ internal sealed class DesignerSurfaceRenderer
         }
     }
 
-    private static IEnumerable<DesignControlNode> GetRenderableChildren(DesignControlNode node)
+    private void DrawNodesInPaintOrder(
+        PaintEventArgs surfacePaintArgs,
+        PaintEventArgs previewPaintArgs,
+        DesignerSession state,
+        DesignerLayoutResult layout,
+        DesignControlCollection nodes,
+        DesignControlNode? parentNode,
+        DesignerSurfaceView view)
     {
-        if (DesignerSpecialContainers.IsTabControl(node))
+        // Ordinary document collections are front-to-back, so paint them from the last element to
+        // index zero. Sequential containers retain runtime collection order and therefore paint
+        // forward. This is deliberately container-aware rather than a global reverse operation.
+        if (parentNode is not null && PreservesSequentialChildOrder(parentNode))
         {
-            if (DesignerSpecialContainers.GetSelectedTabPage(node) is { } page)
-                yield return page;
+            for (var index = 0; index < nodes.Count; index++)
+                DrawNode(surfacePaintArgs, previewPaintArgs, state, layout, nodes[index], view);
 
-            yield break;
+            return;
         }
 
-        foreach (var child in node.Children)
-            yield return child;
+        for (var index = nodes.Count - 1; index >= 0; index--)
+            DrawNode(surfacePaintArgs, previewPaintArgs, state, layout, nodes[index], view);
     }
+
+    private static bool PreservesSequentialChildOrder(DesignControlNode node)
+        => DesignerSpecialContainers.IsFlowLayoutPanel(node)
+        || DesignerSpecialContainers.IsTableLayoutPanel(node)
+        || DesignerSpecialContainers.IsTabControl(node);
 
     private static void DrawTabControl(PaintEventArgs e, DesignControlNode node, System.Drawing.Rectangle bounds)
     {

--- a/ModernFormsNext.Designer/Surface/Layout/DesignerLayoutEngine.cs
+++ b/ModernFormsNext.Designer/Surface/Layout/DesignerLayoutEngine.cs
@@ -23,6 +23,9 @@ internal sealed class DesignerLayoutEngine
     {
         var remaining = new DesignBounds(0, 0, Math.Max(0, parentClientBounds.Width), Math.Max(0, parentClientBounds.Height));
 
+        // The persisted collection is front-to-back. As at runtime, the front-most child consumes
+        // dock space first; authored X/Y values are ignored for docked controls while thickness is
+        // taken from Height (Top/Bottom) or Width (Left/Right).
         foreach (var child in children)
         {
             var localBounds = GetLocalBounds(child, remaining);

--- a/ModernFormsNext.Designing/Hosting/DesignerHost.cs
+++ b/ModernFormsNext.Designing/Hosting/DesignerHost.cs
@@ -43,9 +43,13 @@ public sealed class DesignerHost
     /// </summary>
     /// <param name="x">The horizontal coordinate in document logical pixels.</param>
     /// <param name="y">The vertical coordinate in document logical pixels.</param>
-    /// <returns>The hit-test result. If multiple controls overlap, the last control in document order wins.</returns>
+    /// <returns>
+    /// The hit-test result. For ordinary containers the first control in document order wins.
+    /// Sequential flow, table, and tab containers use their last child as the visual front,
+    /// matching their runtime collection semantics.
+    /// </returns>
     public DesignerHitTestResult HitTest(int x, int y)
-        => HitTest(Document.Controls, x, y, offsetX: 0, offsetY: 0) ?? DesignerHitTestResult.Empty;
+        => HitTest(Document.Controls, parentNode: null, x, y, offsetX: 0, offsetY: 0) ?? DesignerHitTestResult.Empty;
 
     /// <summary>
     /// Selects the node at the specified point, or clears selection when no node is hit.
@@ -62,12 +66,13 @@ public sealed class DesignerHost
 
     private static DesignerHitTestResult? HitTest(
         DesignControlCollection controls,
+        DesignControlNode? parentNode,
         int x,
         int y,
         int offsetX,
         int offsetY)
     {
-        for (var index = controls.Count - 1; index >= 0; index--)
+        foreach (var index in GetFrontToBackIndices(controls.Count, parentNode))
         {
             var control = controls[index];
             var absoluteBounds = new DesignBounds(
@@ -79,11 +84,34 @@ public sealed class DesignerHost
             if (!absoluteBounds.Contains(x, y))
                 continue;
 
-            var childHit = HitTest(control.Children, x, y, absoluteBounds.X, absoluteBounds.Y);
+            var childHit = HitTest(control.Children, control, x, y, absoluteBounds.X, absoluteBounds.Y);
 
             return childHit ?? new DesignerHitTestResult(control, absoluteBounds);
         }
 
         return null;
     }
+
+    private static IEnumerable<int> GetFrontToBackIndices(int count, DesignControlNode? parentNode)
+    {
+        if (parentNode is not null && PreservesSequentialChildOrder(parentNode))
+        {
+            for (var index = count - 1; index >= 0; index--)
+                yield return index;
+
+            yield break;
+        }
+
+        for (var index = 0; index < count; index++)
+            yield return index;
+    }
+
+    private static bool PreservesSequentialChildOrder(DesignControlNode node)
+        => IsType(node.TypeName, "FlowLayoutPanel")
+        || IsType(node.TypeName, "TableLayoutPanel")
+        || IsType(node.TypeName, "TabControl");
+
+    private static bool IsType(string typeName, string shortTypeName)
+        => string.Equals(typeName, shortTypeName, StringComparison.Ordinal)
+        || typeName.EndsWith("." + shortTypeName, StringComparison.Ordinal);
 }

--- a/ModernFormsNext.Designing/Nodes/DesignControlCollection.cs
+++ b/ModernFormsNext.Designing/Nodes/DesignControlCollection.cs
@@ -6,8 +6,13 @@ namespace ModernFormsNext.Designing;
 /// Represents an ordered collection of designer control nodes.
 /// </summary>
 /// <remarks>
-/// The order is significant. It is used for deterministic serialization, generated
-/// field order, and hit-testing from the topmost added node back to earlier nodes.
+/// The order is significant. For ordinary containers it represents front-to-back Z-order, with
+/// index zero as the front-most sibling. For flow, table, and tab containers it represents their
+/// sequential content order; when such children overlap, the last item is visually front-most,
+/// matching runtime. The same container policy drives deterministic serialization, generation,
+/// docking, painting, hit testing, reverse synchronization, and document-outline moves.
+/// Existing documents already persist children as an ordered JSON array, so no separate
+/// child-order field or format migration is required.
 /// </remarks>
 public sealed class DesignControlCollection : Collection<DesignControlNode>
 {

--- a/ModernFormsNext.Designing/Nodes/DesignControlNode.cs
+++ b/ModernFormsNext.Designing/Nodes/DesignControlNode.cs
@@ -59,5 +59,11 @@ public sealed class DesignControlNode
     /// <summary>
     /// Gets or sets child controls owned by this control.
     /// </summary>
+    /// <remarks>
+    /// The collection order is the persistent child-order contract. Ordinary containers store
+    /// the front-most child at index 0. Flow, table, and tab containers store their content
+    /// sequence and use the last overlapping child as the visual front. Serialization, C#
+    /// generation, reverse synchronization, preview, and runtime preserve this container policy.
+    /// </remarks>
     public DesignControlCollection Children { get; set; } = [];
 }

--- a/ModernFormsNext.Tests/ControlZOrderTests.cs
+++ b/ModernFormsNext.Tests/ControlZOrderTests.cs
@@ -1,0 +1,116 @@
+using System.Drawing;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class ControlZOrderTests
+{
+    [Fact]
+    public void LastIndexReceivesPointerInputWhenSiblingsOverlap()
+    {
+        using var root = new VisibleRoot { Size = new Size(40, 40) };
+        var back = new PaintProbe(SKColors.Red) { Bounds = new Rectangle(0, 0, 30, 30) };
+        var front = new PaintProbe(SKColors.Blue) { Bounds = new Rectangle(0, 0, 30, 30) };
+        root.Controls.AddRange(back, front);
+
+        root.MouseDownForTest(new MouseEventArgs(MouseButtons.Left, 1, 10, 10, Point.Empty));
+
+        Assert.Equal(1, front.MouseDownCount);
+        Assert.Equal(0, back.MouseDownCount);
+    }
+
+    [Fact]
+    public void LastIndexIsPaintedOnTopWhenSiblingsOverlap()
+    {
+        using var root = new VisibleRoot { Size = new Size(40, 40) };
+        var back = new PaintProbe(SKColors.Red) { Bounds = new Rectangle(0, 0, 30, 30) };
+        var front = new PaintProbe(SKColors.Blue) { Bounds = new Rectangle(0, 0, 30, 30) };
+        root.Controls.AddRange(back, front);
+        using var bitmap = new SKBitmap(40, 40);
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+
+        root.PaintForTest(new PaintEventArgs(bitmap.Info, canvas, 1d));
+        canvas.Flush();
+
+        Assert.Equal(SKColors.Blue, bitmap.GetPixel(10, 10));
+    }
+
+    [Fact]
+    public void BringToFrontAndSendToBackUpdatePointerAndPaintOrder()
+    {
+        using var root = new VisibleRoot { Size = new Size(40, 40) };
+        var first = new PaintProbe(SKColors.Red) { Bounds = new Rectangle(0, 0, 30, 30) };
+        var second = new PaintProbe(SKColors.Blue) { Bounds = new Rectangle(0, 0, 30, 30) };
+        root.Controls.AddRange(first, second);
+
+        first.BringToFront();
+        root.MouseDownForTest(new MouseEventArgs(MouseButtons.Left, 1, 10, 10, Point.Empty));
+        Assert.Equal(1, first.MouseDownCount);
+        Assert.Equal(0, second.MouseDownCount);
+        Assert.Equal(SKColors.Red, PaintPixel(root));
+
+        first.SendToBack();
+        root.MouseDownForTest(new MouseEventArgs(MouseButtons.Left, 1, 10, 10, Point.Empty));
+        Assert.Equal(1, first.MouseDownCount);
+        Assert.Equal(1, second.MouseDownCount);
+        Assert.Equal(SKColors.Blue, PaintPixel(root));
+    }
+
+    [Fact]
+    public void SkiaControlSurfaceUsesTheSameFrontMostHitTarget()
+    {
+        using var root = new VisibleRoot { Size = new Size(40, 40) };
+        var back = new PaintProbe(SKColors.Red) { Bounds = new Rectangle(0, 0, 30, 30) };
+        var front = new PaintProbe(SKColors.Blue) { Bounds = new Rectangle(0, 0, 30, 30) };
+        root.Controls.AddRange(back, front);
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(40, 40);
+
+        surface.ProcessPointer(1, ControlSurfacePointerAction.Down, 10, 10);
+        surface.ProcessPointer(1, ControlSurfacePointerAction.Up, 10, 10);
+
+        Assert.Equal(1, front.MouseDownCount);
+        Assert.Equal(0, back.MouseDownCount);
+    }
+
+    private static SKColor PaintPixel(VisibleRoot root)
+    {
+        using var bitmap = new SKBitmap(40, 40);
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+        root.PaintForTest(new PaintEventArgs(bitmap.Info, canvas, 1d));
+        canvas.Flush();
+        return bitmap.GetPixel(10, 10);
+    }
+
+    private sealed class VisibleRoot : Control
+    {
+        public override bool Visible
+        {
+            get => true;
+            set => base.Visible = value;
+        }
+
+        public void MouseDownForTest(MouseEventArgs e) => RaiseMouseDown(e);
+
+        public void PaintForTest(PaintEventArgs e) => RaisePaint(e);
+    }
+
+    private sealed class PaintProbe(SKColor color) : Control
+    {
+        public int MouseDownCount { get; private set; }
+
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            base.OnMouseDown(e);
+            MouseDownCount++;
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            e.Canvas.Clear(color);
+        }
+    }
+}

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
@@ -205,6 +205,8 @@ public partial class Control
             if (Owner is not { } owner || !Bounds.Contains(x, y))
                 return null;
 
+            // Accessibility hit testing follows the same front-to-back contract as pointer
+            // dispatch: the last collection index is the first eligible overlapping child.
             for (int i = owner.Controls.Count - 1; i >= 0; i--)
             {
                 var child = owner.Controls[i];

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -343,10 +343,14 @@ namespace ModernFormsNext
         /// <summary>
         /// Moves this control to the front zorder.
         /// </summary>
+        /// <remarks>
+        /// The control is moved to the last index in its parent's child collection. Painting,
+        /// hit testing, and docking all honor that front-most position.
+        /// </remarks>
         public void BringToFront ()
         {
             if (parent != null)
-                parent.Controls.SetChildIndex (this, 0);
+                parent.Controls.SetChildIndex (this, parent.Controls.Count);
         }
 
         /// <summary>
@@ -1517,6 +1521,7 @@ namespace ModernFormsNext
         /// <param name="e">A PaintEventArgs that contains the event data.</param>
         protected virtual void OnPaint (PaintEventArgs e)
         {
+            // Controls enumerate from back to front, so the last/front-most child is composited last.
             foreach (var control in Controls.GetAllControls ().Where (c => c.Visible).ToArray ()) {
                 if (control.Width <= 0 || control.Height <= 0)
                     continue;
@@ -2288,10 +2293,13 @@ namespace ModernFormsNext
         /// <summary>
         /// Sends this control to the back of the zorder.
         /// </summary>
+        /// <remarks>
+        /// The control is moved to index 0 in its parent's child collection.
+        /// </remarks>
         public void SendToBack ()
         {
             if (parent != null)
-                parent.Controls.SetChildIndex (this, parent.Controls.Count);
+                parent.Controls.SetChildIndex (this, 0);
         }
 
         /// <summary>

--- a/ModernFormsNext/ControlAdapter.cs
+++ b/ModernFormsNext/ControlAdapter.cs
@@ -49,6 +49,7 @@ namespace ModernFormsNext
             var form_x = form_border.Left.GetWidth ();
             var form_y = form_border.Top.GetWidth ();
 
+            // ControlCollection enumerates from back to front, matching Control.OnPaint.
             foreach (var control in Controls.GetAllControls ().Where (c => c.Visible).ToArray ()) {
                 if (control.Width <= 0 || control.Height <= 0)
                     continue;

--- a/ModernFormsNext/ControlCollection.cs
+++ b/ModernFormsNext/ControlCollection.cs
@@ -18,6 +18,14 @@ public partial class Control
     /// <summary>
     ///  Represents a collection of Controls.
     /// </summary>
+    /// <remarks>
+    /// The last collection index is the front-most child in Z-order. Enumeration proceeds from
+    /// back to front. <see cref="Add{T}(T)"/> appends a new front-most child, while
+    /// <see cref="Control.BringToFront"/>, <see cref="Control.SendToBack"/>, and
+    /// <see cref="SetChildIndex(Control, int)"/> update the same ordering contract.
+    /// Dock layout and hit testing traverse the collection from the last index to zero, while
+    /// painting enumerates from zero so the front-most child is painted last.
+    /// </remarks>
     [ListBindable (false)]
     public class ControlCollection : IList<Control>
     {
@@ -41,9 +49,9 @@ public partial class Control
         }
 
         /// <summary>
-        ///  Adds a child control to this control. The control becomes the last control in
-        ///  the child control list. If the control is already a child of another control it
-        ///  is first removed from that control.
+        ///  Adds a child control to this control. The control becomes the last, front-most
+        ///  control in the child control list. If the control is already a child of another
+        ///  control it is first removed from that control.
         /// </summary>
         public virtual T Add<T> (T value) where T : Control
         {
@@ -194,6 +202,8 @@ public partial class Control
         internal IEnumerable<Control> GetAllControls (bool includeImplicit = true)
         {
             if (includeImplicit)
+                // Framework-owned chrome such as scrollbars follows explicit content so it stays
+                // at the front in the combined last-index-is-front sequence.
                 return control_list.Concat (implicit_control_list);
 
             return control_list;
@@ -205,6 +215,7 @@ public partial class Control
         ///  is thrown if child is not parented to this
         ///  Control.
         /// </summary>
+        /// <remarks>The last collection index identifies the front-most child in Z-order.</remarks>
         public virtual int GetChildIndex (Control child, bool throwException = true)
         {
             var index = IndexOf (child);
@@ -419,6 +430,7 @@ public partial class Control
         ///  is thrown if child is not parented to this
         ///  Control.
         /// </summary>
+        /// <remarks>The last collection index identifies the front-most child in Z-order.</remarks>
         public virtual void SetChildIndex (Control child, int newIndex) => SetChildIndexInternal (child, newIndex);
 
         /// <summary>

--- a/ModernFormsNext/Layout/DockAndAnchorLayout.cs
+++ b/ModernFormsNext/Layout/DockAndAnchorLayout.cs
@@ -275,8 +275,9 @@ internal partial class DefaultLayout : LayoutEngine
 
         IArrangedElement? mdiClient = null;
 
-        // Docking layout is order dependent. After much debate, we decided to use z-order as the
-        // docking order. (Introducing a DockOrder property was a close second)
+        // Docking layout is order dependent and uses the public ControlCollection Z-order. The
+        // last runtime index is front-most and consumes the available rectangle first. Designer
+        // generation maps its front-to-back document order into this runtime representation.
         var children = container.Children;
         for (var i = children.Count () - 1; i >= 0; i--) {
             var element = children.ElementAt (i);

--- a/docs/designer-architecture.md
+++ b/docs/designer-architecture.md
@@ -119,6 +119,36 @@ MainForm.cs
 
 Both the standalone playground and the Visual Studio extension must follow this same flow.
 
+## Child Order and Z-Order Contract
+
+The ordered `children` array in `.mfdesign` is the canonical child-order representation. For
+ordinary containers, index 0 is the front-most child and later entries are progressively farther
+back. Flow, table, and tab containers instead retain their sequential content order; if their
+children overlap, the last child is front-most, as at runtime. Ordinary Z-order is mapped
+explicitly to the runtime `Control.Controls` contract, whose last index is front-most:
+`BringToFront()` moves a child to the last index, `SendToBack()` moves it to index 0, and
+`Controls.Add(...)` appends a new front-most child.
+The existing ordered array is sufficient, so documents do not require a separate `childOrder` or
+`zIndex` field and older `.mfdesign` files remain compatible without migration.
+
+Each stage preserves that same order:
+
+- save and reload retain the `children` array order;
+- C# generation emits ordinary Z-ordered containers from back to front so runtime `Controls.Add`
+  reconstructs the document Z-order; flow, table, and tab containers stay in authored sequence;
+- reverse synchronization performs the inverse mapping for ordinary containers and preserves
+  invocation order for flow, table, and tab containers;
+- document-outline move-up moves a child toward index 0 and move-down moves it toward the back;
+- designer preview docking consumes document children from front to back, while runtime docking
+  consumes the mapped control collection from its last index to zero;
+- painting composites back to front and hit testing searches front to back in both representations.
+
+Docking uses only the relevant authored size for the dock edge. `Top` and `Bottom` use the saved
+height, `Left` and `Right` use the saved width, and `Fill` consumes the remaining rectangle. The
+saved X/Y position does not choose the docking order; the ordered child collection does. Flow and
+table and tab containers retain their authored child sequence. The generator applies a
+container-aware mapping, not a global reversal.
+
 ## DPI and Coordinate Contract
 
 Designer documents store form and control geometry in logical pixels. The layout engine,


### PR DESCRIPTION
## Summary

- fixes the Designer/runtime child-order mismatch for docked and overlapping siblings;
- defines one explicit child-order/Z-order contract across `.mfdesign`, preview, C# generation, reverse sync, runtime layout, painting, and hit testing;
- preserves sequential ordering for `FlowLayoutPanel`, `TableLayoutPanel`, and `TabControl` instead of applying a global reversal;
- keeps the existing `.mfdesign` format backward-compatible: the ordered `children` array remains the canonical representation, with no version or migration change.

## Root cause

Designer docking consumed ordinary `.mfdesign` children in front-to-back document order, but `CSharpDesignerGenerator` emitted `Controls.Add(...)` calls in that same order. Runtime `ControlCollection` appends each child at the visual front and runtime docking traverses from the last index to zero, so the generated form consumed the siblings in the opposite order. Three authored `DockStyle.Top` panels (`panel1`, `panel2`, `panel21`) therefore appeared as 3/2/1 at runtime even though preview showed 1/2/3.

The runtime also had an internal contradiction: painting, pointer/accessibility hit testing, and docking already treated the last collection index as front-most, while `BringToFront()` and `SendToBack()` moved controls in the opposite direction.

## Child-order contract

- Ordinary `.mfdesign` containers store children front-to-back; index 0 is front-most.
- Runtime `Control.Controls` stores the front-most child at the last index; `Controls.Add(...)` appends at the front.
- `BringToFront()` now moves to the last index and `SendToBack()` to index 0, matching paint, hit test, and docking.
- Flow, table, and tab containers retain authored sequential order. If sequential children overlap, the last runtime child is visually front-most.
- Docked X/Y values do not choose order. Top/Bottom use authored height, Left/Right use authored width, and Fill consumes the remaining rectangle.

## Implementation

- C# generation uses a container-aware mapping: ordinary children are emitted back-to-front, while flow/table/tab children remain forward.
- Reverse sync applies the exact inverse mapping for ordinary containers and preserves invocation order for sequential containers.
- Preview paint order, hit testing, reparent target selection, document-outline moves, and runtime Z-order now use the same container-aware policy.
- Serialization remains deterministic and keeps the existing ordered `children` array; save/reload and repeated generation do not flip the collection.
- The contract and compatibility behavior are documented in XML docs and `docs/designer-architecture.md`.

## Validation

- Debug build: succeeded, 0 errors.
- Debug tests: 840/840 passed (16 cross-platform, 72 Designer, 683 core, 62 Android backend, 7 Windows backend).
- Release build: succeeded, 0 errors.
- Release tests: 840/840 passed with the same project totals.
- No new warnings are attributable to the change; the solution retains its existing dependency, Android, nullable, Skia, and VSIX warnings.
- Regression coverage includes three Top/Bottom/Left/Right siblings, Top+Fill, Top+Bottom+Fill, docked bounds, overlapping non-docked controls, nested containers, save/reload/generate, generate/reverse-sync, outline move up/down, front/back operations, sequential containers, and runtime pointer/paint order.
- Manual Designer preview and generated-runtime checks of the reported `panel1`, `panel2`, `panel21`/120 px/Fill-label structure both showed TestPanel1, TestPanel2, TestPanel3 from top to bottom with matching bounds.
- ControlGallery launched and rendered successfully as a smoke test.

The originally referenced local `MainForm.mfdesign` and `MainForm.Designer.cs` attachments were not available in the worktree, so the manual and automated reproduction uses the exact structure and order described in the report.

No package version was changed and nothing was published or merged.
