### PR TITLE
Extend Brush interpolation compatibility

### DIFF
--- a/ModernFormsNext.Tests/AnimationInterpolatorTests.cs
+++ b/ModernFormsNext.Tests/AnimationInterpolatorTests.cs
@@ -130,6 +130,7 @@ public sealed class AnimationInterpolatorTests
         Assert.Equal(0f, from.GradientStops[0].Offset);
 
         var final = Assert.IsType<LinearGradientBrush>(interpolator.Interpolate(from, to, 1f));
+        Assert.Same(to, final);
         Assert.Equal(GradientSpreadMode.Reflect, final.SpreadMode);
         Assert.Equal(to.GradientStops[0].PaintColor.ToArgb(), final.GradientStops[0].PaintColor.ToArgb());
     }
@@ -183,7 +184,7 @@ public sealed class AnimationInterpolatorTests
     }
 
     [Fact]
-    public void BrushAnimationRejectsMismatchedTypesAndGradientStructuresBeforeScheduling()
+    public void InPlaceBrushAnimationRejectsMismatchedTypesAndGradientStructuresBeforeScheduling()
     {
         using var harness = new AnimationSchedulerTestHarness();
         var solid = new SolidColorBrush(Color.Red);

--- a/ModernFormsNext.Tests/BrushInterpolationCompatibilityTests.cs
+++ b/ModernFormsNext.Tests/BrushInterpolationCompatibilityTests.cs
@@ -1,0 +1,489 @@
+using System.Drawing;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+using Xunit;
+using MfnBrush = ModernFormsNext.Drawing.Brush;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class BrushInterpolationCompatibilityTests
+{
+    [Fact]
+    public void SolidInterpolationReturnsExactEndpointsAndIncludesAlpha()
+    {
+        var from = new SolidColorBrush(Color.FromArgb(20, 10, 30, 50));
+        var to = new SolidColorBrush(Color.FromArgb(220, 110, 130, 150));
+        IAnimationInterpolator<MfnBrush> interpolator = AnimationInterpolators.CreateBrushInterpolator();
+
+        Assert.Same(from, interpolator.Interpolate(from, to, -0.25f));
+        var middle = Assert.IsType<SolidColorBrush>(interpolator.Interpolate(from, to, 0.5f));
+        Assert.Equal(Color.FromArgb(120, 60, 80, 100).ToArgb(), middle.PaintColor.ToArgb());
+        Assert.Same(to, interpolator.Interpolate(from, to, 1f));
+        Assert.Same(to, interpolator.Interpolate(from, to, 1.25f));
+    }
+
+    [Fact]
+    public void DifferentStopCountsNormalizeOnceWithoutMutatingAuthoredCollections()
+    {
+        LinearGradientBrush from = Linear(
+            (Color.Red, 0f),
+            (Color.Blue, 1f));
+        LinearGradientBrush to = Linear(
+            (Color.Green, 0f),
+            (Color.Yellow, 0.5f),
+            (Color.White, 1f));
+        IAnimationInterpolator<MfnBrush> interpolator = AnimationInterpolators.CreateBrushInterpolator();
+
+        var first = Assert.IsType<LinearGradientBrush>(interpolator.Interpolate(from, to, 0.25f));
+        var middle = Assert.IsType<LinearGradientBrush>(interpolator.Interpolate(from, to, 0.5f));
+
+        Assert.Same(first, middle);
+        Assert.Equal([0f, 0.5f, 1f], middle.GradientStops.Select(static stop => stop.Offset));
+        Assert.Equal(3, middle.GradientStops.Count);
+        Assert.Equal(2, from.GradientStops.Count);
+        Assert.Equal(3, to.GradientStops.Count);
+        Assert.Equal(Color.Red.ToArgb(), from.GradientStops[0].PaintColor.ToArgb());
+        Assert.Equal(Color.Yellow.ToArgb(), to.GradientStops[1].PaintColor.ToArgb());
+    }
+
+    [Fact]
+    public void StopNormalizationPreservesHardStopMultiplicityAndStableOrder()
+    {
+        LinearGradientBrush from = Linear(
+            (Color.Red, 0f),
+            (Color.Blue, 0f),
+            (Color.White, 1f));
+        LinearGradientBrush to = Linear(
+            (Color.Green, 0f),
+            (Color.Black, 0.5f),
+            (Color.Yellow, 1f),
+            (Color.White, 1f));
+
+        var middle = Assert.IsType<LinearGradientBrush>(
+            AnimationInterpolators.CreateBrushInterpolator().Interpolate(from, to, 0.5f));
+
+        Assert.Equal([0f, 0f, 0.5f, 1f, 1f], middle.GradientStops.Select(static stop => stop.Offset));
+        Assert.NotEqual(
+            middle.GradientStops[0].PaintColor.ToArgb(),
+            middle.GradientStops[1].PaintColor.ToArgb());
+
+        LinearGradientBrush internalHardStop = Linear(
+            (Color.Red, 0f),
+            (Color.Green, 0.25f),
+            (Color.Blue, 0.25f),
+            (Color.White, 1f));
+        LinearGradientBrush shifted = Linear(
+            (Color.Black, 0f),
+            (Color.Yellow, 0.75f),
+            (Color.White, 1f));
+
+        var shiftedMiddle = Assert.IsType<LinearGradientBrush>(
+            AnimationInterpolators.CreateBrushInterpolator().Interpolate(internalHardStop, shifted, 0.5f));
+
+        Assert.Equal(
+            [0f, 0.25f, 0.25f, 0.75f, 1f],
+            shiftedMiddle.GradientStops.Select(static stop => stop.Offset));
+        Assert.NotEqual(
+            shiftedMiddle.GradientStops[1].PaintColor.ToArgb(),
+            shiftedMiddle.GradientStops[2].PaintColor.ToArgb());
+    }
+
+    [Fact]
+    public void EqualStopCountsContinueToInterpolateOffsets()
+    {
+        LinearGradientBrush from = Linear(
+            (Color.Red, 0f),
+            (Color.Blue, 0.6f));
+        LinearGradientBrush to = Linear(
+            (Color.Green, 0.2f),
+            (Color.White, 1f));
+
+        var middle = Assert.IsType<LinearGradientBrush>(
+            AnimationInterpolators.CreateBrushInterpolator().Interpolate(from, to, 0.5f));
+
+        Assert.Equal(0.1f, middle.GradientStops[0].Offset, 3);
+        Assert.Equal(0.8f, middle.GradientStops[1].Offset, 3);
+    }
+
+    [Fact]
+    public void SolidAndGradientUseTheGradientGeometryWithAConstantSolidEndpoint()
+    {
+        var solid = new SolidColorBrush(Color.Red) { Opacity = 0.4f };
+        LinearGradientBrush gradient = Linear(
+            (Color.Blue, 0f),
+            (Color.Green, 0.4f),
+            (Color.White, 1f));
+        gradient.Start = new PointF(0.2f, 0.3f);
+        gradient.End = new PointF(0.8f, 0.9f);
+        gradient.Opacity = 0.8f;
+
+        var forward = Assert.IsType<LinearGradientBrush>(
+            AnimationInterpolators.CreateBrushInterpolator().Interpolate(solid, gradient, 0.5f));
+        var reverse = Assert.IsType<LinearGradientBrush>(
+            AnimationInterpolators.CreateBrushInterpolator().Interpolate(gradient, solid, 0.5f));
+
+        Assert.Equal(gradient.Start, forward.Start);
+        Assert.Equal(gradient.End, forward.End);
+        Assert.Equal(0.6f, forward.Opacity, 3);
+        Assert.Equal(gradient.GradientStops.Count, forward.GradientStops.Count);
+        Assert.Equal(gradient.Start, reverse.Start);
+        Assert.Equal(gradient.End, reverse.End);
+        Assert.Same(gradient, AnimationInterpolators.CreateBrushInterpolator().Interpolate(solid, gradient, 1f));
+    }
+
+    [Theory]
+    [InlineData("Linear")]
+    [InlineData("Radial")]
+    [InlineData("Sweep")]
+    public void EveryGradientKindNormalizesDifferentStopCounts(string kind)
+    {
+        GradientBrush from = Gradient(
+            kind,
+            (Color.Red, 0f),
+            (Color.Blue, 1f));
+        GradientBrush to = Gradient(
+            kind,
+            (Color.Green, 0f),
+            (Color.Yellow, 0.4f),
+            (Color.White, 1f));
+
+        IAnimationInterpolator<MfnBrush> interpolator = AnimationInterpolators.CreateBrushInterpolator();
+
+        Assert.Same(from, interpolator.Interpolate(from, to, -0.1f));
+        MfnBrush middle = interpolator.Interpolate(from, to, 0.5f);
+        Assert.Same(to, interpolator.Interpolate(from, to, 1.1f));
+
+        Assert.IsType(from.GetType(), middle);
+        Assert.Equal(
+            [0f, 0.4f, 1f],
+            Assert.IsAssignableFrom<GradientBrush>(middle).GradientStops.Select(static stop => stop.Offset));
+        Assert.Equal(2, from.GradientStops.Count);
+        Assert.Equal(3, to.GradientStops.Count);
+    }
+
+    [Theory]
+    [InlineData("Linear")]
+    [InlineData("Radial")]
+    [InlineData("Sweep")]
+    public void SolidPromotionWorksForEveryGradientKind(string kind)
+    {
+        var solid = new SolidColorBrush(Color.FromArgb(96, 10, 20, 30));
+        GradientBrush gradient = Gradient(
+            kind,
+            (Color.Red, 0f),
+            (Color.Green, 0.3f),
+            (Color.Blue, 1f));
+
+        IAnimationInterpolator<MfnBrush> forwardInterpolator = AnimationInterpolators.CreateBrushInterpolator();
+        IAnimationInterpolator<MfnBrush> reverseInterpolator = AnimationInterpolators.CreateBrushInterpolator();
+
+        Assert.Same(solid, forwardInterpolator.Interpolate(solid, gradient, 0f));
+        MfnBrush forward = forwardInterpolator.Interpolate(solid, gradient, 0.5f);
+        Assert.Same(gradient, forwardInterpolator.Interpolate(solid, gradient, 1f));
+        Assert.Same(gradient, reverseInterpolator.Interpolate(gradient, solid, 0f));
+        MfnBrush reverse = reverseInterpolator.Interpolate(gradient, solid, 0.5f);
+        Assert.Same(solid, reverseInterpolator.Interpolate(gradient, solid, 1f));
+
+        Assert.IsType(gradient.GetType(), forward);
+        Assert.IsType(gradient.GetType(), reverse);
+        Assert.Equal(3, Assert.IsAssignableFrom<GradientBrush>(forward).GradientStops.Count);
+        Assert.Equal(3, Assert.IsAssignableFrom<GradientBrush>(reverse).GradientStops.Count);
+    }
+
+    [Fact]
+    public void IncompatibleGeometryGlassNoBrushAndDerivedBrushesUseCompatibilityFallback()
+    {
+        LinearGradientBrush linear = Linear((Color.Red, 0f), (Color.Blue, 1f));
+        RadialGradientBrush radial = Radial((Color.Green, 0f), (Color.White, 1f));
+        SweepGradientBrush sweep = Sweep((Color.Black, 0f), (Color.White, 1f));
+        var solid = new SolidColorBrush(Color.Red);
+        var glass = new GlassBrush();
+        var noBrush = new NoBrush();
+
+        AssertIncompatible(linear, radial);
+        AssertIncompatible(radial, linear);
+        AssertIncompatible(linear, sweep);
+        AssertIncompatible(sweep, linear);
+        AssertIncompatible(radial, sweep);
+        AssertIncompatible(sweep, radial);
+        AssertIncompatible(glass, glass);
+        AssertIncompatible(glass, solid);
+        AssertIncompatible(solid, glass);
+        AssertIncompatible(noBrush, noBrush);
+        AssertIncompatible(noBrush, solid);
+        AssertIncompatible(solid, noBrush);
+        Assert.False(AnimationInterpolators.TryCreateBrushInterpolator(
+            new DerivedSolidBrush(Color.Red),
+            new DerivedSolidBrush(Color.Blue),
+            out _));
+        Assert.Throws<ArgumentException>(() =>
+            AnimationInterpolators.CreateBrushInterpolator().Interpolate(linear, radial, 0.5f));
+    }
+
+    [Fact]
+    public void EmptyGradientDoesNotImplicitlyBecomeTransparentPaint()
+    {
+        var empty = new LinearGradientBrush();
+        var populated = Linear((Color.Red, 0f), (Color.Blue, 1f));
+
+        Assert.False(AnimationInterpolators.TryCreateBrushInterpolator(empty, populated, out _));
+        Assert.False(AnimationInterpolators.TryCreateBrushInterpolator(
+            new SolidColorBrush(Color.Transparent),
+            empty,
+            out _));
+    }
+
+    [Fact]
+    public void PreparedPlanDoesNotAllocatePerIntermediateFrame()
+    {
+        LinearGradientBrush from = Linear(
+            (Color.Red, 0f),
+            (Color.Blue, 1f));
+        LinearGradientBrush to = Linear(
+            (Color.Green, 0f),
+            (Color.Yellow, 0.25f),
+            (Color.White, 1f));
+        Assert.True(BrushAnimationPlan.TryCreateLocal(from, to, out BrushAnimationPlan? plan));
+
+        for (int index = 0; index < 32; index++)
+            plan!.Apply(0.5f);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int index = 0; index < 1_000; index++)
+            plan!.Apply(0.5f);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.InRange(allocated, 0, 256);
+    }
+
+    [Fact]
+    public void VisualStateUsesInterpolatedBackgroundForegroundAndBorderBrushesForRendering()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var control = CreateBrushTransitionButton(harness);
+        control.Text = "Brush";
+        control.Width = 40;
+        control.Height = 20;
+        control.Style.BackgroundBrush = new SolidColorBrush(Color.Red);
+        control.Style.ForegroundBrush = new SolidColorBrush(Color.Black);
+        control.Style.BorderBrush = new SolidColorBrush(Color.Blue);
+        control.Style.Border.Width = 2;
+        control.StyleHover.BackgroundBrush = Linear(
+            (Color.Blue, 0f),
+            (Color.Green, 0.5f),
+            (Color.White, 1f));
+        control.StyleHover.ForegroundBrush = Linear((Color.White, 0f), (Color.Yellow, 1f));
+        control.StyleHover.BorderBrush = Linear((Color.Yellow, 0f), (Color.Magenta, 1f));
+        using var surface = new SkiaControlSurface(control);
+        surface.Resize(40, 20);
+
+        control.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+
+        Assert.IsType<LinearGradientBrush>(control.EffectiveBackgroundBrush);
+        Assert.IsType<LinearGradientBrush>(control.EffectiveTextBrush);
+        Assert.IsType<LinearGradientBrush>(control.EffectiveBorderBrush);
+        using var bitmap = new SKBitmap(40, 20, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        surface.Render(canvas);
+        canvas.Flush();
+        SKColor pixel = bitmap.GetPixel(10, 10);
+        Assert.NotEqual(SKColors.Red, pixel);
+        Assert.NotEqual(SKColors.Blue, pixel);
+    }
+
+    [Fact]
+    public void RapidVisualStateRetargetStartsFromCurrentPresentationBrushAndCleansScheduler()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var control = CreateBrushTransitionButton(harness);
+        control.Style.BackgroundBrush = new SolidColorBrush(Color.Red);
+        control.StyleHover.BackgroundBrush = Linear((Color.Blue, 0f), (Color.Green, 1f));
+        control.StylePressed.BackgroundBrush = Linear(
+            (Color.Yellow, 0f),
+            (Color.Magenta, 0.5f),
+            (Color.White, 1f));
+        AddTransition(control, VisualState.Hover, VisualState.Pressed);
+
+        control.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(25));
+        MfnBrush beforeRetarget = control.EffectiveBackgroundBrush!;
+        control.DownForTest();
+
+        Assert.Same(beforeRetarget, control.EffectiveBackgroundBrush);
+        Assert.Equal(1, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Same(control.StylePressed.BackgroundBrush, control.EffectiveBackgroundBrush);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void UnsupportedAndNullVisualStatePairsSwitchBrushDiscretelyWithoutFaulting()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        AssertDiscreteTransition(
+            harness,
+            Linear((Color.Red, 0f), (Color.Blue, 1f)),
+            Radial((Color.Green, 0f), (Color.White, 1f)));
+        AssertDiscreteTransition(harness, null, null);
+        AssertDiscreteTransition(harness, null, new SolidColorBrush(Color.Red));
+        AssertDiscreteReverseTransitionToNull(harness, new SolidColorBrush(Color.Red));
+        AssertDiscreteTransition(harness, new NoBrush(), new SolidColorBrush(Color.Red));
+        AssertDiscreteTransition(harness, new SolidColorBrush(Color.Red), new NoBrush());
+        AssertDiscreteTransition(harness, new GlassBrush(), new SolidColorBrush(Color.Red));
+        AssertDiscreteTransition(harness, new SolidColorBrush(Color.Red), new GlassBrush());
+        AssertDiscreteTransition(harness, new GlassBrush(), new GlassBrush());
+
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().FaultedCount);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
+    public void ZeroDurationUsesExactTargetAndDoesNotStartTickSource()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        control.Style.BackgroundBrush = new SolidColorBrush(Color.Red);
+        var target = Linear((Color.Blue, 0f), (Color.Green, 1f));
+        control.StyleHover.BackgroundBrush = target;
+        control.StyleTransitions.Add(
+            VisualState.Normal,
+            VisualState.Hover,
+            new VisualStateTransition { Duration = TimeSpan.Zero });
+
+        control.EnterForTest();
+
+        Assert.Same(target, control.EffectiveBackgroundBrush);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    private static TestButton CreateBrushTransitionButton(AnimationSchedulerTestHarness harness)
+    {
+        var control = new TestButton { AnimationSchedulerOverride = harness.Scheduler };
+        AddTransition(control, VisualState.Normal, VisualState.Hover);
+        return control;
+    }
+
+    private static void AddTransition(TestButton control, VisualState from, VisualState to)
+        => control.StyleTransitions.Add(
+            from,
+            to,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                Easing = Easings.Linear
+            });
+
+    private static LinearGradientBrush Linear(params (Color Color, float Offset)[] stops)
+    {
+        var brush = new LinearGradientBrush
+        {
+            Start = new PointF(0f, 0f),
+            End = new PointF(1f, 0f)
+        };
+        foreach ((Color color, float offset) in stops)
+            brush.GradientStops.Add(new GradientStop(color, offset));
+        return brush;
+    }
+
+    private static RadialGradientBrush Radial(params (Color Color, float Offset)[] stops)
+    {
+        var brush = new RadialGradientBrush();
+        foreach ((Color color, float offset) in stops)
+            brush.GradientStops.Add(new GradientStop(color, offset));
+        return brush;
+    }
+
+    private static SweepGradientBrush Sweep(params (Color Color, float Offset)[] stops)
+    {
+        var brush = new SweepGradientBrush();
+        foreach ((Color color, float offset) in stops)
+            brush.GradientStops.Add(new GradientStop(color, offset));
+        return brush;
+    }
+
+    private static void AssertIncompatible(MfnBrush from, MfnBrush to)
+        => Assert.False(AnimationInterpolators.TryCreateBrushInterpolator(from, to, out _));
+
+    private static void AssertDiscreteTransition(
+        AnimationSchedulerTestHarness harness,
+        MfnBrush? from,
+        MfnBrush? to)
+    {
+        using var control = CreateBrushTransitionButton(harness);
+        control.Style.BackgroundBrush = from;
+        control.StyleHover.BackgroundBrush = to;
+
+        control.EnterForTest();
+
+        Assert.Same(to ?? from, control.EffectiveBackgroundBrush);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Same(to ?? from, control.EffectiveBackgroundBrush);
+    }
+
+    private static void AssertDiscreteReverseTransitionToNull(
+        AnimationSchedulerTestHarness harness,
+        MfnBrush from)
+    {
+        using var control = CreateBrushTransitionButton(harness);
+        AddTransition(control, VisualState.Hover, VisualState.Normal);
+        control.Style.BackgroundBrush = null;
+        control.StyleHover.BackgroundBrush = from;
+        control.EnterForTest();
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        control.LeaveForTest();
+
+        Assert.Null(control.EffectiveBackgroundBrush);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+        Assert.Null(control.EffectiveBackgroundBrush);
+    }
+
+    private static GradientBrush Gradient(
+        string kind,
+        params (Color Color, float Offset)[] stops)
+    {
+        GradientBrush brush = kind switch
+        {
+            "Linear" => new LinearGradientBrush
+            {
+                Start = new PointF(0f, 0f),
+                End = new PointF(1f, 1f)
+            },
+            "Radial" => new RadialGradientBrush
+            {
+                CenterPoint = new PointF(0.5f, 0.5f),
+                GradientOrigin = new PointF(0.4f, 0.3f),
+                Radius = 0.8f
+            },
+            "Sweep" => new SweepGradientBrush
+            {
+                CenterPoint = new PointF(0.5f, 0.5f),
+                StartAngle = 10f,
+                EndAngle = 300f
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        };
+        foreach ((Color color, float offset) in stops)
+            brush.GradientStops.Add(new GradientStop(color, offset));
+        return brush;
+    }
+
+    private sealed class DerivedSolidBrush(Color color) : SolidColorBrush(color);
+
+    private sealed class TestButton : Button
+    {
+        public void EnterForTest()
+            => OnMouseEnter(new MouseEventArgs(MouseButtons.None, 0, 0, 0, Point.Empty));
+
+        public void DownForTest()
+            => RaiseMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, Point.Empty));
+
+        public void LeaveForTest()
+            => OnMouseLeave(EventArgs.Empty);
+    }
+}

