### PR TITLE
Add animated layout subsystem

### DIFF
--- a/ModernFormsNext.Tests/AnimatedLayoutTests.cs
+++ b/ModernFormsNext.Tests/AnimatedLayoutTests.cs
@@ -1,0 +1,675 @@
+using System.Drawing;
+using System.Reflection;
+using ModernFormsNext.Animations;
+using ModernFormsNext.WindowKit.Platform;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class AnimatedLayoutTests
+{
+    private static readonly TimeSpan Duration = TimeSpan.FromMilliseconds(100);
+
+    [Fact]
+    public void BoundsChangeWithoutTransitionIsImmediate()
+    {
+        using var root = new Panel { Size = new Size(500, 300) };
+        using var child = new Control { Bounds = new Rectangle(10, 20, 40, 30) };
+        root.Controls.Add(child);
+        using var surface = new SkiaControlSurface(root);
+
+        child.Bounds = new Rectangle(100, 80, 120, 90);
+
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+    }
+
+    [Fact]
+    public void TransitionStartsAtPreviousPresentationBounds()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        Rectangle previous = fixture.Child.Bounds;
+
+        fixture.Child.Bounds = new Rectangle(100, 80, 120, 90);
+
+        Assert.Equal(new RectangleF(previous.X, previous.Y, previous.Width, previous.Height), fixture.Child.PresentationBounds);
+        Assert.True(fixture.Child.HasActiveLayoutTransition);
+    }
+
+    [Fact]
+    public void TransitionFinishesExactlyAtLogicalTarget()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        var target = new Rectangle(101, 83, 127, 91);
+
+        fixture.Child.Bounds = target;
+        harness.AdvanceAndTick(Duration);
+
+        Assert.Equal(target, fixture.Child.Bounds);
+        Assert.Equal(target, Rectangle.Round(fixture.Child.PresentationBounds));
+        Assert.False(fixture.Child.HasActiveLayoutTransition);
+    }
+
+    [Fact]
+    public void TransitionInterpolatesX()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+
+        fixture.Child.Bounds = new Rectangle(110, 20, 40, 30);
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(60f, fixture.Child.PresentationBounds.X);
+    }
+
+    [Fact]
+    public void TransitionInterpolatesY()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+
+        fixture.Child.Bounds = new Rectangle(10, 120, 40, 30);
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(70f, fixture.Child.PresentationBounds.Y);
+    }
+
+    [Fact]
+    public void TransitionInterpolatesWidth()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+
+        fixture.Child.Bounds = new Rectangle(10, 20, 140, 30);
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(90f, fixture.Child.PresentationBounds.Width);
+    }
+
+    [Fact]
+    public void TransitionInterpolatesHeight()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+
+        fixture.Child.Bounds = new Rectangle(10, 20, 40, 130);
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(80f, fixture.Child.PresentationBounds.Height);
+    }
+
+    [Fact]
+    public void RetargetStartsAtCurrentPresentationBounds()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+
+        fixture.Child.Left = 110;
+        harness.AdvanceAndTick(Duration / 2);
+        RectangleF current = fixture.Child.PresentationBounds;
+
+        fixture.Child.Left = 310;
+
+        Assert.Equal(current, fixture.Child.PresentationBounds);
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(185f, fixture.Child.PresentationBounds.X);
+    }
+
+    [Fact]
+    public void RepeatedRetargetsStartAtEachCurrentPresentationBounds()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+
+        fixture.Child.Left = 110;
+        harness.AdvanceAndTick(Duration / 4);
+        RectangleF presentationTowardB = fixture.Child.PresentationBounds;
+
+        fixture.Child.Left = 210;
+        Assert.Equal(presentationTowardB, fixture.Child.PresentationBounds);
+        harness.AdvanceAndTick(Duration / 4);
+        RectangleF presentationTowardC = fixture.Child.PresentationBounds;
+
+        fixture.Child.Left = 410;
+        Assert.Equal(presentationTowardC, fixture.Child.PresentationBounds);
+        harness.AdvanceAndTick(Duration);
+
+        Assert.Equal(fixture.Child.Bounds, Rectangle.Round(fixture.Child.PresentationBounds));
+        Assert.False(fixture.Child.HasActiveLayoutTransition);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void NonPositiveDurationAppliesTargetWithoutStartingTicker(int milliseconds)
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness, TimeSpan.FromMilliseconds(milliseconds));
+        var target = new Rectangle(100, 80, 120, 90);
+
+        fixture.Child.Bounds = target;
+
+        Assert.Equal(target, Rectangle.Round(fixture.Child.PresentationBounds));
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void DisablingTransitionSnapsToTargetAndUnregisters()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        fixture.Child.Left = 210;
+        harness.AdvanceAndTick(Duration / 4);
+
+        fixture.Transition.Enabled = false;
+
+        Assert.Equal(fixture.Child.Bounds, Rectangle.Round(fixture.Child.PresentationBounds));
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void CompletedTransitionStopsSharedScheduler()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+
+        fixture.Child.Left = 210;
+        harness.AdvanceAndTick(Duration);
+
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(1, harness.TickSource.StopTransitions);
+    }
+
+    [Fact]
+    public void FaultedEasingReleasesPresentationStateAndStopsScheduler()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        fixture.Transition.Easing = _ => throw new InvalidOperationException("Expected test fault.");
+        fixture.Child.Left = 210;
+
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(fixture.Child.Bounds, Rectangle.Round(fixture.Child.PresentationBounds));
+        Assert.False(fixture.Child.HasActiveLayoutTransition);
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().FaultedCount);
+    }
+
+    [Fact]
+    public void DisposedControlDoesNotRemainScheduled()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(500, 300) };
+        using var parent = new Panel { Bounds = new Rectangle(10, 20, 200, 120) };
+        using var child = new Panel { Bounds = new Rectangle(15, 25, 80, 60) };
+        using var grandChild = new Control { Bounds = new Rectangle(5, 10, 40, 30) };
+        child.Controls.Add(grandChild);
+        parent.Controls.Add(child);
+        root.Controls.Add(parent);
+        using var surface = new SkiaControlSurface(root);
+        ConfigureTransition(parent, harness);
+        ConfigureTransition(child, harness);
+        ConfigureTransition(grandChild, harness);
+        parent.Left = 210;
+        child.Top = 75;
+        grandChild.Left = 35;
+
+        Assert.Equal(3, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        parent.Dispose();
+
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(parent.Bounds, Rectangle.Round(parent.PresentationBounds));
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+        Assert.Equal(grandChild.Bounds, Rectangle.Round(grandChild.PresentationBounds));
+    }
+
+    [Fact]
+    public void RemovedControlDoesNotRemainScheduled()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        fixture.Child.Left = 210;
+
+        fixture.Root.Controls.Remove(fixture.Child);
+
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(fixture.Child.Bounds, Rectangle.Round(fixture.Child.PresentationBounds));
+    }
+
+    [Fact]
+    public void RemovingSubtreeCancelsNestedLayoutTransitions()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(500, 300) };
+        using var parent = new Panel { Bounds = new Rectangle(10, 20, 200, 120) };
+        using var child = new Panel { Bounds = new Rectangle(15, 25, 80, 60) };
+        using var grandChild = new Control { Bounds = new Rectangle(5, 10, 40, 30) };
+        child.Controls.Add(grandChild);
+        parent.Controls.Add(child);
+        root.Controls.Add(parent);
+        using var surface = new SkiaControlSurface(root);
+        ConfigureTransition(parent, harness);
+        ConfigureTransition(child, harness);
+        ConfigureTransition(grandChild, harness);
+        parent.Left = 210;
+        child.Top = 75;
+        grandChild.Left = 35;
+
+        Assert.Equal(3, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        root.Controls.Remove(parent);
+
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(parent.Bounds, Rectangle.Round(parent.PresentationBounds));
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+        Assert.Equal(grandChild.Bounds, Rectangle.Round(grandChild.PresentationBounds));
+    }
+
+    [Fact]
+    public void MultipleControlsShareOneSchedulerTickSource()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(500, 300) };
+        using var first = CreateAnimatedControl(harness, new Rectangle(10, 20, 40, 30));
+        using var second = CreateAnimatedControl(harness, new Rectangle(10, 80, 40, 30));
+        root.Controls.Add(first);
+        root.Controls.Add(second);
+        using var surface = new SkiaControlSurface(root);
+
+        first.Left = 210;
+        second.Left = 310;
+
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(1, harness.TickSource.StartTransitions);
+    }
+
+    [Fact]
+    public void DockLayoutCommitsTargetBeforeAnimatingPresentation()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(200, 100) };
+        using var child = new Control { Size = new Size(50, 30), Dock = DockStyle.Right };
+        root.Controls.Add(child);
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(200, 100);
+        child.AnimationSchedulerOverride = harness.Scheduler;
+        child.LayoutTransition = LinearTransition();
+        Rectangle oldPresentation = Rectangle.Round(child.PresentationBounds);
+
+        surface.Resize(300, 100);
+
+        Assert.Equal(250, child.Left);
+        Assert.Equal(oldPresentation, Rectangle.Round(child.PresentationBounds));
+        harness.AdvanceAndTick(Duration);
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+    }
+
+    [Fact]
+    public void AnchorLayoutAnimatesComputedWidthWithoutChangingAnchorSemantics()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Control { Size = new Size(200, 100) };
+        using var child = new Control
+        {
+            Bounds = new Rectangle(10, 10, 100, 30)
+        };
+        root.Controls.Add(child);
+        child.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right;
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(200, 100);
+        child.AnimationSchedulerOverride = harness.Scheduler;
+        child.LayoutTransition = LinearTransition();
+
+        surface.Resize(300, 100);
+
+        Assert.Equal(200, child.Width);
+        Assert.Equal(100f, child.PresentationBounds.Width);
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(150f, child.PresentationBounds.Width);
+    }
+
+    [Fact]
+    public void ConstraintsApplyToLogicalTargetBeforeTransition()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        fixture.Child.MinimumSize = new Size(50, 40);
+        fixture.Child.MaximumSize = new Size(120, 100);
+
+        fixture.Child.SetBounds(10, 20, 500, 1);
+
+        Assert.Equal(new Size(120, 40), fixture.Child.Size);
+        harness.AdvanceAndTick(Duration);
+        Assert.Equal(new SizeF(120, 40), fixture.Child.PresentationBounds.Size);
+    }
+
+    [Fact]
+    public void MovingAnimatedParentDoesNotScheduleUnchangedChild()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(500, 300) };
+        using var parent = CreateAnimatedControl(harness, new Rectangle(10, 20, 200, 120));
+        using var child = CreateAnimatedControl(harness, new Rectangle(15, 25, 40, 30));
+        parent.Controls.Add(child);
+        root.Controls.Add(parent);
+        using var surface = new SkiaControlSurface(root);
+        Rectangle childPresentation = Rectangle.Round(child.PresentationBounds);
+
+        parent.Location = new Point(210, 120);
+
+        Assert.True(parent.HasActiveLayoutTransition);
+        Assert.False(child.HasActiveLayoutTransition);
+        Assert.Equal(childPresentation, Rectangle.Round(child.PresentationBounds));
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void ResizingAnimatedParentDoesNotDoubleAnimateDockedDescendants()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(500, 300) };
+        using var parent = new Panel { Bounds = new Rectangle(10, 20, 200, 120) };
+        using var child = new Panel { Dock = DockStyle.Fill };
+        using var grandChild = new Control { Dock = DockStyle.Fill };
+        child.Controls.Add(grandChild);
+        parent.Controls.Add(child);
+        root.Controls.Add(parent);
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(500, 300);
+        parent.PerformLayout();
+        child.PerformLayout();
+
+        foreach (Control control in new Control[] { parent, child, grandChild })
+        {
+            control.AnimationSchedulerOverride = harness.Scheduler;
+            control.LayoutTransition = LinearTransition();
+        }
+
+        parent.Size = new Size(300, 200);
+
+        Assert.True(parent.HasActiveLayoutTransition);
+        Assert.False(child.HasActiveLayoutTransition);
+        Assert.False(grandChild.HasActiveLayoutTransition);
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+        Assert.Equal(grandChild.Bounds, Rectangle.Round(grandChild.PresentationBounds));
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void HitTestingUsesPresentationPositionDuringTransition()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        int clicks = 0;
+        fixture.Child.Click += (_, _) => clicks++;
+        fixture.Child.Left = 110;
+        harness.AdvanceAndTick(Duration / 2);
+
+        fixture.Surface.ProcessPointer(1, ControlSurfacePointerAction.Down, 65, 25);
+        fixture.Surface.ProcessPointer(1, ControlSurfacePointerAction.Up, 65, 25);
+        fixture.Surface.ProcessPointer(2, ControlSurfacePointerAction.Down, 115, 25);
+        fixture.Surface.ProcessPointer(2, ControlSurfacePointerAction.Up, 115, 25);
+
+        Assert.Equal(1, clicks);
+    }
+
+    [Fact]
+    public void PresentationHitTestingMapsScaledWidthBackToLogicalClientCoordinates()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        Point received = Point.Empty;
+        fixture.Child.MouseDown += (_, e) => received = e.Location;
+        fixture.Child.Width = 80;
+        harness.AdvanceAndTick(Duration / 2);
+
+        fixture.Surface.ProcessPointer(3, ControlSurfacePointerAction.Down, 40, 25);
+
+        Assert.Equal(40, received.X);
+    }
+
+    [Fact]
+    public void AccessibilityBoundsIncludeAncestorPresentationScaling()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(500, 300) };
+        using var parent = new Panel { Bounds = new Rectangle(10, 20, 100, 80) };
+        using var child = new Control { Dock = DockStyle.Fill };
+        parent.Controls.Add(child);
+        root.Controls.Add(parent);
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(500, 300);
+        parent.PerformLayout();
+        ConfigureTransition(parent, harness);
+        ConfigureTransition(child, harness);
+
+        parent.Size = new Size(200, 160);
+
+        Assert.Equal(new Size(200, 160), child.Size);
+        Assert.Equal(new Rectangle(10, 20, 100, 80), child.AccessibilityObject.Bounds);
+    }
+
+    [Fact]
+    public void CompletionHasNoAccumulatedRoundingDrift()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        var target = new Rectangle(103, 87, 131, 97);
+        fixture.Child.Bounds = target;
+
+        for (int i = 0; i < 10; i++)
+            harness.AdvanceAndTick(TimeSpan.FromMilliseconds(10));
+
+        Assert.Equal(target, Rectangle.Round(fixture.Child.PresentationBounds));
+    }
+
+    [Fact]
+    public void RapidRetargetingNeverJumpsBeforeNextFrame()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        fixture.Child.Left = 110;
+        harness.AdvanceAndTick(Duration / 4);
+        RectangleF beforeRetargets = fixture.Child.PresentationBounds;
+
+        fixture.Child.Left = 210;
+        Assert.Equal(beforeRetargets, fixture.Child.PresentationBounds);
+        fixture.Child.Left = 310;
+        Assert.Equal(beforeRetargets, fixture.Child.PresentationBounds);
+        fixture.Child.Left = 410;
+
+        Assert.Equal(beforeRetargets, fixture.Child.PresentationBounds);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void FlowLayoutUsesOneComputedChildRectangleAsTransitionTarget()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new FlowLayoutPanel { Size = new Size(400, 100), WrapContents = false };
+        using var first = new Control { Size = new Size(50, 30), Margin = Padding.Empty };
+        using var second = new Control { Size = new Size(50, 30), Margin = Padding.Empty };
+        root.Controls.Add(first);
+        root.Controls.Add(second);
+        using var surface = new SkiaControlSurface(root);
+        root.PerformLayout();
+        second.AnimationSchedulerOverride = harness.Scheduler;
+        second.LayoutTransition = LinearTransition();
+        int oldLeft = second.Left;
+
+        first.Width = 100;
+
+        Assert.True(second.Left > oldLeft);
+        Assert.Equal(oldLeft, Rectangle.Round(second.PresentationBounds).Left);
+    }
+
+    [Fact]
+    public void TableLayoutUsesOneComputedChildRectangleAsTransitionTarget()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new TableLayoutPanel { Size = new Size(200, 100), ColumnCount = 2, RowCount = 1 };
+        root.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        root.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        root.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+        using var first = new Control { Dock = DockStyle.Fill, Margin = Padding.Empty };
+        using var second = new Control { Dock = DockStyle.Fill, Margin = Padding.Empty };
+        root.Controls.Add(first, 0, 0);
+        root.Controls.Add(second, 1, 0);
+        using var surface = new SkiaControlSurface(root);
+        root.PerformLayout();
+        second.AnimationSchedulerOverride = harness.Scheduler;
+        second.LayoutTransition = LinearTransition();
+        Rectangle oldPresentation = Rectangle.Round(second.PresentationBounds);
+
+        root.Width = 300;
+
+        Assert.NotEqual(oldPresentation, second.Bounds);
+        Assert.Equal(oldPresentation, Rectangle.Round(second.PresentationBounds));
+    }
+
+    [Fact]
+    public void WindowHostedControlsWithoutTransitionsKeepImmediateFormPathSemantics()
+    {
+        using var window = new TestWindow();
+        using var child = new Control { Bounds = new Rectangle(10, 20, 40, 30) };
+        window.Controls.Add(child);
+        var target = new Rectangle(100, 80, 120, 90);
+
+        child.Bounds = target;
+
+        Assert.Equal(target, child.Bounds);
+        Assert.Equal(target, Rectangle.Round(child.PresentationBounds));
+    }
+
+    [Fact]
+    public void ClosingWindowCancelsNestedLayoutTransitions()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var window = new TestWindow();
+        using var parent = new Panel { Bounds = new Rectangle(10, 20, 200, 120) };
+        using var child = new Panel { Bounds = new Rectangle(15, 25, 80, 60) };
+        using var grandChild = new Control { Bounds = new Rectangle(5, 10, 40, 30) };
+        child.Controls.Add(grandChild);
+        parent.Controls.Add(child);
+        window.Controls.Add(parent);
+        ConfigureTransition(parent, harness);
+        ConfigureTransition(child, harness);
+        ConfigureTransition(grandChild, harness);
+        parent.Left = 210;
+        child.Top = 75;
+        grandChild.Left = 35;
+
+        Assert.Equal(3, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        window.Close();
+
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(parent.Bounds, Rectangle.Round(parent.PresentationBounds));
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+        Assert.Equal(grandChild.Bounds, Rectangle.Round(grandChild.PresentationBounds));
+    }
+
+    [Fact]
+    public void UserControlWithoutTransitionKeepsImmediateBoundsSemantics()
+    {
+        using var userControl = new UserControl { Size = new Size(300, 200) };
+        using var child = new Control { Bounds = new Rectangle(10, 20, 40, 30) };
+        userControl.Controls.Add(child);
+        using var surface = new SkiaControlSurface(userControl);
+        var target = new Rectangle(100, 80, 120, 90);
+
+        child.Bounds = target;
+
+        Assert.Equal(target, child.Bounds);
+        Assert.Equal(target, Rectangle.Round(child.PresentationBounds));
+    }
+
+    [Fact]
+    public void HidingControlCancelsActiveLayoutTransition()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var fixture = new AnimatedFixture(harness);
+        fixture.Child.Left = 210;
+
+        fixture.Child.Visible = false;
+
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(fixture.Child.Bounds, Rectangle.Round(fixture.Child.PresentationBounds));
+    }
+
+    private static Control CreateAnimatedControl(AnimationSchedulerTestHarness harness, Rectangle bounds)
+        => new()
+        {
+            Bounds = bounds,
+            AnimationSchedulerOverride = harness.Scheduler,
+            LayoutTransition = LinearTransition()
+        };
+
+    private static void ConfigureTransition(Control control, AnimationSchedulerTestHarness harness)
+    {
+        control.AnimationSchedulerOverride = harness.Scheduler;
+        control.LayoutTransition = LinearTransition();
+    }
+
+    private static LayoutTransition LinearTransition(TimeSpan? duration = null)
+        => new()
+        {
+            Duration = duration ?? Duration,
+            Easing = Easings.Linear
+        };
+
+    private sealed class AnimatedFixture : IDisposable
+    {
+        public AnimatedFixture(AnimationSchedulerTestHarness harness, TimeSpan? duration = null)
+        {
+            Root = new Panel { Size = new Size(500, 300) };
+            Child = new Control { Bounds = new Rectangle(10, 20, 40, 30) };
+            Root.Controls.Add(Child);
+            Surface = new SkiaControlSurface(Root);
+            Child.AnimationSchedulerOverride = harness.Scheduler;
+            Transition = LinearTransition(duration);
+            Child.LayoutTransition = Transition;
+        }
+
+        public Panel Root { get; }
+        public Control Child { get; }
+        public SkiaControlSurface Surface { get; }
+        public LayoutTransition Transition { get; }
+
+        public void Dispose()
+        {
+            Surface.Dispose();
+            Root.Dispose();
+        }
+    }
+
+    private sealed class TestWindow : WindowBase
+    {
+        public TestWindow()
+            : base(DispatchProxy.Create<IWindowBaseImpl, NoopWindowProxy>())
+        {
+        }
+    }
+
+    private class NoopWindowProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            Type? returnType = targetMethod?.ReturnType;
+            if (returnType is null || returnType == typeof(void))
+                return null;
+            return returnType.IsValueType ? Activator.CreateInstance(returnType) : null;
+        }
+    }
+}

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
@@ -37,7 +37,11 @@ public partial class Control
                 if (Owner is not { } owner || !owner.Visible)
                     return Rectangle.Empty;
 
