### PR TITLE
Prepare ModernFormsNext 1.9.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build
         run: dotnet build ModernFormsNext.slnx --configuration Release --no-restore --verbosity normal -m:1 /p:UseSharedCompilation=false
 
+      - name: Test
+        run: dotnet test ModernFormsNext.slnx --configuration Release --no-build --verbosity minimal -m:1 /p:UseSharedCompilation=false
+
       - name: Pack
         run: dotnet pack ModernFormsNext.slnx --configuration Release --no-build --output artifacts/packages
 
@@ -42,11 +45,18 @@ jobs:
       - name: Create GitHub Release
         shell: pwsh
         run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          $releaseNotesPath = "docs/$version-release-notes.md"
+          if (-not (Test-Path -LiteralPath $releaseNotesPath)) {
+            throw "Release notes were not found at '$releaseNotesPath'."
+          }
+
           gh release create "${{ github.ref_name }}" `
             artifacts/packages/*.nupkg `
             artifacts/packages/*.snupkg `
-            --title "ModernFormsNext ${{ github.ref_name }}" `
-            --generate-notes
+            --title "ModernFormsNext $version" `
+            --notes-file $releaseNotesPath `
+            --latest
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -63,5 +73,7 @@ jobs:
             dotnet nuget push $_.FullName `
               --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
               --source "https://api.nuget.org/v3/index.json" `
+              --symbol-api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
+              --symbol-source "https://api.nuget.org/v3/index.json" `
               --skip-duplicate
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Pack
         run: dotnet pack ModernFormsNext.slnx --configuration Release --no-build --output artifacts/packages
 
+      - name: Validate package contents
+        shell: pwsh
+        run: .\scripts\Validate-ReleasePackages.ps1 -PackageDirectory artifacts/packages
+
       - name: Create GitHub Release
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable ModernFormsNext changes are documented in this file.
 
 ModernFormsNext follows semantic versioning. Git tags use a `v` prefix, while NuGet package versions do not.
 
-## [1.9.0] - Unreleased
+## [1.9.0] - 2026-08-02
 
 ModernFormsNext 1.9.0 adds the shared paint, animation, and theme foundations used by the framework,
 hardens editor input and Designer ordering, and keeps Windows as the primary supported runtime.
@@ -449,7 +449,7 @@ Published packages:
 - GitHub `Release` workflow completed successfully for tag `v1.5.0`.
 - NuGet public indexes show version `1.5.0` for all published ModernFormsNext packages.
 
-[1.9.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.8.0...master
+[1.9.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ProGraMajster/ModernFormsNext/releases/tag/v1.7.0
 [1.6.0]: https://github.com/ProGraMajster/ModernFormsNext/releases/tag/v1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ ModernFormsNext follows semantic versioning. Git tags use a `v` prefix, while Nu
 
 ModernFormsNext 1.9.0 adds the shared paint, animation, and theme foundations used by the framework,
 hardens editor input and Designer ordering, and keeps Windows as the primary supported runtime.
-Android support remains experimental. See the [full release notes](docs/releases/1.9.0.md) and
+Android support remains experimental. See the [full release notes](docs/1.9.0-release-notes.md) and
 [migration guide](docs/migrations/1.8.0-to-1.9.0.md).
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,100 @@ All notable ModernFormsNext changes are documented in this file.
 
 ModernFormsNext follows semantic versioning. Git tags use a `v` prefix, while NuGet package versions do not.
 
+## [1.9.0] - Unreleased
+
+ModernFormsNext 1.9.0 adds the shared paint, animation, and theme foundations used by the framework,
+hardens editor input and Designer ordering, and keeps Windows as the primary supported runtime.
+Android support remains experimental. See the [full release notes](docs/releases/1.9.0.md) and
+[migration guide](docs/migrations/1.8.0-to-1.9.0.md).
+
+### Added
+
+- Added observable solid, linear, radial, and sweep Brushes with opacity, transforms, spread modes,
+  observable gradient stops, a shared Skia factory, dynamic-resource integration, and Designer
+  serialization.
+- Added one monotonic, idle-aware UI animation scheduler with UI-thread callbacks, cancellation,
+  pause/resume, owner/key replacement, reduced-motion policy, typed interpolation, Windows and
+  experimental Android lifecycle integration, and repaint batching.
+- Added `ThemeManager` with typed/inheritable definitions, strict versioned JSON, validation,
+  diagnostics, atomic UI-thread apply/rollback, dedicated dynamic theme resources, built-in
+  Light/Dark themes, and opt-in animated transitions.
+- Added composable `AnimationDefinition` and `AnimationRun` APIs, sequence, parallel, timeline,
+  keyframes, repeat, auto-reverse, custom definitions, visual-state transitions, target-local
+  `RippleEffect`, and `PressScaleEffect`.
+- Added a Designer collection editor and deterministic serialization/code generation for built-in
+  interaction effects.
+
+### Changed
+
+- Theme commits refresh the active Normal, Hover, Pressed, Focused, or Disabled style across all
+  open framework windows and coalesce visual invalidation into one platform repaint per window per
+  commit or animation tick. Visual-only frames do not force layout.
+- Theme transitions and interaction effects are explicitly opt-in. Generic panels, containers, and
+  DataGridView controls no longer receive implicit click/ripple presentation merely because they
+  participate in standard pointer input.
+- Designer child arrays now have a documented ordering contract. Ordinary containers store front-
+  to-back Z-order and code generation maps that order to runtime `Controls.Add`; flow, table, and
+  tab containers preserve authored layout sequence.
+- Updated all coordinated package, template, and Visual Studio extension versions to `1.9.0` while
+  preserving package IDs, target frameworks, VSIX identity, publisher, and installation targets.
+
+### Fixed
+
+- Fixed theme changes that previously required hover, click, focus, or resize before some controls
+  repainted with their newly resolved resources and active visual state.
+- Fixed the animation opt-in boundary so it cannot suppress base editor input. TextBox, RichTextBox,
+  MarkdownEditor, and editing controls hosted by Panel or DataGridView retain caret placement,
+  selection, drag selection, double-click, focus, capture, and keyboard input.
+- Fixed CRLF/UTF-16 pointer hit mapping for RichTextBox and MarkdownEditor so clicks and subsequent
+  insertion use the expected source index.
+- Fixed pointer/capture cleanup after mouse up, cancellation, focus loss, detach, reparent, and
+  disposal without leaving a stale owner or stuck press scale.
+- Fixed docked and overlapping child order so Designer preview, save/reload, generated C#, reverse
+  sync, runtime layout, document-outline moves, `BringToFront`, and `SendToBack` agree.
+
+### Dependency and warning cleanup
+
+- Removed the vulnerable MessagePack 2.5.192 path and selected MessagePack 3.1.8 for Visual Studio
+  extension builds.
+- Replaced the broad `Microsoft.VisualStudio.SDK` metapackage with the specific Visual Studio
+  contracts used by the extension and excluded unnecessary runtime assets.
+- Updated Android HarfBuzzSharp to 14.2.1.1, removed XA0141, and applied compatible patch/minor
+  dependency updates without changing target frameworks or dependency majors.
+- Restore and Debug/Release solution builds are release-gated at zero warnings; NuGet vulnerability
+  and package-content audits are part of the release validation.
+
+### Compatibility
+
+- No intentional public type removals, package/namespace renames, target-framework removals, or
+  extension identity changes are included.
+- `GradientBrush.GradientStops` now exposes the observable `GradientStopCollection`. Common
+  collection syntax remains source-compatible, but consumers requiring the concrete `List<T>` type
+  must update and compiled consumers must rebuild.
+- Existing `FadeToAsync`, `TranslateToAsync`, `ScaleToAsync`, and `RotateToAsync` helpers remain
+  source-compatible adapters over the shared scheduler.
+- Theme JSON is strict and rejects unknown fields and unsupported values instead of partially
+  accepting them. Existing `.mfdesign` documents remain compatible without a schema migration.
+
+### Known limitations
+
+- There is no general animated-layout subsystem; layout-affecting visual-state metrics switch
+  discretely.
+- Brush animation requires compatible brush kinds and gradient-stop structures.
+- Designer support covers the built-in ripple and press-scale effects; custom effects/animations
+  remain code-first, and there is no general effect-collection undo/redo transaction stack.
+- Android remains experimental, may refresh motion preferences on foreground entry instead of via a
+  live `ContentObserver`, and still requires device/emulator runtime validation.
+- Shapes and AppShell/navigation are not included in 1.9.0.
+
+### Packaging
+
+- The coordinated release produces eight `1.9.0` NuGet packages and seven matching symbol packages;
+  `ModernFormsNext.Templates` intentionally has no `.snupkg`.
+- Package validation checks versions, dependencies, target frameworks, DLL/XML/PDB contents,
+  README/icon metadata, Source Link symbols, archive path safety, and accidental build/IDE/APK/VSIX
+  artifacts. The VSIX is validated separately in Debug and Release.
+
 ## [1.8.0] - 2026-07-17
 
 ModernFormsNext 1.8.0 expands the framework and designer substantially while keeping Windows as
@@ -355,6 +449,7 @@ Published packages:
 - GitHub `Release` workflow completed successfully for tag `v1.5.0`.
 - NuGet public indexes show version `1.5.0` for all published ModernFormsNext packages.
 
+[1.9.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.8.0...master
 [1.8.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ProGraMajster/ModernFormsNext/releases/tag/v1.7.0
 [1.6.0]: https://github.com/ProGraMajster/ModernFormsNext/releases/tag/v1.6.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
-		<ModernFormsNextPackageVersion>1.8.0</ModernFormsNextPackageVersion>
-		<ModernFormsNextVisualStudioExtensionVersion>1.8.0</ModernFormsNextVisualStudioExtensionVersion>
+		<ModernFormsNextPackageVersion>1.9.0</ModernFormsNextPackageVersion>
+		<ModernFormsNextVisualStudioExtensionVersion>1.9.0</ModernFormsNextVisualStudioExtensionVersion>
 
 		<!-- Shared assembly and publication identity. Project-specific package names,
 		     descriptions, products, and tags remain in the owning project. -->

--- a/ModernFormsNext.Templates/README.md
+++ b/ModernFormsNext.Templates/README.md
@@ -26,7 +26,7 @@ The generated project targets:
 Install the templates from NuGet.org:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.8.0
+dotnet new install ModernFormsNext.Templates::1.9.0
 ```
 
 Check that the template is available:
@@ -124,7 +124,7 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="ModernFormsNext" Version="1.8.0" />
+  <PackageReference Include="ModernFormsNext" Version="1.9.0" />
 </ItemGroup>
 ```
 
@@ -144,7 +144,7 @@ If the template is missing, reinstall it:
 
 ```powershell
 dotnet new uninstall ModernFormsNext.Templates
-dotnet new install ModernFormsNext.Templates::1.8.0
+dotnet new install ModernFormsNext.Templates::1.9.0
 ```
 
 ### The generated project cannot restore packages
@@ -154,7 +154,7 @@ Make sure the referenced ModernFormsNext package version exists on NuGet.org.
 Example:
 
 ```xml
-<PackageReference Include="ModernFormsNext" Version="1.8.0" />
+<PackageReference Include="ModernFormsNext" Version="1.9.0" />
 ```
 
 ### The generated project starts as a console application

--- a/ModernFormsNext.Templates/templates/modernformsnext-app/MyApp.csproj
+++ b/ModernFormsNext.Templates/templates/modernformsnext-app/MyApp.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ModernFormsNext" Version="1.8.0" />
+		<PackageReference Include="ModernFormsNext" Version="1.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
+++ b/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
@@ -1,0 +1,146 @@
+using System.Xml.Linq;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class ReleaseVersionConsistencyTests
+{
+    private const string ExpectedVersion = "1.9.0";
+
+    private static readonly string[] PackableProjects =
+    [
+        "ModernFormsNext/ModernFormsNext.csproj",
+        "ModernFormsNext.CodeGeneration/ModernFormsNext.CodeGeneration.csproj",
+        "ModernFormsNext.Designer/ModernFormsNext.Designer.csproj",
+        "ModernFormsNext.Designing/ModernFormsNext.Designing.csproj",
+        "ModernFormsNext.Templates/ModernFormsNext.Templates.csproj",
+        "ModernFormsNext.WindowKit/ModernFormsNext.WindowKit.csproj",
+        "ModernFormsNext.WindowKit.Backend/ModernFormsNext.WindowKit.Backend.csproj",
+        "ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj"
+    ];
+
+    [Fact]
+    public void CentralPackageAndVsixVersionsAreCoordinated()
+    {
+        XDocument properties = LoadXml("Directory.Build.props");
+
+        Assert.Equal(ExpectedVersion, ElementValue(properties, "ModernFormsNextPackageVersion"));
+        Assert.Equal(ExpectedVersion, ElementValue(properties, "ModernFormsNextVisualStudioExtensionVersion"));
+    }
+
+    [Fact]
+    public void EveryPackableProjectUsesTheCentralPackageVersion()
+    {
+        string root = FindRepositoryRoot();
+        string[] actualProjects = Directory
+            .EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories)
+            .Where(path => !ContainsGeneratedDirectory(path))
+            .Where(path => string.Equals(ElementValue(XDocument.Load(path), "IsPackable"), "true", StringComparison.OrdinalIgnoreCase))
+            .Select(path => Path.GetRelativePath(root, path).Replace('\\', '/'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(PackableProjects.Order(StringComparer.Ordinal), actualProjects);
+
+        foreach (string projectPath in PackableProjects)
+        {
+            XDocument project = LoadXml(projectPath);
+            Assert.Equal("$(ModernFormsNextPackageVersion)", ElementValue(project, "Version"));
+        }
+    }
+
+    [Fact]
+    public void ActiveVsixAndTemplateMetadataUseTheReleaseVersion()
+    {
+        XDocument manifest = LoadXml("ModernFormsNext.VisualStudioExtension.Vsix/source.extension.vsixmanifest");
+        XElement identity = Assert.Single(manifest.Descendants(), element => element.Name.LocalName == "Identity");
+        Assert.Equal(ExpectedVersion, identity.Attribute("Version")?.Value);
+
+        XDocument vsixProject = LoadXml("ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsNext.VisualStudioExtension.Vsix.csproj");
+        Assert.Equal("$(ModernFormsNextVisualStudioExtensionVersion)", ElementValue(vsixProject, "Version"));
+        Assert.Equal("$(ModernFormsNextVisualStudioExtensionVersion).0", ElementValue(vsixProject, "AssemblyVersion"));
+        Assert.Equal("$(ModernFormsNextVisualStudioExtensionVersion).0", ElementValue(vsixProject, "FileVersion"));
+
+        XDocument templateProject = LoadXml("ModernFormsNext.Templates/templates/modernformsnext-app/MyApp.csproj");
+        XElement packageReference = Assert.Single(templateProject.Descendants("PackageReference"));
+        Assert.Equal("ModernFormsNext", packageReference.Attribute("Include")?.Value);
+        Assert.Equal(ExpectedVersion, packageReference.Attribute("Version")?.Value);
+
+        AssertRegistrationVersion("ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs");
+        AssertRegistrationVersion("ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsDesignerPackage.cs");
+    }
+
+    [Fact]
+    public void PublishedPackagePolicyRequiresReadmeIconXmlDocsAndSymbols()
+    {
+        XDocument properties = LoadXml("Directory.Build.props");
+        Assert.Equal("README.md", ElementValue(properties, "PackageReadmeFile"));
+        Assert.Equal("icon.png", ElementValue(properties, "PackageIcon"));
+        Assert.Equal("true", ElementValue(properties, "IncludeSymbols"));
+        Assert.Equal("snupkg", ElementValue(properties, "SymbolPackageFormat"));
+        Assert.Equal("true", ElementValue(properties, "PublishRepositoryUrl"));
+
+        foreach (string projectPath in PackableProjects.Where(path => !path.Contains("Templates", StringComparison.Ordinal)))
+        {
+            XDocument project = LoadXml(projectPath);
+            Assert.Equal("true", ElementValue(project, "GenerateDocumentationFile"));
+            Assert.True(project.Descendants().Any(HasPackedFile("README.md")), $"{projectPath} must pack README.md.");
+            Assert.True(project.Descendants().Any(HasPackedFile("icon.png")), $"{projectPath} must pack icon.png.");
+        }
+
+        XDocument template = LoadXml("ModernFormsNext.Templates/ModernFormsNext.Templates.csproj");
+        Assert.Equal("false", ElementValue(template, "IncludeSymbols"));
+        Assert.True(template.Descendants().Any(HasPackedFile("README.md")), "Template package must pack README.md.");
+        Assert.True(template.Descendants().Any(HasPackedFile("icon.png")), "Template package must pack icon.png.");
+    }
+
+    [Fact]
+    public void TemplatePackageExcludesBuildAndIdeArtifacts()
+    {
+        XDocument template = LoadXml("ModernFormsNext.Templates/ModernFormsNext.Templates.csproj");
+        XElement content = Assert.Single(
+            template.Descendants("Content"),
+            element => (element.Attribute("Include")?.Value ?? string.Empty).StartsWith("templates", StringComparison.Ordinal));
+        string exclude = content.Attribute("Exclude")?.Value ?? string.Empty;
+
+        foreach (string requiredPattern in new[] { "bin", "obj", ".vs", "*.user", "*.suo", "*.tmp", "*.cache" })
+            Assert.Contains(requiredPattern, exclude, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Func<XElement, bool> HasPackedFile(string fileName)
+        => element => string.Equals(element.Attribute("Pack")?.Value, "true", StringComparison.OrdinalIgnoreCase)
+            && (element.Attribute("Include")?.Value ?? string.Empty).EndsWith(fileName, StringComparison.OrdinalIgnoreCase);
+
+    private static void AssertRegistrationVersion(string relativePath)
+    {
+        string text = File.ReadAllText(Path.Combine(FindRepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        Assert.Contains($"InstalledProductRegistration", text, StringComparison.Ordinal);
+        Assert.Contains($"\"{ExpectedVersion}\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"1.8.0\"", text, StringComparison.Ordinal);
+    }
+
+    private static XDocument LoadXml(string relativePath)
+        => XDocument.Load(Path.Combine(FindRepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+    private static string? ElementValue(XDocument document, string name)
+        => document.Descendants().FirstOrDefault(element => element.Name.LocalName == name)?.Value.Trim();
+
+    private static bool ContainsGeneratedDirectory(string path)
+    {
+        string normalized = path.Replace('\\', '/');
+        return normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        for (DirectoryInfo? directory = new(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Directory.Build.props"))
+                && File.Exists(Path.Combine(directory.FullName, "ModernFormsNext.slnx")))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the ModernFormsNext repository root from the test output directory.");
+    }
+}

--- a/ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsDesignerPackage.cs
+++ b/ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsDesignerPackage.cs
@@ -23,7 +23,7 @@ namespace ModernFormsNext.VisualStudioExtension;
 /// only exposes Visual Studio registration and validation commands needed to deploy the extension.
 /// </remarks>
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration("ModernFormsNext Designer", "Visual Studio designer support for ModernFormsNext.", "1.8.0")]
+[InstalledProductRegistration("ModernFormsNext Designer", "Visual Studio designer support for ModernFormsNext.", "1.9.0")]
 [ProvideMenuResource("ModernFormsNext.VisualStudioExtension.CTMENU", 1)]
 [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
 [Guid(PackageGuidString)]

--- a/ModernFormsNext.VisualStudioExtension.Vsix/source.extension.vsixmanifest
+++ b/ModernFormsNext.VisualStudioExtension.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ModernFormsNext.Designer" Version="1.8.0" Language="en-US" Publisher="ProGraMajster" />
+    <Identity Id="ModernFormsNext.Designer" Version="1.9.0" Language="en-US" Publisher="ProGraMajster" />
     <DisplayName>ModernFormsNext Designer</DisplayName>
     <Description xml:space="preserve">Visual Studio designer support for ModernFormsNext.</Description>
     <MoreInfo>https://github.com/ProGraMajster/ModernFormsNext</MoreInfo>

--- a/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
+++ b/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
@@ -21,7 +21,7 @@ namespace ModernFormsNext.VisualStudioExtension;
 /// normal C# editor.
 /// </remarks>
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration("#110", "#112", "1.8.0")]
+[InstalledProductRegistration("#110", "#112", "1.9.0")]
 [ProvideMenuResource("ModernFormsNext.VisualStudioExtension.CTMENU", 1)]
 [ProvideEditorFactory(typeof(MfDesignEditorFactory), 101)]
 [ProvideEditorExtension(typeof(MfDesignEditorFactory), DesignFileExtension, 50, NameResourceID = 113, DefaultName = ExtensionDisplayName)]

--- a/ModernFormsNext.VisualStudioExtension/README.md
+++ b/ModernFormsNext.VisualStudioExtension/README.md
@@ -3,8 +3,8 @@
 This project builds the Visual Studio extension that registers the ModernFormsNext designer.
 
 The extension version is stored as `ModernFormsNextVisualStudioExtensionVersion` in
-`Directory.Build.props`. Coordinated framework releases use the same version; the 1.8.0 VSIX is
-therefore versioned 1.8.0. An independent extension-only patch remains possible when it is
+`Directory.Build.props`. Coordinated framework releases use the same version; the 1.9.0 VSIX is
+therefore versioned 1.9.0. An independent extension-only patch remains possible when it is
 deliberate and documented. The same version must be kept in
 `ModernFormsNext.VisualStudioExtension.Vsix\source.extension.vsixmanifest` and
 the two `InstalledProductRegistration` attributes.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The repository does not currently provide supported macOS or Linux application b
 ### Android status
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.8.0 is **Experimental**. APIs, project structure, and
+> Android support in ModernFormsNext 1.9.0 is **Experimental**. APIs, project structure, and
 > runtime behavior may still change. It is not yet recommended for production applications.
 
 The Android backend can host one real ModernFormsNext control tree in an `AndroidSkiaHostView`.
@@ -72,25 +72,25 @@ known limitations, and sample commands.
 
 ## Installation
 
-ModernFormsNext 1.8.0 requires .NET 10. The repository selects SDK `10.0.201` in `global.json` and
+ModernFormsNext 1.9.0 requires .NET 10. The repository selects SDK `10.0.201` in `global.json` and
 allows roll-forward to a later installed .NET 10 feature band.
 
 For an existing Windows application:
 
 ```powershell
-dotnet add package ModernFormsNext --version 1.8.0
+dotnet add package ModernFormsNext --version 1.9.0
 ```
 
 Install the project template and create an application:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.8.0
+dotnet new install ModernFormsNext.Templates::1.9.0
 dotnet new mfn-app -n MyApp
 cd MyApp
 dotnet run
 ```
 
-The package and template commands use the release version and become available after 1.8.0 is
+The package and template commands use the release version and become available after 1.9.0 is
 published. For source builds or pre-release validation, clone the repository and use project
 references instead. See [installation](docs/installation.md) for package, template, VSIX, and
 Experimental Instance instructions.
@@ -139,8 +139,8 @@ Android backend.
 ## Visual Studio Designer
 
 The optional `ModernFormsNextDesigner.vsix` adds **View ModernFormsNext Designer** for designable
-ModernFormsNext forms and a **ModernFormsNext Form** item template. Version 1.8.0 of the VSIX is the
-matching extension for the 1.8.0 framework release.
+ModernFormsNext forms and a **ModernFormsNext Form** item template. Version 1.9.0 of the VSIX is the
+matching extension for the 1.9.0 framework release.
 
 A designable form uses three related files:
 
@@ -174,7 +174,7 @@ ControlGallery rather than in the generated starter experience.
 
 ## Packages
 
-The 1.8.0 release is composed of these intentionally published NuGet packages:
+The 1.9.0 release is composed of these intentionally published NuGet packages:
 
 | Package | Purpose |
 | --- | --- |
@@ -195,6 +195,8 @@ declared as a publishable NuGet package.
 - [Getting started](docs/getting-started.md)
 - [Installation and Visual Studio Designer](docs/installation.md)
 - [Changelog](CHANGELOG.md)
+- [ModernFormsNext 1.9.0 release notes](docs/releases/1.9.0.md)
+- [Migration from 1.8.0 to 1.9.0](docs/migrations/1.8.0-to-1.9.0.md)
 - [Android platform status](docs/platforms/android.md)
 - [Designer architecture](docs/designer-architecture.md)
 - [Dynamic resources](docs/dynamic-resources.md)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ declared as a publishable NuGet package.
 - [Getting started](docs/getting-started.md)
 - [Installation and Visual Studio Designer](docs/installation.md)
 - [Changelog](CHANGELOG.md)
-- [ModernFormsNext 1.9.0 release notes](docs/releases/1.9.0.md)
+- [ModernFormsNext 1.9.0 release notes](docs/1.9.0-release-notes.md)
 - [Migration from 1.8.0 to 1.9.0](docs/migrations/1.8.0-to-1.9.0.md)
 - [Android platform status](docs/platforms/android.md)
 - [Designer architecture](docs/designer-architecture.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,20 +13,20 @@ NuGet package versions use SemVer without a `v` prefix. The shared value is stor
 `Directory.Build.props`:
 
 ```xml
-<ModernFormsNextPackageVersion>1.8.0</ModernFormsNextPackageVersion>
+<ModernFormsNextPackageVersion>1.9.0</ModernFormsNextPackageVersion>
 ```
 
 Git tags use the same version with a `v` prefix:
 
 ```text
-v1.8.0
+v1.9.0
 ```
 
 The Visual Studio extension version is stored separately so an emergency extension-only patch
 remains possible:
 
 ```xml
-<ModernFormsNextVisualStudioExtensionVersion>1.8.0</ModernFormsNextVisualStudioExtensionVersion>
+<ModernFormsNextVisualStudioExtensionVersion>1.9.0</ModernFormsNextVisualStudioExtensionVersion>
 ```
 
 For coordinated framework minor/major releases, the VSIX version must match the framework release.
@@ -72,7 +72,7 @@ the tag.
    symbol-package policy.
 5. Confirm the VSIX manifest, registration attributes, assets, prerequisites, and Visual Studio
    installation targets.
-6. Review platform claims. For 1.8.0, Android must remain explicitly **Experimental** and must not
+6. Review platform claims. For 1.9.0, Android must remain explicitly **Experimental** and must not
    be described as a complete `Application.Run(Form)` or WindowKit implementation.
 7. Review `git diff`, stage only the intended files, and create focused commits. Do not use
    `git add .` without auditing the entire worktree.
@@ -88,7 +88,7 @@ dotnet build .\ModernFormsNext.slnx --configuration Release --no-restore --verbo
 dotnet test .\ModernFormsNext.slnx --configuration Debug --no-restore
 ```
 
-For 1.8.0, additionally validate:
+For 1.9.0, additionally validate:
 
 - `net10.0-windows` framework and samples;
 - the `net10.0-android` backend, cross-platform sample, and Android backend tests when the workload
@@ -112,7 +112,7 @@ The template package intentionally has no `.snupkg`; published library packages 
 
 After the release commit is reviewed and the normal `.NET` workflow is green:
 
-1. Replace `Unreleased` with the actual release date in `CHANGELOG.md` and update the 1.8.0 link
+1. Replace `Unreleased` with the actual release date in `CHANGELOG.md` and update the 1.9.0 link
    from a comparison URL to the final tag URL.
 2. Commit that final release-note change and push it through the normal review path.
 3. Create the annotated or lightweight `vX.Y.Z` tag on the exact reviewed commit.
@@ -128,8 +128,8 @@ Example commands are intentionally explicit:
 ```powershell
 git status
 git log --oneline --decorate -n 20
-git tag v1.8.0
-git push origin v1.8.0
+git tag v1.9.0
+git push origin v1.9.0
 ```
 
 Do not run the tag or push commands until the release is approved. Never force-push or move a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -104,6 +104,7 @@ Package into a clean, ignored output directory:
 
 ```powershell
 dotnet pack .\ModernFormsNext.slnx --configuration Release --no-build --output .\.codex-pack
+.\scripts\Validate-ReleasePackages.ps1 -PackageDirectory .\.codex-pack
 ```
 
 The template package intentionally has no `.snupkg`; published library packages should have one.

--- a/docs/1.9.0-release-notes.md
+++ b/docs/1.9.0-release-notes.md
@@ -1,0 +1,170 @@
+# ModernFormsNext 1.9.0 release notes
+
+ModernFormsNext 1.9.0 is a coordinated framework, Designer, template, and Visual Studio extension
+release. Windows remains the primary supported runtime. Android remains an experimental shared-
+control backend and is not presented as feature-equivalent to Windows.
+
+> [!IMPORTANT]
+> These notes describe the reviewed 1.9.0 release candidate. The packages, VSIX, tag, and GitHub
+> Release are published only after the release pull request is approved and merged.
+
+## Highlights
+
+- A single observable `Brush` model now covers solid color, linear, radial, and sweep gradients,
+  opacity, transforms, spread modes, observable stops, dynamic resources, Designer serialization,
+  and a centralized Skia brush factory.
+- The shared UI animation scheduler provides monotonic, idle-aware UI-thread animation with
+  cancellation, pause/resume, owner/key replacement, reduced-motion policy, typed interpolation,
+  lifecycle integration, and repaint batching.
+- `ThemeManager` adds typed and inheritable themes, strict versioned JSON, atomic apply/rollback,
+  dedicated dynamic theme resources, Light/Dark definitions, optional animated transitions,
+  latest-request-wins cancellation, and full-tree visual refresh after a commit.
+- Composable animation definitions add sequences, parallel groups, timelines, keyframes, repeat,
+  auto-reverse, custom definitions, visual-state transitions, and target-local opt-in ripple and
+  press-scale effects.
+- Editor pointer handling and Designer child ordering were hardened so animation opt-in does not
+  alter standard input and Designer preview, generated code, reverse sync, and runtime share one
+  Z-order contract.
+- Dependency cleanup removes the vulnerable MessagePack 2.5.192 path, uses narrow Visual Studio SDK
+  references, updates MessagePack and Android HarfBuzzSharp, and restores warning-free builds.
+
+## New APIs
+
+### Paint and gradients
+
+- `Brush.Opacity`, `Brush.Transform`, and observable `Brush.Changed` notifications;
+- `SolidColorBrush`, `LinearGradientBrush`, `RadialGradientBrush`, and `SweepGradientBrush`;
+- `GradientStop`, `GradientStopCollection`, and `GradientSpreadMode`;
+- shared Brush-to-Skia conversion used by controls, dynamic resources, themes, and the Designer.
+
+### Animation
+
+- `AnimationScheduler`, `AnimationHandle`, `AnimationOptions`, `AnimationPolicy`, and diagnostics;
+- `AnimationDefinition`, `AnimationRun`, `AnimationContext`, and `PropertyAnimation<T>`;
+- `Animation.Sequence`, `Animation.Parallel`, scheduler-backed delay, and `AnimationTimeline`;
+- `KeyframeAnimation<T>`, finite and infinite repeat, auto-reverse, and custom interpolators;
+- style transitions for Normal, Hover, Pressed, Focused, and Disabled states;
+- explicit `InteractionEffects` with `RippleEffect` and `PressScaleEffect`.
+
+Existing `FadeToAsync`, `TranslateToAsync`, `ScaleToAsync`, and `RotateToAsync` helpers remain
+available as compatibility adapters over the shared scheduler.
+
+### Themes
+
+- `ThemeManager.Current`, `ThemeDefinition`, `ThemeResolvedSnapshot`, and typed `ThemeTokens`;
+- `ThemeApplyOptions`, `ThemeTransitionOptions`, apply results, transition handles, events, and
+  diagnostics;
+- `ThemeJsonSerializer` with a strict versioned allow-list and security limits;
+- `BuiltInThemes.Light` and `BuiltInThemes.Dark` plus the compatible static `Theme` facade;
+- `Application.ThemeResources` as a dedicated fallback below application resources.
+
+## Designer
+
+- Brush and gradient values round-trip through `.mfdesign` and generated C#.
+- The interaction-effect collection editor supports ordered built-in ripple and press-scale
+  descriptions without starting runtime animation services in Designer mode.
+- `.mfdesign` child arrays have an explicit ordering meaning. Ordinary containers store front-to-
+  back Z-order, while flow, table, and tab containers preserve authored layout sequence.
+- Code generation maps ordinary containers to runtime `Controls.Add` order explicitly. Preview,
+  save/reload, generation, reverse sync, document-outline moves, `BringToFront`, and `SendToBack`
+  therefore agree for docked, overlapping, mixed, and nested controls.
+- Docked control bounds contribute the relevant thickness; layout computes their position.
+
+Custom animation definitions, custom interaction-effect types, and custom easing remain code-first.
+The built-in effect editor does not introduce a general Designer transaction/undo stack.
+
+## Windows
+
+- Windows supplies the primary application/window lifecycle and UI dispatcher used by animations
+  and theme commits.
+- Native application animation preferences participate in reduced-motion decisions without a
+  repaint loop.
+- Theme changes refresh all open framework windows and their active visual states in one controlled
+  invalidation batch per commit or animation tick. Visual-only frames do not request layout.
+- The coordinated Visual Studio extension version is 1.9.0 and retains the existing extension ID,
+  publisher, supported Visual Studio targets, and amd64 architecture.
+
+## Experimental Android
+
+- The shared animation, Brush, theme, dynamic-resource, and control-tree code builds for Android.
+- The Android lifecycle excludes background time from scheduler progress and refreshes platform
+  animation-scale settings when the application returns to the foreground.
+- Theme System mode uses the configured Light/Dark fallback because a complete Android system-theme
+  provider is not registered.
+- Android may refresh settings on foreground entry instead of using a live `ContentObserver`.
+- Runtime behavior, frame pacing, transitions, touch, IME, and lifecycle still require an emulator
+  or physical-device check; a successful build/APK validation is not runtime parity.
+
+## Breaking changes and compatibility
+
+No intentional public type removal, package rename, namespace move, target-framework removal, or
+VSIX identity change is included.
+
+- `GradientBrush.GradientStops` now exposes `GradientStopCollection` rather than `List<GradientStop>`.
+  Common collection initializers and operations remain source-compatible, but compiled consumers
+  and code requiring the concrete `List<T>` type must rebuild and accept the new collection type or
+  an interface such as `IList<GradientStop>`.
+- Theme transitions and interaction effects are opt-in. A plain Panel or DataGridView no longer
+  receives an implicit press/ripple presentation merely because it participates in pointer input.
+  Standard hit testing, focus, capture, caret, selection, and keyboard handling remain unconditional.
+- Designer-generated `Controls.Add` statements can change order after regeneration so runtime
+  reproduces the document's declared Z-order. Existing `.mfdesign` files remain readable and need
+  no schema migration.
+- Theme JSON is intentionally strict. Unknown fields or unsupported polymorphic values that a
+  custom loader previously ignored are rejected with diagnostics.
+
+See [Migration from 1.8.0 to 1.9.0](../migrations/1.8.0-to-1.9.0.md) for examples and action items.
+
+## Migration from 1.8.0
+
+Most applications can update package and VSIX references, rebuild, and continue using existing
+controls and animation helpers. Review code that assumes `GradientStops` is exactly a `List<T>`,
+code that expected implicit pressed visuals on generic controls, custom theme loaders, and checked-
+in generated Designer files. Prefer `ThemeManager` and dynamic theme-resource references for new
+theme-aware code; enable transitions and interaction effects explicitly.
+
+## Known limitations
+
+- There is no general animated-layout subsystem ([#25](https://github.com/ProGraMajster/ModernFormsNext/issues/25)).
+- Layout-affecting visual-state metrics switch discretely instead of interpolating per frame
+  ([#26](https://github.com/ProGraMajster/ModernFormsNext/issues/26)).
+- Brush interpolation requires compatible brush types and compatible gradient-stop structures
+  ([#27](https://github.com/ProGraMajster/ModernFormsNext/issues/27));
+  incompatible values switch discretely.
+- Designer support for interaction effects is limited to the built-in `RippleEffect` and
+  `PressScaleEffect`; custom definitions remain code-first
+  ([#28](https://github.com/ProGraMajster/ModernFormsNext/issues/28)).
+- There is no general Designer undo/redo transaction stack for effect-collection editing.
+- Android remains experimental, uses fallback behavior for system themes, and may refresh animation
+  settings only on foreground entry ([#29](https://github.com/ProGraMajster/ModernFormsNext/issues/29)).
+- Shapes ([#11](https://github.com/ProGraMajster/ModernFormsNext/issues/11)) and AppShell/navigation
+  ([#12](https://github.com/ProGraMajster/ModernFormsNext/issues/12)) are not part of 1.9.0.
+
+## Validation
+
+The release candidate is gated by a forced no-cache restore; warning-free Debug and Release solution
+builds; the complete Debug and Release test suites; NuGet vulnerability and dependency audits;
+individual build checks for Windows, Android, Designer, extension, VSIX, ControlGallery, DemoApp,
+and Designer Playground; ZIP inspection of every NuGet/symbol package; VSIX archive validation; and
+Windows startup smoke tests. Device-only and interactive checks are reported separately rather than
+being inferred from deterministic tests.
+
+## Package contents
+
+The release produces eight NuGet packages and seven matching symbol packages. The template package
+contains source content and intentionally has no `.snupkg`.
+
+| Package | Framework/content | Symbols |
+| --- | --- | --- |
+| `ModernFormsNext` | `net10.0`, `net10.0-windows` | yes |
+| `ModernFormsNext.WindowKit` | `net10.0` | yes |
+| `ModernFormsNext.WindowKit.Backend` | `net10.0` | yes |
+| `ModernFormsNext.WindowKit.Backend.Windows` | `net10.0` | yes |
+| `ModernFormsNext.Designing` | `net10.0` | yes |
+| `ModernFormsNext.CodeGeneration` | `net10.0` | yes |
+| `ModernFormsNext.Designer` | `net10.0-windows` | yes |
+| `ModernFormsNext.Templates` | `dotnet new` template content | no |
+
+Each library package contains its DLL and XML documentation plus repository metadata, README, icon,
+and Source Link-enabled symbols. Package validation rejects generated build/IDE state, APK/VSIX
+artifacts, temporary files, absolute local paths, stale release metadata, and mismatched symbols.

--- a/docs/1.9.0-release-notes.md
+++ b/docs/1.9.0-release-notes.md
@@ -4,9 +4,8 @@ ModernFormsNext 1.9.0 is a coordinated framework, Designer, template, and Visual
 release. Windows remains the primary supported runtime. Android remains an experimental shared-
 control backend and is not presented as feature-equivalent to Windows.
 
-> [!IMPORTANT]
-> These notes describe the reviewed 1.9.0 release candidate. The packages, VSIX, tag, and GitHub
-> Release are published only after the release pull request is approved and merged.
+This stable release is tagged as `v1.9.0`. Its NuGet packages and symbols are published through the
+tag-triggered release workflow after the coordinated release branch passes all publication gates.
 
 ## Highlights
 
@@ -142,7 +141,7 @@ theme-aware code; enable transitions and interaction effects explicitly.
 
 ## Validation
 
-The release candidate is gated by a forced no-cache restore; warning-free Debug and Release solution
+The release was gated by a forced no-cache restore; warning-free Debug and Release solution
 builds; the complete Debug and Release test suites; NuGet vulnerability and dependency audits;
 individual build checks for Windows, Android, Designer, extension, VSIX, ControlGallery, DemoApp,
 and Designer Playground; ZIP inspection of every NuGet/symbol package; VSIX archive validation; and

--- a/docs/1.9.0-theme-system.md
+++ b/docs/1.9.0-theme-system.md
@@ -1,8 +1,8 @@
-# ModernFormsNext 1.9.0 theme system — draft notes
+# ModernFormsNext 1.9.0 theme system
 
-> [!IMPORTANT]
-> This is a draft for a future 1.9.0 release. The repository/package version is intentionally not
-> changed, no package is published, and this document is not a release announcement.
+> [!NOTE]
+> This document records the theme-system scope included in ModernFormsNext 1.9.0. Android support
+> remains experimental; see the platform section before relying on it in an application.
 
 ## Added
 

--- a/docs/android-backend.md
+++ b/docs/android-backend.md
@@ -1,7 +1,7 @@
 # Android backend
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.8.0 is **Experimental** and is not recommended for
+> Android support in ModernFormsNext 1.9.0 is **Experimental** and is not recommended for
 > production applications. See the [Android platform status](platforms/android.md) for the
 > supported vertical slice and current limitations.
 

--- a/docs/android-development.md
+++ b/docs/android-development.md
@@ -1,7 +1,7 @@
 # Android development
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.8.0 is **Experimental**. APIs, project structure, and
+> Android support in ModernFormsNext 1.9.0 is **Experimental**. APIs, project structure, and
 > runtime behavior may change, and production use is not yet recommended. Start with the
 > [Android platform status](platforms/android.md).
 

--- a/docs/composable-animations.md
+++ b/docs/composable-animations.md
@@ -1,7 +1,7 @@
-# Draft release notes: composable animations and interaction effects
+# Composable animations and interaction effects in ModernFormsNext 1.9.0
 
-This is an unreleased, version-neutral draft. It does not change package or assembly versions and
-does not authorize publication.
+This document records the composable animation and interaction-effect scope included in
+ModernFormsNext 1.9.0. It does not change the release status or authorize publication.
 
 ## Highlights
 

--- a/docs/cross-platform-sample.md
+++ b/docs/cross-platform-sample.md
@@ -1,7 +1,7 @@
 # Cross-platform sample
 
 > [!WARNING]
-> The Android target is **Experimental** in ModernFormsNext 1.8.0. This sample validates the
+> The Android target is **Experimental** in ModernFormsNext 1.9.0. This sample validates the
 > current shared-control vertical slice; it does not represent complete Android platform parity.
 
 `samples/ModernFormsNext.CrossPlatform.Sample` is intentionally one application project, organized
@@ -125,4 +125,4 @@ This sample proves a real shared-control vertical slice, not complete Android pa
 lacks general `Application.Run(Form)`, multiple framework windows, full accessibility semantics,
 native dialogs, clipboard, file pickers, drag-and-drop, and several backend services. Windows
 remains the primary and best-supported target. See the canonical
-[Android platform status](platforms/android.md) for the complete 1.8.0 support matrix.
+[Android platform status](platforms/android.md) for the complete 1.9.0 support matrix.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ dotnet run --project .\samples\Outlaw\Outlaw.csproj
 The repository contains a template package project in `ModernFormsNext.Templates`. After packing and installing that template package, create a new app with:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.8.0
+dotnet new install ModernFormsNext.Templates::1.9.0
 dotnet new mfn-app -n MyApp
 ```
 
@@ -84,14 +84,14 @@ For packaged usage, reference the package version produced by this repository:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="ModernFormsNext" Version="1.8.0" />
+    <PackageReference Include="ModernFormsNext" Version="1.9.0" />
 </ItemGroup>
 ```
 
 ## Visual Designer
 
-ModernFormsNext 1.8.0 includes the reusable designer stack introduced in 1.7.0 and adds coordinated
-High DPI rendering/input fixes plus `Size`-based form generation. The generated template includes
+ModernFormsNext 1.9.0 includes the reusable designer stack, High DPI rendering/input fixes,
+stable child Z-order, and interaction-effect serialization. The generated template includes
 three related files:
 
 ```text

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ ModernFormsNext is distributed as NuGet packages, project templates, and a Visua
 designer extension. The framework remains code-first, but the designer can edit the companion
 `.mfdesign` document and regenerate the matching `.Designer.cs` file.
 
-The commands below target the coordinated 1.8.0 release. They become publicly available after the
+The commands below target the coordinated 1.9.0 release. They become publicly available after the
 NuGet packages and GitHub release assets are published.
 
 ## Requirements
@@ -18,7 +18,7 @@ NuGet packages and GitHub release assets are published.
 For an existing application, reference the framework package:
 
 ```powershell
-dotnet add package ModernFormsNext --version 1.8.0
+dotnet add package ModernFormsNext --version 1.9.0
 ```
 
 The package provides the runtime controls, forms, rendering, layout, input, dialogs, and
@@ -29,7 +29,7 @@ Windows backend integration used by ModernFormsNext applications.
 Install the template package:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.8.0
+dotnet new install ModernFormsNext.Templates::1.9.0
 ```
 
 Create a new app:
@@ -69,10 +69,10 @@ as a classic Windows Forms marker and may try to open the built-in WinForms desi
 
 ## Install the Visual Studio Designer
 
-Install `ModernFormsNextDesigner.vsix` version `1.8.0` from the matching 1.8.0 release assets when
+Install `ModernFormsNextDesigner.vsix` version `1.9.0` from the matching 1.9.0 release assets when
 available. The extension version matches the framework because this release includes High DPI,
 code-generation, and form-size round-trip changes. Do not install an older `1.7.x` VSIX when
-validating the 1.8.0 designer workflow. During
+validating the 1.9.0 designer workflow. During
 local repository development, build the VSIX project first:
 
 ```powershell
@@ -173,7 +173,7 @@ extension follows the current Visual Studio UI culture where possible.
 ## Android
 
 The packaged project template and Visual Studio designer are Windows-first. Android support in
-ModernFormsNext 1.8.0 is **Experimental**, uses an explicit activity/shared-surface host, and is not
+ModernFormsNext 1.9.0 is **Experimental**, uses an explicit activity/shared-surface host, and is not
 part of the default `mfn-app` template. See [Android platform status](platforms/android.md) before
 creating an Android evaluation project.
 

--- a/docs/migrations/1.8.0-to-1.9.0.md
+++ b/docs/migrations/1.8.0-to-1.9.0.md
@@ -1,0 +1,171 @@
+# Migrating ModernFormsNext 1.8.0 applications to 1.9.0
+
+ModernFormsNext 1.9.0 keeps the existing package IDs, namespaces, target frameworks, VSIX identity,
+and compatibility animation helpers. Most applications can update references and rebuild. The
+items below identify the behavioral and concrete-type changes that deserve review.
+
+## Update package, template, and VSIX versions
+
+Update direct package references to `1.9.0` and use the matching Designer extension:
+
+```xml
+<PackageReference Include="ModernFormsNext" Version="1.9.0" />
+```
+
+```powershell
+dotnet new install ModernFormsNext.Templates::1.9.0
+```
+
+Do not mix a 1.8.0 Designer/VSIX with 1.9.0 framework and design packages when validating generated
+code or `.mfdesign` round trips.
+
+## Brush and gradient API
+
+Brushes are observable values shared by controls, themes, dynamic resources, animation, and the
+Designer. `SolidColorBrush`, `LinearGradientBrush`, `RadialGradientBrush`, and `SweepGradientBrush`
+support opacity and transforms; gradient brushes also support `Pad`, `Repeat`, and `Reflect` spread.
+Use a brush-valued property or dynamic resource when a value should update without recreating the
+control.
+
+`GradientBrush.GradientStops` is now a `GradientStopCollection`. Collection initializers, `Add`,
+`AddRange`, `Insert`, `Remove`, `Move`, and `Clear` notify the owning brush, including when a contained
+stop changes. Code that explicitly stores the property as `List<GradientStop>` must instead use
+`GradientStopCollection`, `IList<GradientStop>`, or `IReadOnlyList<GradientStop>`. Rebuild compiled
+consumers because the concrete property signature changed.
+
+```csharp
+var brush = new LinearGradientBrush();
+brush.GradientStops.AddRange([
+    new GradientStop(Color.CornflowerBlue, 0f),
+    new GradientStop(Color.MediumPurple, 1f)
+]);
+```
+
+## Adopt ThemeManager incrementally
+
+The static `Theme` facade and `Theme.SetBuiltInTheme` remain available. New reusable code should use
+typed `ThemeTokens` and dynamic resource references so controls follow a later theme commit.
+
+```csharp
+ThemeManager.Current.Apply(BuiltInThemes.Dark);
+
+card.SetResourceReference(
+    nameof(Control.BackgroundBrush),
+    ThemeResourceKeys.Create(ThemeTokenCategory.Brush, "ProductCard"));
+```
+
+Lookup order is control, nearest parent, window, `Application.Resources`, then
+`Application.ThemeResources`. Application resources therefore continue to override theme defaults.
+`Apply` and `ApplyAsync` commit atomically on the UI thread, refresh active visual states, and batch
+repaint requests across open windows. Visual-only theme refresh does not force a full layout pass;
+controls whose typography or metrics change may request their existing targeted layout path.
+
+## JSON themes
+
+`ThemeJsonSerializer` reads and writes the versioned theme schema for colors, brushes, gradients,
+typography, metrics, motion, inheritance, and allowed custom resources. Parsing is strict and does
+not resolve arbitrary CLR types or read adjacent files from a `baseTheme` value. Unknown fields,
+unsupported discriminators, invalid ranges, missing bases, and inheritance cycles produce
+diagnostics rather than a partial commit.
+
+If an application had a permissive custom JSON loader, validate its files against
+[the 1.9.0 schema](../theme-json-schema.md) before switching loaders.
+
+## Theme transitions are opt-in
+
+An ordinary `Apply` is immediate. Set `ThemeTransitionOptions.Enabled = true` to animate compatible
+values. Reduced-motion and disabled-animation policies can still make an opted-in transition apply
+its final value immediately. Incompatible brush types or stop structures, and layout-affecting
+metrics, switch discretely.
+
+```csharp
+ThemeManager.Current.Apply(
+    BuiltInThemes.Dark,
+    new ThemeApplyOptions
+    {
+        Transition = new ThemeTransitionOptions
+        {
+            Enabled = true,
+            Duration = TimeSpan.FromMilliseconds(250),
+            RespectReducedMotion = true
+        }
+    });
+```
+
+Treat `ThemeChanged` as the atomic commit notification. Observe `ThemeTransitionCompleted` or the
+returned transition handle when code must know that an animation has ended.
+
+## Composable animations
+
+Existing `FadeToAsync`, `TranslateToAsync`, `ScaleToAsync`, and `RotateToAsync` helpers remain source-
+compatible. New scenarios can create reusable `AnimationDefinition` instances, combine them with
+`Animation.Sequence`, `Animation.Parallel`, or `AnimationTimeline`, and control the returned
+`AnimationRun`. Derive from `AnimationDefinition` for a custom animation; do not introduce a second
+timer or per-control scheduler.
+
+Infinite repeats require explicit cancellation. Owner/key replacement, pause/resume, lifecycle,
+reduced motion, and stale-handle behavior are supplied by the shared scheduler.
+
+## Pressed visuals and interaction effects are opt-in
+
+Standard input is always dispatched independently of animation configuration. Hit testing, focus,
+pointer capture, editor caret placement, selection, drag selection, mouse up, double-click, and
+keyboard input are not conditioned on `StylePressed` or `InteractionEffects`.
+
+A plain Panel, layout container, or DataGridView has no implicit click/ripple effect. Opt in on the
+exact target:
+
+```csharp
+panel.InteractionEffects.Add(new RippleEffect());
+```
+
+Effects do not bubble automatically from a child to its parent. DataGridView has no general cell/
+row effect-target API in 1.9.0, so its default remains none; custom cell-local behavior should stay
+application code until a dedicated target contract is designed.
+
+## Designer interaction-effect serialization
+
+The Property Grid collection editor serializes ordered built-in `RippleEffect` and
+`PressScaleEffect` descriptions and generates explicit `InteractionEffects.Add(...)` calls. Custom
+effects and custom animation definitions remain code-first. Canceling the editor leaves the design
+document unchanged. A general Designer undo/redo transaction stack for effect collections is not
+part of this release.
+
+## Child order and Z-order
+
+For ordinary containers, a `.mfdesign` child array is front-to-back: index zero is front-most.
+Runtime `Controls.Add` appends a new front-most child, so the generator emits ordinary children from
+back to front. Flow, table, and tab containers retain authored layout sequence and are not globally
+reversed.
+
+`BringToFront` moves an ordinary design child to index zero; `SendToBack` moves it to the last index.
+Runtime controls use their corresponding collection semantics. The generator and reverse parser
+perform the mapping explicitly, so preview, save/reload, generation, reverse sync, and runtime agree.
+Regenerating checked-in `.Designer.cs` can therefore reorder `Controls.Add` lines. Existing
+`.mfdesign` files remain compatible and do not need a new `childOrder` field.
+
+For docked controls, stored bounds supply size/thickness while layout computes position. Do not rely
+on stale saved `X`/`Y` coordinates to establish dock order.
+
+## Editor and input regression fixes
+
+The 1.9.0 input path preserves base mouse-down processing before optional visual-state and effect
+observers. RichTextBox and MarkdownEditor also share corrected CRLF/UTF-16 hit mapping. Caret
+placement, typing after a click, Shift+click, drag selection, double-click selection, editor controls
+inside Panel/DataGridView hosts, capture release, focus loss, and detach cleanup no longer depend on
+animation opt-in.
+
+## Experimental Android status
+
+Android builds the shared Brush, theme, animation, and control-tree paths, but remains experimental.
+It uses the existing lifecycle integration, may refresh platform animation settings when returning
+to the foreground rather than through a live `ContentObserver`, and uses an explicit Light/Dark
+fallback for System themes. Validate frame pacing, background/foreground transitions, touch, IME,
+and rendering on a real emulator/device before relying on Android behavior.
+
+## Not included in 1.9.0
+
+The release does not add a general animated-layout subsystem, interpolated layout metrics, complete
+cross-structure Brush interpolation, custom-effect Designer support, Shapes, or AppShell/navigation.
+These remain future roadmap items rather than hidden compatibility promises.
+

--- a/docs/migrations/1.8.0-to-1.9.0.md
+++ b/docs/migrations/1.8.0-to-1.9.0.md
@@ -168,4 +168,3 @@ and rendering on a real emulator/device before relying on Android behavior.
 The release does not add a general animated-layout subsystem, interpolated layout metrics, complete
 cross-structure Brush interpolation, custom-effect Designer support, Shapes, or AppShell/navigation.
 These remain future roadmap items rather than hidden compatibility promises.
-

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -1,10 +1,10 @@
 # Android platform status
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.8.0 is **Experimental**. APIs, project structure, and
+> Android support in ModernFormsNext 1.9.0 is **Experimental**. APIs, project structure, and
 > runtime behavior may still change. It is not yet recommended for production applications.
 
-Windows remains the primary and most mature ModernFormsNext platform. Android 1.8.0 provides a
+Windows remains the primary and most mature ModernFormsNext platform. Android 1.9.0 provides a
 real shared-control vertical slice: a .NET Android host can attach one ModernFormsNext `Control`
 tree to a SkiaSharp surface and exercise framework layout, rendering, input, and text editing.
 It is not yet a general replacement for the Windows `Form` and WindowKit windowing path.

--- a/docs/roadmap/ModernFormsNext-Framework-Roadmap.md
+++ b/docs/roadmap/ModernFormsNext-Framework-Roadmap.md
@@ -1,7 +1,8 @@
 # ModernFormsNext framework roadmap
 
-- Baseline audited: 2026-07-17
+- Baseline audited: 2026-08-01
 - Paint/gradient foundation implemented: 2026-07-19
+- ThemeManager, composable animations, and platform animation polish implemented for 1.9.0
 - SDK baseline: .NET 10 (`10.0.201`)
 - Runtime priority: Windows first; Android is an experimental shared-control Skia vertical slice
 - Purpose: architecture and delivery sequence, not a promise that every listed API is implemented
@@ -20,9 +21,9 @@ or the complete WindowKit service set.
 The architecture should therefore be extended, not replaced. The implementation order is:
 
 1. dynamic resources (first vertical slice implemented with this roadmap);
-2. paint/brush contracts (implemented foundation; theme tokens remain ThemeManager work);
-3. UI animation scheduler hardening (implemented foundation);
-4. ThemeManager and localization;
+2. paint/brush contracts (implemented foundation);
+3. UI animation scheduler, composition, and platform polish (implemented foundation);
+4. ThemeManager (implemented foundation), then localization;
 5. page lifecycle, navigation, routing, tabs, flyout, and shell;
 6. virtualized data controls and SearchBar;
 7. shapes and path geometry;
@@ -48,7 +49,7 @@ already exist.
 | Paints | Observable `Drawing.Brush`; solid, glass, no-fill, linear/radial/sweep gradients; typed stops; opacity/transform/spread; shared Skia adapter | Reuse for ThemeManager and future shapes/charts. Version and implement the documented JSON direction only with ThemeManager validation. |
 | Rendering | Per-control `SKBitmap` back buffers, renderer classes, `PaintEventArgs`, Skia canvas helpers | Shapes/charts/documents render through Skia and existing clipping/invalidation. Avoid native control substitution. |
 | Invalidation | Property setters call `Invalidate`, layout setters use layout transactions; windows invalidate platform surfaces | Dynamic values call normal setters and do not globally repaint. Add dirty-region precision later. |
-| Animation | Shared monotonic `AnimationScheduler`, handles, owner/key replacement, typed interpolators, Brush transitions, motion policy, diagnostics, and compatibility helpers | Reuse for theme/shape/navigation transitions; keep layout invalidation explicit and add native reduced-motion discovery later. |
+| Animation | Shared monotonic `AnimationScheduler`, composable definitions/runs, handles, owner/key replacement, typed interpolators, Brush transitions, native reduced-motion policy, diagnostics, and compatibility helpers | Reuse for theme/shape/navigation transitions; keep layout invalidation explicit and design animated layout as a separate future subsystem. |
 | Input | Framework mouse/keyboard/text/IME pipeline, capture, hit testing, touch scrolling in `SkiaControlSurface` | Collection, SearchBar, pages, charts, and shapes share the same input path. |
 | Data binding | `IBindableComponent`, `Binding`, `BindingContext`, `BindingSource`, list managers and converters | Reuse for items sources and selected values; add collection-change/virtualization contracts instead of a parallel binding engine. |
 | Serialization | `System.Text.Json` in designer and binding conversion; stable design document serializer | Reuse conventions and converters, but keep theme/localization runtime schemas separate from designer files. |
@@ -67,9 +68,10 @@ already exist.
   resolution, brushes for every surface, typography records, shadow, radius, and transitions.
 - Brush mutation, opacity, transforms, stable stop ordering, spread modes, and targeted invalidation
   are implemented. A batch update scope, advanced interpolation, and a versioned JSON loader remain.
-- The shared scheduler now marshals callbacks to the UI dispatcher, uses elapsed monotonic time,
-  stops while idle, and pauses over Android background lifecycle. Native reduced-motion discovery
-  and physical-device Android frame-pacing validation remain future work.
+- The shared scheduler marshals callbacks to the UI dispatcher, uses elapsed monotonic time, stops
+  while idle, pauses over Android background lifecycle, and integrates Windows/experimental Android
+  reduced-motion preferences. A live Android settings observer, physical-device frame-pacing
+  validation, and a general animated-layout subsystem remain future work.
 - No localization catalog/provider, plural rules, missing-key diagnostics, dynamic culture change,
   or verified end-to-end RTL layout behavior.
 - Lists and grids are retained collections; there is no shared item-container generator,
@@ -234,10 +236,10 @@ its active-entry buffer rather than allocating a LINQ snapshot each frame.
 
 Done/tests: deterministic manual clock/tick tests cover progress, delay, dropped frames, pause,
 replacement, cancellation, faults, policy modes, dispatcher affinity, high animation counts,
-interpolation, Brush/dynamic-resource invalidation, and owner lifetime without `Thread.Sleep`.
-ControlGallery provides opt-in manual checks and cancels all work on unload. Native display-link
-pacing, OS reduced-motion discovery, repeat/auto-reverse/groups, and a general animated-layout layer
-are explicitly deferred.
+interpolation, Brush/dynamic-resource invalidation, composition, keyframes, repeat, auto-reverse,
+visual-state transitions, interaction effects, and owner lifetime without `Thread.Sleep`.
+ControlGallery provides opt-in manual checks and cancels all work on unload. A general animated-
+layout layer and physical-device Android frame-pacing validation are explicitly deferred.
 
 #### 3. ThemeManager — implemented foundation
 
@@ -615,8 +617,8 @@ when specialized render models are clearer.
 Exact semantic versions are intentionally not assigned until release capacity is known. Use these
 dependency-based bands:
 
-- Foundation work: dynamic resources, paint hardening, the shared UI animation scheduler, and the
-  ThemeManager/JSON/atomic-transition foundation are implemented.
+- Foundation work: dynamic resources, paint hardening, the shared/composable UI animation platform,
+  interaction effects, and the ThemeManager/JSON/atomic-transition foundation are implemented.
 - Globalization release: localization, culture fallback, live resource updates, and diagnostics on
   the completed theme foundation.
 - Navigation preview: Page/ContentPage/NavigationPage/routing; Windows host plus Android surface host.
@@ -637,8 +639,8 @@ dependency-based bands:
   and explicit reset APIs before broad parallel execution.
 - Reflection-based CLR property references need a trimming/source-generation strategy before AOT is
   advertised.
-- Native reduced-motion discovery and Android physical-device pacing remain open even though shared
-  animation callbacks now use the platform UI dispatcher.
+- Android physical-device pacing and live settings observation remain open even though shared
+  animation callbacks use the platform UI dispatcher and foreground refreshes motion preferences.
 - Virtualization, document rendering, and charts compete for cache/memory budgets. Introduce shared
   diagnostics and bounded caches rather than independent unbounded stores.
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -5,8 +5,8 @@ resource, Brush, `ControlStyle`, static `Theme`, dispatcher, and animation sched
 does not introduce XAML or a second control/property model.
 
 > [!NOTE]
-> This guide documents the planned ModernFormsNext 1.9.0 API in the current source tree. No package
-> version is changed by this work.
+> This guide documents the ModernFormsNext 1.9.0 API. Theme transitions remain opt-in and Android
+> integration remains experimental.
 
 ## Apply built-in themes
 

--- a/scripts/Validate-ReleasePackages.ps1
+++ b/scripts/Validate-ReleasePackages.ps1
@@ -1,0 +1,269 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackageDirectory,
+
+    [string]$ExpectedVersion
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+if ([string]::IsNullOrWhiteSpace($ExpectedVersion)) {
+    $repositoryRoot = Split-Path -Parent $PSScriptRoot
+    [xml]$versionProperties = Get-Content -LiteralPath (Join-Path $repositoryRoot 'Directory.Build.props') -Raw
+    $versionNode = $versionProperties.SelectSingleNode("//*[local-name()='ModernFormsNextPackageVersion']")
+    if ($null -eq $versionNode -or [string]::IsNullOrWhiteSpace($versionNode.InnerText)) {
+        throw "Directory.Build.props does not define ModernFormsNextPackageVersion."
+    }
+    $ExpectedVersion = $versionNode.InnerText.Trim()
+}
+
+$packageSpecs = @(
+    [pscustomobject]@{ Id = "ModernFormsNext"; Frameworks = @("net10.0", "net10.0-windows"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.CodeGeneration"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.Designer"; Frameworks = @("net10.0-windows"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.Designing"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.Templates"; Frameworks = @(); Symbols = $false; Template = $true },
+    [pscustomobject]@{ Id = "ModernFormsNext.WindowKit"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.WindowKit.Backend"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.WindowKit.Backend.Windows"; Frameworks = @("net10.0"); Symbols = $true; Template = $false }
+)
+
+function Get-ArchiveEntryText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$EntryName
+    )
+
+    $entry = $Archive.GetEntry($EntryName)
+    if ($null -eq $entry) {
+        throw "Archive '$($Archive.ToString())' does not contain '$EntryName'."
+    }
+
+    $stream = $entry.Open()
+    try {
+        $reader = [System.IO.StreamReader]::new($stream)
+        try {
+            return $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Get-NuspecMetadata {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PackageId
+    )
+
+    $nuspecEntry = @($Archive.Entries | Where-Object { $_.FullName -ieq "$PackageId.nuspec" })
+    if ($nuspecEntry.Count -ne 1) {
+        throw "Expected one '$PackageId.nuspec' entry, found $($nuspecEntry.Count)."
+    }
+
+    [xml]$nuspec = Get-ArchiveEntryText -Archive $Archive -EntryName $nuspecEntry[0].FullName
+    $metadata = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']")
+    if ($null -eq $metadata) {
+        throw "Package '$PackageId' has no nuspec metadata node."
+    }
+
+    return [pscustomobject]@{ Document = $nuspec; Metadata = $metadata; Text = $nuspec.OuterXml }
+}
+
+function Assert-SafeArchiveEntries {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath
+    )
+
+    foreach ($entry in $Archive.Entries) {
+        $name = $entry.FullName.Replace('\', '/')
+        if ($name -match '(^|/)(bin|obj|\.vs)(/|$)' `
+            -or $name -match '\.(user|suo|apk|vsix|tmp|cache)$' `
+            -or $name -match '(^|/)(tmp|temp)(/|$)' `
+            -or $name -match '^[A-Za-z]:/' `
+            -or $name.StartsWith('/')) {
+            throw "Archive '$ArchivePath' contains forbidden entry '$name'."
+        }
+
+        if ($entry.Length -gt 0 -and $entry.Length -le 1MB -and $name -match '\.(nuspec|props|targets|json|xml|md|csproj)$') {
+            $text = Get-ArchiveEntryText -Archive $Archive -EntryName $entry.FullName
+            if ($text -match '[A-Za-z]:[\\/]Users[\\/]' -or $text -match '/Users/[^/]+/') {
+                throw "Archive '$ArchivePath' contains an absolute local user path in '$name'."
+            }
+        }
+    }
+}
+
+function Test-FrameworkEntry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EntryName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Framework,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FileName
+    )
+
+    $escapedFramework = [regex]::Escape($Framework)
+    $frameworkSuffix = if ($Framework.EndsWith('-windows', [StringComparison]::Ordinal)) { '[^/]*' } else { '' }
+    return $EntryName -match "^lib/$escapedFramework$frameworkSuffix/$([regex]::Escape($FileName))$"
+}
+
+function Assert-PackageArchive {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Spec,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        Assert-SafeArchiveEntries -Archive $archive -ArchivePath $Path
+        $nuspec = Get-NuspecMetadata -Archive $archive -PackageId $Spec.Id
+        $idNode = $nuspec.Metadata.SelectSingleNode("*[local-name()='id']")
+        $versionNode = $nuspec.Metadata.SelectSingleNode("*[local-name()='version']")
+        if ($idNode.InnerText -cne $Spec.Id -or $versionNode.InnerText -cne $ExpectedVersion) {
+            throw "Package '$Path' identifies as '$($idNode.InnerText)' version '$($versionNode.InnerText)'."
+        }
+
+        if ($nuspec.Text.IndexOf('1.8.0', [StringComparison]::Ordinal) -ge 0) {
+            throw "Package '$Path' contains stale 1.8.0 active nuspec metadata."
+        }
+
+        $readmeNode = $nuspec.Metadata.SelectSingleNode("*[local-name()='readme']")
+        $iconNode = $nuspec.Metadata.SelectSingleNode("*[local-name()='icon']")
+        if ($null -eq $readmeNode -or $readmeNode.InnerText -cne 'README.md' -or $null -eq $archive.GetEntry('README.md')) {
+            throw "Package '$Path' does not declare and contain README.md."
+        }
+        if ($null -eq $iconNode -or $iconNode.InnerText -cne 'icon.png' -or $null -eq $archive.GetEntry('icon.png')) {
+            throw "Package '$Path' does not declare and contain icon.png."
+        }
+
+        $repositoryNode = $nuspec.Metadata.SelectSingleNode("*[local-name()='repository']")
+        if ($null -eq $repositoryNode -or $repositoryNode.GetAttribute('url') -cne 'https://github.com/ProGraMajster/ModernFormsNext') {
+            throw "Package '$Path' has missing or unexpected repository metadata."
+        }
+
+        foreach ($dependency in @($nuspec.Metadata.SelectNodes(".//*[local-name()='dependency']"))) {
+            $dependencyId = $dependency.GetAttribute('id')
+            $dependencyVersion = $dependency.GetAttribute('version')
+            if ($dependencyId -ceq 'Microsoft.VisualStudio.SDK' -or ($dependencyId -ceq 'MessagePack' -and $dependencyVersion -match '2\.5\.192')) {
+                throw "Package '$Path' contains forbidden dependency '$dependencyId' version '$dependencyVersion'."
+            }
+            if ($dependencyId.StartsWith('ModernFormsNext', [StringComparison]::Ordinal) -and $dependencyVersion.IndexOf($ExpectedVersion, [StringComparison]::Ordinal) -lt 0) {
+                throw "Package '$Path' has mismatched internal dependency '$dependencyId' version '$dependencyVersion'."
+            }
+        }
+
+        $entries = @($archive.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+        if ($Spec.Template) {
+            if (-not ($entries | Where-Object { $_ -match '(^|/)\.template\.config/template\.json$' }) `
+                -or -not ($entries | Where-Object { $_ -match '(^|/)MyApp\.csproj$' })) {
+                throw "Template package '$Path' is missing template.json or MyApp.csproj."
+            }
+            if ($entries | Where-Object { $_ -match '^lib/' }) {
+                throw "Template package '$Path' unexpectedly contains library output."
+            }
+        }
+        else {
+            foreach ($framework in $Spec.Frameworks) {
+                if (-not ($entries | Where-Object { Test-FrameworkEntry -EntryName $_ -Framework $framework -FileName "$($Spec.Id).dll" })) {
+                    throw "Package '$Path' is missing $($Spec.Id).dll for '$framework'."
+                }
+                if (-not ($entries | Where-Object { Test-FrameworkEntry -EntryName $_ -Framework $framework -FileName "$($Spec.Id).xml" })) {
+                    throw "Package '$Path' is missing XML documentation for '$framework'."
+                }
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+function Assert-SymbolArchive {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Spec,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        Assert-SafeArchiveEntries -Archive $archive -ArchivePath $Path
+        $nuspec = Get-NuspecMetadata -Archive $archive -PackageId $Spec.Id
+        $idNode = $nuspec.Metadata.SelectSingleNode("*[local-name()='id']")
+        $versionNode = $nuspec.Metadata.SelectSingleNode("*[local-name()='version']")
+        if ($idNode.InnerText -cne $Spec.Id -or $versionNode.InnerText -cne $ExpectedVersion) {
+            throw "Symbol package '$Path' has mismatched identity or version."
+        }
+
+        $entries = @($archive.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+        foreach ($framework in $Spec.Frameworks) {
+            if (-not ($entries | Where-Object { Test-FrameworkEntry -EntryName $_ -Framework $framework -FileName "$($Spec.Id).pdb" })) {
+                throw "Symbol package '$Path' is missing $($Spec.Id).pdb for '$framework'."
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+$resolvedPackageDirectory = (Resolve-Path -LiteralPath $PackageDirectory).Path
+$packageFiles = @(Get-ChildItem -LiteralPath $resolvedPackageDirectory -File | Where-Object { $_.Extension -ceq '.nupkg' })
+$symbolFiles = @(Get-ChildItem -LiteralPath $resolvedPackageDirectory -File | Where-Object { $_.Extension -ceq '.snupkg' })
+$expectedSymbolCount = @($packageSpecs | Where-Object Symbols).Count
+
+if ($packageFiles.Count -ne $packageSpecs.Count) {
+    throw "Expected $($packageSpecs.Count) .nupkg files, found $($packageFiles.Count)."
+}
+if ($symbolFiles.Count -ne $expectedSymbolCount) {
+    throw "Expected $expectedSymbolCount .snupkg files, found $($symbolFiles.Count)."
+}
+
+foreach ($spec in $packageSpecs) {
+    $packageName = "$($spec.Id).$ExpectedVersion.nupkg"
+    $package = @($packageFiles | Where-Object Name -CEQ $packageName)
+    if ($package.Count -ne 1) {
+        throw "Expected exactly one '$packageName', found $($package.Count)."
+    }
+    Assert-PackageArchive -Spec $spec -Path $package[0].FullName
+
+    $symbolName = "$($spec.Id).$ExpectedVersion.snupkg"
+    $symbol = @($symbolFiles | Where-Object Name -CEQ $symbolName)
+    if ($spec.Symbols) {
+        if ($symbol.Count -ne 1) {
+            throw "Expected exactly one '$symbolName', found $($symbol.Count)."
+        }
+        Assert-SymbolArchive -Spec $spec -Path $symbol[0].FullName
+    }
+    elseif ($symbol.Count -ne 0) {
+        throw "Package '$($spec.Id)' must not produce a symbol package."
+    }
+}
+
+Write-Host "Validated $($packageFiles.Count) NuGet packages and $($symbolFiles.Count) symbol packages at version $ExpectedVersion."


### PR DESCRIPTION
## Summary

Finalizes ModernFormsNext 1.9.0 across the framework, Designer, templates, Visual Studio extension, documentation, package validation, and tag-triggered publication pipeline.

Release branch: `release/1.9.0`  
Target: `master`  
Version/tag: `1.9.0` / `v1.9.0`

## Release highlights

- `ThemeManager` with typed/inheritable themes, atomic apply/rollback, dynamic theme resources, built-in Light/Dark themes, strict versioned JSON, and immediate or animated switching.
- Shared composable animation platform: sequence, parallel, timeline, keyframes, repeat, auto-reverse, cancellation, reduced-motion policy, and UI-thread repaint batching.
- Ripple and press-scale interaction effects are opt-in and target-local; standard pointer input remains unconditional.
- Active visual states refresh after theme commits and animation ticks without requiring hover, click, focus, resize, or per-frame layout.
- Designer preview, `.mfdesign`, generated C#, reverse sync, document outline, and runtime now share one child/Z-order contract.
- Editor regressions fixed for caret placement, CRLF/UTF-16 hit mapping, drag selection, Shift+click, double-click, focus, capture, and cleanup.
- Dependency and warning cleanup removes the vulnerable MessagePack 2.5.192 path, narrows Visual Studio SDK dependencies, and restores warning-free builds.
- Migration guidance from 1.8.0 to 1.9.0, full release notes, known limitations, version-consistency tests, and archive validators are included.

## Compatibility

No intentional public type removal, package rename, namespace move, target-framework removal, VSIX identity change, or compatibility-helper removal is included.

`GradientBrush.GradientStops` now exposes the observable `GradientStopCollection` rather than `List<GradientStop>`. Common collection operations remain source-compatible; compiled consumers must rebuild, and code depending on the exact concrete `List<T>` type may need adjustment.

Existing `.mfdesign` documents remain compatible and require no schema migration.

## Package matrix

| Package ID | Version | Symbols |
| --- | --- | --- |
| ModernFormsNext | 1.9.0 | yes |
| ModernFormsNext.CodeGeneration | 1.9.0 | yes |
| ModernFormsNext.Designer | 1.9.0 | yes |
| ModernFormsNext.Designing | 1.9.0 | yes |
| ModernFormsNext.Templates | 1.9.0 | not applicable |
| ModernFormsNext.WindowKit | 1.9.0 | yes |
| ModernFormsNext.WindowKit.Backend | 1.9.0 | yes |
| ModernFormsNext.WindowKit.Backend.Windows | 1.9.0 | yes |

The repository validator confirmed exactly 8 `.nupkg` and 7 `.snupkg` archives at version 1.9.0. It checked identity/version, internal dependencies, target-framework DLLs and XML documentation, PDBs, README, icon, repository metadata, template content, archive path safety, stale metadata, and accidental build/IDE/APK/VSIX content.

## Final validation on `fb74193`

- forced no-cache restore: passed, 0 warnings, 0 errors;
- Debug solution build: passed in 52.54 s, 0 warnings, 0 errors;
- Release solution build: passed in 1:44.70, 0 warnings, 0 errors;
- Debug tests: 845/845 passed, 0 failed, 0 skipped;
- Release tests: 845/845 passed, 0 failed, 0 skipped;
- release/version consistency tests: 5/5 passed as part of both full suites;
- NuGet vulnerability audit including transitive dependencies: no vulnerable packages in any project;
- `git diff --check`: passed;
- Release pack: 8 `.nupkg` + 7 `.snupkg`, all archives passed the repository validator;
- Windows backend, experimental Android backend, both Android samples, Designer, extension, VSIX, ControlGallery, DemoApp, Designer Playground, and Cross-Platform Sample all built;
- Release VSIX validator: passed; manifest version 1.9.0;
- Release VSIX SHA-256: `4DAD1E6911F7710DEFFE7645B9CBC91D6CFAC4146C30DD96DA16BBD6C6789B68`;
- Windows startup smoke: ControlGallery, DemoApp, Designer Playground, and Cross-Platform Sample each opened a responsive window, closed normally, and exited with code 0;
- both signed Android APKs passed v1/v2/v3 signature verification.

## Platform status

Windows is the primary supported runtime and passed full build plus startup/clean-shutdown smoke validation.

Android remains experimental. The backend and both samples build, deterministic Android tests pass, and both APKs validate. `adb devices -l` reported no device or emulator, so install, launch, rendering, touch/IME, lifecycle, and frame-pacing behavior are not claimed as runtime-validated.

## Known limitations

Tracked for 1.10.0 and intentionally not included here:

- animated layout subsystem: #25;
- layout-aware visual-state interpolation: #26;
- broader Brush interpolation cases: #27;
- custom animation/effect Designer support and undo/redo infrastructure: #28;
- full Android runtime/device validation and live platform-state observation: #29;
- Shapes and AppShell/navigation: #11 and #12.

## Release workflow

The tag-triggered `Release` workflow now performs checkout, .NET setup, forced restore, Release build, Release tests, pack, package-content validation, stable GitHub Release creation from `docs/1.9.0-release-notes.md`, NuGet trusted publishing, and symbol publication through the NuGet V3 symbol source.

## Publication checklist

### Before merge

- [x] PR is based on `master` and the release branch is not behind
- [x] No merge conflicts
- [x] All review conversations resolved
- [x] Milestone ModernFormsNext 1.9.0 has 0 open issues
- [x] Version is consistently 1.9.0 in central props, package projects, template, VSIX, docs, workflow, and tests
- [x] Tag `v1.9.0` does not exist
- [x] GitHub Release `v1.9.0` does not exist
- [x] No NuGet package ID already contains version 1.9.0
- [x] Restore, Debug/Release builds, Debug/Release tests, vulnerability audit, package validation, VSIX validation, Windows smoke tests, and Android build/APK validation passed
- [x] Windows status and Android experimental limitations documented

### After merge

- [x] Required check on `master` remains green
- [x] Annotated tag `v1.9.0` points exactly to the merge commit
- [x] Tag-triggered Release workflow succeeds
- [x] Stable GitHub Release is published with the validated 8+7 package assets and final Release VSIX
- [x] All eight NuGet packages are accepted and indexed; seven symbol packages are validated/indexed
- [x] Existing Visual Studio Marketplace listing is updated, or the final VSIX is handed off for the only remaining manual upload
- [x] Milestone ModernFormsNext 1.9.0 is closed
- [x] ModernFormsNext Roadmap 1.9.0 items are Done; 1.10.0 issues remain open

## Publication result

- PR merged with a merge commit: `2f55a08df982349c2c61d6f6c6cce53c5135da6b`.
- Annotated tag `v1.9.0` points to the merge commit.
- Master CI and tag-triggered Release workflow passed.
- Stable GitHub Release contains 8 `.nupkg`, 7 `.snupkg`, and `ModernFormsNextDesigner.vsix`.
- All eight NuGet packages are accepted, visible on package pages and flat-container, and searchable as 1.9.0; all seven symbol packages are downloadable.
- Marketplace automation was not attempted because no Marketplace PAT, repository secret, or publish manifest is available. The existing listing must be updated manually with `ModernFormsNextDesigner.vsix` 1.9.0 (identity `ModernFormsNext.Designer`, publisher `ProGraMajster`, SHA-256 `4DAD1E6911F7710DEFFE7645B9CBC91D6CFAC4146C30DD96DA16BBD6C6789B68`).
- Milestone ModernFormsNext 1.9.0 is closed; all 1.9.0 roadmap items are Done and future issues remain open.