--- a/ModernFormsNext.Tests/Theming/ThemeManagerApplyAndTransitionTests.cs
+++ b/ModernFormsNext.Tests/Theming/ThemeManagerApplyAndTransitionTests.cs
@@ -187,13 +187,14 @@ public sealed class ThemeManagerApplyAndTransitionTests
         ThemeApplyResult result = harness.Manager.Apply(target, Animated());
         Assert.NotNull(result.Transition);
         Assert.Equal(1, harness.SchedulerHarness.Scheduler.GetDiagnostics().ActiveAnimationCount);
-        var working = Assert.IsType<SolidColorBrush>(harness.Resources[BrushKey("Card")]);
+        var exactSource = Assert.IsType<SolidColorBrush>(harness.Resources[BrushKey("Card")]);
         harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
 
         Color middle = ResourceColor(harness, ThemeTokens.Colors.Background.ResourceKey);
+        var working = Assert.IsType<SolidColorBrush>(harness.Resources[BrushKey("Card")]);
         Assert.InRange(middle.R, 127, 128);
         Assert.Equal(5d, (double)harness.Resources[ResourceKey("Progress")]!, 6);
-        Assert.Same(working, harness.Resources[BrushKey("Card")]);
+        Assert.NotSame(exactSource, working);
         Assert.NotEqual(Color.Red.ToArgb(), working.PaintColor.ToArgb());
         Assert.NotEqual(Color.Blue.ToArgb(), working.PaintColor.ToArgb());
         Assert.Equal(0.5f, working.Opacity, 3);