-                return new Rectangle(owner.PointToScreen(Point.Empty), owner.ScaledSize);
+                // Transform both corners so an animated size on any ancestor contributes the same
+                // presentation scale that composition and nested hit testing apply to the child.
+                Point location = owner.PointToScreen(Point.Empty);
+                Point bottomRight = owner.PointToScreen(new Point(owner.ScaledWidth, owner.ScaledHeight));
+                return Rectangle.FromLTRB(location.X, location.Y, bottomRight.X, bottomRight.Y);
             }
         }
 

--- a/ModernFormsNext/Animations/LayoutTransition.cs
+++ b/ModernFormsNext/Animations/LayoutTransition.cs
@@ -1,0 +1,109 @@
+using System.ComponentModel;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Configures an opt-in transition between successive logical layout bounds of a control.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The control's public bounds remain the logical target throughout a transition. Rendering and
+/// hit testing use an internal presentation rectangle that approaches that target on the shared
+/// <see cref="AnimationScheduler"/>. Assign an instance to <see cref="Control.LayoutTransition"/>
+/// to enable animated layout for that control.
+/// </para>
+/// <para>
+/// This is code-first UI configuration and should be changed on the UI thread. A future designer
+/// editor can expose known easing functions without changing the transition or control contracts.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// panel.LayoutTransition = new LayoutTransition
+/// {
+///     Duration = TimeSpan.FromMilliseconds(250),
+///     Easing = Easings.EaseOut
+/// };
+/// </code>
+/// </example>
+[TypeConverter(typeof(ExpandableObjectConverter))]
+public sealed class LayoutTransition
+{
+    private bool enabled = true;
+    private TimeSpan duration = TimeSpan.FromMilliseconds(250);
+    private Func<float, float> easing = Easings.EaseOut;
+
+    /// <summary>
+    /// Gets or sets whether logical bounds changes should animate their presentation geometry.
+    /// </summary>
+    /// <remarks>
+    /// Disabling an active transition immediately synchronizes presentation bounds with logical
+    /// bounds and unregisters the control from the shared scheduler.
+    /// </remarks>
+    [DefaultValue(true)]
+    public bool Enabled
+    {
+        get => enabled;
+        set
+        {
+            if (enabled == value)
+                return;
+
+            enabled = value;
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the unscaled duration of each layout transition.
+    /// </summary>
+    /// <remarks>
+    /// A duration less than or equal to zero applies the logical target immediately and does not
+    /// start the scheduler tick source. Positive values are still subject to the shared
+    /// <see cref="AnimationPolicy.DurationScale"/> and reduced-motion policy.
+    /// </remarks>
+    [DefaultValue(typeof(TimeSpan), "00:00:00.250")]
+    public TimeSpan Duration
+    {
+        get => duration;
+        set
+        {
+            if (duration == value)
+                return;
+
+            duration = value;
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the easing function applied to intermediate layout progress.
+    /// </summary>
+    /// <remarks>
+    /// The function follows the same finite-result contract as <see cref="AnimationOptions.Easing"/>.
+    /// Built-in functions from <see cref="Easings"/> are recommended. Delegate-valued easing is
+    /// hidden from ordinary property-grid serialization until a known-easing editor is added.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The assigned function is null.</exception>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public Func<float, float> Easing
+    {
+        get => easing;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            if (easing == value)
+                return;
+
+            easing = value;
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    internal event EventHandler? Changed;
+
+    /// <inheritdoc/>
+    public override string ToString()
+        => Enabled ? $"{Duration.TotalMilliseconds:0.##} ms" : "Disabled";
+}

--- a/ModernFormsNext/Control.Layout.cs
+++ b/ModernFormsNext/Control.Layout.cs
@@ -607,7 +607,7 @@ public partial class Control
     [EditorBrowsable (EditorBrowsableState.Advanced)]
     protected void UpdateBounds (int x, int y, int width, int height)//, int clientWidth, int clientHeight)
     {
-
+        var oldBounds = new Rectangle (_x, _y, _width, _height);
         var newLocation = _x != x || _y != y;
         var newSize = Width != width || Height != height;// ||
                                                           //_clientWidth != clientWidth || _clientHeight != clientHeight;
@@ -618,6 +618,12 @@ public partial class Control
         _height = height;
         //_clientWidth = clientWidth;
         //_clientHeight = clientHeight;
+
+        // Logical geometry commits atomically before presentation animation starts. Layout
+        // engines, public bounds properties, and re-entrant change handlers therefore observe the
+        // final constrained rectangle, while rendering can still begin at the previous visual
+        // rectangle. A re-entrant target change retargets from the current presentation state.
+        UpdateLayoutPresentationBounds (oldBounds, new Rectangle (x, y, width, height));
 
         if (newLocation)
             OnLocationChanged (EventArgs.Empty);

--- a/ModernFormsNext/Control.LayoutAnimation.cs
+++ b/ModernFormsNext/Control.LayoutAnimation.cs
@@ -1,0 +1,460 @@
+using System.ComponentModel;
+using System.Drawing;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Layout;
+using SkiaSharp;
+
+namespace ModernFormsNext;
+
+/// <summary>Provides opt-in presentation geometry for scheduler-backed layout transitions.</summary>
+public partial class Control
+{
+    private const string LayoutTransitionAnimationKey = "Control.LayoutTransition";
+    private static readonly int s_layoutTransitionProperty = PropertyStore.CreateKey();
+    private static readonly int s_layoutPresentationStateProperty = PropertyStore.CreateKey();
+    private int animatedLayoutSizeCommitDepth;
+
+    /// <summary>
+    /// Gets or sets the optional transition used when this control's logical bounds change.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <see langword="null"/> value preserves the existing immediate layout behavior. When a
+    /// transition is configured, <see cref="Bounds"/>, <see cref="Location"/>, <see cref="Size"/>,
+    /// and their scalar counterparts continue to expose the logical target. Only rendering,
+    /// clipping, accessibility geometry, and hit testing observe the interpolated presentation
+    /// rectangle.
+    /// </para>
+    /// <para>
+    /// Bounds produced by Dock, Anchor, FlowLayoutPanel, and TableLayoutPanel use the same path as
+    /// bounds assigned by application code. A replacement target starts from the current
+    /// presentation rectangle. Layout is not rerun on animation frames.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// card.LayoutTransition = new LayoutTransition
+    /// {
+    ///     Duration = TimeSpan.FromMilliseconds(220),
+    ///     Easing = Easings.EaseOut
+    /// };
+    /// card.Bounds = new Rectangle(100, 50, 400, 200);
+    /// </code>
+    /// </example>
+    [DefaultValue(null)]
+    public LayoutTransition? LayoutTransition
+    {
+        get => (LayoutTransition?)Properties.GetObject(s_layoutTransitionProperty);
+        set
+        {
+            LayoutTransition? previous = LayoutTransition;
+            if (ReferenceEquals(previous, value))
+                return;
+
+            if (previous is not null)
+                previous.Changed -= OnLayoutTransitionConfigurationChanged;
+
+            Properties.SetObject(s_layoutTransitionProperty, value);
+
+            if (value is not null)
+                value.Changed += OnLayoutTransitionConfigurationChanged;
+
+            OnLayoutTransitionConfigurationChanged(value, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Gets the current unscaled presentation bounds used by rendering and hit testing.
+    /// </summary>
+    internal RectangleF PresentationBounds
+    {
+        get
+        {
+            if (Properties.GetObject(s_layoutPresentationStateProperty) is LayoutPresentationState state)
+                return state.Current;
+
+            Rectangle logical = Bounds;
+            return new RectangleF(logical.X, logical.Y, logical.Width, logical.Height);
+        }
+    }
+
+    internal bool HasActiveLayoutTransition
+        => Properties.GetObject(s_layoutPresentationStateProperty) is LayoutPresentationState { IsAnimating: true };
+
+    internal bool HasDistinctPresentationBounds
+    {
+        get
+        {
+            if (Properties.GetObject(s_layoutPresentationStateProperty) is not LayoutPresentationState state)
+                return false;
+
+            Rectangle logical = Bounds;
+            return state.Current.X != logical.X ||
+                state.Current.Y != logical.Y ||
+                state.Current.Width != logical.Width ||
+                state.Current.Height != logical.Height;
+        }
+    }
+
+    internal bool HasDistinctPresentationSize
+    {
+        get
+        {
+            if (Properties.GetObject(s_layoutPresentationStateProperty) is not LayoutPresentationState state)
+                return false;
+
+            return state.Current.Width != Width || state.Current.Height != Height;
+        }
+    }
+
+    internal void BeginAnimatedLayoutSizeCommit()
+        => animatedLayoutSizeCommitDepth++;
+
+    internal void EndAnimatedLayoutSizeCommit()
+    {
+        if (animatedLayoutSizeCommitDepth <= 0)
+            throw new InvalidOperationException("An animated layout size commit was not active.");
+
+        animatedLayoutSizeCommitDepth--;
+    }
+
+    internal RectangleF ScaledPresentationBounds
+    {
+        get
+        {
+            RectangleF bounds = PresentationBounds;
+            SizeF factor = ScaleFactor;
+            return new RectangleF(
+                bounds.X * factor.Width,
+                bounds.Y * factor.Height,
+                bounds.Width * factor.Width,
+                bounds.Height * factor.Height);
+        }
+    }
+
+    internal bool PresentationContains(Point parentPoint)
+    {
+        RectangleF bounds = ScaledPresentationBounds;
+        return bounds.Width > 0f && bounds.Height > 0f &&
+            parentPoint.X >= bounds.Left && parentPoint.X < bounds.Right &&
+            parentPoint.Y >= bounds.Top && parentPoint.Y < bounds.Bottom;
+    }
+
+    internal Point ParentPresentationPointToClient(Point parentPoint)
+    {
+        RectangleF presentation = ScaledPresentationBounds;
+        float localX = parentPoint.X - presentation.X;
+        float localY = parentPoint.Y - presentation.Y;
+        int targetWidth = ScaledWidth;
+        int targetHeight = ScaledHeight;
+
+        int x = presentation.Width > 0f && targetWidth > 0
+            ? (int)MathF.Floor(localX * targetWidth / presentation.Width)
+            : 0;
+        int y = presentation.Height > 0f && targetHeight > 0
+            ? (int)MathF.Floor(localY * targetHeight / presentation.Height)
+            : 0;
+        return new Point(x, y);
+    }
+
+    internal Point ClientPointToParentPresentation(Point clientPoint)
+    {
+        RectangleF presentation = ScaledPresentationBounds;
+        int targetWidth = ScaledWidth;
+        int targetHeight = ScaledHeight;
+        float x = targetWidth > 0
+            ? presentation.X + (clientPoint.X * presentation.Width / targetWidth)
+            : presentation.X;
+        float y = targetHeight > 0
+            ? presentation.Y + (clientPoint.Y * presentation.Height / targetHeight)
+            : presentation.Y;
+        return new Point(
+            (int)MathF.Round(x, MidpointRounding.AwayFromZero),
+            (int)MathF.Round(y, MidpointRounding.AwayFromZero));
+    }
+
+    internal void DrawBackBuffer(SKCanvas canvas, SKBitmap buffer, float parentOffsetX = 0f, float parentOffsetY = 0f)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        bool hasRenderTransform =
+            EffectiveOpacity < 0.999f ||
+            Math.Abs(EffectiveRotation) > 0.0001f ||
+            Math.Abs(EffectiveScaleX - 1f) > 0.0001f ||
+            Math.Abs(EffectiveScaleY - 1f) > 0.0001f ||
+            Math.Abs(EffectiveTranslationX) > 0.0001f ||
+            Math.Abs(EffectiveTranslationY) > 0.0001f;
+
+        bool hasPresentationTransform = HasDistinctPresentationBounds;
+        if (!hasRenderTransform && !hasPresentationTransform)
+        {
+            canvas.DrawBitmap(buffer, parentOffsetX + ScaledLeft, parentOffsetY + ScaledTop);
+            return;
+        }
+
+        RectangleF presentation = ScaledPresentationBounds;
+        float drawX = parentOffsetX + presentation.X + (EffectiveTranslationX * ScaleFactor.Width);
+        float drawY = parentOffsetY + presentation.Y + (EffectiveTranslationY * ScaleFactor.Height);
+        float drawWidth = presentation.Width;
+        float drawHeight = presentation.Height;
+
+        if (!hasRenderTransform)
+        {
+            canvas.DrawBitmap(buffer, new SKRect(drawX, drawY, drawX + drawWidth, drawY + drawHeight));
+            return;
+        }
+
+        using var paint = new SKPaint
+        {
+            IsAntialias = true,
+            Color = new SKColor(255, 255, 255, (byte)(255f * EffectiveOpacity))
+        };
+
+        canvas.Save();
+        canvas.Translate(drawX, drawY);
+        canvas.Translate(drawWidth / 2f, drawHeight / 2f);
+        canvas.RotateDegrees(EffectiveRotation);
+        canvas.Scale(EffectiveScaleX, EffectiveScaleY);
+        canvas.Translate(-drawWidth / 2f, -drawHeight / 2f);
+        if (hasPresentationTransform)
+            canvas.DrawBitmap(buffer, new SKRect(0f, 0f, drawWidth, drawHeight), paint);
+        else
+            canvas.DrawBitmap(buffer, 0f, 0f, paint);
+        canvas.Restore();
+    }
+
+    internal void UpdateLayoutPresentationBounds(Rectangle oldLogicalBounds, Rectangle newLogicalBounds)
+    {
+        if (oldLogicalBounds == newLogicalBounds)
+            return;
+
+        LayoutPresentationState? state =
+            Properties.GetObject(s_layoutPresentationStateProperty) as LayoutPresentationState;
+        RectangleF from = state?.Current ?? new RectangleF(
+            oldLogicalBounds.X,
+            oldLogicalBounds.Y,
+            oldLogicalBounds.Width,
+            oldLogicalBounds.Height);
+
+        LayoutTransition? transition = LayoutTransition;
+        if (!CanAnimateLayout(transition, from, newLogicalBounds))
+        {
+            if (state is not null)
+                ResetLayoutPresentationBounds(cancelScheduledAnimation: true);
+            return;
+        }
+
+        BeginLayoutPresentationTransition(from, newLogicalBounds, transition!);
+    }
+
+    internal void ResetLayoutPresentationAfterOwnerCancellation()
+    {
+        if (Properties.GetObject(s_layoutPresentationStateProperty) is not LayoutPresentationState state)
+            return;
+
+        state.Generation++;
+        RectangleF previous = state.Current;
+        Rectangle logical = Bounds;
+        Properties.SetObject(s_layoutPresentationStateProperty, null);
+        InvalidatePresentationChange(previous, new RectangleF(logical.X, logical.Y, logical.Width, logical.Height));
+    }
+
+    internal void DisposeLayoutTransitionConfiguration()
+    {
+        if (LayoutTransition is { } transition)
+            transition.Changed -= OnLayoutTransitionConfigurationChanged;
+        Properties.SetObject(s_layoutTransitionProperty, null);
+        Properties.SetObject(s_layoutPresentationStateProperty, null);
+    }
+
+    private bool CanAnimateLayout(LayoutTransition? transition, RectangleF from, Rectangle target)
+    {
+        if (transition is null || !transition.Enabled || transition.Duration <= TimeSpan.Zero)
+            return false;
+        if (!Created || Parent is null || !Visible || Site?.DesignMode == true)
+            return false;
+        if (from.Width <= 0f || from.Height <= 0f || target.Width <= 0 || target.Height <= 0)
+            return false;
+        if (HasAncestorCommittingAnimatedLayoutSize())
+            return false;
+
+        AnimationScheduler scheduler = AnimationSchedulerOverride ?? AnimationScheduler.Default;
+        return !scheduler.Policy.ShouldCompleteImmediately;
+    }
+
+    private bool HasAncestorCommittingAnimatedLayoutSize()
+    {
+        for (Control? ancestor = Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor.animatedLayoutSizeCommitDepth > 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    private void BeginLayoutPresentationTransition(
+        RectangleF from,
+        Rectangle target,
+        LayoutTransition transition)
+    {
+        var targetPresentation = new RectangleF(target.X, target.Y, target.Width, target.Height);
+        if (from == targetPresentation)
+        {
+            ResetLayoutPresentationBounds(cancelScheduledAnimation: true);
+            return;
+        }
+
+        LayoutPresentationState state =
+            Properties.GetObject(s_layoutPresentationStateProperty) as LayoutPresentationState ?? new();
+        state.Current = from;
+        state.IsAnimating = true;
+        int generation = ++state.Generation;
+        Properties.SetObject(s_layoutPresentationStateProperty, state);
+
+        AnimationScheduler scheduler = AnimationSchedulerOverride ?? AnimationScheduler.Default;
+        var options = new AnimationOptions
+        {
+            Duration = transition.Duration,
+            // Layout evaluates the configured easing inside its update callback so a fault can
+            // release presentation state before the scheduler marks the entry faulted. The shared
+            // scheduler still owns timing, replacement, terminal state, and diagnostics.
+            Easing = Easings.Linear,
+            ReplacementMode = AnimationReplacementMode.Replace
+        };
+
+        try
+        {
+            scheduler.StartFrames(
+                this,
+                LayoutTransitionAnimationKey,
+                frame =>
+                {
+                    if (state.Generation != generation)
+                        return;
+
+                    try
+                    {
+                        float easedProgress = frame.Progress switch
+                        {
+                            <= 0f => 0f,
+                            >= 1f => 1f,
+                            _ => transition.Easing(frame.Progress)
+                        };
+                        if (!float.IsFinite(easedProgress))
+                            throw new InvalidOperationException(
+                                "The layout transition easing function returned NaN or infinity.");
+
+                        RectangleF previous = state.Current;
+                        RectangleF current = frame.Progress >= 1f
+                            ? targetPresentation
+                            : AnimationInterpolators.RectangleF.Interpolate(from, targetPresentation, easedProgress);
+                        state.Current = current;
+                        if (frame.Progress >= 1f)
+                        {
+                            state.IsAnimating = false;
+                            Properties.SetObject(s_layoutPresentationStateProperty, null);
+                        }
+
+                        if (previous != current)
+                            InvalidatePresentationChange(previous, current);
+                    }
+                    catch
+                    {
+                        // A scheduler fault removes the entry but cannot know about the control's
+                        // presentation cache. Release it here so a bad custom easing or invalidation
+                        // handler cannot strand the control at an intermediate visual rectangle.
+                        if (state.Generation == generation)
+                        {
+                            RectangleF previous = state.Current;
+                            state.Generation++;
+                            state.IsAnimating = false;
+                            Properties.SetObject(s_layoutPresentationStateProperty, null);
+                            try
+                            {
+                                if (previous != targetPresentation)
+                                    InvalidatePresentationChange(previous, targetPresentation);
+                            }
+                            catch
+                            {
+                                // Preserve the original callback failure reported by the scheduler.
+                            }
+                        }
+
+                        throw;
+                    }
+                },
+                options);
+        }
+        catch
+        {
+            state.Generation++;
+            state.IsAnimating = false;
+            Properties.SetObject(s_layoutPresentationStateProperty, null);
+            InvalidatePresentationChange(from, targetPresentation);
+            throw;
+        }
+    }
+
+    private void OnLayoutTransitionConfigurationChanged(object? sender, EventArgs e)
+    {
+        LayoutPresentationState? state =
+            Properties.GetObject(s_layoutPresentationStateProperty) as LayoutPresentationState;
+        if (state is null)
+            return;
+
+        Rectangle logical = Bounds;
+        LayoutTransition? transition = LayoutTransition;
+        if (!CanAnimateLayout(transition, state.Current, logical))
+        {
+            ResetLayoutPresentationBounds(cancelScheduledAnimation: true);
+            return;
+        }
+
+        BeginLayoutPresentationTransition(state.Current, logical, transition!);
+    }
+
+    private void ResetLayoutPresentationBounds(bool cancelScheduledAnimation)
+    {
+        if (Properties.GetObject(s_layoutPresentationStateProperty) is not LayoutPresentationState state)
+            return;
+
+        state.Generation++;
+        if (cancelScheduledAnimation)
+        {
+            AnimationScheduler scheduler = AnimationSchedulerOverride ?? AnimationScheduler.Default;
+            scheduler.Cancel(this, LayoutTransitionAnimationKey);
+        }
+
+        RectangleF previous = state.Current;
+        Rectangle logical = Bounds;
+        var current = new RectangleF(logical.X, logical.Y, logical.Width, logical.Height);
+        Properties.SetObject(s_layoutPresentationStateProperty, null);
+        InvalidatePresentationChange(previous, current);
+    }
+
+    private void InvalidatePresentationChange(RectangleF previous, RectangleF current)
+    {
+        Control compositionOwner = Parent ?? this;
+        compositionOwner.SetState(States.IsDirty, true);
+
+        RectangleF union = RectangleF.Union(previous, current);
+        var invalidated = Rectangle.FromLTRB(
+            (int)MathF.Floor(union.Left),
+            (int)MathF.Floor(union.Top),
+            (int)MathF.Ceiling(union.Right),
+            (int)MathF.Ceiling(union.Bottom));
+
+        if (FindWindow() is { } window)
+            Application.RequestVisualInvalidation(window);
+        compositionOwner.OnInvalidated(new EventArgs<Rectangle>(invalidated));
+    }
+
+    private sealed class LayoutPresentationState
+    {
+        public RectangleF Current;
+        public int Generation;
+        public bool IsAnimating;
+    }
+}

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -39,11 +39,23 @@ public partial class Control
             scheduler.CancelAll(this);
         else
             AnimationScheduler.CancelOwnedIfInitialized(this);
+        ResetLayoutPresentationAfterOwnerCancellation();
         if (transitionStyle is not null)
         {
             transitionStyle = null;
             ApplyStateTransforms(GetStyleForState(currentVisualState));
         }
+    }
+
+    internal void CancelOwnedControlAnimationsForSubtree()
+    {
+        CancelOwnedControlAnimations();
+        var controls = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
+        if (controls is null)
+            return;
+
+        foreach (Control child in controls.GetAllControls(true).ToArray())
+            child.CancelOwnedControlAnimationsForSubtree();
     }
 
     /// <summary>Gets the style used while pointer or keyboard activation is held.</summary>

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -98,7 +98,7 @@ namespace ModernFormsNext
             // Update the parent
             parent = value;
             if (previousParent is not null && value is null)
-                CancelOwnedControlAnimations();
+                CancelOwnedControlAnimationsForSubtree();
             RefreshResourceBindingsForSubtree ();
             OnParentChanged (EventArgs.Empty);
 
@@ -1542,42 +1542,7 @@ namespace ModernFormsNext
                     }
                 }
 
-                //e.Canvas.DrawBitmap (buffer, control.ScaledLeft, control.ScaledTop);
-
-                var hasRenderTransform =
-                    control.EffectiveOpacity < 0.999f ||
-                    Math.Abs (control.EffectiveRotation) > 0.0001f ||
-                    Math.Abs (control.EffectiveScaleX - 1f) > 0.0001f ||
-                    Math.Abs (control.EffectiveScaleY - 1f) > 0.0001f ||
-                    Math.Abs (control.EffectiveTranslationX) > 0.0001f ||
-                    Math.Abs (control.EffectiveTranslationY) > 0.0001f;
-
-                if (!hasRenderTransform) {
-                    e.Canvas.DrawBitmap (buffer, control.ScaledLeft, control.ScaledTop);
-                    continue;
-                }
-
-                var drawX = control.ScaledLeft + (control.EffectiveTranslationX * control.ScaleFactor.Width);
-                var drawY = control.ScaledTop + (control.EffectiveTranslationY * control.ScaleFactor.Height);
-                var drawWidth = control.ScaledWidth;
-                var drawHeight = control.ScaledHeight;
-
-                var centerX = drawWidth / 2f;
-                var centerY = drawHeight / 2f;
-
-                using var paint = new SKPaint {
-                    IsAntialias = true,
-                    Color = new SKColor (255, 255, 255, (byte)(255f * control.EffectiveOpacity))
-                };
-
-                e.Canvas.Save ();
-                e.Canvas.Translate (drawX, drawY);
-                e.Canvas.Translate (centerX, centerY);
-                e.Canvas.RotateDegrees (control.EffectiveRotation);
-                e.Canvas.Scale (control.EffectiveScaleX, control.EffectiveScaleY);
-                e.Canvas.Translate (-centerX, -centerY);
-                e.Canvas.DrawBitmap (buffer, 0, 0, paint);
-                e.Canvas.Restore ();
+                control.DrawBackBuffer (e.Canvas, buffer);
             }
         }
 
@@ -1663,7 +1628,22 @@ namespace ModernFormsNext
             //    Invalidate ();
             //}
 
-            LayoutTransaction.DoLayout (this, this, PropertyNames.Bounds);
+            // A presentation size transform already scales this control's complete logical back
+            // buffer. Dock/Anchor changes produced for descendants by this layout pass must remain
+            // logical-only; animating those local rectangles too would apply the same resize twice.
+            // Keep the scope around framework layout only so user Resize handlers may still start
+            // independent child transitions.
+            var suppressDescendantTransitions = HasDistinctPresentationSize;
+            if (suppressDescendantTransitions)
+                BeginAnimatedLayoutSizeCommit ();
+
+            try {
+                LayoutTransaction.DoLayout (this, this, PropertyNames.Bounds);
+            } finally {
+                if (suppressDescendantTransitions)
+                    EndAnimatedLayoutSizeCommit ();
+            }
+
             (Events[s_resizeEvent] as EventHandler)?.Invoke (this, e);
         }
 
@@ -1832,7 +1812,7 @@ namespace ModernFormsNext
 
             // If this isn't the top, we need to add our location to the point
             // and ask our parent to translate that
-            point.Offset (ScaledBounds.Location);
+            point = ClientPointToParentPresentation (point);
 
             // If we aren't parented to a Form, this method is pretty meaningless
             return Parent?.PointToScreen (point) ?? point;
@@ -1851,7 +1831,7 @@ namespace ModernFormsNext
                 return;
             }
 
-            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.ScaledBounds.Contains (e.Location));
+            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.PresentationContains (e.Location));
 
             if (child != null)
                 child.RaiseClick (TranslateMouseEvents (e, child));
@@ -1872,7 +1852,7 @@ namespace ModernFormsNext
                 return;
             }
 
