### PR TITLE
Animate layout-aware visual-state metrics

### DIFF
--- a/ModernFormsNext.Tests/AnimationInterpolatorTests.cs
+++ b/ModernFormsNext.Tests/AnimationInterpolatorTests.cs
@@ -24,6 +24,11 @@ public sealed class AnimationInterpolatorTests
                 new RectangleF(0f, 0f, 10f, 10f),
                 new RectangleF(10f, 20f, 20f, 30f),
                 0.5f));
+        Assert.Equal(new Padding(5, 10, 15, 20),
+            AnimationInterpolators.Padding.Interpolate(
+                new Padding(0, 0, 10, 10),
+                new Padding(10, 20, 20, 30),
+                0.5f));
     }
 
     [Fact]

--- a/ModernFormsNext.Tests/LayoutAwareVisualStateMetricTests.cs
+++ b/ModernFormsNext.Tests/LayoutAwareVisualStateMetricTests.cs
@@ -1,0 +1,802 @@
+using System.Drawing;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Layout;
+using ModernFormsNext.Renderers;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class LayoutAwareVisualStateMetricTests
+{
+    private static readonly TimeSpan Duration = TimeSpan.FromMilliseconds(100);
+
+    [Fact]
+    public void PaddingWithoutTransitionAppliesImmediately()
+    {
+        using var panel = CreatePanel();
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+
+        panel.EnterForTest();
+
+        Assert.Equal(new Padding(12), panel.PresentationPadding);
+        Assert.Equal(new Padding(12), panel.StyleHover.Padding);
+    }
+
+    [Fact]
+    public void PaddingInterpolatesEverySideAndEndsExactlyAtTarget()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(2, 4, 6, 8);
+        panel.StyleHover.Padding = new Padding(10, 12, 14, 16);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Padding(6, 8, 10, 12), panel.PresentationPadding);
+        Assert.Equal(new Padding(10, 12, 14, 16), panel.StyleHover.Padding);
+
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Padding(10, 12, 14, 16), panel.PresentationPadding);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void RapidNormalHoverPressedRetargetsFromCurrentPresentationPadding()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        panel.StylePressed.Padding = new Padding(20);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        AddTransition(panel, VisualState.Hover, VisualState.Pressed);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(new Padding(8), panel.PresentationPadding);
+
+        panel.DownForTest();
+        Assert.Equal(new Padding(8), panel.PresentationPadding);
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Padding(14), panel.PresentationPadding);
+        Assert.Equal(new Padding(20), panel.StylePressed.Padding);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void LeavingHoverDuringTransitionDoesNotJump()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        AddTransition(panel, VisualState.Hover, VisualState.Normal);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+        panel.LeaveForTest();
+
+        Assert.Equal(new Padding(8), panel.PresentationPadding);
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(new Padding(6), panel.PresentationPadding);
+    }
+
+    [Fact]
+    public void ZeroDurationAndDisabledPolicyApplyTargetWithoutTicking()
+    {
+        using var zeroHarness = new AnimationSchedulerTestHarness();
+        using var zeroPanel = CreatePanel(zeroHarness);
+        zeroPanel.Style.Padding = new Padding(4);
+        zeroPanel.StyleHover.Padding = new Padding(12);
+        AddTransition(zeroPanel, VisualState.Normal, VisualState.Hover, TimeSpan.Zero);
+
+        zeroPanel.EnterForTest();
+
+        Assert.Equal(new Padding(12), zeroPanel.PresentationPadding);
+        Assert.False(zeroHarness.TickSource.IsRunning);
+
+        using var disabledHarness = new AnimationSchedulerTestHarness();
+        disabledHarness.Policy.AnimationsEnabled = false;
+        using var disabledPanel = CreatePanel(disabledHarness);
+        disabledPanel.Style.Padding = new Padding(4);
+        disabledPanel.StyleHover.Padding = new Padding(12);
+        AddTransition(disabledPanel, VisualState.Normal, VisualState.Hover);
+
+        disabledPanel.EnterForTest();
+
+        Assert.Equal(new Padding(12), disabledPanel.PresentationPadding);
+        Assert.False(disabledHarness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void ActiveTransitionUsesConfigurationSnapshot()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        var transition = new VisualStateTransition
+        {
+            Duration = Duration,
+            Easing = Easings.Linear
+        };
+        panel.StyleTransitions.Add(VisualState.Normal, VisualState.Hover, transition);
+
+        panel.EnterForTest();
+        transition.Duration = TimeSpan.Zero;
+        transition.Easing = static _ => throw new InvalidOperationException("future transitions only");
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Padding(8), panel.PresentationPadding);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().FaultedCount);
+
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(new Padding(12), panel.PresentationPadding);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void PaddingTransitionRearrangesDockFillChildWithoutDoubleAnimation()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Size = new Size(200, 100);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        using var child = new Control
+        {
+            Dock = DockStyle.Fill,
+            AnimationSchedulerOverride = harness.Scheduler,
+            LayoutTransition = LinearLayoutTransition()
+        };
+        panel.Controls.Add(child);
+        using var surface = new SkiaControlSurface(panel);
+        panel.PerformLayout();
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Rectangle(8, 8, 184, 84), child.Bounds);
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+        Assert.False(child.HasActiveLayoutTransition);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(new Rectangle(12, 12, 176, 76), child.Bounds);
+    }
+
+    [Fact]
+    public void PaddingTransitionKeepsExistingAnchorSemanticsWithoutRedundantAnimation()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Size = new Size(200, 100);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        using var child = new Control
+        {
+            Bounds = new Rectangle(10, 10, 100, 30),
+            Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right,
+            AnimationSchedulerOverride = harness.Scheduler,
+            LayoutTransition = LinearLayoutTransition()
+        };
+        panel.Controls.Add(child);
+        using var surface = new SkiaControlSurface(panel);
+        panel.PerformLayout();
+        Rectangle start = child.Bounds;
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+        Rectangle middle = child.Bounds;
+        Assert.Equal(AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right, child.Anchor);
+        Assert.Equal(new Rectangle(8, 8, 184, 84), panel.DisplayRectangle);
+        harness.AdvanceAndTick(Duration / 2);
+        Rectangle target = child.Bounds;
+
+        Assert.Equal(start, middle);
+        Assert.Equal(start, target);
+        Assert.False(child.HasActiveLayoutTransition);
+        Assert.Equal(new Padding(12), panel.PresentationPadding);
+    }
+
+    [Fact]
+    public void ScrollableControlRecalculatesRangeAndPreservesOffsetFromPresentationPadding()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Size = new Size(100, 60);
+        panel.AutoScroll = true;
+        panel.Style.Padding = Padding.Empty;
+        panel.StyleHover.Padding = new Padding(0, 0, 20, 0);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        using var child = new Control { Bounds = new Rectangle(0, 0, 120, 20) };
+        panel.Controls.Add(child);
+        using var surface = new SkiaControlSurface(panel);
+        panel.PerformLayout();
+        int startMaximum = panel.HorizontalScrollProperties.Maximum;
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+        int middleMaximum = panel.HorizontalScrollProperties.Maximum;
+        panel.HorizontalScrollProperties.Value = 10;
+
+        Assert.True(startMaximum < middleMaximum);
+        Assert.Equal(10, panel.TouchScrollPosition.X);
+        Assert.Equal(-10, child.Left);
+        Assert.Equal(90, panel.DisplayRectangle.Width);
+
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.True(middleMaximum < panel.HorizontalScrollProperties.Maximum);
+        Assert.Equal(10, panel.TouchScrollPosition.X);
+    }
+
+    [Fact]
+    public void PaddingAndBorderThicknessUseOneCoherentProgress()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.Style.Border.Width = 2;
+        panel.StyleHover.Padding = new Padding(12);
+        panel.StyleHover.Border.Width = 6;
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Padding(8), panel.PresentationPadding);
+        Assert.Equal(4, panel.CurrentStyle.Border.GetWidth());
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(new Padding(12), panel.PresentationPadding);
+        Assert.Equal(6, panel.CurrentStyle.Border.GetWidth());
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void BorderSidesInterpolateIndependently()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        SetBorderSides(panel.Style, 1, 2, 3, 4);
+        SetBorderSides(panel.StyleHover, 5, 6, 7, 8);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(3, panel.CurrentStyle.Border.Left.GetWidth());
+        Assert.Equal(4, panel.CurrentStyle.Border.Top.GetWidth());
+        Assert.Equal(5, panel.CurrentStyle.Border.Right.GetWidth());
+        Assert.Equal(6, panel.CurrentStyle.Border.Bottom.GetWidth());
+
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(5, panel.CurrentStyle.Border.Left.GetWidth());
+        Assert.Equal(6, panel.CurrentStyle.Border.Top.GetWidth());
+        Assert.Equal(7, panel.CurrentStyle.Border.Right.GetWidth());
+        Assert.Equal(8, panel.CurrentStyle.Border.Bottom.GetWidth());
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void BorderOnlyTransitionNotifiesInternalContentCaches()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var control = new PresentationContentMetricsObserver
+        {
+            AnimationSchedulerOverride = harness.Scheduler
+        };
+        control.Style.Border.Width = 2;
+        control.StyleHover.Border.Width = 6;
+        AddTransition(control, VisualState.Normal, VisualState.Hover);
+
+        control.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(1, control.PresentationContentMetricsChangeCount);
+        Assert.Equal(4, control.CurrentStyle.Border.GetWidth());
+    }
+
+    [Fact]
+    public void TextLayoutConsumesPresentationPaddingAndBorderThickness()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var button = new TestButton
+        {
+            Size = new Size(180, 60),
+            AnimationSchedulerOverride = harness.Scheduler
+        };
+        button.Style.Padding = new Padding(4);
+        button.Style.Border.Width = 2;
+        button.StyleHover.Padding = new Padding(12);
+        button.StyleHover.Border.Width = 6;
+        AddTransition(button, VisualState.Normal, VisualState.Hover);
+        Rectangle start = TextImageLayoutEngine.Layout(button).Field;
+
+        button.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+        Rectangle middle = TextImageLayoutEngine.Layout(button).Field;
+        harness.AdvanceAndTick(Duration / 2);
+        Rectangle target = TextImageLayoutEngine.Layout(button).Field;
+
+        Assert.NotEqual(start, middle);
+        Assert.NotEqual(middle, target);
+        Assert.True(start.Left < middle.Left && middle.Left < target.Left);
+    }
+
+    [Fact]
+    public void PresentationPaddingNotifiesInternalCachesWithoutRaisingPublicPaddingChanged()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var control = new PresentationContentMetricsObserver
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Padding = new Padding(3)
+        };
+        control.Style.Padding = new Padding(4);
+        control.StyleHover.Padding = new Padding(12);
+        AddTransition(control, VisualState.Normal, VisualState.Hover);
+        int publicChanges = 0;
+        control.PaddingChanged += (_, _) => publicChanges++;
+
+        control.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(1, control.PresentationContentMetricsChangeCount);
+        Assert.Equal(0, publicChanges);
+        Assert.Equal(new Padding(3), control.Padding);
+    }
+
+    [Fact]
+    public void ScrollControlViewportAndTextCacheUsePresentationContentMetrics()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var textBox = new TestTextBox
+        {
+            AnimationSchedulerOverride = harness.Scheduler
+        };
+        textBox.Style.Padding = new Padding(2, 4, 6, 8);
+        textBox.Style.Border.Width = 1;
+        textBox.StyleHover.Padding = new Padding(10, 12, 14, 16);
+        textBox.StyleHover.Border.Width = 5;
+        AddTransition(textBox, VisualState.Normal, VisualState.Hover);
+        textBox.Size = new Size(200, 60);
+
+        textBox.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Rectangle(9, 11, 178, 34), textBox.PaddedClientRectangle);
+        Assert.Equal(textBox.PaddedClientRectangle.Width, textBox.document.Width);
+    }
+
+    [Fact]
+    public void ComboBoxGlyphUsesPresentationRightPadding()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var comboBox = new TestComboBox
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(100, 30)
+        };
+        comboBox.Style.Padding = new Padding(0, 0, 1, 0);
+        comboBox.StyleHover.Padding = new Padding(0, 0, 9, 0);
+        AddTransition(comboBox, VisualState.Normal, VisualState.Hover);
+        var renderer = new ComboBoxRendererProbe();
+        using var bitmap = new SKBitmap(100, 30);
+        using var canvas = new SKCanvas(bitmap);
+        var paintArgs = new PaintEventArgs(bitmap.Info, canvas, 1d);
+
+        comboBox.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+        Rectangle buttonArea = renderer.GetDropDownButtonAreaForTest(comboBox, paintArgs);
+
+        Assert.Equal(new Rectangle(85, 0, 10, 30), buttonArea);
+    }
+
+    [Fact]
+    public void GroupBoxDisplayAndPreferredSizeUsePresentationPadding()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var groupBox = new TestGroupBox
+        {
+            AnimationSchedulerOverride = harness.Scheduler,
+            Size = new Size(200, 100),
+            Text = "Metrics"
+        };
+        groupBox.Style.Padding = new Padding(4);
+        groupBox.Style.Border.Width = 0;
+        groupBox.StyleHover.Padding = new Padding(12);
+        groupBox.StyleHover.Border.Width = 0;
+        AddTransition(groupBox, VisualState.Normal, VisualState.Hover);
+        Size startPreferred = groupBox.GetPreferredSize(Size.Empty);
+
+        groupBox.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+        Rectangle middleDisplay = groupBox.DisplayRectangle;
+        Size middlePreferred = groupBox.GetPreferredSize(Size.Empty);
+        harness.AdvanceAndTick(Duration / 2);
+        Size targetPreferred = groupBox.GetPreferredSize(Size.Empty);
+
+        Assert.Equal(8, middleDisplay.Left);
+        Assert.Equal(184, middleDisplay.Width);
+        Assert.True(startPreferred.Width < middlePreferred.Width);
+        Assert.True(middlePreferred.Width < targetPreferred.Width);
+        Assert.True(startPreferred.Height < middlePreferred.Height);
+        Assert.True(middlePreferred.Height < targetPreferred.Height);
+    }
+
+    [Fact]
+    public void PersistentPaddingAndTargetStylesNeverExposeIntermediateValues()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Padding = new Padding(3);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Padding(3), panel.Padding);
+        Assert.Equal(new Padding(4), panel.Style.Padding);
+        Assert.Equal(new Padding(12), panel.StyleHover.Padding);
+        Assert.Equal(new Padding(8), panel.PresentationPadding);
+    }
+
+    [Fact]
+    public void ReentrantStateChangeDuringLayoutKeepsLatestStateAuthoritative()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        panel.StylePressed.Padding = new Padding(20);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        AddTransition(panel, VisualState.Hover, VisualState.Pressed);
+        bool retargeted = false;
+        panel.Layout += (_, _) =>
+        {
+            if (!retargeted && panel.VisualState == VisualState.Hover)
+            {
+                retargeted = true;
+                panel.DownForTest();
+            }
+        };
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(VisualState.Pressed, panel.VisualState);
+        Assert.Equal(new Padding(20), panel.StylePressed.Padding);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void RapidStateThrashingCompletesLatestTargetAndLeavesNoSchedulerEntry()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleFocused.Padding = new Padding(8);
+        panel.StyleHover.Padding = new Padding(12);
+        panel.StylePressed.Padding = new Padding(20);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        AddTransition(panel, VisualState.Hover, VisualState.Pressed);
+        AddTransition(panel, VisualState.Pressed, VisualState.Hover);
+        AddTransition(panel, VisualState.Hover, VisualState.Focused);
+        AddTransition(panel, VisualState.Focused, VisualState.Normal);
+        AddTransition(panel, VisualState.Hover, VisualState.Normal);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(20));
+        Padding beforeRetarget = panel.PresentationPadding;
+        panel.DownForTest();
+        Assert.Equal(beforeRetarget, panel.PresentationPadding);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(20));
+        beforeRetarget = panel.PresentationPadding;
+        panel.UpForTest();
+        Assert.Equal(beforeRetarget, panel.PresentationPadding);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(20));
+        panel.FocusForTest();
+        Assert.Equal(VisualState.Hover, panel.VisualState);
+        beforeRetarget = panel.PresentationPadding;
+        panel.LeaveForTest();
+        Assert.Equal(VisualState.Focused, panel.VisualState);
+        Assert.Equal(beforeRetarget, panel.PresentationPadding);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(20));
+        beforeRetarget = panel.PresentationPadding;
+        panel.BlurForTest();
+        Assert.Equal(beforeRetarget, panel.PresentationPadding);
+
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        harness.AdvanceAndTick(Duration);
+
+        Assert.Equal(VisualState.Normal, panel.VisualState);
+        Assert.Equal(new Padding(4), panel.PresentationPadding);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void DisabledRetargetsFromPressedAndReenablesIntoCurrentHoverState()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        panel.StylePressed.Padding = new Padding(20);
+        panel.StyleDisabled.Padding = new Padding(28);
+        AddTransition(panel, VisualState.Normal, VisualState.Hover);
+        AddTransition(panel, VisualState.Hover, VisualState.Pressed);
+        AddTransition(panel, VisualState.Pressed, VisualState.Disabled);
+        AddTransition(panel, VisualState.Disabled, VisualState.Hover);
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(20));
+        panel.DownForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(20));
+        Padding beforeDisabled = panel.PresentationPadding;
+
+        panel.Enabled = false;
+        Assert.Equal(VisualState.Disabled, panel.VisualState);
+        Assert.Equal(beforeDisabled, panel.PresentationPadding);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(20));
+        Padding beforeEnabled = panel.PresentationPadding;
+
+        panel.Enabled = true;
+        Assert.Equal(VisualState.Hover, panel.VisualState);
+        Assert.Equal(beforeEnabled, panel.PresentationPadding);
+        harness.AdvanceAndTick(Duration);
+
+        Assert.Equal(new Padding(12), panel.PresentationPadding);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void ResizingAnimatedAncestorAndChildMetricTransitionDoNotDoubleTransformDescendants()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(500, 260) };
+        using var parent = new Panel
+        {
+            Bounds = new Rectangle(10, 20, 220, 120),
+            AnimationSchedulerOverride = harness.Scheduler,
+            LayoutTransition = LinearLayoutTransition()
+        };
+        using var child = CreatePanel(harness);
+        child.Dock = DockStyle.Fill;
+        child.Style.Padding = new Padding(4);
+        child.StyleHover.Padding = new Padding(12);
+        AddTransition(child, VisualState.Normal, VisualState.Hover);
+        using var grandChild = new Control
+        {
+            Dock = DockStyle.Fill,
+            AnimationSchedulerOverride = harness.Scheduler,
+            LayoutTransition = LinearLayoutTransition()
+        };
+        child.Controls.Add(grandChild);
+        parent.Controls.Add(child);
+        root.Controls.Add(parent);
+        using var surface = new SkiaControlSurface(root);
+        root.PerformLayout();
+        parent.PerformLayout();
+        child.PerformLayout();
+
+        parent.Size = new Size(320, 180);
+        child.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new SizeF(270, 150), parent.PresentationBounds.Size);
+        Assert.Equal(new Padding(8), child.PresentationPadding);
+        Assert.False(child.HasActiveLayoutTransition);
+        Assert.False(grandChild.HasActiveLayoutTransition);
+        Assert.Equal(grandChild.Bounds, Rectangle.Round(grandChild.PresentationBounds));
+        Assert.Equal(2, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(new Padding(12), child.PresentationPadding);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void FaultingEasingReleasesPresentationMetricsAndSchedulerEntry()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var panel = CreatePanel(harness);
+        panel.Style.Padding = new Padding(4);
+        panel.StyleHover.Padding = new Padding(12);
+        panel.StyleTransitions.Add(
+            VisualState.Normal,
+            VisualState.Hover,
+            new VisualStateTransition
+            {
+                Duration = Duration,
+                Easing = static _ => throw new InvalidOperationException("test fault")
+            });
+
+        panel.EnterForTest();
+        harness.AdvanceAndTick(Duration / 2);
+
+        Assert.Equal(new Padding(12), panel.PresentationPadding);
+        Assert.Same(panel.StyleHover, panel.CurrentStyle);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().FaultedCount);
+    }
+
+    [Fact]
+    public void DisposeAndDetachSubtreeCancelMetricAnimations()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(400, 200) };
+        var parent = CreatePanel(harness);
+        var child = CreatePanel(harness);
+        var grandChild = CreatePanel(harness);
+        parent.Controls.Add(child);
+        child.Controls.Add(grandChild);
+        root.Controls.Add(parent);
+        using var surface = new SkiaControlSurface(root);
+        foreach (TestPanel item in new[] { parent, child, grandChild })
+        {
+            item.Style.Padding = new Padding(2);
+            item.StyleHover.Padding = new Padding(10);
+            AddTransition(item, VisualState.Normal, VisualState.Hover);
+            item.EnterForTest();
+        }
+
+        Assert.Equal(3, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+
+        root.Controls.Remove(parent);
+
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(new Padding(10), parent.PresentationPadding);
+        Assert.Equal(new Padding(10), child.PresentationPadding);
+        Assert.Equal(new Padding(10), grandChild.PresentationPadding);
+
+        parent.Dispose();
+    }
+
+    [Fact]
+    public void UserControlWithoutStateMetricsKeepsExistingPaddingSemantics()
+    {
+        using var userControl = new UserControl { Padding = new Padding(9) };
+
+        Assert.Equal(userControl.Padding, userControl.PresentationPadding);
+        Assert.Null(userControl.Style.Padding);
+    }
+
+    private static TestPanel CreatePanel(AnimationSchedulerTestHarness? harness = null)
+        => new()
+        {
+            AnimationSchedulerOverride = harness?.Scheduler
+        };
+
+    private static void AddTransition(
+        Control control,
+        VisualState from,
+        VisualState to,
+        TimeSpan? duration = null)
+        => control.StyleTransitions.Add(
+            from,
+            to,
+            new VisualStateTransition
+            {
+                Duration = duration ?? Duration,
+                Easing = Easings.Linear
+            });
+
+    private static LayoutTransition LinearLayoutTransition()
+        => new()
+        {
+            Duration = Duration,
+            Easing = Easings.Linear
+        };
+
+    private static void SetBorderSides(ControlStyle style, int left, int top, int right, int bottom)
+    {
+        style.Border.Left.Width = left;
+        style.Border.Top.Width = top;
+        style.Border.Right.Width = right;
+        style.Border.Bottom.Width = bottom;
+    }
+
+    private sealed class TestPanel : Panel
+    {
+        public TestPanel()
+        {
+            SetControlBehavior(ControlBehaviors.Hoverable);
+        }
+
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+
+        public void LeaveForTest()
+            => OnMouseLeave(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+
+        public void DownForTest()
+            => RaiseMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, Point.Empty));
+
+        public void UpForTest()
+            => RaiseMouseUp(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, Point.Empty));
+
+        public void FocusForTest()
+            => OnGotFocus(EventArgs.Empty);
+
+        public void BlurForTest()
+            => OnLostFocus(EventArgs.Empty);
+    }
+
+    private sealed class TestButton : Button
+    {
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+    }
+
+    private sealed class TestTextBox : TextBox
+    {
+        public TestTextBox()
+        {
+            SetControlBehavior(ControlBehaviors.Hoverable);
+        }
+
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+    }
+
+    private sealed class TestComboBox : ComboBox
+    {
+        public TestComboBox()
+        {
+            SetControlBehavior(ControlBehaviors.Hoverable);
+        }
+
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+    }
+
+    private sealed class ComboBoxRendererProbe : ComboBoxRenderer
+    {
+        public Rectangle GetDropDownButtonAreaForTest(ComboBox control, PaintEventArgs e)
+            => GetDropDownButtonArea(control, e);
+    }
+
+    private sealed class TestGroupBox : GroupBox
+    {
+        public TestGroupBox()
+        {
+            SetControlBehavior(ControlBehaviors.Hoverable);
+        }
+
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+    }
+
+    private sealed class PresentationContentMetricsObserver : Panel
+    {
+        public PresentationContentMetricsObserver()
+        {
+            SetControlBehavior(ControlBehaviors.Hoverable);
+        }
+
+        public int PresentationContentMetricsChangeCount { get; private set; }
+
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+
+        internal override void OnPresentationContentMetricsChanged()
+            => PresentationContentMetricsChangeCount++;
+    }
+}

