### PR TITLE
Eliminate repository build and NuGet warnings

### DIFF
--- a/ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsNext.VisualStudioExtension.Vsix.csproj
+++ b/ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsNext.VisualStudioExtension.Vsix.csproj
@@ -33,7 +33,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" ExcludeAssets="runtime" />
+    <!--
+      Reference only the Visual Studio contracts used by the in-process package.
+      The Microsoft.VisualStudio.SDK metapackage also restores unrelated editor,
+      language-service, and tooling packages that are neither compiled nor
+      shipped by this VSIX.
+    -->
+    <PackageReference Include="envdte" Version="17.14.40260" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.14.40260" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.14.40264" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="17.14.40260" ExcludeAssets="runtime" />
+    <!-- Override the vulnerable legacy version selected by the VS SDK dependency graph. -->
+    <PackageReference Include="MessagePack" Version="3.1.8" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2142" PrivateAssets="all" />
   </ItemGroup>
 

--- a/ModernFormsNext.VisualStudioExtension/ModernFormsNext.VisualStudioExtension.csproj
+++ b/ModernFormsNext.VisualStudioExtension/ModernFormsNext.VisualStudioExtension.csproj
@@ -22,7 +22,31 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" ExcludeAssets="runtime" />
+    <!--
+      Reference only the Visual Studio contracts used by the extension. The broad
+      Microsoft.VisualStudio.SDK metapackage also restores editor, language-service,
+      Linux tooling, T4, and BrowserLink assemblies that this project never loads.
+    -->
+    <PackageReference Include="envdte" Version="17.14.40260" ExcludeAssets="runtime" />
+    <!--
+      Shell.15.0 still declares these build-time-only .NET Framework compatibility
+      packages. They are not shipped by this extension, and NU1701 is scoped to
+      the exact package references instead of being disabled for the project.
+    -->
+    <PackageReference Include="Microsoft.VisualStudio.GraphModel" Version="17.14.40260" ExcludeAssets="runtime" PrivateAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="17.14.40264" ExcludeAssets="runtime" PrivateAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.IO.Redist" Version="6.1.3" ExcludeAssets="all" PrivateAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.14.40260" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="17.14.40260" ExcludeAssets="runtime" />
+    <!--
+      The package also carries net472 compatibility assets for Visual Studio's
+      in-process host. NU1701 is limited to this compile-time contract graph;
+      runtime assets are excluded from the extension output.
+    -->
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.14.40264" ExcludeAssets="runtime" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="17.14.40260" ExcludeAssets="runtime" />
+    <!-- Shell contracts require MessagePack for design-time metadata; use the audited release. -->
+    <PackageReference Include="MessagePack" Version="3.1.8" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2142" PrivateAssets="all" />
   </ItemGroup>
 