-            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.ScaledBounds.Contains (e.Location));
+            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.PresentationContains (e.Location));
 
             if (child != null)
                 child.RaiseDoubleClick (TranslateMouseEvents (e, child));
@@ -1935,7 +1915,7 @@ namespace ModernFormsNext
         /// </summary>
         internal void RaiseMouseDown (MouseEventArgs e)
         {
-            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.ScaledBounds.Contains (e.Location));
+            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.PresentationContains (e.Location));
 
             if (child != null)
                 child.RaiseMouseDown (TranslateMouseEvents (e, child));
@@ -1990,7 +1970,7 @@ namespace ModernFormsNext
         /// </summary>
         internal void RaiseMouseEnter (MouseEventArgs e)
         {
-            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.ScaledBounds.Contains (e.Location));
+            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.PresentationContains (e.Location));
 
             if (child != null)
                 child.RaiseMouseEnter (TranslateMouseEvents (e, child));
@@ -2025,7 +2005,7 @@ namespace ModernFormsNext
                 return;
             }
 
-            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.ScaledBounds.Contains (e.Location));
+            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.PresentationContains (e.Location));
 
             if (current_mouse_in != null && current_mouse_in != child) {
                 current_mouse_in.RaiseMouseLeave (e);
@@ -2061,7 +2041,7 @@ namespace ModernFormsNext
                 return;
             }
 