--- a/ModernFormsNext.Tests/VisualStateTransitionTests.cs
+++ b/ModernFormsNext.Tests/VisualStateTransitionTests.cs
@@ -40,12 +40,10 @@ public sealed class VisualStateTransitionTests
         control.StyleHover.ScaleX = 1.2f;
         control.StyleHover.TranslationX = 8f;
         control.StyleHover.Rotation = 10f;
-        control.StyleHover.Border.Width = 8;
         int layouts = 0;
         control.Layout += (_, _) => layouts++;
 
         control.EnterForTest();
-        Assert.Equal(8, control.CurrentStyle.Border.GetWidth());
         harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
 
         Assert.Equal(new SKColor(128, 0, 128), control.CurrentStyle.GetBackgroundColor());

--- a/ModernFormsNext/Animations/AnimationInterpolators.cs
+++ b/ModernFormsNext/Animations/AnimationInterpolators.cs
@@ -60,6 +60,21 @@ public static class AnimationInterpolators
             Lerp(from.Height, to.Height, progress)));
 
     /// <summary>
+    /// Gets the component-wise <see cref="Padding"/> interpolator.
+    /// </summary>
+    /// <remarks>
+    /// Each side uses the same deterministic midpoint-away-from-zero rounding as
+    /// <see cref="Int32"/>. The interpolator does not clamp overshooting easing output; consumers
+    /// that require non-negative layout metrics must apply their normal layout constraints.
+    /// </remarks>
+    public static IAnimationInterpolator<Padding> Padding { get; } =
+        new DelegateInterpolator<Padding>(static (from, to, progress) => new Padding(
+            Int32.Interpolate(from.Left, to.Left, progress),
+            Int32.Interpolate(from.Top, to.Top, progress),
+            Int32.Interpolate(from.Right, to.Right, progress),
+            Int32.Interpolate(from.Bottom, to.Bottom, progress)));
+
+    /// <summary>
     /// Gets the alpha-aware <see cref="Color"/> interpolator.
     /// </summary>
     /// <remarks>Overshoot channel values are clamped to 0..255.</remarks>