@@ -201,6 +202,7 @@ public sealed class ThemeManagerApplyAndTransitionTests
         harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
         Assert.Equal(ThemeTransitionStatus.Completed, await result.Transition!.Completion);
         Assert.Equal(Color.White.ToArgb(), ResourceColor(harness, ThemeTokens.Colors.Background.ResourceKey).ToArgb());
+        Assert.NotSame(working, harness.Resources[BrushKey("Card")]);
         Assert.Equal(0, harness.SchedulerHarness.Scheduler.GetDiagnostics().ActiveAnimationCount);
         Assert.False(harness.SchedulerHarness.TickSource.IsRunning);
     }
@@ -220,10 +222,11 @@ public sealed class ThemeManagerApplyAndTransitionTests
         harness.Manager.Apply(start, Immediate());
 
         ThemeApplyResult result = harness.Manager.Apply(target, Animated());
-        var working = Assert.IsAssignableFrom<GradientBrush>(harness.Resources[BrushKey("Gradient")]);
+        var exactSource = Assert.IsAssignableFrom<GradientBrush>(harness.Resources[BrushKey("Gradient")]);
         harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
 
-        Assert.Same(working, harness.Resources[BrushKey("Gradient")]);
+        var working = Assert.IsAssignableFrom<GradientBrush>(harness.Resources[BrushKey("Gradient")]);
+        Assert.NotSame(exactSource, working);
         Assert.Equal(0.5f, working.Opacity, 3);
         Assert.Equal(5f, working.Transform.M31, 3);
         Assert.Equal(10f, working.Transform.M32, 3);
@@ -234,29 +237,46 @@ public sealed class ThemeManagerApplyAndTransitionTests
 
         harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
         Assert.Equal(ThemeTransitionStatus.Completed, await result.Transition!.Completion);
+        Assert.NotSame(working, harness.Resources[BrushKey("Gradient")]);
     }
 
     [Fact]
-    public void LayoutTokensAndIncompatibleBrushesSwitchImmediately()
+    public async Task LayoutTokensSwitchImmediatelyWhileSolidToGradientBrushAnimates()
     {
         using var harness = new ThemeManagerTestHarness();
         ThemeDefinition start = Theme("incompatible.start", Color.Black);
         start.Spacing["LayoutGap"] = 4d;
         start.Brushes["Card"] = new SolidColorBrush(Color.Red);
+        start.Brushes["Categorical"] = new GlassBrush();
+        start.Brushes["CrossGradient"] = Gradient(
+            "radial", Color.Red, Color.Blue, 0f, 1f, Matrix3x2.Identity, 1f);
         ThemeDefinition target = Theme("incompatible.target", Color.Black);
         target.Spacing["LayoutGap"] = 20d;
         target.Brushes["Card"] = Gradient("linear", Color.Blue, Color.Green, 0f, 1f, Matrix3x2.Identity, 1f);
+        target.Brushes["Categorical"] = new NoBrush();
+        target.Brushes["CrossGradient"] = Gradient(
+            "linear", Color.Green, Color.White, 0f, 1f, Matrix3x2.Identity, 1f);
         harness.Manager.Apply(start, Immediate());
 
         ThemeApplyResult result = harness.Manager.Apply(target, Animated());
 
-        Assert.Null(result.Transition);
+        Assert.NotNull(result.Transition);
         Assert.Equal(20d, (double)harness.Resources[SpacingKey("LayoutGap")]!);
+        Assert.IsType<SolidColorBrush>(harness.Resources[BrushKey("Card")]);
+        Assert.IsType<NoBrush>(harness.Resources[BrushKey("Categorical")]);
+        Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("CrossGradient")]);
+        harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        var working = Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]);
+        Assert.IsType<NoBrush>(harness.Resources[BrushKey("Categorical")]);
+        Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("CrossGradient")]);
+        harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        Assert.Equal(ThemeTransitionStatus.Completed, await result.Transition!.Completion);
         Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]);
+        Assert.NotSame(working, harness.Resources[BrushKey("Card")]);
     }
 
     [Fact]
-    public void DifferentGradientStopCountsSwitchThatBrushImmediately()
+    public async Task DifferentGradientStopCountsAnimateAndPublishExactTarget()
     {
         using var harness = new ThemeManagerTestHarness();
         ThemeDefinition start = Theme("stops.start", Color.Black);
@@ -267,11 +287,74 @@ public sealed class ThemeManagerApplyAndTransitionTests
         start.Brushes["Card"] = two;
         target.Brushes["Card"] = three;
         harness.Manager.Apply(start, Immediate());
+        int notifications = 0;
+        harness.Resources.ResourceChanged += (_, args) =>
+        {
+            if (Equals(args.Key, BrushKey("Card")))
+                notifications++;
+        };
 
         ThemeApplyResult result = harness.Manager.Apply(target, Animated());
 
-        Assert.Null(result.Transition);
-        Assert.Equal(3, Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]).GradientStops.Count);
+        Assert.NotNull(result.Transition);
+        Assert.Equal(2, Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]).GradientStops.Count);
+        harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        var working = Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]);
+        Assert.Equal(3, working.GradientStops.Count);
+        harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(50));
+        Assert.Equal(ThemeTransitionStatus.Completed, await result.Transition!.Completion);
+        var exactTarget = Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]);
+        Assert.Equal(3, exactTarget.GradientStops.Count);
+        Assert.NotSame(working, exactTarget);
+        Assert.True(notifications >= 2);
+    }
+
+    [Fact]
+    public async Task BrushRetargetStartsFromPublishedPresentationAndLeavesOnlyLatestRun()
+    {
+        using var harness = new ThemeManagerTestHarness();
+        ThemeDefinition start = Theme("brush.rapid.start", Color.Black);
+        start.Brushes["Card"] = new SolidColorBrush(Color.Red);
+        ThemeDefinition firstTarget = Theme("brush.rapid.first", Color.Black);
+        firstTarget.Brushes["Card"] = Gradient(
+            "linear",
+            Color.Blue,
+            Color.Green,
+            0f,
+            1f,
+            Matrix3x2.Identity,
+            1f);
+        ThemeDefinition finalTarget = Theme("brush.rapid.final", Color.Black);
+        var finalBrush = Gradient(
+            "linear",
+            Color.Yellow,
+            Color.Magenta,
+            0f,
+            0.7f,
+            Matrix3x2.CreateTranslation(8f, 4f),
+            0.75f);
+        finalBrush.GradientStops.Add(new GradientStop(Color.White, 1f));
+        finalTarget.Brushes["Card"] = finalBrush;
+        harness.Manager.Apply(start, Immediate());
+
+        ThemeApplyResult first = harness.Manager.Apply(firstTarget, Animated());
+        harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(25));
+        var presentationAtRetarget = Assert.IsType<LinearGradientBrush>(
+            harness.Resources[BrushKey("Card")]);
+
+        ThemeApplyResult latest = harness.Manager.Apply(finalTarget, Animated());
+
+        Assert.Equal(ThemeTransitionStatus.Canceled, await first.Transition!.Completion);
+        Assert.Same(presentationAtRetarget, harness.Resources[BrushKey("Card")]);
+        Assert.Equal(1, harness.SchedulerHarness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(ThemeTransitionStatus.Completed, await latest.Transition!.Completion);
+        var exactTarget = Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]);
+        Assert.Equal(3, exactTarget.GradientStops.Count);
+        Assert.Equal(0.75f, exactTarget.Opacity, 3);
+        Assert.Equal(0, harness.SchedulerHarness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.SchedulerHarness.TickSource.IsRunning);
     }
 
     [Fact]
@@ -316,14 +399,24 @@ public sealed class ThemeManagerApplyAndTransitionTests
     public async Task ExplicitCancellationSnapsToTargetAndLeavesNoOrphanedWork()
     {
         using var harness = new ThemeManagerTestHarness();
-        harness.Manager.Apply(Theme("cancel.red", Color.Red), Immediate());
-        ThemeApplyResult target = harness.Manager.Apply(Theme("cancel.blue", Color.Blue), Animated());
+        ThemeDefinition start = Theme("cancel.red", Color.Red);
+        start.Brushes["Card"] = new SolidColorBrush(Color.Red);
+        ThemeDefinition final = Theme("cancel.blue", Color.Blue);
+        var finalBrush = Gradient(
+            "linear", Color.Blue, Color.Green, 0f, 0.5f, Matrix3x2.Identity, 0.8f);
+        finalBrush.GradientStops.Add(new GradientStop(Color.White, 1f));
+        final.Brushes["Card"] = finalBrush;
+        harness.Manager.Apply(start, Immediate());
+        ThemeApplyResult target = harness.Manager.Apply(final, Animated());
         harness.SchedulerHarness.AdvanceAndTick(TimeSpan.FromMilliseconds(25));
 
         target.Transition!.Cancel();
 
         Assert.Equal(ThemeTransitionStatus.Canceled, await target.Transition.Completion);
         Assert.Equal(Color.Blue.ToArgb(), ResourceColor(harness, ThemeTokens.Colors.Background.ResourceKey).ToArgb());
+        var appliedBrush = Assert.IsType<LinearGradientBrush>(harness.Resources[BrushKey("Card")]);
+        Assert.Equal(3, appliedBrush.GradientStops.Count);
+        Assert.Equal(0.8f, appliedBrush.Opacity, 3);
         Assert.Equal(0, harness.SchedulerHarness.Scheduler.GetDiagnostics().ActiveAnimationCount);
         Assert.False(harness.SchedulerHarness.TickSource.IsRunning);
     }

--- a/ModernFormsNext/Animations/AnimationInterpolators.cs
+++ b/ModernFormsNext/Animations/AnimationInterpolators.cs
@@ -115,14 +115,38 @@ public static class AnimationInterpolators
     /// <returns>A new stateful interpolator intended for one scheduled animation.</returns>
     /// <remarks>
     /// The interpolator creates one local working brush from the start value and mutates it on
-    /// subsequent calls. It supports solid, linear, radial, and sweep brushes. Gradient types must
-    /// match and contain the same number of stops. Source and target brushes are not mutated, which
-    /// prevents a local transition from unexpectedly changing other consumers of a shared dynamic
-    /// resource. Use <see cref="BrushAnimationExtensions.AnimateTo"/> for intentional in-place
-    /// resource animation.
+    /// subsequent intermediate calls. It supports solid, linear, radial, and sweep brushes.
+    /// Gradients of the same kind may have different stop counts; their color functions are
+    /// normalized once before interpolation. A solid brush can transition to or from any supported
+    /// gradient by using the gradient endpoint's geometry with a constant-color representation of
+    /// the solid endpoint. Different gradient kinds, glass, no-fill, custom, and derived brushes
+    /// are incompatible. Source and target brushes are not mutated, which prevents a local
+    /// transition from unexpectedly changing other consumers of a shared dynamic resource. At
+    /// progress zero and one the exact source and target references are returned. Use
+    /// <see cref="BrushAnimationExtensions.AnimateTo"/> for intentional in-place resource
+    /// animation. Visual-state and theme transitions probe compatibility before using this
+    /// interpolator and switch unsupported pairs discretely. Calling the returned interpolator
+    /// directly with an unsupported pair throws <see cref="ArgumentException"/>.
     /// </remarks>
     public static IAnimationInterpolator<MfnBrush> CreateBrushInterpolator()
         => new ReusableBrushInterpolator();