-            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.ScaledBounds.Contains (e.Location));
+            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.PresentationContains (e.Location));
 
             if (child != null)
                 child.RaiseMouseUp (TranslateMouseEvents (e, child));
@@ -2106,7 +2086,7 @@ namespace ModernFormsNext
         /// </summary>
         internal void RaiseMouseWheel (MouseEventArgs e)
         {
-            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.ScaledBounds.Contains (e.Location));
+            var child = Controls.GetAllControls ().LastOrDefault (c => c.Visible && c.GetControlBehavior (ControlBehaviors.ReceivesMouseEvents) && c.PresentationContains (e.Location));
 
             if (child != null)
                 child.RaiseMouseWheel (TranslateMouseEvents (e, child));
@@ -2359,6 +2339,12 @@ namespace ModernFormsNext
 
                 SetState (States.Visible, value);
 
+                // Hidden controls have no presentation surface to animate. Snap an active layout
+                // transition to its logical target so the shared scheduler does not retain idle
+                // work and showing the control later starts from current layout.
+                if (!value)
+                    ResetLayoutPresentationBounds (cancelScheduledAnimation: true);
+
                 if (Parent is not null)
                     using (new LayoutTransaction (Parent, this, PropertyNames.Visible))
                         OnVisibleChanged (EventArgs.Empty);