--- a/ModernFormsNext/Animations/VisualStateTransition.cs
+++ b/ModernFormsNext/Animations/VisualStateTransition.cs
@@ -6,7 +6,13 @@ public sealed class VisualStateTransition
     private TimeSpan duration = TimeSpan.FromMilliseconds(150);
     private Func<float, float> easing = Easings.CubicOut;
 
-    /// <summary>Gets or sets the unscaled visual-only transition duration.</summary>
+    /// <summary>
+    /// Gets or sets the unscaled duration shared by visual and supported layout-aware metrics.
+    /// </summary>
+    /// <remarks>
+    /// A zero duration applies the target style immediately without starting the shared tick
+    /// source. Negative values are rejected.
+    /// </remarks>
     public TimeSpan Duration
     {
         get => duration;

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -27,6 +27,7 @@ public partial class Control
     private float visualStateScaleX = 1f;
     private float visualStateScaleY = 1f;
     private float visualStateRotation;
+    private int visualStateTransitionGeneration;
     private Brush? subscribedStateBackgroundBrush;
     private Brush? subscribedStateForegroundBrush;
     private Brush? subscribedStateBorderBrush;
@@ -35,6 +36,8 @@ public partial class Control
 
     internal void CancelOwnedControlAnimations()
     {
+        VisualStateLayoutMetrics previousMetrics = CapturePresentationLayoutMetrics();
+        visualStateTransitionGeneration++;
         if (AnimationSchedulerOverride is { } scheduler)
             scheduler.CancelAll(this);
         else
@@ -44,6 +47,7 @@ public partial class Control
         {
             transitionStyle = null;
             ApplyStateTransforms(GetStyleForState(currentVisualState));
+            ApplyVisualStateLayoutMetrics(previousMetrics, CapturePresentationLayoutMetrics());
         }
     }
 
@@ -77,7 +81,8 @@ public partial class Control
     /// <remarks>
     /// <para>
     /// Each control starts with its own empty collection. Without a matching explicitly added
-    /// transition, state changes apply the target style immediately and only invalidate rendering.
+    /// transition, state changes apply the target style immediately. Render-only values invalidate
+    /// painting, while supported layout-aware metrics request one grouped layout pass.
     /// Container and data-surface controls do not enter the Pressed state merely because they
     /// receive pointer input; they must opt in through a pressed style or transition.
     /// </para>
@@ -114,6 +119,13 @@ public partial class Control
     internal Brush? EffectiveBackgroundBrush => BackgroundBrush ?? CurrentStyle.GetResolvedBackgroundBrush();
     internal Brush? EffectiveTextBrush => TextBrush ?? CurrentStyle.GetResolvedForegroundBrush();
     internal Brush? EffectiveBorderBrush => CurrentStyle.GetResolvedBorderBrush();
+
+    /// <summary>
+    /// Gets the padding used by current presentation layout without changing the persistent
+    /// <see cref="Padding"/> property.
+    /// </summary>
+    internal Padding PresentationPadding
+        => ResolveVisualStatePadding(transitionStyle ?? GetStyleForState(currentVisualState));
 
     internal ControlStyle ResolveCurrentStyle()
     {
@@ -176,10 +188,12 @@ public partial class Control
         if (targetState == previousState)
             return;
 
+        VisualStateLayoutMetrics previousMetrics = CapturePresentationLayoutMetrics();
         bool continuesActiveTransition = transitionStyle is not null;
         ControlStyle sourceStyle = transitionStyle ?? GetStyleForState(previousState);
         ControlStyle targetStyle = GetStyleForState(targetState);
         currentVisualState = targetState;
+        int generation = ++visualStateTransitionGeneration;
 
         if (Properties.GetObject(s_styleTransitionsProperty) is not VisualStateTransitionCollection transitions ||
             !transitions.TryGet(previousState, targetState, out VisualStateTransition? transition))
@@ -188,6 +202,7 @@ public partial class Control
                 EffectiveAnimationScheduler.Cancel(this, VisualStateAnimationKey);
             transitionStyle = null;
             ApplyStateTransforms(targetStyle);
+            ApplyVisualStateLayoutMetrics(previousMetrics, CapturePresentationLayoutMetrics());
             Invalidate();
             return;
         }
@@ -197,35 +212,101 @@ public partial class Control
             targetStyle,
             this,
             continuesActiveTransition);