--- a/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/Ast.cs
+++ b/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/Ast.cs
@@ -7,9 +7,9 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
     public class AstAttributeNode
     {
         public string Name { get; set; }
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
-        public AstAttributeNode(string name, string value)
+        public AstAttributeNode(string name, string? value)
         {
             Name = name;
             Value = value;
@@ -39,7 +39,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
     public class AstEnumNode : List<AstEnumMemberNode>, IAstNodeWithAttributes
     {
         public AstAttributes Attributes { get; set; } = new AstAttributes();
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
         public override string ToString() => "Enum " + Name;
 
         public AstEnumNode Clone()
@@ -53,9 +53,9 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
     public class AstEnumMemberNode
     {
         public string Name { get; set; }
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
-        public AstEnumMemberNode(string name, string value)
+        public AstEnumMemberNode(string name, string? value)
         {
             Name = name;
             Value = value;
@@ -68,7 +68,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
     public class AstStructNode : List<AstStructMemberNode>, IAstNodeWithAttributes
     {
         public AstAttributes Attributes { get; set; } = new AstAttributes();
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
         public override string ToString() => "Struct " + Name;
         
         public AstStructNode Clone()
@@ -81,7 +81,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
 
     public class AstTypeNode
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
         public int PointerLevel { get; set; }
         public bool IsLink { get; set; }
 
@@ -97,8 +97,8 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
 
     public class AstStructMemberNode : IAstNodeWithAttributes
     {
-        public string Name { get; set; }
-        public AstTypeNode Type { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public AstTypeNode Type { get; set; } = new AstTypeNode();
 
         public override string ToString() => $"Struct member {Type.Format()} {Name}";
         public AstStructMemberNode Clone() => new AstStructMemberNode() { Name = Name, Type = Type.Clone() };
@@ -108,8 +108,8 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
     public class AstInterfaceNode : List<AstInterfaceMemberNode>, IAstNodeWithAttributes
     {
         public AstAttributes Attributes { get; set; } = new AstAttributes();
-        public string Name { get; set; }
-        public string Inherits { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Inherits { get; set; }
         
         public override string ToString()
         {
@@ -127,8 +127,8 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
 
     public class AstInterfaceMemberNode : List<AstInterfaceMemberArgumentNode>, IAstNodeWithAttributes
     {
-        public string Name { get; set; }
-        public AstTypeNode ReturnType { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public AstTypeNode ReturnType { get; set; } = new AstTypeNode();
         public AstAttributes Attributes { get; set; } = new AstAttributes();
 
         public AstInterfaceMemberNode Clone()
@@ -147,8 +147,8 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
 
     public class AstInterfaceMemberArgumentNode : IAstNodeWithAttributes
     {
-        public string Name { get; set; }
-        public AstTypeNode Type { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public AstTypeNode Type { get; set; } = new AstTypeNode();
         public AstAttributes Attributes { get; set; } = new AstAttributes();
 
         
@@ -173,7 +173,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.Ast
             return value;
         }
         
-        public static string GetAttributeOrDefault(this IAstNodeWithAttributes node, string s) 
+        public static string? GetAttributeOrDefault(this IAstNodeWithAttributes node, string s)
             => node.Attributes.FirstOrDefault(a => a.Name == s)?.Value;
     }
 

--- a/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/AstParser.cs
+++ b/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/AstParser.cs
@@ -182,7 +182,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
         static AstInterfaceNode ParseInterface(AstAttributes interfaceAttrs, ref TokenParser parser)
         {
             var interfaceName = parser.ParseIdentifier();
-            string inheritsFrom = null; 
+            string? inheritsFrom = null;
             if (parser.TryConsume(":")) 
                 inheritsFrom = parser.ParseIdentifier();
 

--- a/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/CSharpGen.InterfaceGen.cs
+++ b/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/CSharpGen.InterfaceGen.cs
@@ -19,9 +19,9 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
     {
         abstract class Arg
         {
-            public string Name;
-            public string NativeType;
-            public AstAttributes Attributes { get; set; }
+            public required string Name;
+            public required string NativeType;
+            public AstAttributes Attributes { get; set; } = new AstAttributes();
             public virtual StatementSyntax CreateFixed(StatementSyntax inner) => inner;
 
             public virtual void PreMarshal(List<StatementSyntax> body)
@@ -49,7 +49,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
 
         class InterfaceReturnArg : Arg
         {
-            public string InterfaceType;
+            public required string InterfaceType;
             public override ExpressionSyntax Value(bool isHresultReturn) => ParseExpression("&" + PName);
             public override string ManagedType => InterfaceType;
 
@@ -79,7 +79,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
 
         class InterfaceArg : Arg
         {
-            public string InterfaceType;
+            public required string InterfaceType;
 
             public override ExpressionSyntax Value(bool isHresultReturn) =>
                 ParseExpression("ModernFormsNext.WindowKit.Backend.MicroCom.MicroComRuntime.GetNativePointer(" + Name + ")");
@@ -106,7 +106,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
 
         class BypassArg : Arg
         {
-            public string Type { get; set; }
+            public required string Type { get; set; }
             public int PointerLevel;
             public override string ManagedType => Type + new string('*', PointerLevel);
             public override string ReturnManagedType => Type + new string('*', PointerLevel - 1);
@@ -435,7 +435,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
             var inheritsUnknown = iface.Inherits == null || iface.Inherits == "IUnknown";
 
             var ifaceDec = InterfaceDeclaration(iface.Name)
-                .WithBaseType(inheritsUnknown ? "ModernFormsNext.WindowKit.Backend.MicroCom.IUnknown" : iface.Inherits)
+                .WithBaseType(inheritsUnknown ? "ModernFormsNext.WindowKit.Backend.MicroCom.IUnknown" : iface.Inherits!)
                 .AddModifiers(Token(_visibility), Token(SyntaxKind.UnsafeKeyword), Token(SyntaxKind.PartialKeyword));
 
             var proxyClassName = "__MicroCom" + iface.Name + "Proxy";
@@ -482,9 +482,9 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
                                            proxyClassName + "(p, owns));")
                         )))
                 .AddMembers(ParseMemberDeclaration("public " + proxyClassName +
-                                                   "(IntPtr nativePointer, bool ownsHandle) : base(nativePointer, ownsHandle) {}"))
+                                                   "(IntPtr nativePointer, bool ownsHandle) : base(nativePointer, ownsHandle) {}")!)
                 .AddMembers(ParseMemberDeclaration("protected override int VTableSize => base.VTableSize + " +
-                                                   iface.Count + ";"));
+                                                   iface.Count + ";")!);
             
             ns = ns.AddMembers(RewriteMethodsToProperties(ifaceDec));
             implNs = implNs.AddMembers(RewriteMethodsToProperties(proxy), RewriteMethodsToProperties(vtbl));

--- a/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/CSharpGen.Utils.cs
+++ b/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/CSharpGen.Utils.cs
@@ -40,7 +40,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
         SyntaxToken Semicolon() => Token(SyntaxKind.SemicolonToken);
 
         static VariableDeclarationSyntax DeclareVar(string type, string name,
-            ExpressionSyntax initializer = null)
+            ExpressionSyntax? initializer = null)
             => VariableDeclaration(ParseTypeName(type),
                 SingletonSeparatedList(VariableDeclarator(name)
                     .WithInitializer(initializer == null ? null : EqualsValueClause(initializer))));
@@ -57,7 +57,7 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
         FieldDeclarationSyntax DeclareField(string type, string name, params SyntaxKind[] modifiers) =>
             DeclareField(type, name, null, modifiers);
 
-        FieldDeclarationSyntax DeclareField(string type, string name, EqualsValueClauseSyntax initializer,
+        FieldDeclarationSyntax DeclareField(string type, string name, EqualsValueClauseSyntax? initializer,
             params SyntaxKind[] modifiers) =>
             FieldDeclaration(
                     VariableDeclaration(ParseTypeName(type),

--- a/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/CSharpGen.cs
+++ b/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/CSharpGen.cs
@@ -23,11 +23,13 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
         {
             _idl = idl.Clone();
             new AstRewriter(_idl.Attributes.Where(a => a.Name == "clr-map")
-                .Select(x => x.Value.Trim().Split(' '))
+                .Select(x => (x.Value ?? throw new CodeGenException("clr-map requires a value")).Trim().Split(' '))
                 .ToDictionary(x => x[0], x => x[1])
             ).VisitAst(_idl);
             
-            _extraUsings = _idl.Attributes.Where(u => u.Name == "clr-using").Select(u => u.Value).ToList();
+            _extraUsings = _idl.Attributes.Where(u => u.Name == "clr-using")
+                .Select(u => u.Value ?? throw new CodeGenException("clr-using requires a value"))
+                .ToList();
             _namespace = _idl.GetAttribute("clr-namespace");
             var visibilityString = _idl.GetAttribute("clr-access");
 

--- a/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="CommandLineParser" Version="2.8.0" />
+		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
 	</ItemGroup>
 

--- a/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/Program.cs
+++ b/ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator/Program.cs
@@ -10,13 +10,13 @@ namespace ModernFormsNext.WindowKit.Backend.Tools.MicroComGenerator
         public class Options
         {
             [Option('i', "input", Required = true, HelpText = "Input IDL file")]
-            public string Input { get; set; }
+            public string Input { get; set; } = string.Empty;
 
             [Option("cpp", Required = false, HelpText = "C++ output file")]
-            public string CppOutput { get; set; }
+            public string? CppOutput { get; set; }
 
             [Option("cs", Required = false, HelpText = "C# output file")]
-            public string CSharpOutput { get; set; }
+            public string? CSharpOutput { get; set; }
 
         }
 

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/AssemblyInfo.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.Versioning;
+
+// This project validates the Windows backend contract and is intentionally
+// executed only on Windows hosts.
+[assembly: SupportedOSPlatform("windows")]

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/DataObject.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/DataObject.cs
@@ -269,7 +269,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
                 try
                 {
-                    stream.Read(buffer, 0, length);
+                    stream.ReadExactly(buffer, 0, length);
                     return WriteBytesToHGlobal(ref hGlobal, buffer.AsSpan(0, length));
                 }
                 finally

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/OffscreenParentWindow.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/OffscreenParentWindow.cs
@@ -7,12 +7,12 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 {
     class OffscreenParentWindow
     {
+        // Keep the delegate rooted for the lifetime of the registered window class.
+        private static readonly UnmanagedMethods.WndProc s_wndProcDelegate = ParentWndProc;
         public static IntPtr Handle { get; } = CreateParentWindow();
-        private static UnmanagedMethods.WndProc s_wndProcDelegate;
+
         private static IntPtr CreateParentWindow()
         {
-            s_wndProcDelegate = new UnmanagedMethods.WndProc(ParentWndProc);
-
             var wndClassEx = new UnmanagedMethods.WNDCLASSEX
             {
                 cbSize = Marshal.SizeOf<UnmanagedMethods.WNDCLASSEX>(),

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/Win32PlatformSettings.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/Win32PlatformSettings.cs
@@ -34,7 +34,7 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
     {
         //if (Win32Platform.WindowsVersion.Major < 10)
         //{
-            return base.GetColorValues();
+            return _lastColorValues = base.GetColorValues();
         //}
 
         //var uiSettings = NativeWinRTMethods.CreateInstance<IUISettings3>("Windows.UI.ViewManagement.UISettings");

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.cs
@@ -47,7 +47,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
         private Thickness _extendedMargins;
         private Thickness _offScreenMargin;
         private double _extendTitleBarHint = -1;
-        private readonly bool _isUsingComposition;
+        private readonly bool _isUsingComposition = false;
         private readonly IBlurHost? _blurHost;
         private WindowResizeReason _resizeReason;
         private MOUSEMOVEPOINT _lastWmMousePoint;
@@ -61,7 +61,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
         private readonly WindowsMouseDevice _mouseDevice;
         //private readonly PenDevice _penDevice;
         private readonly FramebufferManager _framebuffer;
-        private readonly object? _gl;
+        private readonly object? _gl = null;
         private readonly bool _wmPointerEnabled;
 
         //private readonly Win32NativeControlHost _nativeControlHost;
@@ -84,9 +84,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
         private WindowImpl? _parent;
         private ExtendClientAreaChromeHints _extendChromeHints = ExtendClientAreaChromeHints.Default;
         private bool _isCloseRequested;
-        private bool _shown;
         private bool _hiddenWindowIsParent;
-        private uint _langid;
         internal bool _ignoreWmChar;
         private WindowTransparencyLevel _transparencyLevel;
 
@@ -99,6 +97,9 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
         public WindowImpl()
         {
+            // The composition path is currently disabled; keep its optional host
+            // explicit until the connector is restored.
+            _blurHost = null;
             _touchDevice = new TouchDevice();
             _mouseDevice = new WindowsMouseDevice();
             //_penDevice = new PenDevice();
@@ -177,7 +178,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
         }
 
         internal IInputRoot Owner
-            => _owner; // ?? throw new InvalidOperationException($"{nameof(SetInputRoot)} must have been called");
+            => _owner ?? throw new InvalidOperationException($"{nameof(SetInputRoot)} must have been called");
 
         public Action? Activated { get; set; }
 
@@ -454,22 +455,14 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
         private void SetTransparencyAcrylicBlur(Version windowsVersion)
         {
-            // Acrylic blur only supported with composition on Windows >= 10.0.15063.
-            //if (!_isUsingComposition || windowsVersion < WinUiCompositionShared.MinAcrylicVersion)
-                return;
-
-            SetUseHostBackdropBrush(true);
-            _blurHost?.SetBlur(BlurEffect.Acrylic);
+            // Acrylic composition support is intentionally disabled until the
+            // WinUI composition connector is restored.
         }
 
         private void SetTransparencyMica(Version windowsVersion)
         {
-            // Mica only supported with composition on Windows >= 10.0.22000.
-            //if (!_isUsingComposition || windowsVersion < WinUiCompositionShared.MinHostBackdropVersion)
-                return;
-
-            SetUseHostBackdropBrush(false);
-            _blurHost?.SetBlur(BlurEffect.Mica);
+            // Mica composition support is intentionally disabled until the
+            // WinUI composition connector is restored.
         }
 
         private void SetAccentState(AccentState state)
@@ -494,14 +487,8 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
         private void SetUseHostBackdropBrush(bool useHostBackdropBrush)
         {
-            //if (Win32Platform.WindowsVersion < WinUiCompositionShared.MinHostBackdropVersion)
-                return;
-
-            unsafe
-            {
-                var pvUseBackdropBrush = useHostBackdropBrush ? 1 : 0;
-                DwmSetWindowAttribute(_hwnd, (int)DwmWindowAttribute.DWMWA_USE_HOSTBACKDROPBRUSH, &pvUseBackdropBrush, sizeof(int));
-            }
+            // Host-backdrop composition support is intentionally disabled with
+            // the rest of the WinUI composition connector.
         }
 
         //public IEnumerable<object> Surfaces
@@ -652,7 +639,6 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
         public void Hide()
         {
             UnmanagedMethods.ShowWindow(_hwnd, ShowWindowCommand.Hide);
-            _shown = false;
         }
 
         public virtual void Show(bool activate, bool isDialog)
@@ -1059,7 +1045,6 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
         private void ShowWindow(WindowState state, bool activate)
         {
-            _shown = true;
 
             if (_isClientAreaExtended)
             {

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsKeyboardDevice.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsKeyboardDevice.cs
@@ -8,7 +8,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32.Input
     {
         private readonly byte[] _keyStates = new byte[256];
 
-        public new static WindowsKeyboardDevice Instance { get; } = new WindowsKeyboardDevice();
+        public static WindowsKeyboardDevice Instance { get; } = new WindowsKeyboardDevice();
 
         public RawInputModifiers Modifiers
         {

--- a/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Drawing.Common" Version="10.0.5" />
+		<PackageReference Include="System.Drawing.Common" Version="10.0.10" />
 		<PackageReference Include="SkiaSharp" Version="3.119.2" />
 	</ItemGroup>
 

--- a/ModernFormsNext.WindowKit.Backend.Windows/Properties/AssemblyInfo.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 [assembly: InternalsVisibleTo("ModernFormsNext.WindowKit.Backend.Windows.Tests")]
+[assembly: SupportedOSPlatform("windows")]

--- a/ModernFormsNext.WindowKit.Backend/MicroCom/IMicroComShadowContainer.cs
+++ b/ModernFormsNext.WindowKit.Backend/MicroCom/IMicroComShadowContainer.cs
@@ -9,9 +9,10 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
     public interface IMicroComShadowContainer
     {
         /// <summary>
-        /// Gets or sets the shadow wrapper.
+        /// Gets or sets the shadow wrapper, or <see langword="null"/> before a wrapper is created
+        /// or after it has been released.
         /// </summary>
-        MicroComShadow Shadow { get; set; }
+        MicroComShadow? Shadow { get; set; }
 
         /// <summary>
         /// Called when the object is referenced from native code.

--- a/ModernFormsNext.WindowKit.Backend/MicroCom/MicroComProxyBase.cs
+++ b/ModernFormsNext.WindowKit.Backend/MicroCom/MicroComProxyBase.cs
@@ -41,7 +41,7 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
     {
         private IntPtr _nativePointer;
         private bool _ownsHandle;
-        private SynchronizationContext _synchronizationContext;
+        private readonly SynchronizationContext? _synchronizationContext;
 
         /// <summary>
         /// Gets the wrapped native interface pointer.
@@ -246,7 +246,7 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
         /// Releases a proxy instance on a synchronization context callback.
         /// </summary>
         /// <param name="state">The proxy instance to dispose.</param>
-        private static void DisposeOnContext(object state)
+        private static void DisposeOnContext(object? state)
         {
             (state as MicroComProxyBase)?.Dispose(false);
         }

--- a/ModernFormsNext.WindowKit.Backend/MicroCom/MicroComRuntime.cs
+++ b/ModernFormsNext.WindowKit.Backend/MicroCom/MicroComRuntime.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace ModernFormsNext.WindowKit.Backend.MicroCom
@@ -193,10 +194,10 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
 
             if (obj is IMicroComShadowContainer container)
             {
-                container.Shadow ??= new MicroComShadow(container);
+                var shadow = container.Shadow ??= new MicroComShadow(container);
 
                 void* ptr = null;
-                var res = container.Shadow.GetOrCreateNativePointer(typeof(T), &ptr);
+                var res = shadow.GetOrCreateNativePointer(typeof(T), &ptr);
                 if (res != 0)
                     throw new COMException(
                         "Unable to create native callable wrapper for type " + typeof(T) + " for instance of type " +
@@ -204,7 +205,7 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
                         res);
 
                 if (owned)
-                    container.Shadow.AddRef((Ccw*)ptr);
+                    shadow.AddRef((Ccw*)ptr);
 
                 return ptr;
             }
@@ -224,7 +225,8 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
         public static object GetObjectFromCcw(IntPtr ccw)
         {
             var ptr = (Ccw*)ccw;
-            var shadow = (MicroComShadow)GCHandle.FromIntPtr(ptr->GcShadowHandle).Target;
+            var shadow = GCHandle.FromIntPtr(ptr->GcShadowHandle).Target as MicroComShadow
+                ?? throw new InvalidOperationException("The callable wrapper no longer references a MicroCom shadow.");
             return shadow.Target;
         }
 
@@ -239,7 +241,8 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
         /// <returns>
         /// <see langword="true"/> if a matching type was found; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool TryGetTypeForGuid(Guid guid, out Type t) => _guidsToTypes.TryGetValue(guid, out t);
+        public static bool TryGetTypeForGuid(Guid guid, [NotNullWhen(true)] out Type? t) =>
+            _guidsToTypes.TryGetValue(guid, out t);
 
         /// <summary>
         /// Attempts to get the registered vtable pointer for the specified managed interface type.

--- a/ModernFormsNext.WindowKit.Backend/MicroCom/MicroComShadow.cs
+++ b/ModernFormsNext.WindowKit.Backend/MicroCom/MicroComShadow.cs
@@ -272,7 +272,7 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
         {
             lock (_lock)
             {
-                List<IntPtr> toRemove = null;
+                List<IntPtr>? toRemove = null;
 
                 foreach (var kv in _backShadows)
                 {
@@ -320,6 +320,8 @@ namespace ModernFormsNext.WindowKit.Backend.MicroCom
         /// Gets the <see cref="MicroComShadow"/> associated with this callable wrapper.
         /// </summary>
         /// <returns>The owning <see cref="MicroComShadow"/> instance.</returns>
-        public MicroComShadow GetShadow() => (MicroComShadow)GCHandle.FromIntPtr(GcShadowHandle).Target;
+        public MicroComShadow GetShadow() =>
+            GCHandle.FromIntPtr(GcShadowHandle).Target as MicroComShadow
+            ?? throw new InvalidOperationException("The callable wrapper no longer references a MicroCom shadow.");
     }
 }

--- a/ModernFormsNext.WindowKit/Avalonia.Skia/SkiaSharpExtensions.cs
+++ b/ModernFormsNext.WindowKit/Avalonia.Skia/SkiaSharpExtensions.cs
@@ -20,6 +20,7 @@ namespace ModernFormsNext.WindowKit.Skia
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when <paramref name="interpolationMode"/> is not recognized.
         /// </exception>
+#pragma warning disable CS0618 // Retained for source and binary compatibility with existing callers.
         public static SKFilterQuality ToSKFilterQuality(this BitmapInterpolationMode interpolationMode)
         {
             switch (interpolationMode)
@@ -36,6 +37,21 @@ namespace ModernFormsNext.WindowKit.Skia
                 default:
                     throw new ArgumentOutOfRangeException(nameof(interpolationMode), interpolationMode, null);
             }
+        }
+#pragma warning restore CS0618
+
+        internal static SKSamplingOptions ToSKSamplingOptions(this BitmapInterpolationMode interpolationMode)
+        {
+            return interpolationMode switch
+            {
+                BitmapInterpolationMode.None => new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None),
+                BitmapInterpolationMode.Unspecified or BitmapInterpolationMode.LowQuality =>
+                    new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None),
+                BitmapInterpolationMode.MediumQuality =>
+                    new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear),
+                BitmapInterpolationMode.HighQuality => new SKSamplingOptions(SKCubicResampler.Mitchell),
+                _ => throw new ArgumentOutOfRangeException(nameof(interpolationMode), interpolationMode, null)
+            };
         }
 
         //public static SKBlendMode ToSKBlendMode(this BitmapBlendingMode blendingMode)

--- a/ModernFormsNext.WindowKit/Avalonia.Skia/WriteableBitmapImpl.cs
+++ b/ModernFormsNext.WindowKit/Avalonia.Skia/WriteableBitmapImpl.cs
@@ -70,7 +70,7 @@ namespace ModernFormsNext.WindowKit.Skia
 
                 if (bmp.Width != desired.Width || bmp.Height != desired.Height)
                 {
-                    var scaledBmp = bmp.Resize(desired, interpolationMode.ToSKFilterQuality());
+                    var scaledBmp = bmp.Resize(desired, interpolationMode.ToSKSamplingOptions());
                     bmp.Dispose();
                     bmp = scaledBmp;
                 }

--- a/ModernFormsNext.WindowKit/Dispatcher.Invoke.cs
+++ b/ModernFormsNext.WindowKit/Dispatcher.Invoke.cs
@@ -30,9 +30,7 @@ public partial class Dispatcher
     ///     An Action delegate to invoke through the dispatcher.
     /// </param>
     /// <param name="priority">
-    ///     The priority that determines in what order the specified
-    ///     callback is invoked relative to the other pending operations
-    ///     in the Dispatcher.
+    ///     The priority used to order the callback relative to other pending operations.
     /// </param>
     public void Invoke(Action callback, DispatcherPriority priority)
     {
@@ -580,11 +578,6 @@ public partial class Dispatcher
     /// </summary>
     /// <param name="action">
     ///     A Func&lt;Task&lt;TResult&gt;&gt; delegate to invoke through the dispatcher.
-    /// </param>
-    /// <param name="priority">
-    ///     The priority that determines in what order the specified
-    ///     callback is invoked relative to the other pending operations
-    ///     in the Dispatcher.
     /// </param>
     /// <returns>
     ///     An task that completes after the task returned from callback finishes

--- a/ModernFormsNext.WindowKit/Dispatcher.Queue.cs
+++ b/ModernFormsNext.WindowKit/Dispatcher.Queue.cs
@@ -76,8 +76,8 @@ public partial class Dispatcher
         {
         }
 
-        public event Action? Signaled;
-        public event Action? Timer;
+        public event Action? Signaled { add { } remove { } }
+        public event Action? Timer { add { } remove { } }
         public long Now => 0;
         public void UpdateTimer(long? dueTimeInMs)
         {

--- a/ModernFormsNext.WindowKit/Extensions/AnonymousDisposable.cs
+++ b/ModernFormsNext.WindowKit/Extensions/AnonymousDisposable.cs
@@ -11,7 +11,7 @@ namespace System.Reactive.Disposables
     /// </summary>
     internal sealed class AnonymousDisposable : ICancelable
     {
-        private volatile Action _dispose;
+        private volatile Action? _dispose;
 
         /// <summary>
         /// Constructs a new disposable with the given action used for disposal.
@@ -19,9 +19,7 @@ namespace System.Reactive.Disposables
         /// <param name="dispose">Disposal action which will be run upon calling Dispose.</param>
         public AnonymousDisposable(Action dispose)
         {
-            System.Diagnostics.Debug.Assert(dispose != null);
-
-            _dispose = dispose;
+            _dispose = dispose ?? throw new ArgumentNullException(nameof(dispose));
         }
 
         /// <summary>

--- a/ModernFormsNext.WindowKit/IDispatcherImpl.cs
+++ b/ModernFormsNext.WindowKit/IDispatcherImpl.cs
@@ -150,8 +150,8 @@ class NullDispatcherImpl : IDispatcherImpl
         
     }
     
-    public event Action? Signaled;
-    public event Action? Timer;
+    public event Action? Signaled { add { } remove { } }
+    public event Action? Timer { add { } remove { } }
 
     public long Now => 0;
 

--- a/ModernFormsNext.WindowKit/ModernFormsNext.WindowKit.csproj
+++ b/ModernFormsNext.WindowKit/ModernFormsNext.WindowKit.csproj
@@ -31,10 +31,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
 		<PackageReference Include="SkiaSharp" Version="3.119.2" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
-		<PackageReference Include="System.Drawing.Common" Version="10.0.5" />
+		<PackageReference Include="System.Drawing.Common" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ModernFormsNext.WindowKit/MouseDevice.cs
+++ b/ModernFormsNext.WindowKit/MouseDevice.cs
@@ -23,8 +23,6 @@ namespace ModernFormsNext.WindowKit.Input
         //private ulong _lastClickTime;
 
         private readonly Pointer _pointer;
-        private bool _disposed;
-        private MouseButton _lastMouseDownButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MouseDevice"/> class.
@@ -296,8 +294,7 @@ namespace ModernFormsNext.WindowKit.Input
         /// <inheritdoc />
         public void Dispose()
         {
-            _disposed = true;
-            _pointer?.Dispose();
+            _pointer.Dispose();
         }
         
         /// <inheritdoc />

--- a/ModernFormsNext.WindowKit/Rect.cs
+++ b/ModernFormsNext.WindowKit/Rect.cs
@@ -249,7 +249,7 @@ namespace ModernFormsNext.WindowKit
                    p.Y >= _y && p.Y < _y + _height;
         }
 
-        /// </summary>
+        /// <summary>
         /// Determines whether the rectangle fully contains another rectangle.
         /// </summary>
         /// <param name="r">The rectangle.</param>

--- a/ModernFormsNext.WindowKit/TouchDevice.cs
+++ b/ModernFormsNext.WindowKit/TouchDevice.cs
@@ -23,9 +23,6 @@ namespace ModernFormsNext.WindowKit.Input
     {
         private readonly Dictionary<long, Pointer> _pointers = new Dictionary<long, Pointer>();
         private bool _disposed;
-        private int _clickCount;
-        private Rect _lastClickRect;
-        private ulong _lastClickTime;
 
         static RawInputModifiers GetModifiers(RawInputModifiers modifiers, bool isLeftButtonDown)
         {

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -568,7 +568,8 @@ namespace ModernFormsNext
                     throw new NotSupportedException(SR.BindingNotSupported);
                 }
 
-                if (!Properties.TryGetValue(s_bindingsProperty, out ControlBindingsCollection? bindings))
+                if (!Properties.TryGetValue(s_bindingsProperty, out ControlBindingsCollection? bindings)
+                    || bindings is null)
                 {
                     bindings = Properties.AddValue(s_bindingsProperty, new ControlBindingsCollection(this));
                 }

--- a/ModernFormsNext/DataBinding/BindingValueFormatter.cs
+++ b/ModernFormsNext/DataBinding/BindingValueFormatter.cs
@@ -20,8 +20,9 @@ namespace ModernFormsNext.DataBinding
     {
         internal static object? GetDefaultDataSourceNullValue(Type? type)
         {
-            Type? underlyingType = Nullable.GetUnderlyingType(type);
-            return underlyingType is not null ? null : DBNull.Value;
+            return type is not null && Nullable.GetUnderlyingType(type) is not null
+                ? null
+                : DBNull.Value;
         }
 
         internal static bool IsNullData(object? value, object? dataSourceNullValue)

--- a/ModernFormsNext/Extensions/SkiaExtensions.cs
+++ b/ModernFormsNext/Extensions/SkiaExtensions.cs
@@ -238,6 +238,7 @@ namespace ModernFormsNext
         /// <summary>
         /// Draws a bitmap.
         /// </summary>
+#pragma warning disable CS0618 // DrawBitmap still consumes sampling through SKPaint in this SkiaSharp API.
         public static void DrawBitmap (this SKCanvas canvas, SKBitmap bitmap, Rectangle rect, bool disabled = false)
         {
             using var paint = new SKPaint { FilterQuality = SKFilterQuality.High };
@@ -260,6 +261,7 @@ namespace ModernFormsNext
 
             canvas.DrawBitmap (bitmap, x, y, paint);
         }
+#pragma warning restore CS0618
 
         /// <summary>
         /// Draws a control's border.

--- a/ModernFormsNext/ImageCollection.cs
+++ b/ModernFormsNext/ImageCollection.cs
@@ -40,7 +40,7 @@ public class ImageCollection : IDictionary<string, SKBitmap>
         }
 
         // The image is not the correct size, resize it
-        var resized = value.Resize (ImageSize.ToSizeI (), SKFilterQuality.High);
+        var resized = value.Resize (ImageSize.ToSizeI (), new SKSamplingOptions (SKCubicResampler.Mitchell));
         _images.Add (key, resized);
     }
 

--- a/ModernFormsNext/Renderers/DateTimePickerCalendarRenderer.cs
+++ b/ModernFormsNext/Renderers/DateTimePickerCalendarRenderer.cs
@@ -26,7 +26,7 @@ namespace ModernFormsNext.Renderers
 
             using var textPaint = CreateTextPaint (control, control.DisplayMonth.ToString ("Y", CultureInfo.CurrentCulture));
             using var mutedTextPaint = CreateTextPaint (control, "pon.");
-            mutedTextPaint.Color = mutedTextPaint.Color.WithAlpha (150);
+            mutedTextPaint.Paint.Color = mutedTextPaint.Paint.Color.WithAlpha (150);
 
             using var accentPaint = new SKPaint {
                 IsAntialias = true,
@@ -69,7 +69,7 @@ namespace ModernFormsNext.Renderers
             }
         }
 
-        private static void DrawHeader (DateTimePickerCalendar control, SKCanvas canvas, SKPaint textPaint, SKPaint hoverPaint)
+        private static void DrawHeader (DateTimePickerCalendar control, SKCanvas canvas, TextPaintResources textPaint, SKPaint hoverPaint)
         {
             DrawButton (canvas, "<", control.PreviousButtonRectangle, textPaint, hoverPaint, control.HoveredRectangle == control.PreviousButtonRectangle);
             DrawButton (canvas, ">", control.NextButtonRectangle, textPaint, hoverPaint, control.HoveredRectangle == control.NextButtonRectangle);
@@ -93,7 +93,7 @@ namespace ModernFormsNext.Renderers
             DrawCenteredText (canvas, yearText, control.YearTitleRectangle, yearPaint);
         }
 
-        private static void DrawDayHeaders (DateTimePickerCalendar control, SKCanvas canvas, SKPaint textPaint)
+        private static void DrawDayHeaders (DateTimePickerCalendar control, SKCanvas canvas, TextPaintResources textPaint)
         {
             var names = GetDayNames();
             int y = control.MonthTitleRectangle.Bottom;
@@ -118,8 +118,8 @@ namespace ModernFormsNext.Renderers
         private static void DrawDayCells (
             DateTimePickerCalendar control,
             SKCanvas canvas,
-            SKPaint textPaint,
-            SKPaint mutedTextPaint,
+            TextPaintResources textPaint,
+            TextPaintResources mutedTextPaint,
             SKPaint accentPaint,
             SKPaint hoverPaint,
             SKPaint borderPaint,
@@ -153,15 +153,15 @@ namespace ModernFormsNext.Renderers
                 using var cellPaint = CreateTextPaintFrom (basePaint, date.Day.ToString (CultureInfo.CurrentCulture));
 
                 if (!isEnabled)
-                    cellPaint.Color = cellPaint.Color.WithAlpha (90);
+                    cellPaint.Paint.Color = cellPaint.Paint.Color.WithAlpha (90);
                 else if (isSelected)
-                    cellPaint.Color = SKColors.White;
+                    cellPaint.Paint.Color = SKColors.White;
 
                 DrawCenteredText (canvas, date.Day.ToString (CultureInfo.CurrentCulture), rect, cellPaint);
             }
         }
 
-        private static void DrawMonthCells (DateTimePickerCalendar control, SKCanvas canvas, SKPaint textPaint, SKPaint hoverPaint, SKPaint borderPaint, SKPaint accentPaint)
+        private static void DrawMonthCells (DateTimePickerCalendar control, SKCanvas canvas, TextPaintResources textPaint, SKPaint hoverPaint, SKPaint borderPaint, SKPaint accentPaint)
         {
             var dtf = CultureInfo.CurrentCulture.DateTimeFormat;
 
@@ -182,13 +182,13 @@ namespace ModernFormsNext.Renderers
                 string text = dtf.AbbreviatedMonthNames[i];
                 using var paint = CreateTextPaintFrom (textPaint, text);
                 if (isSelected)
-                    paint.Color = SKColors.White;
+                    paint.Paint.Color = SKColors.White;
 
                 DrawCenteredText (canvas, text, rect, paint);
             }
         }
 
-        private static void DrawYearCells (DateTimePickerCalendar control, SKCanvas canvas, SKPaint textPaint, SKPaint hoverPaint, SKPaint borderPaint, SKPaint accentPaint)
+        private static void DrawYearCells (DateTimePickerCalendar control, SKCanvas canvas, TextPaintResources textPaint, SKPaint hoverPaint, SKPaint borderPaint, SKPaint accentPaint)
         {
             for (int i = 0; i < control.YearCellRectangles.Length; i++) {
                 var rect = control.YearCellRectangles[i];
@@ -207,13 +207,13 @@ namespace ModernFormsNext.Renderers
                 string text = year.ToString (CultureInfo.CurrentCulture);
                 using var paint = CreateTextPaintFrom (textPaint, text);
                 if (isSelected)
-                    paint.Color = SKColors.White;
+                    paint.Paint.Color = SKColors.White;
 
                 DrawCenteredText (canvas, text, rect, paint);
             }
         }
 
-        private static void DrawTodayButton (DateTimePickerCalendar control, SKCanvas canvas, SKPaint textPaint, SKPaint hoverPaint, SKPaint borderPaint)
+        private static void DrawTodayButton (DateTimePickerCalendar control, SKCanvas canvas, TextPaintResources textPaint, SKPaint hoverPaint, SKPaint borderPaint)
         {
             bool hovered = control.HoveredRectangle == control.TodayButtonRectangle;
 
@@ -227,7 +227,7 @@ namespace ModernFormsNext.Renderers
             DrawCenteredText (canvas, text, control.TodayButtonRectangle, paint);
         }
 
-        private static void DrawButton (SKCanvas canvas, string text, Rectangle rect, SKPaint textPaint, SKPaint hoverPaint, bool hovered)
+        private static void DrawButton (SKCanvas canvas, string text, Rectangle rect, TextPaintResources textPaint, SKPaint hoverPaint, bool hovered)
         {
             if (hovered)
                 canvas.DrawRect (ToSKRect (rect), hoverPaint);
@@ -236,24 +236,28 @@ namespace ModernFormsNext.Renderers
             DrawCenteredText (canvas, text, rect, paint);
         }
 
-        private static SKPaint CreateTextPaint (DateTimePickerCalendar control, string sampleText)
+        private static TextPaintResources CreateTextPaint (DateTimePickerCalendar control, string sampleText)
         {
-            return new SKPaint {
+            var paint = new SKPaint {
                 IsAntialias = true,
-                Color = control.CurrentStyle.ForegroundColor ?? SKColors.Black,
-                TextSize = control.CurrentStyle.FontSize ?? Theme.FontSize,
-                Typeface = ResolveTypeface (control.CurrentStyle.Font ?? Theme.UIFont, sampleText)
+                Color = control.CurrentStyle.ForegroundColor ?? SKColors.Black
             };
+            var font = new SKFont (
+                ResolveTypeface (control.CurrentStyle.Font ?? Theme.UIFont, sampleText),
+                control.CurrentStyle.FontSize ?? Theme.FontSize);
+            return new TextPaintResources (paint, font);
         }
 
-        private static SKPaint CreateTextPaintFrom (SKPaint source, string text)
+        private static TextPaintResources CreateTextPaintFrom (TextPaintResources source, string text)
         {
-            return new SKPaint {
-                IsAntialias = source.IsAntialias,
-                Color = source.Color,
-                TextSize = source.TextSize,
-                Typeface = ResolveTypeface (source.Typeface, text)
+            var paint = new SKPaint {
+                IsAntialias = source.Paint.IsAntialias,
+                Color = source.Paint.Color
             };
+            var font = new SKFont (
+                ResolveTypeface (source.Font.Typeface, text),
+                source.Font.Size);
+            return new TextPaintResources (paint, font);
         }
 
         private static SKTypeface? ResolveTypeface (SKTypeface? preferred, string text)
@@ -284,12 +288,31 @@ namespace ModernFormsNext.Renderers
             return true;
         }
 
-        private static void DrawCenteredText (SKCanvas canvas, string text, Rectangle rect, SKPaint paint)
+        private static void DrawCenteredText (SKCanvas canvas, string text, Rectangle rect, TextPaintResources textPaint)
         {
-            var metrics = paint.FontMetrics;
-            float x = rect.Left + (rect.Width - paint.MeasureText (text)) / 2f;
+            var metrics = textPaint.Font.Metrics;
+            float x = rect.Left + (rect.Width - textPaint.Font.MeasureText (text)) / 2f;
             float y = rect.Top + ((rect.Height - (metrics.Descent - metrics.Ascent)) / 2f) - metrics.Ascent;
-            canvas.DrawText (text, x, y, paint);
+            canvas.DrawText (text, x, y, SKTextAlign.Left, textPaint.Font, textPaint.Paint);
+        }
+
+        private sealed class TextPaintResources : IDisposable
+        {
+            public TextPaintResources (SKPaint paint, SKFont font)
+            {
+                Paint = paint;
+                Font = font;
+            }
+
+            public SKPaint Paint { get; }
+
+            public SKFont Font { get; }
+
+            public void Dispose ()
+            {
+                Font.Dispose ();
+                Paint.Dispose ();
+            }
         }
 
         private static SKRect ToSKRect (Rectangle rect)

--- a/ModernFormsNext/Renderers/DateTimePickerRenderer.cs
+++ b/ModernFormsNext/Renderers/DateTimePickerRenderer.cs
@@ -197,18 +197,19 @@ namespace ModernFormsNext.Renderers
 
             using var paint = new SKPaint {
                 IsAntialias = true,
-                Color = GetForegroundColor (control),
-                TextSize = GetTextSize (control),
-                Typeface = GetTypeface (control)
+                Color = GetForegroundColor (control)
             };
+            using var font = new SKFont (GetTypeface (control), GetTextSize (control));
 
-            var metrics = paint.FontMetrics;
+            var metrics = font.Metrics;
             float baseline = rect.Top + ((rect.Height - (metrics.Descent - metrics.Ascent)) / 2f) - metrics.Ascent;
 
             canvas.DrawText (
                 control.DisplayText,
                 rect.Left + TextHorizontalPadding,
                 baseline,
+                SKTextAlign.Left,
+                font,
                 paint);
         }
 

--- a/ModernFormsNext/Renderers/LinkLabelRenderer.cs
+++ b/ModernFormsNext/Renderers/LinkLabelRenderer.cs
@@ -69,13 +69,14 @@ namespace ModernFormsNext.Renderers
         {
             EnsureLayoutCache(control);
 
-            using var paint = CreatePaint(control);
-            var metrics = paint.FontMetrics;
+            using var paint = CreatePaint();
+            using var font = CreateFont(control);
+            var metrics = font.Metrics;
             var line_height = (float)Math.Ceiling(metrics.Descent - metrics.Ascent + metrics.Leading);
             var baseline_offset = -metrics.Ascent;
 
             var lines = BuildLines(control.Text ?? string.Empty);
-            var line_rectangles = MeasureLines(paint, lines, layout.TextBounds, line_height, control.TextAlign);
+            var line_rectangles = MeasureLines(font, lines, layout.TextBounds, line_height, control.TextAlign);
 
             var current_index = 0;
 
@@ -90,7 +91,7 @@ namespace ModernFormsNext.Renderers
                 for (var i = 0; i < line.Length; i++)
                 {
                     var character = line[i].ToString();
-                    var width = Math.Max(1f, paint.MeasureText(character));
+                    var width = Math.Max(1f, font.MeasureText(character));
 
                     var text_index = current_index + i;
                     var link = GetLinkAtIndex(control, text_index);
@@ -101,7 +102,7 @@ namespace ModernFormsNext.Renderers
                         var color = control.ResolveLinkColor(link);
                         paint.Color = color;
 
-                        e.Canvas.DrawText(character, x, baseline, paint);
+                        e.Canvas.DrawText(character, x, baseline, SKTextAlign.Left, font, paint);
 
                         if (control.ShouldUnderline(link))
                         {
@@ -116,7 +117,7 @@ namespace ModernFormsNext.Renderers
                             ? (control.Style.ForegroundColor ?? Theme.ForegroundColor)
                             : Theme.ForegroundDisabledColor;
 
-                        e.Canvas.DrawText(character, x, baseline, paint);
+                        e.Canvas.DrawText(character, x, baseline, SKTextAlign.Left, font, paint);
                     }
 
                     x += width;
@@ -136,13 +137,13 @@ namespace ModernFormsNext.Renderers
 
             control.Links.ClearVisualBounds();
 
-            using var paint = CreatePaint(control);
-            var metrics = paint.FontMetrics;
+            using var font = CreateFont(control);
+            var metrics = font.Metrics;
             var line_height = (float)Math.Ceiling(metrics.Descent - metrics.Ascent + metrics.Leading);
 
             var layout = LayoutTextAndImage(control);
             var lines = BuildLines(control.Text ?? string.Empty);
-            var line_rectangles = MeasureLines(paint, lines, layout.TextBounds, line_height, control.TextAlign);
+            var line_rectangles = MeasureLines(font, lines, layout.TextBounds, line_height, control.TextAlign);
 
             var current_index = 0;
 
@@ -156,7 +157,7 @@ namespace ModernFormsNext.Renderers
                 for (var i = 0; i < line.Length; i++)
                 {
                     var character = line[i].ToString();
-                    var width = Math.Max(1f, paint.MeasureText(character));
+                    var width = Math.Max(1f, font.MeasureText(character));
                     var text_index = current_index + i;
 
                     var link = GetLinkAtIndex(control, text_index);
@@ -178,15 +179,18 @@ namespace ModernFormsNext.Renderers
             control.ValidateLayout();
         }
 
-        private static SKPaint CreatePaint(LinkLabel control)
+        private static SKPaint CreatePaint()
         {
             return new SKPaint
             {
-                IsAntialias = true,
-                Typeface = control.CurrentStyle.GetFont(),
-                TextSize = control.LogicalToDeviceUnits(control.CurrentStyle.GetFontSize())
+                IsAntialias = true
             };
         }
+
+        private static SKFont CreateFont(LinkLabel control) =>
+            new SKFont(
+                control.CurrentStyle.GetFont(),
+                control.LogicalToDeviceUnits(control.CurrentStyle.GetFontSize()));
 
         private static List<string> BuildLines(string text)
         {
@@ -209,7 +213,7 @@ namespace ModernFormsNext.Renderers
         }
 
         private static List<RectangleF> MeasureLines(
-            SKPaint paint,
+            SKFont font,
             List<string> lines,
             Rectangle available_bounds,
             float line_height,
@@ -227,7 +231,7 @@ namespace ModernFormsNext.Renderers
 
             for (var i = 0; i < lines.Count; i++)
             {
-                var width = paint.MeasureText(lines[i]);
+                var width = font.MeasureText(lines[i]);
                 var x = alignment switch
                 {
                     ContentAlignment.TopCenter or ContentAlignment.MiddleCenter or ContentAlignment.BottomCenter => available_bounds.Left + ((available_bounds.Width - width) / 2f),

--- a/samples/ControlGallery/ControlGallery.csproj
+++ b/samples/ControlGallery/ControlGallery.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -241,7 +241,9 @@ namespace ControlGallery
         private static void DrawThemeColor (SKCanvas canvas, int x, int y, int width, int height, SKColor color)
         {
             canvas.FillRectangle (x, y, width, height, color);
-            canvas.DrawText (color.ToString (), x + 10, y + 20, new SKPaint { Typeface = Theme.UIFont, Color = Theme.ForegroundColor });
+            using var paint = new SKPaint { Color = Theme.ForegroundColor };
+            using var font = new SKFont (Theme.UIFont, 12f);
+            canvas.DrawText (color.ToString (), x + 10, y + 20, SKTextAlign.Left, font, paint);
         }
 
         protected override void OnPaintBackground (PaintEventArgs e)

--- a/samples/ControlGallery/Panels/ColorDialogPanel.cs
+++ b/samples/ControlGallery/Panels/ColorDialogPanel.cs
@@ -25,8 +25,12 @@ namespace ControlGallery.Panels
             });
 
             button.Click += async (s, e) => {
+                var owner = FindForm ();
+                if (owner is null)
+                    return;
+
                 var dlg = new ColorDialog ();
-                var result = await dlg.ShowDialog (this.FindForm());
+                var result = await dlg.ShowDialog (owner);
 
                 if (result == DialogResult.OK) {
                     color_panel.Style.BackgroundColor = dlg.Color;

--- a/samples/ControlGallery/Panels/FontDialogPanel.cs
+++ b/samples/ControlGallery/Panels/FontDialogPanel.cs
@@ -54,7 +54,7 @@ namespace ControlGallery.Panels
             ApplySelection();
         }
 
-        private async void Button_Click(object sender, MouseEventArgs e)
+        private async void Button_Click(object? sender, MouseEventArgs e)
         {
             var dialog = new FontDialog
             {

--- a/samples/ControlGallery/Panels/NotifyIconPanel.cs
+++ b/samples/ControlGallery/Panels/NotifyIconPanel.cs
@@ -8,10 +8,10 @@ namespace ControlGallery.Panels
     public class NotifyIconPanel : BasePanel
     {
         private readonly Label status_label;
-        private NotifyIcon notify_icon;
-        private NotifyIconContextMenu context_menu;
-        private NotifyIconMenuItem pause_item;
-        private SKBitmap tray_icon_bitmap;
+        private NotifyIcon? notify_icon;
+        private NotifyIconContextMenu? context_menu;
+        private NotifyIconMenuItem? pause_item;
+        private SKBitmap? tray_icon_bitmap;
         private int tooltip_version;
 
         public NotifyIconPanel ()
@@ -108,11 +108,12 @@ namespace ControlGallery.Panels
             if (!IsWindowsTrayAvailable ())
                 return;
 
-            if (!EnsureTrayIcon ())
+            var icon = EnsureTrayIcon ();
+            if (icon is null)
                 return;
 
             tooltip_version++;
-            notify_icon.Text = $"ControlGallery NotifyIcon #{tooltip_version}";
+            icon.Text = $"ControlGallery NotifyIcon #{tooltip_version}";
             SetStatus ($"Tooltip changed to version {tooltip_version}.");
         }
 
@@ -199,12 +200,12 @@ namespace ControlGallery.Panels
             SetStatus ("Tray icon disposed.");
         }
 
-        private bool EnsureTrayIcon ()
+        private NotifyIcon? EnsureTrayIcon ()
         {
             if (notify_icon is null)
                 CreateNotifyIcon ();
 
-            return notify_icon is not null;
+            return notify_icon;
         }
 
         private void HideTrayIcon ()
@@ -226,11 +227,12 @@ namespace ControlGallery.Panels
             if (!IsWindowsTrayAvailable ())
                 return;
 
-            if (!EnsureTrayIcon ())
+            var icon = EnsureTrayIcon ();
+            if (icon is null)
                 return;
 
-            notify_icon.ActivationWindow = FindForm ();
-            notify_icon.ActivationBehavior = NotifyIconActivationBehavior.ShowWindow;
+            icon.ActivationWindow = FindForm ();
+            icon.ActivationBehavior = NotifyIconActivationBehavior.ShowWindow;
             SetStatus ("Form hidden. Left-click the notification area icon to restore it.");
             FindForm ()?.Hide ();
         }
@@ -248,13 +250,14 @@ namespace ControlGallery.Panels
             if (!IsWindowsTrayAvailable ())
                 return;
 
-            if (!EnsureTrayIcon ())
+            var icon = EnsureTrayIcon ();
+            if (icon is null)
                 return;
 
-            if (!notify_icon.Visible)
-                notify_icon.Visible = true;
+            if (!icon.Visible)
+                icon.Visible = true;
 
-            notify_icon.ShowBalloonTip (
+            icon.ShowBalloonTip (
                 3000,
                 "ControlGallery",
                 "This notification came from NotifyIconPanel.",
@@ -268,20 +271,21 @@ namespace ControlGallery.Panels
             if (!IsWindowsTrayAvailable ())
                 return;
 
-            if (!EnsureTrayIcon ())
+            var icon = EnsureTrayIcon ();
+            if (icon is null)
                 return;
 
-            notify_icon.Visible = true;
+            icon.Visible = true;
             SetStatus ("Tray icon visible.");
         }
 
         private void ToggleCheckedItem ()
         {
-            if (!EnsureTrayIcon ())
+            if (EnsureTrayIcon () is null || pause_item is not { } pauseItem)
                 return;
 
-            pause_item.Checked = !pause_item.Checked;
-            SetStatus ($"Pause notifications checked: {pause_item.Checked}.");
+            pauseItem.Checked = !pauseItem.Checked;
+            SetStatus ($"Pause notifications checked: {pauseItem.Checked}.");
         }
 
         [SupportedOSPlatformGuard ("windows")]

--- a/samples/ControlGallery/Panels/PaintAndGradientsPanel.cs
+++ b/samples/ControlGallery/Panels/PaintAndGradientsPanel.cs
@@ -85,7 +85,7 @@ public sealed class PaintAndGradientsPanel : Panel
         });
     }
 
-    private Panel AddCard(int left, int top, string caption, ModernFormsNext.Drawing.Brush brush)
+    private Panel AddCard(int left, int top, string caption, ModernFormsNext.Drawing.Brush? brush)
     {
         var card = Controls.Add(new Panel
         {

--- a/samples/ControlGallery/Panels/PrintingPanel.cs
+++ b/samples/ControlGallery/Panels/PrintingPanel.cs
@@ -27,6 +27,14 @@ namespace ControlGallery.Panels
             document.BeginPrint += (_, _) => pageNumber = 1;
             document.PrintPage += Document_PrintPage;
 
+            statusLabel = Controls.Add(new Label
+            {
+                Location = new Point(565, 170),
+                Size = new Size(340, 120),
+                Multiline = true,
+                Text = "Ready."
+            });
+
             var pageSetupButton = Controls.Add(new Button
             {
                 Location = new Point(20, 20),
@@ -126,16 +134,9 @@ namespace ControlGallery.Panels
             });
             columnsBox.ValueChanged += (_, _) => previewControl.Columns = (int)Math.Round(columnsBox.Value);
 
-            statusLabel = Controls.Add(new Label
-            {
-                Location = new Point(565, 170),
-                Size = new Size(340, 120),
-                Multiline = true,
-                Text = "Ready."
-            });
         }
 
-        private async void PageSetupButton_Click(object sender, MouseEventArgs e)
+        private async void PageSetupButton_Click(object? sender, MouseEventArgs e)
         {
             var dialog = new PageSetupDialog
             {
@@ -146,7 +147,13 @@ namespace ControlGallery.Panels
             };
             dialog.HelpRequest += (_, _) => statusLabel.Text = "Page setup help requested.";
 
-            if (await dialog.ShowDialog(FindForm()) == DialogResult.OK) {
+            var owner = FindForm();
+            if (owner is null) {
+                statusLabel.Text = "Page setup requires an owning form.";
+                return;
+            }
+
+            if (await dialog.ShowDialog(owner) == DialogResult.OK) {
                 previewControl.InvalidatePreview();
                 statusLabel.Text = $"Page setup accepted: {document.DefaultPageSettings.PaperSize.PaperName}, margins {document.DefaultPageSettings.Margins}.";
             } else {
@@ -154,7 +161,7 @@ namespace ControlGallery.Panels
             }
         }
 
-        private async void PrintDialogButton_Click(object sender, MouseEventArgs e)
+        private async void PrintDialogButton_Click(object? sender, MouseEventArgs e)
         {
             var dialog = new PrintDialog
             {
@@ -168,13 +175,19 @@ namespace ControlGallery.Panels
             };
             dialog.HelpRequest += (_, _) => statusLabel.Text = "Print dialog help requested.";
 
-            if (await dialog.ShowDialog(FindForm()) == DialogResult.OK)
+            var owner = FindForm();
+            if (owner is null) {
+                statusLabel.Text = "Print dialog requires an owning form.";
+                return;
+            }
+
+            if (await dialog.ShowDialog(owner) == DialogResult.OK)
                 statusLabel.Text = $"Print dialog accepted: {document.PrinterSettings.PrinterName}, copies {document.PrinterSettings.Copies}.";
             else
                 statusLabel.Text = "Print dialog canceled.";
         }
 
-        private async void PreviewDialogButton_Click(object sender, MouseEventArgs e)
+        private async void PreviewDialogButton_Click(object? sender, MouseEventArgs e)
         {
             using var dialog = new PrintPreviewDialog
             {
@@ -183,11 +196,17 @@ namespace ControlGallery.Panels
                 UseAntiAlias = true
             };
 
-            await dialog.ShowDialog(FindForm());
+            var owner = FindForm();
+            if (owner is null) {
+                statusLabel.Text = "Print preview requires an owning form.";
+                return;
+            }
+
+            await dialog.ShowDialog(owner);
             statusLabel.Text = "Preview dialog closed.";
         }
 
-        private void Document_PrintPage(object sender, PrintPageEventArgs e)
+        private void Document_PrintPage(object? sender, PrintPageEventArgs e)
         {
             using var titleFont = new SKFont(Theme.UIFont, 34);
             using var bodyFont = new SKFont(Theme.UIFont, 18);

--- a/samples/ControlGallery/Panels/ThemeManagerPanel.cs
+++ b/samples/ControlGallery/Panels/ThemeManagerPanel.cs
@@ -336,19 +336,19 @@ public sealed class ThemeManagerPanel : BasePanel
         Apply(first, animated: false);
     }
 
-    private void HandleThemeChanged(object sender, ThemeChangedEventArgs e)
+    private void HandleThemeChanged(object? sender, ThemeChangedEventArgs e)
     {
         resultLabel.Text = $"Committed '{e.Current.Name}'. Transition: {e.Transition?.State.ToString() ?? "none"}.";
         UpdateDiagnostics();
     }
 
-    private void HandleTransitionCompleted(object sender, ThemeTransitionCompletedEventArgs e)
+    private void HandleTransitionCompleted(object? sender, ThemeTransitionCompletedEventArgs e)
     {
         resultLabel.Text = $"Transition for '{e.ThemeId}' ended with {e.Status}.";
         UpdateDiagnostics();
     }
 
-    private void HandleThemeApplyFailed(object sender, ThemeApplyFailedEventArgs e)
+    private void HandleThemeApplyFailed(object? sender, ThemeApplyFailedEventArgs e)
     {
         resultLabel.Text = "Apply rejected: " + FormatDiagnostics(e.Result.Diagnostics);
         UpdateDiagnostics();
@@ -373,7 +373,7 @@ public sealed class ThemeManagerPanel : BasePanel
             $"Tokens: {theme.TokenCounts.Total} | bases: {string.Join(" → ", theme.BaseChain)} | switches completed/canceled/failed: {theme.SuccessfulSwitches}/{theme.CanceledSwitches}/{theme.FailedSwitches}\n" +
             $"Scheduler active: {animation.ActiveAnimationCount} | ticks: {animation.TickCount} | tick source: {(animation.IsTickSourceRunning ? "running" : "stopped")} | paused: {animation.IsPaused}";
 
-        ThemeResolvedSnapshot snapshot = manager.ActiveSnapshot;
+        ThemeResolvedSnapshot? snapshot = manager.ActiveSnapshot;
         if (snapshot is null)
         {
             semanticLabel.Text = "No active snapshot.";
@@ -383,7 +383,8 @@ public sealed class ThemeManagerPanel : BasePanel
         string primary = snapshot.Colors.TryGetValue(ThemeTokens.Colors.Primary.Name, out Color color)
             ? $"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}"
             : "missing";
-        string typography = snapshot.Typography.TryGetValue(ThemeTokens.Typography.Title.Name, out ThemeTypography title)
+        string typography = snapshot.Typography.TryGetValue(ThemeTokens.Typography.Title.Name, out ThemeTypography? title)
+            && title is not null
             ? $"{title.FontFamily} {title.Size}pt {title.Style}"
             : "missing";
         snapshot.Spacing.TryGetValue("Medium", out double spacing);

--- a/samples/ControlGallery/Panels/ToolTipPanel.cs
+++ b/samples/ControlGallery/Panels/ToolTipPanel.cs
@@ -103,7 +103,7 @@ namespace ControlGallery.Panels
             ownerDrawToolTip.Dispose();
         }
 
-        private static void OwnerDrawToolTip_Draw(object sender, DrawToolTipEventArgs e)
+        private static void OwnerDrawToolTip_Draw(object? sender, DrawToolTipEventArgs e)
         {
             e.Canvas.FillRoundedRectangle(e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, new SKColor(28, 31, 36), 8, 8);
             e.Canvas.DrawRoundedRectangle(e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, Theme.AccentColor2, 8, 8);

--- a/samples/ModernFormsNext.CrossPlatform.Sample/ModernFormsNext.CrossPlatform.Sample.csproj
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/ModernFormsNext.CrossPlatform.Sample.csproj
@@ -53,9 +53,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
     <ProjectReference Include="..\..\ModernFormsNext.WindowKit.Backend.Android\ModernFormsNext.WindowKit.Backend.Android.csproj" />
+    <!-- Override RichTextKit's legacy HarfBuzz runtime with Android 16-compatible native assets. -->
+    <PackageReference Include="HarfBuzzSharp" Version="14.2.1.1" />
     <!-- System.Drawing.Common references this assembly, but its Android AOT dependency is not
          selected transitively. Keep the explicit reference until the upstream asset graph does. -->
-    <PackageReference Include="System.Formats.Nrbf" Version="10.0.5" />
+    <PackageReference Include="System.Formats.Nrbf" Version="10.0.10" />
     <Compile Remove="Platforms\Windows\**\*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Cleanup restore/build warnings and dependencies without risky major migrations.

The change replaces an overly broad Visual Studio SDK dependency graph, removes known MessagePack vulnerabilities, updates safe patch/minor dependencies, and resolves nullable, XML documentation, analyzer, and obsolete SkiaSharp warnings across the framework, Windows backend, MicroCom tooling, and ControlGallery.

## Package changes

| Package | Previous | New | Reason |
| --- | --- | --- | --- |
| `Microsoft.VisualStudio.SDK` | `17.14.40265` | Removed | Replaced the broad metapackage in the extension and VSIX projects with only the contracts they use. |
| `envdte` | Transitive through the SDK metapackage | Direct `17.14.40260` | Compile-time DTE contract without the unrelated SDK dependency graph. |
| `Microsoft.VisualStudio.Interop` | Transitive through the SDK metapackage | Direct `17.14.40260` | Precise compile-time Visual Studio interop contract. |
| `Microsoft.VisualStudio.OLE.Interop` | Transitive through the SDK metapackage | Direct `17.14.40260` | Precise OLE interop contract used by the extension. |
| `Microsoft.VisualStudio.Shell.15.0` | Transitive through the SDK metapackage | Direct `17.14.40264` | Precise shell contract while preserving the existing Visual Studio 17.x dependency line. |
| `Microsoft.VisualStudio.Shell.Interop` | Transitive through the SDK metapackage | Direct `17.14.40260` | Precise shell interop contract. |
| `Microsoft.VisualStudio.GraphModel` | Transitive through `Shell.15.0` | Direct `17.14.40260` | Scope unavoidable legacy compatibility metadata and its `NU1701` suppression to this exact compile-time package. |
| `Microsoft.VisualStudio.Imaging` | Transitive through `Shell.15.0` | Direct `17.14.40264` | Scope unavoidable legacy compatibility metadata and its `NU1701` suppression to this exact compile-time package. |
| `Microsoft.IO.Redist` | Transitive through `Shell.15.0` | Direct `6.1.3`, assets excluded | Prevent a build-time redistribution package from being compiled against or shipped and scope `NU1701` locally. |
| `MessagePack` | Transitive `2.5.192` | Direct `3.1.8` | Remove the vulnerable version selected by the former SDK graph. Runtime assets remain excluded from the extension output. |
| `HarfBuzzSharp` | Transitive `7.3.0.1` on Android | Direct Android-only `14.2.1.1` | Override legacy Android native assets and eliminate the Android 16 KB page-size warning. |
| `Microsoft.SourceLink.GitHub` | `10.0.201` | `10.0.301` | Safe patch/minor tooling update. |
| `System.Drawing.Common` | `10.0.5` | `10.0.10` | Safe servicing update in WindowKit and the Windows backend. |
| `System.Formats.Nrbf` | `10.0.5` | `10.0.10` | Safe servicing update for the Android sample's explicit AOT dependency. |
| `CommandLineParser` | `2.8.0` | `2.9.1` | Safe minor update for the non-packable MicroCom generator. |

`Microsoft.VSSDK.BuildTools` remains `17.14.2142`. Roslyn package versions and SkiaSharp `3.119.2` are unchanged.

## Removed vulnerabilities

`MessagePack 2.5.192` was removed from the restored graph and replaced by direct `MessagePack 3.1.8` references in the Visual Studio extension projects.

- High: `GHSA-hv8m-jj95-wg3x`, `GHSA-vh6j-jc39-fggf`
- Moderate: `GHSA-2f33-pr97-265q`, `GHSA-2x83-8g95-xh59`, `GHSA-cj9g-3mj2-g8vv`, `GHSA-cxmj-83gh-fp49`, `GHSA-q2h6-ghwm-5qm8`, `GHSA-qhmf-xw27-6rqr`, `GHSA-v72x-2h86-7f8m`, `GHSA-w567-gjr2-hm5j`, `GHSA-wfr3-xj75-pfwh`

The final transitive NuGet audit reports no vulnerable packages, including no high or critical findings, and restored assets contain no `MessagePack 2.5.192` entry.

## Visual Studio SDK dependency cleanup

Both Visual Studio projects previously referenced `Microsoft.VisualStudio.SDK 17.14.40265`, which restored editor, language-service, T4, BrowserLink, and other packages not used by this extension. They now reference only the DTE, Shell, and Interop contracts required at compile time, plus an audited direct MessagePack version.

This removes the broad source of `NU1701` and vulnerability warnings. Runtime assets for Visual Studio contracts remain excluded, so the VSIX continues to rely on the Visual Studio host for those assemblies.

## Intentional NoWarn entries

All new suppressions are on exact package references in `ModernFormsNext.VisualStudioExtension`; there is no new project-wide or repository-wide `NoWarn`.

| Project | Package | Warning | Reason | Scope |
| --- | --- | --- | --- | --- |
| `ModernFormsNext.VisualStudioExtension` | `Microsoft.VisualStudio.GraphModel 17.14.40260` | `NU1701` | Visual Studio ships a legacy .NET Framework compatibility contract in the Shell graph. | Exact package; runtime excluded; private asset. |
| `ModernFormsNext.VisualStudioExtension` | `Microsoft.VisualStudio.Imaging 17.14.40264` | `NU1701` | Visual Studio ships a legacy .NET Framework compatibility contract in the Shell graph. | Exact package; runtime excluded; private asset. |
| `ModernFormsNext.VisualStudioExtension` | `Microsoft.IO.Redist 6.1.3` | `NU1701` | Build-time redistribution dependency is neither compiled against nor shipped. | Exact package; all assets excluded; private asset. |
| `ModernFormsNext.VisualStudioExtension` | `Microsoft.VisualStudio.Shell.15.0 17.14.40264` | `NU1701` | The package retains net472 assets for the in-process Visual Studio host. | Exact package; runtime excluded. |

Existing `CA1416`, `NU5128`, and `SYSLIB0011` project suppressions were not modified. No warning from repository-owned C# code is hidden.

## Compatibility

- No major SkiaSharp upgrade.
- No major Roslyn upgrade.
- No major Visual Studio SDK or VSSDK BuildTools upgrade.
- No target framework change.
- No ModernFormsNext package-version change; local packs remain `1.8.0`.
- No packages were published, and no tag or release was created.
- Existing public APIs are preserved; obsolete public Skia conversion remains available with a narrowly scoped local compiler suppression.

## Validation

- `dotnet restore ModernFormsNext.slnx --force --no-cache`: 0 warnings, 0 errors.
- Debug solution build, single-node and shared compilation disabled: 0 warnings, 0 errors.
- Release solution build, single-node and shared compilation disabled: 0 warnings, 0 errors.
- Debug tests: 840/840 passed.
- Release tests: 840/840 passed.
- GitHub Actions `build`: passed in 5m37s.
- Transitive NuGet vulnerability audit: no vulnerable packages; no high/critical findings.
- Local pack: 8 `.nupkg` and 7 `.snupkg`, all version `1.8.0`; expected DLL/XML documentation present and no `bin`, `obj`, `.user`, VSIX, APK, or temporary files inside packages.
- Visual Studio Extension and VSIX: Debug and Release builds passed; both VSIX files passed `Validate-Vsix.ps1` and have logically matching manifests.
- Android backend, CrossPlatform sample, and Android smoke sample built successfully in the full Debug/Release solution builds.
- Android outputs: signed Debug APK plus signed and unsigned Release APK for both Android samples.
- ControlGallery: main window started and closed through the normal window-close path with exit code 0.
- Designer Playground: main window started and closed through the normal window-close path with exit code 0.
- Windows DemoApp: main window started and closed through the normal window-close path with exit code 0.
- Visual Studio Experimental Instance: VSIX installation, configuration refresh, template refresh, and startup with a temporary template project completed; the activity log contains no ModernFormsNext-related error.

## Known limitations

- No Android emulator or physical device was connected, so Android runtime behavior was not claimed; build/APK validation only.
- Automated desktop access could verify application startup and window lifecycle but not click through every requested ControlGallery panel or Designer Property Grid/save-reload workflow.
- Visual Studio Exp did not exit within the timeout after a standard close request and was terminated. Installation and startup succeeded, and no ModernFormsNext-specific error was logged, but full interactive `.mfdesign` editing remains a manual follow-up.
- The four package-scoped `NU1701` suppressions listed above remain intentionally for legacy Visual Studio host contracts.