@@ -2471,11 +2457,13 @@ namespace ModernFormsNext
             if (control == null)
                 return e;
 
+            Point local = control.ParentPresentationPointToClient (e.Location);
+
             return new MouseEventArgs (
                 e.Button,
                 e.Clicks,
-                e.Location.X - control.ScaledLeft,
-                e.Location.Y - control.ScaledTop,
+                local.X,
+                local.Y,
                 e.Delta,
                 e.Location.X,
                 e.Location.Y,
@@ -2562,6 +2550,7 @@ namespace ModernFormsNext
             if (!disposedValue) {
                 DisposeInteractionEffects ();
                 CancelOwnedControlAnimations();
+                DisposeLayoutTransitionConfiguration ();
                 DisposeResourceReferences ();
                 DisposeBrushInvalidationSubscriptions ();
                 FreeBackBuffer ();

--- a/ModernFormsNext/ControlAdapter.cs
+++ b/ModernFormsNext/ControlAdapter.cs
@@ -70,42 +70,7 @@ namespace ModernFormsNext
                     }
                 }
 
-                //e.Canvas.DrawBitmap (buffer, form_x + control.ScaledLeft, form_y + control.ScaledTop);
-
-                var hasRenderTransform =
-                    control.EffectiveOpacity < 0.999f ||
-                    Math.Abs (control.EffectiveRotation) > 0.0001f ||
-                    Math.Abs (control.EffectiveScaleX - 1f) > 0.0001f ||
-                    Math.Abs (control.EffectiveScaleY - 1f) > 0.0001f ||
-                    Math.Abs (control.EffectiveTranslationX) > 0.0001f ||
-                    Math.Abs (control.EffectiveTranslationY) > 0.0001f;
-
-                if (!hasRenderTransform) {
-                    e.Canvas.DrawBitmap (buffer, form_x + control.ScaledLeft, form_y + control.ScaledTop);
-                    continue;
-                }
-
-                var drawX = form_x + control.ScaledLeft + (control.EffectiveTranslationX * control.ScaleFactor.Width);
-                var drawY = form_y + control.ScaledTop + (control.EffectiveTranslationY * control.ScaleFactor.Height);
-                var drawWidth = control.ScaledWidth;
-                var drawHeight = control.ScaledHeight;
-
-                var centerX = drawWidth / 2f;
-                var centerY = drawHeight / 2f;
-
-                using var paint = new SKPaint {
-                    IsAntialias = true,
-                    Color = new SKColor (255, 255, 255, (byte)(255f * control.EffectiveOpacity))
-                };
-
-                e.Canvas.Save ();
-                e.Canvas.Translate (drawX, drawY);
-                e.Canvas.Translate (centerX, centerY);
-                e.Canvas.RotateDegrees (control.EffectiveRotation);
-                e.Canvas.Scale (control.EffectiveScaleX, control.EffectiveScaleY);
-                e.Canvas.Translate (-centerX, -centerY);
-                e.Canvas.DrawBitmap (buffer, 0, 0, paint);
-                e.Canvas.Restore ();
+                control.DrawBackBuffer (e.Canvas, buffer, form_x, form_y);
             }
         }
 

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -490,10 +490,10 @@ public sealed class SkiaControlSurface : IDisposable
     {
         foreach (var child in parent.Controls.GetAllControls().Reverse())
         {
-            if (!child.Visible || !child.Enabled || !child.Bounds.Contains(point))
+            if (!child.Visible || !child.Enabled || !child.PresentationContains(point))
                 continue;
 
-            var childPoint = new Point(point.X - child.Left, point.Y - child.Top);
+            Point childPoint = child.ParentPresentationPointToClient(point);
             var descendant = FindSelectableAt(child, childPoint);
             if (descendant is not null)
                 return descendant;
@@ -601,10 +601,10 @@ public sealed class SkiaControlSurface : IDisposable
     {
         foreach (var child in control.Controls.GetAllControls().Reverse())
         {
-            if (!child.Visible || !child.Enabled || !child.ScaledBounds.Contains(localPoint))
+            if (!child.Visible || !child.Enabled || !child.PresentationContains(localPoint))
                 continue;
 
-            var childPoint = new Point(localPoint.X - child.ScaledLeft, localPoint.Y - child.ScaledTop);
+            Point childPoint = child.ParentPresentationPointToClient(localPoint);
             var descendant = HitTest(child, childPoint);
             if (descendant is not null)
                 return descendant;
@@ -658,7 +658,7 @@ public sealed class SkiaControlSurface : IDisposable
         for (var current = target; current.Parent is not null; current = current.Parent)
             ancestors.Push(current);
         while (ancestors.TryPop(out var control))
-            result.Offset(-control.ScaledLeft, -control.ScaledTop);
+            result = control.ParentPresentationPointToClient(result);
         return result;
     }
 

--- a/ModernFormsNext/WindowBase.cs
+++ b/ModernFormsNext/WindowBase.cs
@@ -39,7 +39,13 @@ namespace ModernFormsNext
             window.Input = OnInput;
             window.Paint = DoPaint;
             window.Resized = OnResize;
-            window.Closed = () => Closed?.Invoke (this, EventArgs.Empty);
+            window.Closed = () => {
+                // A secondary window can close without shutting down the process-wide scheduler.
+                // Release every control-owned animation so callbacks cannot retain its detached
+                // visual tree. The operation is idempotent with the explicit Close path below.
+                adapter.CancelOwnedControlAnimationsForSubtree ();
+                Closed?.Invoke (this, EventArgs.Empty);
+            };
             window.Deactivated = () => {
                 // If we're clicking off the form, deactivate any active menus
                 Application.ClosePopups ();
@@ -86,6 +92,7 @@ namespace ModernFormsNext
                 Application.OpenForms.Remove (f);
             }
             
+            adapter.CancelOwnedControlAnimationsForSubtree ();
             window.Dispose (); 
         }
 

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -9,6 +9,30 @@ The scheduler starts its single tick source when the first animation needs it an
 last animation completes, is canceled, or faults. It does not create a timer for each control or
 animation.
 
+## Animated layout
+
+Assign `Control.LayoutTransition` when a control should animate a complete layout result:
+
+```csharp
+card.LayoutTransition = new LayoutTransition
+{
+    Duration = TimeSpan.FromMilliseconds(250),
+    Easing = Easings.EaseOut
+};
+
+card.Bounds = new Rectangle(100, 50, 400, 200);
+```
+
+`Bounds` is the logical target immediately. Rendering, accessibility geometry, and hit testing use
+an internal presentation rectangle while it approaches that target. Dock, Anchor, flow, and table
+layout keep their existing semantics because they commit logical geometry before the transition.
+Retargeting begins at the current presentation rectangle, and disabling the transition snaps to the
+logical target and unregisters the control from the scheduler. No layout pass runs on animation
+frames.
+
+See [Animated layout architecture](architecture/animated-layout.md) for rendering, input,
+lifecycle, constraints, and current limitations.
+
 ## Basic control animation
 
 Use `Control.Animate` for a custom eased-progress callback owned by a control:

--- a/docs/architecture/animated-layout.md
+++ b/docs/architecture/animated-layout.md
@@ -1,0 +1,143 @@
+# Animated layout architecture
+
+## Purpose and scope
+
+Animated layout is an opt-in presentation layer over the existing ModernFormsNext layout engine.
+It lets a control move and resize smoothly after application code or a layout engine commits a new
+rectangle. It does not introduce another visual tree, layout engine, timer, or platform-specific
+control implementation.
+
+The first version interpolates the complete `RectangleF` (`X`, `Y`, `Width`, and `Height`) as one
+value. Full visual-state orchestration, navigation transitions, designer editing, and Android-
+specific runtime integration remain separate work.
+
+## Logical and presentation geometry
+
+`Control.Bounds`, `Location`, `Size`, `Left`, `Top`, `Width`, and `Height` continue to represent the
+logical target. Constraints and layout are complete before these properties change. Code reading a
+control during a transition therefore sees one stable, final layout result rather than frame-
+dependent intermediate values.
+
+An internal presentation rectangle begins at the previous visual rectangle and approaches the
+logical target. Parent composition, hit testing, coordinate conversion, and accessibility bounds
+use this presentation rectangle. At completion it is discarded, making presentation geometry
+exactly equal to logical geometry with no accumulated rounding drift. Controls without a
+`LayoutTransition` retain the previous rendering and input path.
+
+The control back buffer is still created and painted at the logical target size. Composition scales
+that buffer into the current presentation rectangle. A child is therefore rendered once in its
+parent's local coordinate system and naturally follows a moving or resizing parent; changing only
+the parent's absolute position does not create redundant child transitions.
+
+When an animated parent resize causes Dock or Anchor to recompute descendant rectangles, those
+descendants commit their new logical bounds without starting redundant local transitions during
+that layout pass. The parent's presentation scaling already carries the complete subtree between
+the old and new sizes. Independent descendant changes outside that layout pass remain eligible for
+their own transitions.
+
+## Starting and retargeting
+
+`Control.UpdateBounds` is the single integration point after `SetBoundsCore` has applied
+`MinimumSize` and `MaximumSize`. Layout engines already converge on this path by assigning one
+complete child rectangle. Dock, Anchor, FlowLayoutPanel, TableLayoutPanel, and direct bounds changes
+therefore share the same transition behavior without changing their logical semantics.
+
+If a target changes while a transition is active, owner-and-key replacement cancels the previous
+scheduler entry and the replacement starts at the current presentation rectangle. It never jumps
+back to the old source or forward to the replaced target. Several setters in one synchronous layout
+pass can replace the pending target, but only one scheduler entry remains active for the control.
+
+The transition is immediate when it is absent, disabled, has a non-positive duration, motion policy
+requests immediate completion, the control is not attached and created, either rectangle has no
+positive area, or the control is hidden. Disabling or removing a transition during animation
+cancels its scheduler entry and snaps presentation geometry to the logical target.
+
+## Scheduling, easing, and threading
+
+Animated layout uses `AnimationScheduler.Default`, the same monotonic, dispatcher-backed scheduler
+as the rest of the animation system. Every control uses the owner key `Control.LayoutTransition`, so
+retargeting uses normal replacement semantics. `LayoutTransition.Easing` accepts the existing
+`Easings` functions; rectangle interpolation uses `AnimationInterpolators.RectangleF`.
+
+There is no timer per control. The scheduler starts its one tick source for the first active
+transition, removes completed, canceled, and faulted entries, and stops when idle. Production
+callbacks run through the registered UI dispatcher. Tests inject the existing manual clock and tick
+source and never sleep.
+
+Each frame updates only presentation state and requests repaint. It does not write logical bounds or
+run layout. Invalidation marks the composition owner dirty, reports the union of the old and new
+presentation rectangles, and uses the existing window-level coalesced frame request. Android keeps
+using its main-Looper dispatcher and `PostInvalidateOnAnimation` rendering endpoint; the core has no
+Android or Windows dependency.
+
+## Rendering, clipping, and input
+
+Both the normal control compositor and the form adapter call the same back-buffer composition
+helper. This preserves the previous fast path when there is no presentation or render transform and
+keeps opacity, translation, scale, and rotation compatible with animated geometry.
+
+Hit testing checks presentation bounds. A point inside a resized presentation rectangle is mapped
+back into the logical back-buffer coordinate system before nested routing and event delivery. This
+keeps pointer input aligned with what is drawn, including nested controls. `PointToScreen` and
+accessibility bounds use the same presentation mapping. Logical layout calculations continue to use
+logical bounds only.
+
+Parent clipping is unchanged. A presentation rectangle is composed inside the parent's existing
+back buffer and clip, just like an immediate child rectangle. Animated layout does not relax
+overflow or introduce a separate clip tree.
+
+## Dock, Anchor, and constraints
+
+Dock and Anchor calculate their final child rectangles exactly as before. A right-docked control
+receives its new logical position immediately after its parent resizes; presentation then moves to
+that position. A left-and-right anchored control receives its constrained target width first and
+presentation interpolates the width. Flow and table layout results use the same bounds path.
+
+`MinimumSize` and `MaximumSize` are applied by `SetBoundsCore` before transition creation. The exact
+final presentation rectangle is consequently always the already-constrained logical rectangle.
+Intermediate presentation sizes are visual interpolation values and do not feed back into layout.
+
+## Lifecycle and ownership
+
+The control owns its scheduler entry. Hiding, detaching, or disposing a control cancels the active
+transition and synchronizes presentation state. Detaching a subtree and closing a window recursively
+cancel animation ownership for descendants as well, preventing captured callbacks from retaining a
+dead visual tree. Application shutdown continues to use the scheduler's global shutdown path.
+
+Transition configuration changes must occur on the UI thread, like other control properties. The
+scheduler can accept starts and cancellation from any thread, but all presentation updates and
+invalidation callbacks follow its UI-dispatcher contract.
+
+## Public API
+
+```csharp
+using ModernFormsNext.Animations;
+
+card.LayoutTransition = new LayoutTransition
+{
+    Enabled = true,
+    Duration = TimeSpan.FromMilliseconds(250),
+    Easing = Easings.EaseOut
+};
+
+// Bounds is the logical target immediately. Rendering and input transition to it.
+card.Bounds = new Rectangle(100, 50, 400, 200);
+```
+
+`LayoutTransition` is expandable in a property grid. `Enabled` and `Duration` are ordinary editable
+properties. Easing remains a code-first delegate and is hidden from designer serialization until a
+future known-easing editor can represent it without serializing arbitrary delegates.
+
+## Current limitations
+
+- transitions are configured per control; there is no inherited container policy;
+- controls without positive source and target area snap instead of animating through zero size;
+- parent overflow and clipping behavior is unchanged;
+- the Visual Studio Designer has no transition editor or preview integration yet;
+- Android uses the shared scheduler contract, but broader Android animation-runtime work remains
+  deferred to issue #29;
+- visual-state and higher-level layout-transition composition remain deferred to issues #26 and
+  #28.
+
+The ControlGallery **Animated layout** page provides manual checks for movement, resizing, rapid
+retargeting, hit testing, nested content, and disabling a transition mid-flight.

--- a/docs/architecture/ui-animation-scheduler.md
+++ b/docs/architecture/ui-animation-scheduler.md
@@ -6,7 +6,8 @@ This document records the state of animation timing after the Paint/Brush founda
 and defines the shared scheduler that ModernFormsNext should use on Windows and experimental
 Android. The scope is scheduling, time, cancellation, replacement, interpolation, lifecycle, and
 diagnostics. It deliberately excludes ThemeManager, Shape controls, navigation transitions, and a
-complete animated-layout system.
+designer-authored transition system. The animated-layout foundation now consumes this scheduler as
+described in [Animated layout architecture](animated-layout.md); it does not add another ticker.
 
 ## Pre-change state
 
@@ -171,7 +172,8 @@ The scheduler does not invalidate globally. Existing property setters retain res
 
 - `Control` opacity and render transforms request repaint only;
 - observable brush and gradient-stop setters repaint controls subscribed to that brush;
-- future layout-property helpers must call the established layout path explicitly.
+- animated layout commits logical bounds through the established layout path, then updates only its
+  presentation rectangle and composition invalidation on frames.
 
 Cancellation performs no property write, so it creates no extra repaint. Layout and render
 invalidation remain separate concerns.
@@ -194,8 +196,8 @@ resolution.
 
 Shape properties can use the same typed interpolators and owner keys. Navigation surfaces can use
 multiple keys for opacity and transform without owning timers. Neither feature is implemented in
-this stage. Animated layout will require focused helpers that route each update through layout
-invalidation rather than the render-only control transform path.
+this stage. Animated layout uses a focused presentation-geometry helper: layout computes the target
+once, while scheduler frames request composition invalidation without rerunning layout.
 
 ## Reduced motion
 

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -21,6 +21,7 @@ namespace ControlGallery
 
             tree.Items.Add ("Button", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Animations", ImageLoader.Get ("swatches.png"));
+            tree.Items.Add ("Animated layout", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Animations and Interaction Effects", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("CheckBox", ImageLoader.Get ("button.png"));
             tree.Items.Add ("CheckedListBox", ImageLoader.Get ("button.png"));
@@ -105,6 +106,8 @@ namespace ControlGallery
             switch (text) {
                 case "Animations":
                     return new AnimationSchedulerPanel ();
+                case "Animated layout":
+                    return new AnimatedLayoutPanel ();
                 case "Animations and Interaction Effects":
                     return new AnimationsAndInteractionEffectsPanel ();
                 case "Button":

--- a/samples/ControlGallery/Panels/AnimatedLayoutPanel.cs
+++ b/samples/ControlGallery/Panels/AnimatedLayoutPanel.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Drawing;
+using ModernFormsNext;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+
+namespace ControlGallery.Panels;
+
+/// <summary>
+/// Provides manual checks for opt-in logical-to-presentation layout transitions.
+/// </summary>
+public sealed class AnimatedLayoutPanel : BasePanel
+{
+    private static readonly Rectangle StartBounds = new(24, 34, 190, 100);
+    private static readonly Rectangle EndBounds = new(430, 142, 260, 150);
+
+    private readonly Panel card;
+    private readonly LayoutTransition transition;
+    private readonly Label status;
+    private readonly Button transitionButton;
+    private bool atEnd;
+
+    /// <summary>
+    /// Initializes the animated-layout demonstration.
+    /// </summary>
+    public AnimatedLayoutPanel()
+    {
+        AutoScroll = true;
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 18,
+            Width = 760,
+            Height = 30,
+            Text = "Animated layout",
+            Font = new ModernFormsNext.Font("Segoe UI", 16)
+        });
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 52,
+            Width = 760,
+            Height = 42,
+            Multiline = true,
+            Text = "Bounds changes remain logical and immediate to code, while the card is composed and hit-tested at an interpolated presentation rectangle. Its child content moves with it as one visual subtree."
+        });
+
+        var stage = Controls.Add(new Panel
+        {
+            Left = 24,
+            Top = 106,
+            Width = 720,
+            Height = 326,
+            BackColor = new SKColor(242, 245, 249)
+        });
+        stage.Style.Border.Width = 1;
+        stage.Style.Border.Color = Theme.BorderMidColor;
+
+        transition = new LayoutTransition
+        {
+            Duration = TimeSpan.FromMilliseconds(550),
+            Easing = Easings.EaseOut
+        };
+        card = stage.Controls.Add(new Panel
+        {
+            Bounds = StartBounds,
+            BackgroundBrush = new SolidColorBrush(Color.MediumPurple),
+            LayoutTransition = transition
+        });
+        card.Style.Border.Width = 1;
+        card.Style.Border.Color = new SKColor(75, 0, 130);
+        Label cardContent = card.Controls.Add(new Label
+        {
+            Dock = DockStyle.Fill,
+            Text = "Click while moving",
+            TextAlign = ModernFormsNext.ContentAlignment.MiddleCenter,
+            ForeColor = SKColors.White
+        });
+
+        AddButton(24, 450, 158, "Move + resize", ToggleTarget);
+        AddButton(190, 450, 158, "Rapid retarget", RapidRetarget);
+        transitionButton = AddButton(356, 450, 178, string.Empty, ToggleTransition);
+        AddButton(542, 450, 158, "Reset", ResetCard);
+
+        status = Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 500,
+            Width = 720,
+            Height = 54,
+            Multiline = true
+        });
+        card.Click += (_, _) => ReportCardClick();
+        cardContent.Click += (_, _) => ReportCardClick();
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 562,
+            Width = 720,
+            Height = 58,
+            Multiline = true,
+            Text = "Manual checks: click the moving card, retarget it repeatedly, and disable the transition mid-flight. The visual must not jump on retarget, hit testing must follow the card, and disabling must snap to the current logical target."
+        });
+
+        UpdateStatus();
+    }
+
+    private Button AddButton(int left, int top, int width, string text, Action action)
+    {
+        var button = Controls.Add(new Button
+        {
+            Left = left,
+            Top = top,
+            Width = width,
+            Height = 36,
+            Text = text
+        });
+        button.Click += (_, _) => action();
+        return button;
+    }
+
+    private void ToggleTarget()
+    {
+        atEnd = !atEnd;
+        card.Bounds = atEnd ? EndBounds : StartBounds;
+        UpdateStatus();
+    }
+
+    private void RapidRetarget()
+    {
+        card.Bounds = new Rectangle(110, 62, 220, 118);
+        card.Bounds = new Rectangle(300, 188, 170, 112);
+        card.Bounds = atEnd ? StartBounds : EndBounds;
+        atEnd = !atEnd;
+        UpdateStatus();
+    }
+
+    private void ToggleTransition()
+    {
+        transition.Enabled = !transition.Enabled;
+        UpdateStatus();
+    }
+
+    private void ResetCard()
+    {
+        atEnd = false;
+        card.Bounds = StartBounds;
+        UpdateStatus();
+    }
+
+    private void UpdateStatus()
+    {
+        transitionButton.Text = transition.Enabled ? "Transition: enabled" : "Transition: disabled";
+        status.Text = $"Logical Bounds = {card.Bounds} | Duration = {transition.Duration.TotalMilliseconds:0} ms | {(transition.Enabled ? "EaseOut" : "immediate")}";
+    }
+
+    private void ReportCardClick()
+    {
+        status.Text = $"Card clicked. Logical Bounds = {card.Bounds}";
+    }
+}


### PR DESCRIPTION
## Summary

- separates logical target bounds from internal presentation bounds
- adds the opt-in `LayoutTransition` API backed by the shared animation scheduler
- supports smooth retargeting from the current presentation rectangle
- aligns rendering, clipping, hit testing, coordinate conversion, and accessibility geometry
- integrates with existing Dock, Anchor, Flow/Table layout, and size constraints
- recursively cancels animations for detached, disposed, and closed control subtrees
- adds deterministic manual-clock regression coverage and a ControlGallery validation page

Closes #25

## Validation

- Debug build: passed, 0 errors, 0 warnings
- Release build: passed, 0 errors, 0 warnings
- Tests: 924/924 passed in a clean validation copy
- VSIX validation: Debug and Release passed
- `git diff --check`: passed