+        TimeSpan duration = transition!.Duration;
+        Func<float, float> easing = transition.Easing;
         transitionStyle = runtime.AnimatedStyle;
-        EffectiveAnimationScheduler.StartFrames(
-            this,
-            VisualStateAnimationKey,
-            frame =>
+        try
+        {
+            EffectiveAnimationScheduler.StartFrames(
+                this,
+                VisualStateAnimationKey,
+                frame =>
+                {
+                    if (visualStateTransitionGeneration != generation)
+                        return;
+
+                    VisualStateLayoutMetrics beforeFrame = CapturePresentationLayoutMetrics();
+                    try
+                    {
+                        float easedProgress = frame.Progress switch
+                        {
+                            <= 0f => 0f,
+                            >= 1f => 1f,
+                            _ => easing(frame.Progress)
+                        };
+                        if (!float.IsFinite(easedProgress))
+                        {
+                            throw new InvalidOperationException(
+                                "The visual-state transition easing function returned NaN or infinity.");
+                        }
+
+                        runtime.Apply(easedProgress, this);
+                        if (visualStateTransitionGeneration != generation)
+                            return;
+
+                        // Raw timeline completion, rather than overshooting eased progress, owns
+                        // release of the transient presentation style.
+                        if (frame.Progress >= 1f)
+                            transitionStyle = null;
+
+                        ApplyVisualStateLayoutMetrics(beforeFrame, CapturePresentationLayoutMetrics());
+                        Invalidate();
+                    }
+                    catch
+                    {
+                        if (visualStateTransitionGeneration == generation)
+                        {
+                            transitionStyle = null;
+                            ApplyStateTransforms(targetStyle);
+                            try
+                            {
+                                ApplyVisualStateLayoutMetrics(
+                                    beforeFrame,
+                                    CapturePresentationLayoutMetrics());
+                                Invalidate();
+                            }
+                            catch
+                            {
+                                // Preserve the original callback failure reported by the scheduler.
+                            }
+                        }
+
+                        throw;
+                    }
+                },
+                new AnimationOptions
+                {
+                    Duration = duration,
+                    // Evaluate easing in the callback so a fault can release presentation metrics
+                    // before the scheduler marks and removes the shared entry.
+                    Easing = Easings.Linear,
+                    ReplacementMode = AnimationReplacementMode.Replace
+                });
+        }
+        catch
+        {
+            if (visualStateTransitionGeneration == generation)
             {
-                runtime.Apply(frame.EasedProgress, this);
-                // Easing is intentionally allowed to overshoot. Only raw timeline completion may
-                // release the transient style; otherwise an early eased value >= 1 makes the
-                // control jump to the target style while its animation is still active.
-                if (frame.Progress >= 1f)
-                    transitionStyle = null;
+                transitionStyle = null;
+                ApplyStateTransforms(targetStyle);
+                ApplyVisualStateLayoutMetrics(previousMetrics, CapturePresentationLayoutMetrics());
                 Invalidate();
-            },
-            new AnimationOptions
-            {
-                Duration = transition!.Duration,
-                Easing = transition.Easing,
-                ReplacementMode = AnimationReplacementMode.Replace
-            });
+            }
+
+            throw;
+        }
     }
 
     internal void RefreshVisualStateAfterThemeChange()
     {
+        VisualStateLayoutMetrics previousMetrics = CapturePresentationLayoutMetrics();
+        visualStateTransitionGeneration++;
         if (transitionStyle is not null)
             EffectiveAnimationScheduler.Cancel(this, VisualStateAnimationKey);
         transitionStyle = null;
         currentVisualState = ResolveVisualState();
         ApplyStateTransforms(GetStyleForState(currentVisualState));
+        ApplyVisualStateLayoutMetrics(previousMetrics, CapturePresentationLayoutMetrics());
     }
 
     private VisualState ResolveVisualState()