+
+    internal static bool TryCreateBrushInterpolator(
+        MfnBrush from,
+        MfnBrush to,
+        out IAnimationInterpolator<MfnBrush>? interpolator)
+    {
+        ArgumentNullException.ThrowIfNull(from);
+        ArgumentNullException.ThrowIfNull(to);
+        if (!BrushAnimationPlan.TryCreateLocal(from, to, out BrushAnimationPlan? plan))
+        {
+            interpolator = null;
+            return false;
+        }
+
+        interpolator = new ReusableBrushInterpolator(from, to, plan!);
+        return true;
+    }
 
     private static float Lerp(float from, float to, float progress) => from + ((to - from) * progress);
 
@@ -163,6 +187,20 @@ public static class AnimationInterpolators
         private MfnBrush? fromBrush;
         private MfnBrush? toBrush;
 
+        public ReusableBrushInterpolator()
+        {
+        }
+
+        public ReusableBrushInterpolator(
+            MfnBrush from,
+            MfnBrush to,
+            BrushAnimationPlan plan)
+        {
+            fromBrush = from;
+            toBrush = to;
+            this.plan = plan;
+        }
+
         public MfnBrush Interpolate(MfnBrush from, MfnBrush to, float progress)
         {
             ArgumentNullException.ThrowIfNull(from);
@@ -172,8 +210,7 @@ public static class AnimationInterpolators
 
             if (plan is null)
             {
-                MfnBrush workingBrush = BrushAnimationPlan.CloneSupportedBrush(from);
-                plan = BrushAnimationPlan.Create(from, to, workingBrush);
+                plan = BrushAnimationPlan.CreateLocal(from, to);
                 fromBrush = from;
                 toBrush = to;
             }
@@ -182,8 +219,7 @@ public static class AnimationInterpolators
                 throw new InvalidOperationException("A brush interpolator instance can be used for only one source and target pair.");
             }
 
-            plan.Apply(progress);
-            return plan.Destination;
+            return plan.Interpolate(progress);
         }
     }
 }

--- a/ModernFormsNext/Animations/BrushAnimationExtensions.cs
+++ b/ModernFormsNext/Animations/BrushAnimationExtensions.cs
@@ -21,8 +21,12 @@ public static class BrushAnimationExtensions
     /// <para>
     /// Supported concrete types are <see cref="SolidColorBrush"/>,
     /// <see cref="LinearGradientBrush"/>, <see cref="RadialGradientBrush"/>, and
-    /// <see cref="SweepGradientBrush"/>. Gradient source and target must have the same number of
-    /// stops. Type and structure validation happens before the animation is scheduled.
+    /// <see cref="SweepGradientBrush"/>. Because this helper preserves and mutates the identity of
+    /// <paramref name="brush"/>, source and target must have the same concrete type and gradient
+    /// stop count. Value-style transitions that can replace a brush reference use
+    /// <see cref="AnimationInterpolators.CreateBrushInterpolator"/> and additionally support
+    /// normalized stop counts and solid-to-gradient transitions. Type and structure validation
+    /// happens before the in-place animation is scheduled.
     /// </para>
     /// <para>
     /// This method intentionally mutates <paramref name="brush"/>. If it is stored in a dynamic

--- a/ModernFormsNext/Animations/BrushAnimationPlan.cs
+++ b/ModernFormsNext/Animations/BrushAnimationPlan.cs
@@ -5,13 +5,29 @@ using MfnBrush = ModernFormsNext.Drawing.Brush;
 
 namespace ModernFormsNext.Animations;
 
+/// <summary>
+/// Captures one compatible brush transition and mutates a single animation-local destination.
+/// </summary>
+/// <remarks>
+/// Planning performs all structural work, including gradient-stop normalization. Applying a frame
+/// does not inspect authored collections, invoke user code, or allocate replacement stop arrays.
+/// </remarks>
 internal sealed class BrushAnimationPlan
 {
+    private readonly MfnBrush source;
+    private readonly MfnBrush target;
     private readonly BrushSnapshot from;
     private readonly BrushSnapshot to;
 
-    private BrushAnimationPlan(BrushSnapshot from, BrushSnapshot to, MfnBrush destination)
+    private BrushAnimationPlan(
+        MfnBrush source,
+        MfnBrush target,
+        BrushSnapshot from,
+        BrushSnapshot to,
+        MfnBrush destination)
     {
+        this.source = source;
+        this.target = target;
         this.from = from;
         this.to = to;
         Destination = destination;
@@ -19,6 +35,10 @@ internal sealed class BrushAnimationPlan
 
     public MfnBrush Destination { get; }
 
+    /// <summary>
+    /// Creates an in-place plan for a destination whose concrete type and gradient structure are
+    /// already stable.
+    /// </summary>
     public static BrushAnimationPlan Create(MfnBrush from, MfnBrush to, MfnBrush destination)
     {
         ArgumentNullException.ThrowIfNull(from);
@@ -26,44 +46,120 @@ internal sealed class BrushAnimationPlan
         ArgumentNullException.ThrowIfNull(destination);
 
         if (from.GetType() != to.GetType() || from.GetType() != destination.GetType())
-            throw new ArgumentException("Brush animations require matching concrete source, target, and destination types.", nameof(to));
-
-        BrushSnapshot fromSnapshot = BrushSnapshot.Capture(from);
-        BrushSnapshot toSnapshot = BrushSnapshot.Capture(to);
-        ValidateCompatibility(fromSnapshot, toSnapshot);
-        return new BrushAnimationPlan(fromSnapshot, toSnapshot, destination);
-    }
-
-    public static MfnBrush CloneSupportedBrush(MfnBrush source)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        MfnBrush clone = source switch
         {
-            SolidColorBrush solid when solid.GetType() == typeof(SolidColorBrush) => new SolidColorBrush(solid.PaintColor),
-            LinearGradientBrush linear when linear.GetType() == typeof(LinearGradientBrush) => CloneLinear(linear),
-            RadialGradientBrush radial when radial.GetType() == typeof(RadialGradientBrush) => CloneRadial(radial),
-            SweepGradientBrush sweep when sweep.GetType() == typeof(SweepGradientBrush) => CloneSweep(sweep),
-            _ => throw new NotSupportedException(
-                $"Brush animation does not support the concrete type '{source.GetType().FullName}'.")
-        };
+            throw new ArgumentException(
+                "In-place brush animations require matching concrete source, target, and destination types.",
+                nameof(to));
+        }
 
-        clone.Opacity = source.Opacity;
-        clone.Transform = source.Transform;
-        return clone;
+        if (!TryCapture(from, out BrushSnapshot fromSnapshot) ||
+            !TryCapture(to, out BrushSnapshot toSnapshot) ||
+            !TryCapture(destination, out BrushSnapshot destinationSnapshot))
+        {
+            throw new NotSupportedException(
+                $"Brush animation does not support the concrete type '{from.GetType().FullName}'.");
+        }
+
+        if (fromSnapshot is GradientSnapshot fromGradient &&
+            toSnapshot is GradientSnapshot toGradient &&
+            (fromGradient.Stops.Length != toGradient.Stops.Length ||
+             fromGradient.Stops.Length != ((GradientSnapshot)destinationSnapshot).Stops.Length))
+        {
+            throw new ArgumentException(
+                "In-place gradient animations require the same number of source, target, and destination stops.",
+                nameof(to));
+        }
+
+        return new BrushAnimationPlan(from, to, fromSnapshot, toSnapshot, destination);
     }
 
+    /// <summary>
+    /// Attempts to create a local plan that may normalize gradient structures or promote a solid
+    /// color to the geometry of the other endpoint.
+    /// </summary>
+    public static bool TryCreateLocal(
+        MfnBrush from,
+        MfnBrush to,
+        out BrushAnimationPlan? plan)
+    {
+        ArgumentNullException.ThrowIfNull(from);
+        ArgumentNullException.ThrowIfNull(to);
+
+        plan = null;
+        if (!TryCapture(from, out BrushSnapshot fromSnapshot) ||
+            !TryCapture(to, out BrushSnapshot toSnapshot) ||
+            !TryPrepareLocalSnapshots(ref fromSnapshot, ref toSnapshot))
+        {
+            return false;
+        }
+
+        MfnBrush destination = CreateBrush(fromSnapshot);
+        plan = new BrushAnimationPlan(from, to, fromSnapshot, toSnapshot, destination);
+        return true;
+    }
+
+    public static BrushAnimationPlan CreateLocal(MfnBrush from, MfnBrush to)
+        => TryCreateLocal(from, to, out BrushAnimationPlan? plan)
+            ? plan!
+            : throw new ArgumentException(
+                $"Brush types '{from.GetType().FullName}' and '{to.GetType().FullName}' do not have a safe interpolation path.",
+                nameof(to));
+
+    /// <summary>
+    /// Returns an exact endpoint outside the open interval and the reusable working brush within
+    /// it. This is used by value-style transitions that can replace a brush reference.
+    /// </summary>
+    public MfnBrush Interpolate(float progress)
+    {
+        ValidateProgress(progress);
+        if (progress <= 0f)
+            return source;
+        if (progress >= 1f)
+            return target;
+
+        ApplyCore(progress);
+        return Destination;
+    }
+
+    /// <summary>
+    /// Applies a frame to the fixed destination used by explicit in-place brush animation.
+    /// </summary>
     public void Apply(float progress)
     {
-        if (!float.IsFinite(progress))
-            throw new ArgumentOutOfRangeException(nameof(progress), progress, "Brush animation progress must be finite.");
+        ValidateProgress(progress);
+        if (progress <= 0f)
+        {
+            ApplySnapshot(from, Destination);
+            return;
+        }
 
-        Destination.Opacity = Math.Clamp(AnimationInterpolators.Float.Interpolate(from.Opacity, to.Opacity, progress), 0f, 1f);
-        Destination.Transform = AnimationInterpolators.Matrix3x2.Interpolate(from.Transform, to.Transform, progress);
+        if (progress >= 1f)
+        {
+            ApplySnapshot(to, Destination);
+            return;
+        }
+
+        ApplyCore(progress);
+    }
+
+    private void ApplyCore(float progress)
+    {
+        Destination.Opacity = Math.Clamp(
+            AnimationInterpolators.Float.Interpolate(from.Opacity, to.Opacity, progress),
+            0f,
+            1f);
+        Destination.Transform = AnimationInterpolators.Matrix3x2.Interpolate(
+            from.Transform,
+            to.Transform,
+            progress);
 
         switch (from, to, Destination)
         {
             case (SolidSnapshot start, SolidSnapshot end, SolidColorBrush destination):
-                destination.PaintColor = AnimationInterpolators.Color.Interpolate(start.Color, end.Color, progress);
+                destination.PaintColor = AnimationInterpolators.Color.Interpolate(
+                    start.Color,
+                    end.Color,
+                    progress);
                 break;
             case (LinearSnapshot start, LinearSnapshot end, LinearGradientBrush destination):
                 destination.Start = AnimationInterpolators.PointF.Interpolate(start.Start, end.Start, progress);
@@ -73,13 +169,21 @@ internal sealed class BrushAnimationPlan
             case (RadialSnapshot start, RadialSnapshot end, RadialGradientBrush destination):
                 destination.CenterPoint = AnimationInterpolators.PointF.Interpolate(start.Center, end.Center, progress);
                 destination.GradientOrigin = AnimationInterpolators.PointF.Interpolate(start.Origin, end.Origin, progress);
-                destination.Radius = Math.Max(0f, AnimationInterpolators.Float.Interpolate(start.Radius, end.Radius, progress));
+                destination.Radius = Math.Max(
+                    0f,
+                    AnimationInterpolators.Float.Interpolate(start.Radius, end.Radius, progress));
                 ApplyGradient(start, end, destination, progress);
                 break;
             case (SweepSnapshot start, SweepSnapshot end, SweepGradientBrush destination):
                 destination.CenterPoint = AnimationInterpolators.PointF.Interpolate(start.Center, end.Center, progress);
-                destination.StartAngle = AnimationInterpolators.Float.Interpolate(start.StartAngle, end.StartAngle, progress);
-                destination.EndAngle = AnimationInterpolators.Float.Interpolate(start.EndAngle, end.EndAngle, progress);
+                destination.StartAngle = AnimationInterpolators.Float.Interpolate(
+                    start.StartAngle,
+                    end.StartAngle,
+                    progress);
+                destination.EndAngle = AnimationInterpolators.Float.Interpolate(
+                    start.EndAngle,
+                    end.EndAngle,
+                    progress);
                 ApplyGradient(start, end, destination, progress);
                 break;
             default:
@@ -87,59 +191,335 @@ internal sealed class BrushAnimationPlan
         }
     }
 