@@ -315,6 +396,56 @@ public partial class Control
         return created;
     }
 
+    private Padding ResolveVisualStatePadding(ControlStyle style)
+        => style.GetResolvedPadding() is { } padding
+            ? LayoutUtils.ClampNegativePaddingToZero(padding)
+            : Padding;
+
+    private VisualStateLayoutMetrics CapturePresentationLayoutMetrics()
+        => VisualStateLayoutMetrics.Capture(
+            transitionStyle ?? GetStyleForState(currentVisualState),
+            this);
+
+    private void ApplyVisualStateLayoutMetrics(
+        VisualStateLayoutMetrics previous,
+        VisualStateLayoutMetrics current)
+    {
+        if (previous == current || GetState(States.Disposing | States.Disposed))
+            return;
+
+        // Padding and border thickness both change the content rectangle. Batch all metrics from
+        // this scheduler frame into one self-layout. Auto-sized controls additionally ask their
+        // parent to measure once. The #25 suppression scope keeps resulting child bounds from
+        // starting a second eased transition for the same visual-state change.
+        Control transitionSuppressionRoot = AutoSize && Parent is not null ? Parent : this;
+        transitionSuppressionRoot.BeginAnimatedLayoutSizeCommit();
+        try
+        {
+            OnPresentationContentMetricsChanged();
+
+            SetState(States.LayoutIsDirty, true);
+            if (AutoSize && Parent is not null)
+                LayoutTransaction.DoLayout(Parent, this, PropertyNames.PreferredSize);
+            LayoutTransaction.DoLayout(this, this, PropertyNames.Padding);
+        }
+        finally
+        {
+            transitionSuppressionRoot.EndAnimatedLayoutSizeCommit();
+        }
+    }
+
+    /// <summary>
+    /// Notifies framework controls that cached content layout depends on presentation padding or
+    /// border thickness.
+    /// </summary>
+    /// <remarks>
+    /// This does not raise <see cref="PaddingChanged"/> because the persistent public
+    /// <see cref="Padding"/> value has not changed.
+    /// </remarks>
+    internal virtual void OnPresentationContentMetricsChanged()
+    {
+    }
+
     private void ApplyStateTransforms(ControlStyle style)
     {
         visualStateOpacity = Math.Clamp(style.GetResolvedOpacity() ?? 1f, 0f, 1f);
@@ -378,6 +509,18 @@ public partial class Control
                 from.ForegroundBrush, to.ForegroundBrush, foregroundInterpolator, progress);
             AnimatedStyle.BorderBrush = InterpolateBrush(
                 from.BorderBrush, to.BorderBrush, borderInterpolator, progress);
+            AnimatedStyle.Padding = LayoutUtils.ClampNegativePaddingToZero(
+                AnimationInterpolators.Padding.Interpolate(from.Padding, to.Padding, progress));
+            AnimatedStyle.Border.Width = AnimationInterpolators.Int32.Interpolate(
+                from.BorderWidth, to.BorderWidth, progress);
+            AnimatedStyle.Border.Left.Width = AnimationInterpolators.Int32.Interpolate(
+                from.BorderLeftWidth, to.BorderLeftWidth, progress);
+            AnimatedStyle.Border.Top.Width = AnimationInterpolators.Int32.Interpolate(
+                from.BorderTopWidth, to.BorderTopWidth, progress);
+            AnimatedStyle.Border.Right.Width = AnimationInterpolators.Int32.Interpolate(
+                from.BorderRightWidth, to.BorderRightWidth, progress);
+            AnimatedStyle.Border.Bottom.Width = AnimationInterpolators.Int32.Interpolate(
+                from.BorderBottomWidth, to.BorderBottomWidth, progress);
             control.visualStateOpacity = Lerp(from.Opacity, to.Opacity, progress);
             control.visualStateTranslationX = Lerp(from.TranslationX, to.TranslationX, progress);
             control.visualStateTranslationY = Lerp(from.TranslationY, to.TranslationY, progress);
@@ -439,6 +582,12 @@ public partial class Control
         Brush? BackgroundBrush,
         Brush? ForegroundBrush,
         Brush? BorderBrush,
+        Padding Padding,
+        int BorderWidth,
+        int BorderLeftWidth,
+        int BorderTopWidth,
+        int BorderRightWidth,
+        int BorderBottomWidth,
         float Opacity,
         float TranslationX,
         float TranslationY,
@@ -457,11 +606,33 @@ public partial class Control
                 style.GetResolvedBackgroundBrush(),
                 style.GetResolvedForegroundBrush(),
                 style.GetResolvedBorderBrush(),
+                control.ResolveVisualStatePadding(style),
+                style.Border.GetWidth(),
+                style.Border.Left.GetWidth(),
+                style.Border.Top.GetWidth(),
+                style.Border.Right.GetWidth(),
+                style.Border.Bottom.GetWidth(),
                 useCurrentTransform ? control.GetVisualOpacity() : Math.Clamp(style.GetResolvedOpacity() ?? 1f, 0f, 1f),
                 useCurrentTransform ? control.GetVisualTranslationX() : style.GetResolvedTranslationX() ?? 0f,
                 useCurrentTransform ? control.GetVisualTranslationY() : style.GetResolvedTranslationY() ?? 0f,
                 useCurrentTransform ? control.GetVisualScaleX() : style.GetResolvedScaleX() ?? 1f,
                 useCurrentTransform ? control.GetVisualScaleY() : style.GetResolvedScaleY() ?? 1f,
                 useCurrentTransform ? control.GetVisualRotation() : style.GetResolvedRotation() ?? 0f);
+    }
+
+    private readonly record struct VisualStateLayoutMetrics(
+        Padding Padding,
+        int BorderLeftWidth,
+        int BorderTopWidth,
+        int BorderRightWidth,
+        int BorderBottomWidth)
+    {
+        public static VisualStateLayoutMetrics Capture(ControlStyle style, Control control)
+            => new(
+                control.ResolveVisualStatePadding(style),
+                style.Border.Left.GetWidth(),
+                style.Border.Top.GetWidth(),
+                style.Border.Right.GetWidth(),
+                style.Border.Bottom.GetWidth());
     }
 }

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -1752,11 +1752,12 @@ namespace ModernFormsNext
         public virtual Rectangle PaddedClientRectangle {
             get {
                 var client_rect = ClientRectangle;
+                var padding = PresentationPadding;
 
-                var x = client_rect.Left + Padding.Left;
-                var y = client_rect.Top + Padding.Top;
-                var w = client_rect.Width - Padding.Horizontal;
-                var h = client_rect.Height - Padding.Vertical;
+                var x = client_rect.Left + padding.Left;
+                var y = client_rect.Top + padding.Top;
+                var w = client_rect.Width - padding.Horizontal;
+                var h = client_rect.Height - padding.Vertical;
                 return new Rectangle (x, y, w, h);
             }
         }

--- a/ModernFormsNext/ControlStyle.cs
+++ b/ModernFormsNext/ControlStyle.cs
@@ -115,6 +115,29 @@ namespace ModernFormsNext
         public float? Rotation { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional state-specific interior spacing of the control.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A null value inherits the padding from <see cref="ParentStyle"/> and ultimately falls
+        /// back to <see cref="Control.Padding"/>. Non-negative values can be interpolated by a
+        /// configured visual-state transition. The control's persistent <see cref="Control.Padding"/>
+        /// value is not modified by that transition.
+        /// </para>
+        /// <para>
+        /// Padding affects content measurement and child layout. Assign state padding on the UI
+        /// thread before the state is activated.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// button.Style.Padding = new Padding(4);
+        /// button.StyleHover.Padding = new Padding(10);
+        /// </code>
+        /// </example>
+        public Padding? Padding { get; set; }
+
+        /// <summary>
         /// Gets the style from which unset values are inherited.
         /// </summary>
         /// <remarks>
@@ -233,6 +256,9 @@ namespace ModernFormsNext
 
         internal float? GetResolvedRotation()
             => ResolveNullableValue(static style => style.Rotation);
+
+        internal Padding? GetResolvedPadding()
+            => ResolveNullableValue(static style => style.Padding);
 
         internal int GetInheritanceTraversalLimit ()
             => StyleInheritanceTraversal.GetLimit(this, static style => style.ParentStyle);

--- a/ModernFormsNext/DocumentViewer.cs
+++ b/ModernFormsNext/DocumentViewer.cs
@@ -572,6 +572,10 @@ public class DocumentViewer : ScrollControl
     }
 
     /// <inheritdoc/>