-    private static LinearGradientBrush CloneLinear(LinearGradientBrush source)
+    private static bool TryPrepareLocalSnapshots(
+        ref BrushSnapshot from,
+        ref BrushSnapshot to)
     {
-        var clone = new LinearGradientBrush
+        if (from.GetType() == to.GetType())
         {
-            Start = source.Start,
-            End = source.End,
-            SpreadMode = source.SpreadMode
+            if (from is not GradientSnapshot fromGradient || to is not GradientSnapshot toGradient)
+                return true;
+
+            return TryNormalizeGradientPair(ref from, ref to, fromGradient, toGradient);
+        }
+
+        if (from is SolidSnapshot fromSolid && to is GradientSnapshot toGradientSnapshot)
+        {
+            if (toGradientSnapshot.Stops.Length == 0)
+                return false;
+            from = PromoteSolid(fromSolid, toGradientSnapshot);
+            return true;
+        }
+
+        if (from is GradientSnapshot fromGradientSnapshot && to is SolidSnapshot toSolid)
+        {
+            if (fromGradientSnapshot.Stops.Length == 0)
+                return false;
+            to = PromoteSolid(toSolid, fromGradientSnapshot);
+            return true;
+        }
+
+        // Geometry has no unambiguous morph between linear, radial, and sweep gradients.
+        return false;
+    }
+
+    private static bool TryNormalizeGradientPair(
+        ref BrushSnapshot from,
+        ref BrushSnapshot to,
+        GradientSnapshot fromGradient,
+        GradientSnapshot toGradient)
+    {
+        if (fromGradient.Stops.Length == toGradient.Stops.Length)
+            return true;
+
+        // An empty gradient means no paint. Treating it as transparent would change the authored
+        // compositing contract, so only two equally empty gradients are compatible.
+        if (fromGradient.Stops.Length == 0 || toGradient.Stops.Length == 0)
+            return false;
+
+        float[] canonicalOffsets = BuildCanonicalOffsets(
+            fromGradient.Stops,
+            toGradient.Stops);
+        from = WithStops(fromGradient, ResampleStops(fromGradient.Stops, canonicalOffsets));
+        to = WithStops(toGradient, ResampleStops(toGradient.Stops, canonicalOffsets));
+        return true;
+    }
+
+    private static GradientSnapshot PromoteSolid(
+        SolidSnapshot solid,
+        GradientSnapshot geometry)
+    {
+        var stops = new StopSnapshot[geometry.Stops.Length];
+        for (int index = 0; index < stops.Length; index++)
+            stops[index] = new StopSnapshot(solid.Color, geometry.Stops[index].Offset);
+
+        return geometry switch
+        {
+            LinearSnapshot linear => new LinearSnapshot(
+                solid.Opacity,
+                solid.Transform,
+                stops,
+                linear.SpreadMode,
+                linear.Start,
+                linear.End),
+            RadialSnapshot radial => new RadialSnapshot(
+                solid.Opacity,
+                solid.Transform,
+                stops,
+                radial.SpreadMode,
+                radial.Center,
+                radial.Origin,
+                radial.Radius),
+            SweepSnapshot sweep => new SweepSnapshot(
+                solid.Opacity,
+                solid.Transform,
+                stops,
+                sweep.SpreadMode,
+                sweep.Center,
+                sweep.StartAngle,
+                sweep.EndAngle),
+            _ => throw new InvalidOperationException("Unknown gradient snapshot type.")
         };
-        CopyStops(source, clone);
-        return clone;
     }
 
-    private static RadialGradientBrush CloneRadial(RadialGradientBrush source)
+    private static float[] BuildCanonicalOffsets(
+        StopSnapshot[] first,
+        StopSnapshot[] second)
     {
-        var clone = new RadialGradientBrush
+        int count = CountCanonicalOffsets(first, second);
+        var result = new float[count];
+        int firstIndex = 0;
+        int secondIndex = 0;
+        int resultIndex = 0;
+
+        while (firstIndex < first.Length || secondIndex < second.Length)
         {
-            CenterPoint = source.CenterPoint,
-            GradientOrigin = source.GradientOrigin,
-            Radius = source.Radius,
-            SpreadMode = source.SpreadMode
+            float offset = secondIndex >= second.Length ||
+                firstIndex < first.Length && first[firstIndex].Offset < second[secondIndex].Offset
+                    ? first[firstIndex].Offset
+                    : second[secondIndex].Offset;
+            int firstCount = CountOffset(first, ref firstIndex, offset);
+            int secondCount = CountOffset(second, ref secondIndex, offset);
+            int multiplicity = Math.Max(firstCount, secondCount);
+            for (int occurrence = 0; occurrence < multiplicity; occurrence++)
+                result[resultIndex++] = offset;
+        }
+
+        return result;
+    }
+
+    private static int CountCanonicalOffsets(StopSnapshot[] first, StopSnapshot[] second)
+    {
+        int firstIndex = 0;
+        int secondIndex = 0;
+        int count = 0;
+        while (firstIndex < first.Length || secondIndex < second.Length)
+        {
+            float offset = secondIndex >= second.Length ||
+                firstIndex < first.Length && first[firstIndex].Offset < second[secondIndex].Offset
+                    ? first[firstIndex].Offset
+                    : second[secondIndex].Offset;
+            int firstCount = CountOffset(first, ref firstIndex, offset);
+            int secondCount = CountOffset(second, ref secondIndex, offset);
+            count += Math.Max(firstCount, secondCount);
+        }
+
+        return count;
+    }
+
+    private static int CountOffset(StopSnapshot[] stops, ref int index, float offset)
+    {
+        int start = index;
+        while (index < stops.Length && stops[index].Offset.Equals(offset))
+            index++;
+        return index - start;
+    }
+
+    private static StopSnapshot[] ResampleStops(
+        StopSnapshot[] sourceStops,
+        float[] canonicalOffsets)
+    {
+        var result = new StopSnapshot[canonicalOffsets.Length];
+        int sourceIndex = 0;
+        int resultIndex = 0;
+
+        while (resultIndex < canonicalOffsets.Length)
+        {
+            float offset = canonicalOffsets[resultIndex];
+            int resultStart = resultIndex;
+            while (resultIndex < canonicalOffsets.Length && canonicalOffsets[resultIndex].Equals(offset))
+                resultIndex++;
+            int resultCount = resultIndex - resultStart;
+
+            while (sourceIndex < sourceStops.Length && sourceStops[sourceIndex].Offset < offset)
+                sourceIndex++;
+            int exactStart = sourceIndex;
+            while (sourceIndex < sourceStops.Length && sourceStops[sourceIndex].Offset.Equals(offset))
+                sourceIndex++;
+            int exactCount = sourceIndex - exactStart;
+
+            if (exactCount > 0)
+            {
+                for (int occurrence = 0; occurrence < resultCount; occurrence++)
+                {
+                    result[resultStart + occurrence] = new StopSnapshot(
+                        SampleDuplicateColor(
+                            sourceStops,
+                            exactStart,
+                            exactCount,
+                            occurrence,
+                            resultCount),
+                        offset);
+                }
+                continue;
+            }
+
+            Color sampled = SampleColorBetweenStops(sourceStops, sourceIndex, offset);
+            for (int occurrence = 0; occurrence < resultCount; occurrence++)
+                result[resultStart + occurrence] = new StopSnapshot(sampled, offset);
+        }
+
+        return result;
+    }
+
+    private static Color SampleDuplicateColor(
+        StopSnapshot[] stops,
+        int start,
+        int sourceCount,
+        int destinationOccurrence,
+        int destinationCount)
+    {
+        if (sourceCount == 1 || destinationCount == 1)
+            return stops[start].Color;
+
+        float position = destinationOccurrence * (sourceCount - 1f) / (destinationCount - 1f);
+        int lower = (int)MathF.Floor(position);
+        int upper = Math.Min(lower + 1, sourceCount - 1);
+        float progress = position - lower;
+        return AnimationInterpolators.Color.Interpolate(
+            stops[start + lower].Color,
+            stops[start + upper].Color,
+            progress);
+    }
+
+    private static Color SampleColorBetweenStops(
+        StopSnapshot[] stops,
+        int rightIndex,
+        float offset)
+    {
+        if (rightIndex <= 0)
+            return stops[0].Color;
+        if (rightIndex >= stops.Length)
+            return stops[^1].Color;
+
+        StopSnapshot left = stops[rightIndex - 1];
+        StopSnapshot right = stops[rightIndex];
+        float distance = right.Offset - left.Offset;
+        if (distance <= 0f)
+            return right.Color;
+        float progress = (offset - left.Offset) / distance;
+        return AnimationInterpolators.Color.Interpolate(left.Color, right.Color, progress);
+    }
+
+    private static GradientSnapshot WithStops(
+        GradientSnapshot snapshot,
+        StopSnapshot[] stops)
+        => snapshot switch
+        {
+            LinearSnapshot linear => linear with { Stops = stops },
+            RadialSnapshot radial => radial with { Stops = stops },
+            SweepSnapshot sweep => sweep with { Stops = stops },
+            _ => throw new InvalidOperationException("Unknown gradient snapshot type.")
         };
-        CopyStops(source, clone);
-        return clone;
-    }
 
-    private static SweepGradientBrush CloneSweep(SweepGradientBrush source)
+    private static MfnBrush CreateBrush(BrushSnapshot snapshot)
     {
-        var clone = new SweepGradientBrush
+        MfnBrush brush = snapshot switch
         {
-            CenterPoint = source.CenterPoint,
-            StartAngle = source.StartAngle,
-            EndAngle = source.EndAngle,
-            SpreadMode = source.SpreadMode
+            SolidSnapshot solid => new SolidColorBrush(solid.Color),
+            LinearSnapshot linear => new LinearGradientBrush
+            {
+                Start = linear.Start,
+                End = linear.End,
+                SpreadMode = linear.SpreadMode
+            },
+            RadialSnapshot radial => new RadialGradientBrush
+            {
+                CenterPoint = radial.Center,
+                GradientOrigin = radial.Origin,
+                Radius = radial.Radius,
+                SpreadMode = radial.SpreadMode
+            },
+            SweepSnapshot sweep => new SweepGradientBrush
+            {
+                CenterPoint = sweep.Center,
+                StartAngle = sweep.StartAngle,
+                EndAngle = sweep.EndAngle,
+                SpreadMode = sweep.SpreadMode
+            },
+            _ => throw new InvalidOperationException("Unknown brush snapshot type.")
         };
-        CopyStops(source, clone);
-        return clone;
-    }
 
-    private static void CopyStops(GradientBrush source, GradientBrush destination)
-    {
-        foreach (GradientStop stop in source.GradientStops)
-            destination.GradientStops.Add(new GradientStop(stop.PaintColor, stop.Offset));
-    }
-
-    private static void ValidateCompatibility(BrushSnapshot from, BrushSnapshot to)
-    {
-        if (from.GetType() != to.GetType())
-            throw new ArgumentException("Source and target brush snapshots are incompatible.", nameof(to));
-
-        if (from is GradientSnapshot fromGradient && to is GradientSnapshot toGradient &&
-            fromGradient.Stops.Length != toGradient.Stops.Length)
+        brush.Opacity = snapshot.Opacity;
+        brush.Transform = snapshot.Transform;
+        if (snapshot is GradientSnapshot gradient && brush is GradientBrush destinationGradient)
         {
-            throw new ArgumentException("Gradient brush animations require the same number of stops.", nameof(to));
+            for (int index = 0; index < gradient.Stops.Length; index++)
+            {
+                StopSnapshot stop = gradient.Stops[index];
+                destinationGradient.GradientStops.Add(new GradientStop(stop.Color, stop.Offset));
+            }
+        }
+
+        return brush;
+    }
+
+    private static void ApplySnapshot(BrushSnapshot snapshot, MfnBrush destination)
+    {
+        destination.Opacity = snapshot.Opacity;
+        destination.Transform = snapshot.Transform;
+
+        switch (snapshot, destination)
+        {
+            case (SolidSnapshot solid, SolidColorBrush solidDestination):
+                solidDestination.PaintColor = solid.Color;
+                break;
+            case (LinearSnapshot linear, LinearGradientBrush linearDestination):
+                linearDestination.Start = linear.Start;
+                linearDestination.End = linear.End;
+                ApplyGradientSnapshot(linear, linearDestination);
+                break;
+            case (RadialSnapshot radial, RadialGradientBrush radialDestination):
+                radialDestination.CenterPoint = radial.Center;
+                radialDestination.GradientOrigin = radial.Origin;
+                radialDestination.Radius = radial.Radius;
+                ApplyGradientSnapshot(radial, radialDestination);
+                break;
+            case (SweepSnapshot sweep, SweepGradientBrush sweepDestination):
+                sweepDestination.CenterPoint = sweep.Center;
+                sweepDestination.StartAngle = sweep.StartAngle;
+                sweepDestination.EndAngle = sweep.EndAngle;
+                ApplyGradientSnapshot(sweep, sweepDestination);
+                break;
+            default:
+                throw new InvalidOperationException("The brush snapshot does not match its destination.");
+        }
+    }
+
+    private static void ApplyGradientSnapshot(
+        GradientSnapshot snapshot,
+        GradientBrush destination)
+    {
+        if (destination.GradientStops.Count != snapshot.Stops.Length)
+            throw new InvalidOperationException("The destination gradient structure changed during animation.");
+
+        destination.SpreadMode = snapshot.SpreadMode;
+        for (int index = 0; index < snapshot.Stops.Length; index++)
+        {
+            StopSnapshot source = snapshot.Stops[index];
+            GradientStop targetStop = destination.GradientStops[index];
+            targetStop.PaintColor = source.Color;
+            targetStop.Offset = source.Offset;
         }
     }
 
@@ -149,7 +529,12 @@ internal sealed class BrushAnimationPlan
         GradientBrush destination,
         float progress)
     {
-        destination.SpreadMode = progress >= 1f ? to.SpreadMode : from.SpreadMode;
+        if (destination.GradientStops.Count != from.Stops.Length || from.Stops.Length != to.Stops.Length)
+            throw new InvalidOperationException("The destination gradient structure changed during animation.");
+
+        // Spread mode is categorical. Keep the source mode for intermediate frames; the exact
+        // target snapshot is applied by Apply when progress reaches one.
+        destination.SpreadMode = from.SpreadMode;
         for (int index = 0; index < from.Stops.Length; index++)
         {
             StopSnapshot start = from.Stops[index];
@@ -163,54 +548,68 @@ internal sealed class BrushAnimationPlan
         }
     }
 
-    private abstract record BrushSnapshot(float Opacity, Matrix3x2 Transform)
+    private static bool TryCapture(MfnBrush brush, out BrushSnapshot snapshot)
     {
-        public static BrushSnapshot Capture(MfnBrush brush)
-            => brush switch
-            {
-                SolidColorBrush solid when solid.GetType() == typeof(SolidColorBrush) =>
-                    new SolidSnapshot(solid.Opacity, solid.Transform, solid.PaintColor),
-                LinearGradientBrush linear when linear.GetType() == typeof(LinearGradientBrush) =>
-                    new LinearSnapshot(
-                        linear.Opacity,
-                        linear.Transform,
-                        CaptureStops(linear),
-                        linear.SpreadMode,
-                        linear.Start,
-                        linear.End),
-                RadialGradientBrush radial when radial.GetType() == typeof(RadialGradientBrush) =>
-                    new RadialSnapshot(
-                        radial.Opacity,
-                        radial.Transform,
-                        CaptureStops(radial),
-                        radial.SpreadMode,
-                        radial.CenterPoint,
-                        radial.GradientOrigin,
-                        radial.Radius),
-                SweepGradientBrush sweep when sweep.GetType() == typeof(SweepGradientBrush) =>
-                    new SweepSnapshot(
-                        sweep.Opacity,
-                        sweep.Transform,
-                        CaptureStops(sweep),
-                        sweep.SpreadMode,
-                        sweep.CenterPoint,
-                        sweep.StartAngle,
-                        sweep.EndAngle),
-                _ => throw new NotSupportedException(
-                    $"Brush animation does not support the concrete type '{brush.GetType().FullName}'.")
-            };
-
-        private static StopSnapshot[] CaptureStops(GradientBrush brush)
+        snapshot = brush switch
         {
-            var result = new StopSnapshot[brush.GradientStops.Count];
-            for (int index = 0; index < result.Length; index++)
-            {
-                GradientStop stop = brush.GradientStops[index];
-                result[index] = new StopSnapshot(stop.PaintColor, stop.Offset);
-            }
-            return result;
+            SolidColorBrush solid when solid.GetType() == typeof(SolidColorBrush) =>
+                new SolidSnapshot(solid.Opacity, solid.Transform, solid.PaintColor),
+            LinearGradientBrush linear when linear.GetType() == typeof(LinearGradientBrush) =>
+                new LinearSnapshot(
+                    linear.Opacity,
+                    linear.Transform,
+                    CaptureStops(linear),
+                    linear.SpreadMode,
+                    linear.Start,
+                    linear.End),
+            RadialGradientBrush radial when radial.GetType() == typeof(RadialGradientBrush) =>
+                new RadialSnapshot(
+                    radial.Opacity,
+                    radial.Transform,
+                    CaptureStops(radial),
+                    radial.SpreadMode,
+                    radial.CenterPoint,
+                    radial.GradientOrigin,
+                    radial.Radius),
+            SweepGradientBrush sweep when sweep.GetType() == typeof(SweepGradientBrush) =>
+                new SweepSnapshot(
+                    sweep.Opacity,
+                    sweep.Transform,
+                    CaptureStops(sweep),
+                    sweep.SpreadMode,
+                    sweep.CenterPoint,
+                    sweep.StartAngle,
+                    sweep.EndAngle),
+            _ => null!
+        };
+        return snapshot is not null;
+    }
+
+    private static StopSnapshot[] CaptureStops(GradientBrush brush)
+    {
+        GradientStop[] ordered = brush.GetOrderedStops();
+        var result = new StopSnapshot[ordered.Length];
+        for (int index = 0; index < result.Length; index++)
+        {
+            GradientStop stop = ordered[index];
+            result[index] = new StopSnapshot(stop.PaintColor, stop.Offset);
+        }
+
+        return result;
+    }
+
+    private static void ValidateProgress(float progress)
+    {
+        if (!float.IsFinite(progress))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(progress),
+                progress,
+                "Brush animation progress must be finite.");
         }
     }
+
+    private abstract record BrushSnapshot(float Opacity, Matrix3x2 Transform);
 
     private sealed record SolidSnapshot(float Opacity, Matrix3x2 Transform, Color Color)
         : BrushSnapshot(Opacity, Transform);