+    internal override void OnPresentationContentMetricsChanged()
+        => InvalidateDocumentLayout(refreshImageSources: false);
+
+    /// <inheritdoc/>
     protected override void OnPaint(PaintEventArgs e)
     {
         base.OnPaint(e);

--- a/ModernFormsNext/GroupBox.cs
+++ b/ModernFormsNext/GroupBox.cs
@@ -408,7 +408,7 @@ namespace ModernFormsNext
             get
             {
                 var baseRectangle = base.DisplayRectangle;
-                var padding = Padding;
+                var padding = PresentationPadding;
                 int captionHeight = CaptionHeight;
 
                 return new Rectangle(
@@ -628,7 +628,7 @@ namespace ModernFormsNext
                 }
             }
 
-            var padding = Padding;
+            var padding = PresentationPadding;
             int captionHeight = CaptionHeight;
             int captionWidth = GetCaptionTextWidth();
 

--- a/ModernFormsNext/Layout/DockAndAnchorLayout.cs
+++ b/ModernFormsNext/Layout/DockAndAnchorLayout.cs
@@ -509,7 +509,7 @@ internal partial class DefaultLayout : LayoutEngine
             var containerPadding = Padding.Empty;
             if (container is Control control) {
                 // Calling this will respect Control.DefaultPadding.
-                containerPadding = control.Padding;
+                containerPadding = control.PresentationPadding;
             } else {
                 // Not likely to happen but handle this gracefully.
                 containerPadding = CommonProperties.GetPadding (container, Padding.Empty);

--- a/ModernFormsNext/Layout/TextImageLayoutEngine.cs
+++ b/ModernFormsNext/Layout/TextImageLayoutEngine.cs
@@ -24,10 +24,11 @@ internal static class TextImageLayoutEngine
 
     private static void CalculateFace (Control control, TextImageLayoutData layout)
     {
-        var left_border = control.Style.Border.Left.GetWidth ();
-        var top_border = control.Style.Border.Top.GetWidth ();
-        var right_border = control.Style.Border.Right.GetWidth ();
-        var bottom_border = control.Style.Border.Bottom.GetWidth ();
+        BorderStyle border = control.CurrentStyle.Border;
+        var left_border = border.Left.GetWidth ();
+        var top_border = border.Top.GetWidth ();
+        var right_border = border.Right.GetWidth ();
+        var bottom_border = border.Bottom.GetWidth ();
 
         var face = new Rectangle (
             layout.Client.X + left_border,
@@ -42,10 +43,11 @@ internal static class TextImageLayoutEngine
     private static void CalculateInitialField (Control control, TextImageLayoutData layout)
     {
         // The initial field is Control's ClientRectangle minus the border and padding.
-        var left_padding = control.Padding.Left;
-        var top_padding = control.Padding.Top;
-        var right_padding = control.Padding.Right;
-        var bottom_padding = control.Padding.Bottom;
+        Padding padding = control.PresentationPadding;
+        var left_padding = padding.Left;
+        var top_padding = padding.Top;
+        var right_padding = padding.Right;
+        var bottom_padding = padding.Bottom;
 
         var field = new Rectangle (
             layout.Face.X + left_padding,

--- a/ModernFormsNext/LinkLabel.cs
+++ b/ModernFormsNext/LinkLabel.cs
@@ -425,6 +425,13 @@ namespace ModernFormsNext
         }
 
         /// <inheritdoc/>
+        internal override void OnPresentationContentMetricsChanged()
+        {
+            InvalidateLayout();
+            Invalidate();
+        }
+
+        /// <inheritdoc/>
         protected override void OnPaint(PaintEventArgs e)
         {
             RenderManager.Render(this, e);

--- a/ModernFormsNext/MarkdownEditorTextBox.cs
+++ b/ModernFormsNext/MarkdownEditorTextBox.cs
@@ -324,6 +324,13 @@ internal sealed class MarkdownEditorTextBox : RichTextBox
         UpdateDocumentWidth();
     }
 
+    /// <inheritdoc/>
+    internal override void OnPresentationContentMetricsChanged()
+    {
+        base.OnPresentationContentMetricsChanged();
+        UpdateDocumentWidth();
+    }
+
     protected internal override void OnThemeChanged(EventArgs e)
     {
         base.OnThemeChanged(e);

--- a/ModernFormsNext/Renderers/ComboBoxRenderer.cs
+++ b/ModernFormsNext/Renderers/ComboBoxRenderer.cs
@@ -41,7 +41,7 @@ namespace ModernFormsNext.Renderers
         {
             var glyph_size = e.LogicalToDeviceUnits (GLYPH_SIZE);
 
-            return new Rectangle (control.ScaledWidth - glyph_size, 0, glyph_size - e.LogicalToDeviceUnits (control.Padding.Right), control.ScaledHeight);
+            return new Rectangle (control.ScaledWidth - glyph_size, 0, glyph_size - e.LogicalToDeviceUnits (control.PresentationPadding.Right), control.ScaledHeight);
         }
 
         /// <summary>

--- a/ModernFormsNext/RichTextBox.cs
+++ b/ModernFormsNext/RichTextBox.cs
@@ -959,6 +959,13 @@ namespace ModernFormsNext
             RaiseContentsResizedIfNeeded();
         }
 
+        /// <inheritdoc/>
+        internal override void OnPresentationContentMetricsChanged()
+        {
+            base.OnPresentationContentMetricsChanged();
+            cachedRichTextBlock = null;
+        }
+
         /// <summary>
         /// Raises the <see cref="ContentsResized"/> event.
         /// </summary>

--- a/ModernFormsNext/ScrollControl.cs
+++ b/ModernFormsNext/ScrollControl.cs
@@ -54,11 +54,12 @@ namespace ModernFormsNext
         public override Rectangle PaddedClientRectangle {
             get {
                 var client_rect = ClientRectangle;
+                var padding = PresentationPadding;
 
-                var x = client_rect.Left + Padding.Left;
-                var y = client_rect.Top + Padding.Top;
-                var w = client_rect.Width - Padding.Horizontal;
-                var h = client_rect.Height - Padding.Vertical;
+                var x = client_rect.Left + padding.Left;
+                var y = client_rect.Top + padding.Top;
+                var w = client_rect.Width - padding.Horizontal;
+                var h = client_rect.Height - padding.Vertical;
 
                 if (hscrollbar.Visible)
                     h -= hscrollbar.Height;

--- a/ModernFormsNext/ScrollableControl.cs
+++ b/ModernFormsNext/ScrollableControl.cs
@@ -107,8 +107,8 @@ namespace ModernFormsNext
         {
             var width = 0;
             var height = 0;
-            var extra_width = hscrollbar.Value + Padding.Right;
-            var extra_height = vscrollbar.Value + Padding.Bottom;
+            var extra_width = hscrollbar.Value + PresentationPadding.Right;
+            var extra_height = vscrollbar.Value + PresentationPadding.Bottom;
 
             foreach (var c in Controls) {
                 if (IsInternalScrollControl (c))
@@ -172,7 +172,7 @@ namespace ModernFormsNext
                 if (vscrollbar.Visible)
                     rect.Width -= vscrollbar.Width;
 
-                return LayoutUtils.DeflateRect (rect, Padding);
+                return LayoutUtils.DeflateRect (rect, PresentationPadding);
             }
         }
 

--- a/ModernFormsNext/TextBox.cs
+++ b/ModernFormsNext/TextBox.cs
@@ -437,6 +437,13 @@ namespace ModernFormsNext
             document.Width = PaddedClientRectangle.Width;
         }
 
+        /// <inheritdoc/>
+        internal override void OnPresentationContentMetricsChanged ()
+        {
+            base.OnPresentationContentMetricsChanged ();
+            document.Width = PaddedClientRectangle.Width;
+        }
+
         /// <summary>
         /// Gets or sets a character to display instead of the actual text.
         /// </summary>

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -413,8 +413,22 @@ button.StyleTransitions.Add(
 
 `StylePressed`, `StyleFocused`, and `StyleDisabled` complement the existing `Style` and
 `StyleHover`. Compatible foreground, background, and border brushes, plus opacity, translation,
-scale, and rotation, interpolate. Layout metrics such as border width switch immediately and do
-not request layout per frame.
+scale, and rotation, interpolate. `ControlStyle.Padding` and aggregate or per-side border width use
+the same timeline as layout-aware metrics. Padding is interpolated component by component, and the
+control performs at most one grouped layout when rounded presentation metrics change.
+
+```csharp
+card.Style.Padding = new Padding(8);
+card.StyleHover.Padding = new Padding(20);
+card.Style.Border.Width = 1;
+card.StyleHover.Border.Width = 3;
+```
+
+The persistent `Control.Padding` fallback and state target styles never receive intermediate
+values. Docked content follows the presentation content rectangle. Child bounds transitions are
+suppressed during this metric-driven layout so the same state change is not eased twice. See
+[Layout-aware visual-state metrics](architecture/layout-aware-visual-state-metrics.md) for
+retargeting, invalidation, lifecycle, Anchor behavior, and current exclusions.
 
 Rapid state changes replace the old transition from its current presentation; the latest state is
 authoritative. Theme and dynamic-resource changes cancel the stale transition, re-resolve the

--- a/docs/architecture/animated-layout.md
+++ b/docs/architecture/animated-layout.md
@@ -8,8 +8,9 @@ rectangle. It does not introduce another visual tree, layout engine, timer, or p
 control implementation.
 
 The first version interpolates the complete `RectangleF` (`X`, `Y`, `Width`, and `Height`) as one
-value. Full visual-state orchestration, navigation transitions, designer editing, and Android-
-specific runtime integration remain separate work.
+value. Navigation transitions, designer editing, and Android-specific runtime integration remain
+separate work. Selected visual-state content metrics build on this foundation through the linked
+layout-aware contract below.
 
 ## Logical and presentation geometry
 
@@ -34,6 +35,11 @@ descendants commit their new logical bounds without starting redundant local tra
 that layout pass. The parent's presentation scaling already carries the complete subtree between
 the old and new sizes. Independent descendant changes outside that layout pass remain eligible for
 their own transitions.
+
+Visual-state padding and border metrics are a separate presentation input that can require a
+grouped layout when their rounded value changes. That path reuses this subsystem's descendant
+transition suppression so child rectangles are not eased twice. See
+[Layout-aware visual-state metrics](layout-aware-visual-state-metrics.md).
 
 ## Starting and retargeting
 
@@ -136,8 +142,9 @@ future known-easing editor can represent it without serializing arbitrary delega
 - the Visual Studio Designer has no transition editor or preview integration yet;
 - Android uses the shared scheduler contract, but broader Android animation-runtime work remains
   deferred to issue #29;
-- visual-state and higher-level layout-transition composition remain deferred to issues #26 and
-  #28.
+- layout-aware visual-state composition is defined in
+  [Layout-aware visual-state metrics](layout-aware-visual-state-metrics.md); Designer editing of
+  custom transition definitions remains deferred to issue #28.
 
 The ControlGallery **Animated layout** page provides manual checks for movement, resizing, rapid
 retargeting, hit testing, nested content, and disabling a transition mid-flight.

--- a/docs/architecture/layout-aware-visual-state-metrics.md
+++ b/docs/architecture/layout-aware-visual-state-metrics.md
@@ -1,0 +1,89 @@
+# Layout-aware visual-state metrics
+
+Visual states can transition selected metrics that affect a control's content rectangle without
+creating a second animation system. This layer extends the existing visual-state transition runtime
+and uses the same process-wide `AnimationScheduler` as ordinary visual transitions and
+[animated bounds](animated-layout.md).
+
+## Resolution and state ownership
+
+Controls continue to resolve states in this order:
+
+```text
+Disabled > Pressed > Hover > Focused > Normal
+```
+
+`Style`, `StyleHover`, `StylePressed`, `StyleFocused`, and `StyleDisabled` remain the authoritative
+target styles. State styles inherit unset values through their `ControlStyle.ParentStyle` chain.
+The transition runtime creates one temporary presentation style; it never writes interpolated
+values back to a target style.
+
+Issue #26 supports these metrics:
+
+- `ControlStyle.Padding`, interpolated independently on all four sides;
+- aggregate and per-side `BorderStyle.Width` values.
+
+`Control.Padding` remains the persistent fallback and never reports an interpolated value.
+State-specific `ControlStyle.Padding`, when set, overrides that fallback for presentation layout.
+Negative presentation padding produced by an overshooting easing is clamped through the normal
+layout padding constraint.
+
+Margin, explicit Width/Height/Size, MinimumSize/MaximumSize, font metrics, and container-specific
+spacing are not visual-state metrics in the current style model and are deliberately outside this
+contract. Corner radius remains render-only and is not part of this issue.
+
+## One timeline and retargeting
+
+Colors, brushes, transforms, padding, and border thickness are captured in one transition snapshot.
+One scheduler entry advances the complete snapshot with the selected `VisualStateTransition`
+duration and easing. Configuration is captured when the transition starts, so changing the
+`VisualStateTransition` object affects future transitions without changing an active timeline.
+There is no timer per control or per property.
+
+When a newer state replaces an active transition, its source snapshot is the current presentation
+style. A rapid `Normal -> Hover -> Pressed -> Hover` sequence therefore continues from what was
+last displayed. A generation guard keeps a state change raised reentrantly during layout from
+allowing an older callback to release the newer presentation style.
+
+Zero-duration transitions, disabled animations, reduced motion, and design-time immediate policy
+apply the exact target once without starting the tick source. If custom easing throws or returns a
+non-finite value, the scheduler faults and removes that entry while the control first releases its
+temporary style and synchronizes presentation metrics to the latest target.
+
+## Layout, invalidation, and animated bounds
+
+The runtime compares the previous and current integer presentation metrics after interpolation.
+If rounding did not change padding or border thickness, no layout is requested. Otherwise all
+changed metrics from that frame are applied in one self-layout; an auto-sized control also asks its
+parent to measure once. Painting is invalidated through the existing control path.
+Framework controls with cached content layout receive one internal presentation-content-metrics
+notification for padding or border changes. Text, link, document, and rich-text caches therefore
+use the same content rectangle that is rendered and hit-tested. The public `PaddingChanged` event
+is not raised because `Control.Padding` itself did not change.
+
+During that grouped layout, the animated-layout suppression scope from issue #25 prevents child
+bounds computed from the presentation content rectangle from starting their own
+`LayoutTransition`. This avoids applying the visual-state easing and then easing the same child
+geometry a second time. The logical layout engine, Dock rules, constraints, and public
+`Control.Bounds` implementation are unchanged.
+
+`DockStyle.Fill` children consume the changing presentation display rectangle and resize
+progressively. The current Anchor implementation does not rearrange anchored local bounds when
+only container padding changes; layout-aware transitions preserve the same behavior as assigning
+`Control.Padding` directly rather than introducing different animated semantics. Existing anchor
+responses to container bounds changes remain owned by the normal layout and issue #25.
+
+## Lifecycle and performance
+
+The visual-state animation continues to use the control-owned scheduler key
+`Control.VisualState`. Detach, recursive subtree removal, disposal, and window close cancel the
+same owner entries and synchronize presentation metrics to the latest state. The scheduler stops
+its shared tick source when the final entry is gone.
+
+The frame path performs no reflection or full style reconstruction. Snapshots are value types,
+interpolation is component-wise, and one existing temporary `ControlStyle` is reused throughout
+the transition. Layout runs only when an integer layout metric actually changes.
+
+Designer transition editing remains outside this issue. `ControlStyle.Padding` is an ordinary
+code-first style property suitable for future serialization, while delegate-valued transitions
+remain hidden from current Designer serialization as before.

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -22,6 +22,7 @@ namespace ControlGallery
             tree.Items.Add ("Button", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Animations", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Animated layout", ImageLoader.Get ("swatches.png"));
+            tree.Items.Add ("Layout-aware visual states", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Animations and Interaction Effects", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("CheckBox", ImageLoader.Get ("button.png"));
             tree.Items.Add ("CheckedListBox", ImageLoader.Get ("button.png"));
@@ -108,6 +109,8 @@ namespace ControlGallery
                     return new AnimationSchedulerPanel ();
                 case "Animated layout":
                     return new AnimatedLayoutPanel ();
+                case "Layout-aware visual states":
+                    return new LayoutAwareVisualStatesPanel ();
                 case "Animations and Interaction Effects":
                     return new AnimationsAndInteractionEffectsPanel ();
                 case "Button":

--- a/samples/ControlGallery/Panels/LayoutAwareVisualStatesPanel.cs
+++ b/samples/ControlGallery/Panels/LayoutAwareVisualStatesPanel.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Drawing;
+using ModernFormsNext;
+using ModernFormsNext.Animations;
+using SkiaSharp;
+
+namespace ControlGallery.Panels;
+
+/// <summary>
+/// Provides a manual hover and press check for layout-aware visual-state metrics.
+/// </summary>
+public sealed class LayoutAwareVisualStatesPanel : BasePanel
+{
+    /// <summary>
+    /// Initializes the layout-aware visual-state demonstration.
+    /// </summary>
+    public LayoutAwareVisualStatesPanel()
+    {
+        AutoScroll = true;
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 18,
+            Width = 760,
+            Height = 30,
+            Text = "Layout-aware visual states",
+            Font = new ModernFormsNext.Font("Segoe UI", 16)
+        });
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 54,
+            Width = 760,
+            Height = 48,
+            Multiline = true,
+            Text = "Hover and press the card. Padding and border thickness share one visual-state timeline; the Dock.Fill child follows the changing content rectangle without a second bounds transition."
+        });
+
+        var stage = Controls.Add(new Panel
+        {
+            Left = 24,
+            Top = 118,
+            Width = 720,
+            Height = 330,
+            BackColor = new SKColor(242, 245, 249)
+        });
+        stage.Style.Border.Width = 1;
+        stage.Style.Border.Color = Theme.BorderMidColor;
+
+        var card = stage.Controls.Add(new HoverPanel
+        {
+            Bounds = new Rectangle(170, 72, 380, 180),
+            BackColor = new SKColor(92, 64, 171)
+        });
+        card.Style.Padding = new Padding(12);
+        card.Style.Border.Width = 2;
+        card.Style.Border.Color = new SKColor(55, 35, 120);
+        card.StyleHover.Padding = new Padding(28);
+        card.StyleHover.Border.Width = 6;
+        card.StylePressed.Padding = new Padding(36);
+        card.StylePressed.Border.Width = 8;
+
+        AddTransition(card, VisualState.Normal, VisualState.Hover, 260);
+        AddTransition(card, VisualState.Hover, VisualState.Normal, 220);
+        AddTransition(card, VisualState.Hover, VisualState.Pressed, 120);
+        AddTransition(card, VisualState.Pressed, VisualState.Hover, 160);
+
+        card.Controls.Add(new PassiveLabel
+        {
+            Dock = DockStyle.Fill,
+            Text = "Normal 12 / Hover 28 / Pressed 36",
+            TextAlign = ModernFormsNext.ContentAlignment.MiddleCenter,
+            ForeColor = SKColors.White,
+            BackColor = new SKColor(126, 94, 205)
+        });
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 470,
+            Width = 720,
+            Height = 54,
+            Multiline = true,
+            Text = "Manual check: quickly move in/out and press repeatedly. Content must remain smooth, the final inset must be exact, and no delayed child animation should continue after the state settles."
+        });
+    }
+
+    private static void AddTransition(
+        Control control,
+        VisualState from,
+        VisualState to,
+        int durationMilliseconds)
+        => control.StyleTransitions.Add(
+            from,
+            to,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(durationMilliseconds),
+                Easing = Easings.CubicOut
+            });
+
+    private sealed class HoverPanel : Panel
+    {
+        public HoverPanel()
+        {
+            SetControlBehavior(ControlBehaviors.Hoverable);
+        }
+    }
+
+    private sealed class PassiveLabel : Label
+    {
+        public PassiveLabel()
+        {
+            SetControlBehavior(ControlBehaviors.ReceivesMouseEvents, false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- animates presentation Padding and aggregate or per-side border metrics while preserving logical property values
- shares one scheduler, progress, clock, and easing path across the active visual-state metric transition
- retargets from the current presentation values during rapid state changes
- integrates with the animated layout subsystem from #25 and suppresses redundant LayoutTransition easing
- keeps Dock, content rectangles, text/image layout, scrolling, and geometry caches synchronized
- recursively cleans up active metric animations on detach and disposal
- adds deterministic regression coverage for precedence, retargeting, lifecycle, layout, scrolling, cache invalidation, and double-animation prevention

Closes #26