--- a/ModernFormsNext/Control.VisualStates.cs
+++ b/ModernFormsNext/Control.VisualStates.cs
@@ -531,9 +531,11 @@ public partial class Control
 
         private static IAnimationInterpolator<Brush>? TryCreateBrushInterpolator(Brush? from, Brush? to)
         {
-            if (from is null || to is null || from.GetType() != to.GetType())
+            if (from is null || to is null)
                 return null;
-            return AnimationInterpolators.CreateBrushInterpolator();
+            return AnimationInterpolators.TryCreateBrushInterpolator(from, to, out IAnimationInterpolator<Brush>? interpolator)
+                ? interpolator
+                : null;
         }
 
         private static Brush? InterpolateBrush(
@@ -544,18 +546,7 @@ public partial class Control
         {
             if (interpolator is null)
                 return to;
-            try
-            {
-                return interpolator.Interpolate(from!, to!, progress);
-            }
-            catch (InvalidOperationException)
-            {
-                return to;
-            }
-            catch (NotSupportedException)
-            {
-                return to;
-            }
+            return interpolator.Interpolate(from!, to!, progress);
         }
 
         private static SKColor Interpolate(SKColor from, SKColor to, float progress)

--- a/ModernFormsNext/Theming/ThemeManagerInfrastructure.cs
+++ b/ModernFormsNext/Theming/ThemeManagerInfrastructure.cs
@@ -168,7 +168,7 @@ internal sealed class ThemeTransitionPlan
 {
     private readonly List<ResourceColorTransition> resourceColors = [];
     private readonly List<ResourceNumberTransition> resourceNumbers = [];
-    private readonly List<BrushAnimationPlan> brushPlans = [];
+    private readonly List<ResourceBrushTransition> resourceBrushes = [];
     private readonly List<LegacyColorTransition> legacyColors = [];
 
     private ThemeTransitionPlan(
@@ -181,7 +181,7 @@ internal sealed class ThemeTransitionPlan
 
     public Dictionary<object, object?> Resources { get; }
     public Dictionary<string, object> LegacyValues { get; }
-    public bool HasAnimations => resourceColors.Count > 0 || resourceNumbers.Count > 0 || brushPlans.Count > 0 || legacyColors.Count > 0;
+    public bool HasAnimations => resourceColors.Count > 0 || resourceNumbers.Count > 0 || resourceBrushes.Count > 0 || legacyColors.Count > 0;
 
     public static ThemeTransitionPlan Create(
         Dictionary<object, object?> currentResources,
@@ -232,8 +232,8 @@ internal sealed class ThemeTransitionPlan
         using Application.ThemeTransitionFrameScope transitionFrame = Application.BeginThemeTransitionFrame();
         using Application.VisualInvalidationBatchScope batch = Application.BeginVisualInvalidationBatch();
 
-        foreach (BrushAnimationPlan brushPlan in brushPlans)
-            brushPlan.Apply(progress);
+        foreach (ResourceBrushTransition transition in resourceBrushes)
+            Resources[transition.Key] = transition.Plan.Interpolate(progress);
 
         foreach (ResourceColorTransition transition in resourceColors)
             Resources[transition.Key] = AnimationInterpolators.Color.Interpolate(transition.From, transition.To, progress);
@@ -259,17 +259,14 @@ internal sealed class ThemeTransitionPlan
         MfnBrush to,
         Dictionary<object, object?> targetResources)
     {
-        try
-        {
-            MfnBrush working = ThemeValueCloner.CloneBrush(from);
-            BrushAnimationPlan brushPlan = BrushAnimationPlan.Create(from, to, working);
-            targetResources[key] = working;
-            plan.brushPlans.Add(brushPlan);
-        }
-        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
-        {
-            // Incompatible brush types or gradient stop counts switch immediately by contract.
-        }
+        if (!BrushAnimationPlan.TryCreateLocal(from, to, out BrushAnimationPlan? brushPlan))
+            return;
+
+        // The exact source reference remains visible at progress zero. Intermediate frames reuse
+        // the plan's private working brush, and completion replaces it with the exact resolved
+        // target reference so resource identity and notifications remain deterministic.
+        targetResources[key] = from;
+        plan.resourceBrushes.Add(new ResourceBrushTransition(key, brushPlan!));
     }
 
     private static SKColor Interpolate(SKColor from, SKColor to, float progress)
@@ -283,5 +280,6 @@ internal sealed class ThemeTransitionPlan
 
     private sealed record ResourceColorTransition(object Key, Color From, Color To);
     private sealed record ResourceNumberTransition(object Key, double From, double To);
+    private sealed record ResourceBrushTransition(object Key, BrushAnimationPlan Plan);
     private sealed record LegacyColorTransition(string Key, SKColor From, SKColor To);
 }

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -321,9 +321,9 @@ remove a newer replacement because scheduler removal checks entry identity.
 
 There are two deliberately different Brush patterns.
 
-For a local transition, create one animation-local interpolator. It clones the source brush once,
-then reuses and mutates that working clone. The original and target remain unchanged, so other
-controls that share either endpoint are unaffected:
+For a local transition, create one animation-local interpolator. It captures the endpoints once,
+then reuses and mutates one working brush for intermediate frames. The original and target remain
+unchanged, so other controls that share either endpoint are unaffected:
 
 ```csharp
 ModernFormsNext.Drawing.Brush from = new SolidColorBrush(Color.MediumPurple);
@@ -354,11 +354,19 @@ AnimationHandle handle = sharedBrush.AnimateTo(
     easing: Easings.EaseInOut);
 ```
 
+Local transitions support solid-to-solid, same-kind gradient pairs with equal or different
+non-empty stop counts, and solid-to-linear/radial/sweep promotion. Exact endpoints retain their
+authored references; normalization never mutates authored brushes. Cross-kind gradients,
+`GlassBrush`, `NoBrush`, null, empty-to-populated gradients, and custom/derived brushes use the
+calling subsystem's discrete fallback. See the
+[brush interpolation compatibility matrix](architecture/brush-interpolation.md) for the precise
+normalization and fallback rules.
+
 In-place mutation raises the existing `Brush.Changed` notifications on the UI thread. Every live
-control using that brush repaints, and no layout is requested. Supported concrete pairs are
-`SolidColorBrush`, `LinearGradientBrush`, `RadialGradientBrush`, and `SweepGradientBrush`. Gradient
-pairs must have the same concrete type and stop count. Incompatible structures throw before the
-animation is scheduled; there is no implicit snap or structural blending.
+control using that brush repaints, and no layout is requested. Because the destination object's
+identity and stop collection must remain stable, this explicit compatibility helper continues to
+require matching built-in concrete types and equal gradient stop counts. Incompatible structures
+throw before the animation is scheduled.
 
 Compatible animations include color, opacity, `Matrix3x2` transform, linear start/end points,
 radial center/origin/radius, sweep angles, stop colors and offsets. `GradientSpreadMode` changes at
@@ -663,10 +671,10 @@ stops when no runnable work remains.
 
 ## Current limitations
 
-- There is no general animated-layout subsystem. Updating bounds or spacing uses the existing
-  setters and can be more expensive than render-only transforms.
-- Brush interpolation requires matching built-in concrete types and equal gradient stop counts.
-- Visual-state layout metrics switch discretely rather than interpolate.
+- Animated layout covers bounds, while visual-state metric interpolation currently covers padding
+  and border widths. Other layout-aware state metrics remain discrete.
+- Brush cross-kind geometry, `GlassBrush`, `NoBrush`, null, empty-to-populated gradients, and
+  custom/derived brush types switch discretely.
 - The Designer collection editor supports the built-in `RippleEffect` and `PressScaleEffect` only;
   custom effects and easing delegates remain code-first, and Designer undo/redo is not available.
 - Android platform preference refresh occurs on startup/foreground or explicit refresh; there is no
@@ -676,6 +684,7 @@ stops when no runnable work remains.
   validation.
 
 See [the scheduler architecture](architecture/ui-animation-scheduler.md), the
+[brush interpolation compatibility matrix](architecture/brush-interpolation.md), the
 [scheduler architecture decision](architecture/decisions/ADR-UI-Animation-Scheduler.md), the
 [composable-animation architecture decision](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md),
 the [animation platform polish decision](architecture/decisions/ADR-Animation-Platform-Polish.md),

--- a/docs/architecture/brush-interpolation.md
+++ b/docs/architecture/brush-interpolation.md
@@ -1,0 +1,138 @@
+# Brush interpolation compatibility
+
+## Purpose
+
+ModernFormsNext uses one platform-neutral brush interpolation planner for control visual states,
+theme resources, and the public typed animation APIs. It extends the shared animation scheduler;
+it does not introduce another timer, frame loop, renderer, or public brush hierarchy.
+
+The planner has two responsibilities:
+
+1. decide whether two authored brushes have a safe visual interpolation path; and
+2. prepare all structural data once so an animation frame only updates an existing working brush.
+
+The source and target brushes are never modified by a local transition. Progress at or below zero
+returns the exact source reference, progress at or above one returns the exact target reference,
+and only the open interval uses the animation-local working brush. This gives theme resources and
+visual states deterministic identity and notification behavior at both endpoints.
+
+## Compatibility matrix
+
+The table describes the end-to-end behavior of visual-state and `ThemeManager` transitions. Those
+callers probe compatibility before creating a local interpolator and apply their established
+discrete fallback when no plan exists. A directly created
+`AnimationInterpolators.CreateBrushInterpolator()` accepts only compatible non-null pairs and
+retains the existing validation exception for an unsupported pair because
+`IAnimationInterpolator<T>` has no `TryInterpolate` result.
+
+| From / to | Solid | Linear | Radial | Sweep | Glass | NoBrush, null, custom |
+| --- | --- | --- | --- | --- | --- | --- |
+| Solid | interpolate | promote to linear | promote to radial | promote to sweep | discrete | discrete |
+| Linear | promote to linear | interpolate | discrete | discrete | discrete | discrete |
+| Radial | promote to radial | discrete | interpolate | discrete | discrete | discrete |
+| Sweep | promote to sweep | discrete | discrete | interpolate | discrete | discrete |
+| Glass | discrete | discrete | discrete | discrete | discrete | discrete |
+| NoBrush, null, custom | discrete | discrete | discrete | discrete | discrete | discrete |
+
+Only the exact built-in `SolidColorBrush`, `LinearGradientBrush`, `RadialGradientBrush`, and
+`SweepGradientBrush` types participate. A derived or otherwise unknown brush may add state with no
+safe generic interpolation rule, so it deliberately uses the caller's existing discrete fallback.
+There is no implicit reflection or user-code invocation to discover a custom path.
+
+Linear, radial, and sweep geometry is not morphed across kinds. Such a morph would need an authored
+geometry contract rather than an arbitrary conversion, so these pairs also remain discrete.
+
+## Solid and gradient transitions
+
+For a solid-to-gradient pair, the solid is represented internally as a gradient whose stops all
+have the solid color. The other endpoint supplies the gradient kind, geometry, stop offsets, and
+spread mode. The reverse path uses the same rule. The working brush therefore has stable structure
+during the open interval, while changing to or from the exact solid endpoint remains visually
+continuous.
+
+Opacity and transform come from each authored endpoint and continue to interpolate normally.
+No synthetic gradient is stored back into either authored brush.
+
+## Gradient-stop normalization
+
+Stops are ordered and captured once when the plan is created.
+
+- Equal stop counts retain ordinal pairing. Stop colors and offsets both interpolate, preserving
+  the behavior of the original brush animator.
+- Different non-empty stop counts use a sorted canonical union of both offset sets. For a repeated
+  offset, the union retains the larger multiplicity from either endpoint, preserving hard stops.
+- Each endpoint is resampled onto that canonical structure once. Exact duplicate colors retain
+  stable order; missing offsets use piecewise color interpolation between neighboring authored
+  stops.
+- An empty gradient is treated as no paint, not as a transparent color. Empty-to-populated and
+  solid-to-empty pairs therefore use the discrete fallback. Two empty gradients of the same kind
+  remain structurally compatible.
+
+The canonical offsets stay fixed for intermediate frames. The exact authored target replaces the
+working brush at completion, so normalization cannot permanently alter authored stop count,
+ordering, offsets, or identity.
+
+## Other brush state
+
+Compatible plans interpolate:
+
+- color channels, including alpha, in the existing sRGB byte interpolation;
+- brush opacity;
+- `Matrix3x2` transform;
+- linear start and end points;
+- radial center, origin, and radius;
+- sweep center, start angle, and end angle;
+- gradient-stop colors and offsets.
+
+`GradientSpreadMode` is categorical. The source mode is retained for intermediate frames and the
+exact target mode becomes visible at completion. Radius remains non-negative.
+
+## Scheduling, retargeting, and lifecycle
+
+Brush transitions use `AnimationScheduler` and the same manual-clock test infrastructure as other
+animations. There is no timer per brush, property, control, or resource. Visual-state transitions
+share the control's state-transition entry; theme brush values share the single theme-transition
+entry.
+
+When a visual state or theme is replaced during a transition, the currently published presentation
+brush is captured as the next source. The old scheduler entry is canceled and replaced, so the new
+run continues from what was visible rather than restarting from an authored endpoint. Completion,
+cancellation, control disposal, subtree detach, and theme replacement continue to use the existing
+scheduler ownership and cleanup rules.
+
+An explicit `Brush.AnimateTo` is different: it intentionally preserves the destination object's
+identity and mutates it in place. Because its structure cannot change without replacing that
+object, this compatibility API still requires matching exact built-in types and equal gradient
+stop counts. It raises normal observable brush notifications on every changed frame.
+
+## Rendering and resource notifications
+
+Control visual-state rendering reads effective/current presentation brushes for background, text,
+and borders. An intermediate working brush is therefore what the renderer paints and what a rapid
+retarget captures. Authored `Style`, `StyleHover`, and other state brushes are not changed.
+
+`ThemeManager` publishes the exact source at transition start, the reusable working brush during
+intermediate frames, and the exact resolved target at completion. `ResourceDictionary` change
+notifications follow those reference replacements. Controls already bound through dynamic
+resources continue to invalidate through the established resource and observable-brush paths.
+
+## Performance contract
+
+Plan creation may allocate snapshots, sorted stop arrays, a canonical offset array, and one working
+brush. The frame path performs indexed loops over fixed arrays and mutates existing brush and stop
+objects. It does not use reflection, LINQ, structural parsing, replacement stop arrays, or a new
+brush per frame. Scheduler batching retains the existing one-invalidation-batch-per-tick behavior.
+
+## Deliberate limitations
+
+- Cross-kind gradient geometry, `GlassBrush`, `NoBrush`, `null`, and custom/derived brushes use a
+  discrete fallback.
+- Color channels use the existing sRGB interpolation; linear-light or color-space selection is not
+  introduced here.
+- No new Designer editor or serialized transition format is added; that belongs to issue #28.
+- The planner is platform-neutral. Experimental Android compiles against it, but full device frame
+  pacing and runtime validation remain part of issue #29.
+
+See also [Paint and gradient architecture](paint-and-gradients.md),
+[UI animation scheduler architecture](ui-animation-scheduler.md), and
+[Animations](../animations.md).

--- a/docs/architecture/ui-animation-scheduler.md
+++ b/docs/architecture/ui-animation-scheduler.md
@@ -158,13 +158,15 @@ cover `float`, `double`, `int`, `PointF`, `SizeF`, `RectangleF`, `Color` includi
 results use explicit midpoint rounding. Color channels interpolate independently in the current
 sRGB byte representation; linear-light interpolation is deferred.
 
-Brush animation uses the recently introduced observable model without allocating a new brush on
-every tick. The generic Brush interpolator clones the source once and mutates that animation-local
-working value, leaving shared source and target instances unchanged. An explicit `AnimateTo` helper
-instead mutates an existing Brush in place when shared-resource animation is intended. Solid,
-linear, radial, and sweep brushes are supported. Gradient brushes require the same concrete type
-and stop count. Incompatible types or stop structures are rejected before scheduling. Discrete
-spread mode changes at completion.
+Brush animation uses the observable model without allocating a new brush on every tick. The generic
+Brush interpolator captures its endpoints once and mutates one animation-local working value,
+leaving shared source and target instances unchanged. It supports solid pairs, same-kind gradients
+with equal or different non-empty stop counts, and solid-to-linear/radial/sweep promotion. Stop
+normalization is planned once and preserves hard-stop multiplicity. Cross-kind gradients,
+`GlassBrush`, `NoBrush`, null, empty-to-populated gradients, and custom/derived brushes retain a
+discrete fallback. An explicit `AnimateTo` helper instead mutates an existing Brush in place and
+therefore still requires the same built-in type and stop count. Spread mode changes at completion.
+The full matrix is documented in [Brush interpolation compatibility](brush-interpolation.md).
 
 ## Invalidation
 
@@ -182,15 +184,17 @@ invalidation remain separate concerns.
 
 The owner of an explicit in-place brush animation is the brush itself. Its synchronous `Changed`
 event continues through the weak, reference-counted subscriptions introduced with dynamic
-resources. A local transition normally uses its control as owner and assigns the cloned working
-brush. Replacing a resource while its previous brush is animating does not transfer the animation
-to the new object: consumers rebind to the replacement, and the old animation can be canceled by
-its handle or owner key. A future ThemeManager should retain and cancel handles for all transition
-participants when a newer theme replaces a transition.
+resources. A local transition normally uses its control as owner and assigns its animation-local
+working brush. Replacing a resource while its previous brush is animating does not transfer an
+explicit in-place animation to the new object: consumers rebind to the replacement, and the old
+animation can be canceled by its handle or owner key. `ThemeManager` uses local value plans
+instead; it retains the published presentation brush when a newer theme replaces an active
+transition.
 
-The JSON ThemeManager should serialize target theme values, not live scheduler state or native
-timer data. Theme transitions will construct compatible local animation plans after resource
-resolution.
+The JSON ThemeManager serializes target theme values, not live scheduler state or native timer
+data. Theme transitions construct compatible local animation plans after resource resolution,
+publish the current presentation brush during a rapid replacement, and restore the exact target
+reference at completion.
 
 ## Future Shape and navigation work
 

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -23,6 +23,7 @@ namespace ControlGallery
             tree.Items.Add ("Animations", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Animated layout", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Layout-aware visual states", ImageLoader.Get ("swatches.png"));
+            tree.Items.Add ("Brush interpolation", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Animations and Interaction Effects", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("CheckBox", ImageLoader.Get ("button.png"));
             tree.Items.Add ("CheckedListBox", ImageLoader.Get ("button.png"));
@@ -111,6 +112,8 @@ namespace ControlGallery
                     return new AnimatedLayoutPanel ();
                 case "Layout-aware visual states":
                     return new LayoutAwareVisualStatesPanel ();
+                case "Brush interpolation":
+                    return new BrushInterpolationPanel ();
                 case "Animations and Interaction Effects":
                     return new AnimationsAndInteractionEffectsPanel ();
                 case "Button":

--- a/samples/ControlGallery/Panels/BrushInterpolationPanel.cs
+++ b/samples/ControlGallery/Panels/BrushInterpolationPanel.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Drawing;
+using ModernFormsNext;
+using ModernFormsNext.Animations;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+
+namespace ControlGallery.Panels;
+
+/// <summary>
+/// Provides a compact manual check for compatible visual-state brush transitions.
+/// </summary>
+public sealed class BrushInterpolationPanel : BasePanel
+{
+    /// <summary>
+    /// Initializes the brush-interpolation demonstration.
+    /// </summary>
+    public BrushInterpolationPanel()
+    {
+        AutoScroll = true;
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 18,
+            Width = 760,
+            Height = 30,
+            Text = "Brush interpolation compatibility",
+            Font = new ModernFormsNext.Font("Segoe UI", 16)
+        });
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 54,
+            Width = 760,
+            Height = 52,
+            Multiline = true,
+            Text = "Hover and press both cards. The left card stays Solid; the right moves from Solid through three- and two-stop linear gradients. Rapidly retarget the states and watch for jumps."
+        });
+
+        var stage = Controls.Add(new Panel
+        {
+            Left = 24,
+            Top = 122,
+            Width = 720,
+            Height = 320,
+            BackColor = new SKColor(241, 244, 249)
+        });
+        stage.Style.Border.Width = 1;
+        stage.Style.Border.Color = Theme.BorderMidColor;
+
+        var solidCard = stage.Controls.Add(new HoverPanel
+        {
+            Bounds = new Rectangle(20, 68, 330, 184)
+        });
+        solidCard.Style.BackgroundBrush = new SolidColorBrush(Color.FromArgb(255, 78, 70, 180));
+        solidCard.Style.BorderBrush = new SolidColorBrush(Color.FromArgb(255, 45, 38, 120));
+        solidCard.Style.Border.Width = 4;
+        solidCard.StyleHover.BackgroundBrush = new SolidColorBrush(Color.FromArgb(255, 28, 166, 154));
+        solidCard.StyleHover.BorderBrush = new SolidColorBrush(Color.White);
+        solidCard.StylePressed.BackgroundBrush = new SolidColorBrush(Color.FromArgb(255, 225, 72, 118));
+        solidCard.StylePressed.BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 224, 130));
+        AddCardTransitions(solidCard);
+        solidCard.Controls.Add(new PassiveLabel
+        {
+            Dock = DockStyle.Fill,
+            Text = "Solid  <->  Solid",
+            TextAlign = ModernFormsNext.ContentAlignment.MiddleCenter,
+            ForeColor = SKColors.White,
+            BackColor = SKColors.Transparent
+        });
+
+        var mixedCard = stage.Controls.Add(new HoverPanel
+        {
+            Bounds = new Rectangle(370, 68, 330, 184)
+        });
+        mixedCard.Style.BackgroundBrush = new SolidColorBrush(Color.FromArgb(255, 78, 70, 180));
+        mixedCard.Style.BorderBrush = new SolidColorBrush(Color.FromArgb(255, 45, 38, 120));
+        mixedCard.Style.Border.Width = 4;
+        mixedCard.StyleHover.BackgroundBrush = Linear(
+            (Color.FromArgb(255, 28, 126, 214), 0f),
+            (Color.FromArgb(255, 53, 196, 154), 0.52f),
+            (Color.FromArgb(255, 247, 193, 72), 1f));
+        mixedCard.StyleHover.BorderBrush = Linear(
+            (Color.White, 0f),
+            (Color.FromArgb(255, 28, 126, 214), 1f));
+        mixedCard.StylePressed.BackgroundBrush = Linear(
+            (Color.FromArgb(255, 225, 72, 118), 0f),
+            (Color.FromArgb(255, 111, 65, 190), 1f));
+        mixedCard.StylePressed.BorderBrush = new SolidColorBrush(Color.White);
+
+        AddCardTransitions(mixedCard);
+
+        mixedCard.Controls.Add(new PassiveLabel
+        {
+            Dock = DockStyle.Fill,
+            Text = "Solid  <->  3 stops  <->  2 stops",
+            TextAlign = ModernFormsNext.ContentAlignment.MiddleCenter,
+            ForeColor = SKColors.White,
+            BackColor = SKColors.Transparent
+        });
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 462,
+            Width = 720,
+            Height = 58,
+            Multiline = true,
+            Text = "Expected: color, alpha, stop structure and border paint move smoothly; releasing or leaving lands exactly on the authored state and the scheduler returns to idle."
+        });
+    }
+
+    private static LinearGradientBrush Linear(params (Color Color, float Offset)[] stops)
+    {
+        var brush = new LinearGradientBrush
+        {
+            Start = new PointF(0f, 0f),
+            End = new PointF(1f, 1f)
+        };
+        foreach ((Color color, float offset) in stops)
+            brush.GradientStops.Add(new GradientStop(color, offset));
+        return brush;
+    }
+
+    private static void AddTransition(
+        Control control,
+        VisualState from,
+        VisualState to,
+        int durationMilliseconds)
+        => control.StyleTransitions.Add(
+            from,
+            to,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(durationMilliseconds),
+                Easing = Easings.CubicOut
+            });
+
+    private static void AddCardTransitions(Control control)
+    {
+        AddTransition(control, VisualState.Normal, VisualState.Hover, 320);
+        AddTransition(control, VisualState.Hover, VisualState.Normal, 260);
+        AddTransition(control, VisualState.Hover, VisualState.Pressed, 140);
+        AddTransition(control, VisualState.Pressed, VisualState.Hover, 180);
+    }
+
+    private sealed class HoverPanel : Panel
+    {
+        public HoverPanel()
+        {
+            SetControlBehavior(ControlBehaviors.Hoverable);
+        }
+    }
+
+    private sealed class PassiveLabel : Label
+    {
+        public PassiveLabel()
+        {
+            SetControlBehavior(ControlBehaviors.ReceivesMouseEvents, false);
+        }
+    }
+}


### PR DESCRIPTION
Closes #27

## Summary

- extends the built-in Brush compatibility matrix across `SolidColorBrush`, `LinearGradientBrush`, `RadialGradientBrush`, and `SweepGradientBrush`
- supports Solid ↔ Gradient promotion and gradients with different stop counts
- normalizes gradient stops deterministically, including hard stops and duplicate offsets
- interpolates gradient geometry, `Opacity`, and `Transform`
- captures immutable animation plans and preserves smooth retargeting from the current presentation Brush
- shares the same behavior between Visual States and ThemeManager transitions
- keeps unsupported, custom, null, `GlassBrush`, `NoBrush`, and cross-gradient pairs on a safe discrete fallback path
- adds deterministic regression coverage and a focused ControlGallery smoke-test

## Validation

- all tests: 968/968
- Debug and Release builds: 0 errors, 0 warnings
- VSIX Debug and Release validation: passed
- `git diff --check`: clean