### PR TITLE
Add Designer support for animation and effect definitions

### DIFF
--- a/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerationOptions.cs
+++ b/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerationOptions.cs
@@ -1,3 +1,5 @@
+using ModernFormsNext.Designing;
+
 namespace ModernFormsNext.CodeGeneration.CSharp;
 
 /// <summary>
@@ -5,6 +7,14 @@ namespace ModernFormsNext.CodeGeneration.CSharp;
 /// </summary>
 public sealed class CSharpDesignerGenerationOptions
 {
+    /// <summary>
+    /// Gets or sets detached descriptors for explicitly designable project interaction effects.
+    /// </summary>
+    /// <remarks>
+    /// The generator never loads the project assembly. Hosts populate this list from safe source
+    /// discovery. Built-in effect descriptors are always available and need not be repeated.
+    /// </remarks>
+    public IReadOnlyList<DesignAnimationDefinitionDescriptor> AnimationDefinitions { get; set; } = [];
     /// <summary>
     /// Gets or sets an optional namespace that replaces the namespace stored in the design document.
     /// </summary>

--- a/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
+++ b/ModernFormsNext.CodeGeneration/CSharp/CSharpDesignerGenerator.cs
@@ -135,7 +135,7 @@ public sealed class CSharpDesignerGenerator
             writer.WriteLine();
 
         foreach (var control in controls)
-            WriteControlInitialization(writer, control, controlExpressions[control], validation);
+            WriteControlInitialization(writer, control, controlExpressions[control], validation, options);
 
         foreach (var control in controls)
             WriteControlEvents(writer, control, controlExpressions[control]);
@@ -159,7 +159,8 @@ public sealed class CSharpDesignerGenerator
                 || document.RootKind == DesignRootKind.Form && string.Equals(property.Key, "Text", StringComparison.Ordinal))
                 continue;
 
-            WritePropertyAssignment(writer, "this", property.Key, property.Value, "design root", validation);
+            if (!TryWriteAnimationProperty(writer, "this", property.Key, property.Value, "design root", validation, options))
+                WritePropertyAssignment(writer, "this", property.Key, property.Value, "design root", validation);
         }
 
         foreach (var eventBinding in document.Events)
@@ -244,7 +245,8 @@ public sealed class CSharpDesignerGenerator
         CodeWriter writer,
         DesignControlNode control,
         string controlExpression,
-        DesignDocumentValidationResult validation)
+        DesignDocumentValidationResult validation,
+        CSharpDesignerGenerationOptions options)
     {
         writer.WriteLine($"        {controlExpression}.Name = {CSharpLiteralWriter.WriteStringLiteral(control.Name)};");
         writer.WriteLine($"        {controlExpression}.Bounds = new System.Drawing.Rectangle({control.Bounds.X}, {control.Bounds.Y}, {control.Bounds.Width}, {control.Bounds.Height});");
@@ -259,9 +261,12 @@ public sealed class CSharpDesignerGenerator
 
             if (string.Equals(property.Key, InteractionEffectDesignValue.PropertyName, StringComparison.Ordinal))
             {
-                WriteInteractionEffects(writer, controlExpression, property.Value, control.Name, validation);
+                WriteInteractionEffects(writer, controlExpression, property.Value, control.Name, validation, options);
                 continue;
             }
+
+            if (TryWriteAnimationProperty(writer, controlExpression, property.Key, property.Value, control.Name, validation, options))
+                continue;
 
             WritePropertyAssignment(writer, controlExpression, property.Key, property.Value, control.Name, validation);
         }
@@ -274,7 +279,8 @@ public sealed class CSharpDesignerGenerator
         string targetExpression,
         DesignPropertyValue value,
         string ownerName,
-        DesignDocumentValidationResult validation)
+        DesignDocumentValidationResult validation,
+        CSharpDesignerGenerationOptions options)
     {
         if (!InteractionEffectDesignValue.TryRead(value, out IReadOnlyList<DesignPropertyValue> effects, out string? error))
         {
@@ -286,7 +292,7 @@ public sealed class CSharpDesignerGenerator
         {
             try
             {
-                string expression = WriteInteractionEffect(effects[index]);
+                string expression = WriteInteractionEffect(effects[index], options);
                 writer.WriteLine($"        {targetExpression}.InteractionEffects.Add({expression});");
             }
             catch (Exception exception) when (exception is NotSupportedException
@@ -300,45 +306,178 @@ public sealed class CSharpDesignerGenerator
         }
     }
 
-    private static string WriteInteractionEffect(DesignPropertyValue effect)
+    private static string WriteInteractionEffect(
+        DesignPropertyValue effect,
+        CSharpDesignerGenerationOptions options)
     {
         IReadOnlyDictionary<string, DesignPropertyValue> properties = effect.ObjectProperties
             ?? throw new FormatException("The effect description does not contain properties.");
         string typeName = effect.ObjectTypeName ?? string.Empty;
 
-        if (IsEffectType(typeName, "RippleEffect"))
+        DesignAnimationDefinitionDescriptor descriptor = FindEffectDescriptor(typeName, options.AnimationDefinitions)
+            ?? throw new NotSupportedException($"Interaction effect type '{typeName}' is not registered for code generation.");
+        ValidateEffectDescriptor(descriptor);
+        ValidateEffectProperties(properties, descriptor.Properties.Select(item => item.Name).ToArray());
+
+        var assignments = new List<string>(properties.Count);
+        foreach (DesignAnimationPropertyDescriptor property in descriptor.Properties)
         {
-            ValidateEffectProperties(properties,
-                "Enabled", "ColorArgb", "DurationMilliseconds", "StartFromPointer", "RadiusMode",
-                "FixedRadius", "Layer", "MaxConcurrentRipples", "OverflowPolicy");
-            int argb = ReadInt(properties, "ColorArgb", unchecked((int)0x5AFFFFFF));
-            uint color = unchecked((uint)argb);
-            return "new ModernFormsNext.Animations.RippleEffect { "
-                + $"Enabled = {ReadBoolLiteral(properties, "Enabled", true)}, "
-                + $"Color = System.Drawing.Color.FromArgb({color >> 24}, {(color >> 16) & 0xFF}, {(color >> 8) & 0xFF}, {color & 0xFF}), "
-                + $"Duration = System.TimeSpan.FromMilliseconds({ReadDoubleLiteral(properties, "DurationMilliseconds", 450d)}), "
-                + $"StartFromPointer = {ReadBoolLiteral(properties, "StartFromPointer", true)}, "
-                + $"RadiusMode = {ReadEnumLiteral(properties, "RadiusMode", "ModernFormsNext.Animations.RippleRadiusMode", "CoverControl", "CoverControl", "Fixed")}, "
-                + $"FixedRadius = {ReadFloatLiteral(properties, "FixedRadius", 48d)}, "
-                + $"Layer = {ReadEnumLiteral(properties, "Layer", "ModernFormsNext.Animations.RippleLayer", "AboveBackgroundBelowContent", "AboveBackgroundBelowContent", "AboveContent")}, "
-                + $"MaxConcurrentRipples = {ReadInt(properties, "MaxConcurrentRipples", 4)}, "
-                + $"OverflowPolicy = {ReadEnumLiteral(properties, "OverflowPolicy", "ModernFormsNext.Animations.RippleOverflowPolicy", "RemoveOldest", "RemoveOldest", "RemoveNewest", "IgnoreNew", "ReplaceAll")} "
-                + "}";
+            if (properties.TryGetValue(property.Name, out DesignPropertyValue? stored))
+                assignments.Add($"{property.RuntimePropertyName} = {WriteAnimationValue(property, stored)}");
+        }
+        string initializer = assignments.Count == 0 ? string.Empty : " " + string.Join(", ", assignments) + " ";
+        return $"new {descriptor.TypeName} {{" + initializer + "}";
+    }
+
+    private static DesignAnimationDefinitionDescriptor? FindEffectDescriptor(
+        string typeName,
+        IReadOnlyList<DesignAnimationDefinitionDescriptor> customDefinitions)
+    {
+        string normalized = typeName.Replace("global::", string.Empty, StringComparison.Ordinal);
+        return BuiltInAnimationDefinitionCatalog.Definitions.Concat(customDefinitions ?? [])
+            .FirstOrDefault(item => item.Kind == DesignAnimationDefinitionKind.InteractionEffect
+                && (string.Equals(item.TypeName, normalized, StringComparison.Ordinal)
+                    || item.IsBuiltIn && string.Equals(item.TypeName.Split('.').Last(), normalized, StringComparison.Ordinal)));
+    }
+
+    private static string WriteAnimationValue(
+        DesignAnimationPropertyDescriptor descriptor,
+        DesignPropertyValue value)
+        => descriptor.Kind switch
+        {
+            DesignAnimationPropertyKind.Boolean when value.Kind == DesignPropertyValueKind.Boolean
+                => value.Value is true ? "true" : "false",
+            DesignAnimationPropertyKind.Int32 when value.Kind == DesignPropertyValueKind.Int32
+                => WriteAnimationInteger(descriptor, value),
+            DesignAnimationPropertyKind.Number when value.Kind is DesignPropertyValueKind.Int32 or DesignPropertyValueKind.Double
+                => WriteAnimationNumber(descriptor, value, descriptor.RuntimeTypeName),
+            DesignAnimationPropertyKind.TimeSpan when value.Kind is DesignPropertyValueKind.Int32 or DesignPropertyValueKind.Double
+                => $"System.TimeSpan.FromMilliseconds({WriteAnimationNumber(descriptor, value, null)})",
+            DesignAnimationPropertyKind.Easing when value.Kind == DesignPropertyValueKind.String
+                && KnownEasingDesignValue.IsKnown(value.GetString())
+                => $"ModernFormsNext.Animations.Easings.{value.GetString()}",
+            DesignAnimationPropertyKind.Enum when value.Kind == DesignPropertyValueKind.Enum
+                && descriptor.EnumMembers.Contains(value.GetString(), StringComparer.Ordinal)
+                => $"{descriptor.EnumTypeName}.{value.GetString()}",
+            DesignAnimationPropertyKind.ColorArgb when value.Kind == DesignPropertyValueKind.Int32
+                => WriteColor(value),
+            DesignAnimationPropertyKind.String when value.Kind == DesignPropertyValueKind.String
+                => CSharpLiteralWriter.WriteStringLiteral(value.GetString()),
+            _ => throw new FormatException($"Property '{descriptor.Name}' has an invalid designer value.")
+        };
+
+    private static void ValidateEffectDescriptor(DesignAnimationDefinitionDescriptor descriptor)
+    {
+        if (!IsQualifiedIdentifier(descriptor.TypeName))
+            throw new NotSupportedException($"Interaction effect type name '{descriptor.TypeName}' is not safe C# syntax.");
+        if (descriptor.Properties.Select(item => item.Name).Distinct(StringComparer.Ordinal).Count() != descriptor.Properties.Count
+            || descriptor.Properties.Select(item => item.RuntimePropertyName).Distinct(StringComparer.Ordinal).Count() != descriptor.Properties.Count)
+            throw new NotSupportedException($"Interaction effect descriptor '{descriptor.TypeName}' contains duplicate properties.");
+
+        foreach (DesignAnimationPropertyDescriptor property in descriptor.Properties)
+        {
+            if (!CSharpIdentifierSanitizer.IsValidIdentifier(property.Name)
+                || !CSharpIdentifierSanitizer.IsValidIdentifier(property.RuntimePropertyName))
+                throw new NotSupportedException($"Interaction effect descriptor '{descriptor.TypeName}' contains an invalid property name.");
+            if (property.Kind == DesignAnimationPropertyKind.Enum
+                && (!IsQualifiedIdentifier(property.EnumTypeName)
+                    || property.EnumMembers.Any(member => !CSharpIdentifierSanitizer.IsValidIdentifier(member))))
+                throw new NotSupportedException($"Enum metadata for '{descriptor.TypeName}.{property.Name}' is not safe C# syntax.");
+            if (property.Minimum > property.Maximum)
+                throw new NotSupportedException($"Numeric metadata for '{descriptor.TypeName}.{property.Name}' has an invalid range.");
+        }
+    }
+
+    private static bool IsQualifiedIdentifier(string? value)
+        => !string.IsNullOrWhiteSpace(value)
+        && value.Split('.').All(CSharpIdentifierSanitizer.IsValidIdentifier);
+
+    private static string WriteAnimationInteger(
+        DesignAnimationPropertyDescriptor descriptor,
+        DesignPropertyValue value)
+    {
+        int number = Convert.ToInt32(value.Value, CultureInfo.InvariantCulture);
+        ValidateAnimationNumber(descriptor, number);
+        return number.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string WriteAnimationNumber(
+        DesignAnimationPropertyDescriptor descriptor,
+        DesignPropertyValue value,
+        string? runtimeTypeName)
+    {
+        double number = Convert.ToDouble(value.Value, CultureInfo.InvariantCulture);
+        ValidateAnimationNumber(descriptor, number);
+
+        bool requiresSingleLiteral = runtimeTypeName?.Split('.').Last() is "float" or "Single";
+        if (requiresSingleLiteral)
+        {
+            float single = (float)number;
+            if (!float.IsFinite(single) || single == 0f && number != 0d)
+                throw new FormatException($"Property '{descriptor.Name}' cannot be represented as a finite Single value.");
         }
 
-        if (IsEffectType(typeName, "PressScaleEffect"))
-        {
-            ValidateEffectProperties(properties,
-                "Enabled", "PressedScale", "PressDurationMilliseconds", "ReleaseDurationMilliseconds");
-            return "new ModernFormsNext.Animations.PressScaleEffect { "
-                + $"Enabled = {ReadBoolLiteral(properties, "Enabled", true)}, "
-                + $"PressedScale = {ReadFloatLiteral(properties, "PressedScale", 0.97d)}, "
-                + $"PressDuration = System.TimeSpan.FromMilliseconds({ReadDoubleLiteral(properties, "PressDurationMilliseconds", 80d)}), "
-                + $"ReleaseDuration = System.TimeSpan.FromMilliseconds({ReadDoubleLiteral(properties, "ReleaseDurationMilliseconds", 120d)}) "
-                + "}";
-        }
+        string literal = number.ToString("R", CultureInfo.InvariantCulture);
+        return requiresSingleLiteral ? literal + "f" : literal;
+    }
 
-        throw new NotSupportedException($"Interaction effect type '{typeName}' is not registered for code generation.");
+    private static void ValidateAnimationNumber(
+        DesignAnimationPropertyDescriptor descriptor,
+        double number)
+    {
+        if (!double.IsFinite(number))
+            throw new FormatException($"Property '{descriptor.Name}' must be finite.");
+        if (number < descriptor.Minimum || number > descriptor.Maximum)
+        {
+            throw new FormatException(
+                $"Property '{descriptor.Name}' must be between "
+                + $"{descriptor.Minimum.ToString("R", CultureInfo.InvariantCulture)} and "
+                + $"{descriptor.Maximum.ToString("R", CultureInfo.InvariantCulture)}.");
+        }
+    }
+
+    private static string WriteColor(DesignPropertyValue value)
+    {
+        uint color = unchecked((uint)Convert.ToInt32(value.Value, CultureInfo.InvariantCulture));
+        return $"System.Drawing.Color.FromArgb({color >> 24}, {(color >> 16) & 0xFF}, {(color >> 8) & 0xFF}, {color & 0xFF})";
+    }
+
+    private static bool TryWriteAnimationProperty(
+        CodeWriter writer,
+        string targetExpression,
+        string propertyName,
+        DesignPropertyValue value,
+        string ownerName,
+        DesignDocumentValidationResult validation,
+        CSharpDesignerGenerationOptions options)
+    {
+        if (string.Equals(propertyName, InteractionEffectDesignValue.PropertyName, StringComparison.Ordinal))
+        {
+            WriteInteractionEffects(writer, targetExpression, value, ownerName, validation, options);
+            return true;
+        }
+        if (string.Equals(propertyName, LayoutTransitionDesignValue.PropertyName, StringComparison.Ordinal))
+        {
+            if (!LayoutTransitionDesignValue.TryRead(value, out bool enabled, out double duration, out string easing, out string? error))
+                validation.AddWarning($"LayoutTransition on '{ownerName}' was skipped: {error}");
+            else
+                writer.WriteLine($"        {targetExpression}.LayoutTransition = new ModernFormsNext.Animations.LayoutTransition {{ Enabled = {(enabled ? "true" : "false")}, Duration = System.TimeSpan.FromMilliseconds({duration.ToString("R", CultureInfo.InvariantCulture)}), Easing = ModernFormsNext.Animations.Easings.{easing} }};");
+            return true;
+        }
+        if (string.Equals(propertyName, VisualStateTransitionDesignValue.PropertyName, StringComparison.Ordinal))
+        {
+            if (!VisualStateTransitionDesignValue.TryRead(value, out var transitions, out string? error))
+            {
+                validation.AddWarning($"StyleTransitions on '{ownerName}' was skipped: {error}");
+                return true;
+            }
+            foreach (DesignVisualStateTransition transition in transitions)
+            {
+                writer.WriteLine($"        {targetExpression}.StyleTransitions.Add(ModernFormsNext.Animations.VisualState.{transition.From}, ModernFormsNext.Animations.VisualState.{transition.To}, new ModernFormsNext.Animations.VisualStateTransition {{ Duration = System.TimeSpan.FromMilliseconds({transition.DurationMilliseconds.ToString("R", CultureInfo.InvariantCulture)}), Easing = ModernFormsNext.Animations.Easings.{transition.Easing} }});");
+            }
+            return true;
+        }
+        return false;
     }
 
     private static void ValidateEffectProperties(
@@ -349,91 +488,6 @@ public sealed class CSharpDesignerGenerator
         string? unsupported = properties.Keys.FirstOrDefault(name => !supported.Contains(name));
         if (unsupported is not null)
             throw new NotSupportedException($"Property '{unsupported}' is not supported for this interaction effect.");
-    }
-
-    private static bool IsEffectType(string typeName, string shortName)
-        => string.Equals(typeName, shortName, StringComparison.Ordinal)
-        || string.Equals(typeName, "ModernFormsNext.Animations." + shortName, StringComparison.Ordinal);
-
-    private static int ReadInt(
-        IReadOnlyDictionary<string, DesignPropertyValue> properties,
-        string name,
-        int fallback)
-    {
-        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
-            return fallback;
-        if (value.Kind != DesignPropertyValueKind.Int32 || value.Value is not int result)
-            throw new FormatException($"Property '{name}' must be a 32-bit integer.");
-        return result;
-    }
-
-    private static string ReadDoubleLiteral(
-        IReadOnlyDictionary<string, DesignPropertyValue> properties,
-        string name,
-        double fallback)
-    {
-        double result;
-        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
-        {
-            result = fallback;
-        }
-        else if (value.Kind is DesignPropertyValueKind.Double or DesignPropertyValueKind.Int32)
-        {
-            result = Convert.ToDouble(value.Value, CultureInfo.InvariantCulture);
-        }
-        else
-        {
-            throw new FormatException($"Property '{name}' must be numeric.");
-        }
-        if (!double.IsFinite(result))
-            throw new FormatException($"Property '{name}' must be finite.");
-        return result.ToString("R", CultureInfo.InvariantCulture);
-    }
-
-    private static string ReadFloatLiteral(
-        IReadOnlyDictionary<string, DesignPropertyValue> properties,
-        string name,
-        double fallback)
-    {
-        float result = (float)double.Parse(
-            ReadDoubleLiteral(properties, name, fallback),
-            CultureInfo.InvariantCulture);
-        if (!float.IsFinite(result))
-            throw new FormatException($"Property '{name}' must fit in a finite single-precision value.");
-        return result.ToString("R", CultureInfo.InvariantCulture) + "f";
-    }
-
-    private static string ReadBoolLiteral(
-        IReadOnlyDictionary<string, DesignPropertyValue> properties,
-        string name,
-        bool fallback)
-    {
-        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
-            return fallback ? "true" : "false";
-        if (value.Kind != DesignPropertyValueKind.Boolean || value.Value is not bool result)
-            throw new FormatException($"Property '{name}' must be a Boolean.");
-        return result ? "true" : "false";
-    }
-
-    private static string ReadEnumLiteral(
-        IReadOnlyDictionary<string, DesignPropertyValue> properties,
-        string name,
-        string enumTypeName,
-        string fallbackMember,
-        params string[] supportedMembers)
-    {
-        if (!properties.TryGetValue(name, out DesignPropertyValue? value))
-            return enumTypeName + "." + fallbackMember;
-        string shortTypeName = enumTypeName.Split('.').Last();
-        string member = value.GetString();
-        if (value.Kind != DesignPropertyValueKind.Enum
-            || (!string.Equals(value.EnumTypeName, enumTypeName, StringComparison.Ordinal)
-                && !string.Equals(value.EnumTypeName, shortTypeName, StringComparison.Ordinal))
-            || !supportedMembers.Contains(member, StringComparer.Ordinal))
-        {
-            throw new FormatException($"Property '{name}' is not a supported {shortTypeName} value.");
-        }
-        return enumTypeName + "." + member;
     }
 
     private static void WritePropertyAssignment(

--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParseOptions.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParseOptions.cs
@@ -7,6 +7,9 @@ namespace ModernFormsNext.CodeGeneration.Reverse;
 /// </summary>
 public sealed class CSharpDesignerParseOptions
 {
+    /// <summary>Gets or sets detached descriptors for project interaction effects accepted by reverse sync.</summary>
+    /// <remarks>The parser uses metadata only and never loads or constructs the described types.</remarks>
+    public IReadOnlyList<DesignAnimationDefinitionDescriptor> AnimationDefinitions { get; set; } = [];
     /// <summary>
     /// Gets or sets the kind of design root represented by the generated partial class.
     /// </summary>

--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
@@ -23,6 +23,7 @@ public sealed class CSharpDesignerParser
     private readonly Dictionary<string, DesignControlNode> nodes = new(StringComparer.Ordinal);
     private readonly List<string> nodeOrder = [];
     private readonly List<ControlAddOperation> addOperations = [];
+    private IReadOnlyList<DesignAnimationDefinitionDescriptor> animationDefinitions = [];
 
     /// <summary>
     /// Parses generated C# designer source into a ModernFormsNext design document.
@@ -37,6 +38,7 @@ public sealed class CSharpDesignerParser
         ArgumentNullException.ThrowIfNull(sourceText);
 
         options ??= new CSharpDesignerParseOptions();
+        animationDefinitions = options.AnimationDefinitions ?? [];
         diagnostics.Clear();
         fields.Clear();
         nodes.Clear();
@@ -172,7 +174,7 @@ public sealed class CSharpDesignerParser
                 break;
 
             case ExpressionStatementSyntax { Expression: InvocationExpressionSyntax invocation }:
-                ProcessInvocation(invocation);
+                ProcessInvocation(invocation, document);
                 break;
 
             case EmptyStatementSyntax:
@@ -240,9 +242,9 @@ public sealed class CSharpDesignerParser
         AddUnsupported(assignment, "Unsupported assignment in InitializeComponent.");
     }
 
-    private void ProcessInvocation(InvocationExpressionSyntax invocation)
+    private void ProcessInvocation(InvocationExpressionSyntax invocation, DesignDocument document)
     {
-        if (TryProcessInteractionEffectAdd(invocation))
+        if (TryProcessInteractionEffectAdd(invocation, document) || TryProcessVisualStateTransitionAdd(invocation, document))
             return;
 
         if (TryReadControlsAdd(invocation, out var parentName, out var childName))
@@ -254,7 +256,7 @@ public sealed class CSharpDesignerParser
         AddUnsupported(invocation, "Unsupported method call in InitializeComponent.");
     }
 
-    private bool TryProcessInteractionEffectAdd(InvocationExpressionSyntax invocation)
+    private bool TryProcessInteractionEffectAdd(InvocationExpressionSyntax invocation, DesignDocument document)
     {
         if (invocation.Expression is not MemberAccessExpressionSyntax addAccess
             || !string.Equals(addAccess.Name.Identifier.ValueText, "Add", StringComparison.Ordinal)
@@ -265,11 +267,20 @@ public sealed class CSharpDesignerParser
             return false;
         }
 
-        string? ownerName = syntaxReader.GetObjectReferenceName(effectsAccess.Expression);
-        if (string.IsNullOrWhiteSpace(ownerName)
-            || !TryGetNode(ownerName, invocation, out DesignControlNode node))
-        {
+        string? ownerName = effectsAccess.Expression is ThisExpressionSyntax
+            ? "this"
+            : syntaxReader.GetObjectReferenceName(effectsAccess.Expression);
+        if (string.IsNullOrWhiteSpace(ownerName))
             return true;
+
+        IDictionary<string, DesignPropertyValue> properties;
+        if (string.Equals(ownerName, "this", StringComparison.Ordinal))
+            properties = document.Properties;
+        else
+        {
+            if (!TryGetNode(ownerName, invocation, out DesignControlNode node))
+                return true;
+            properties = node.Properties;
         }
 
         if (!TryReadInteractionEffect(invocation.ArgumentList.Arguments[0].Expression, out DesignPropertyValue effect))
@@ -278,19 +289,19 @@ public sealed class CSharpDesignerParser
             return true;
         }
 
-        node.Properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? existing);
+        properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? existing);
         if (!InteractionEffectDesignValue.TryRead(existing, out IReadOnlyList<DesignPropertyValue> effects, out string? error))
         {
             AddUnsupported(invocation, $"Cannot append interaction effect for '{ownerName}': {error}");
             return true;
         }
 
-        node.Properties[InteractionEffectDesignValue.PropertyName] =
+        properties[InteractionEffectDesignValue.PropertyName] =
             InteractionEffectDesignValue.Create(effects.Append(effect));
         return true;
     }
 
-    private static bool TryReadInteractionEffect(ExpressionSyntax expression, out DesignPropertyValue effect)
+    private bool TryReadInteractionEffect(ExpressionSyntax expression, out DesignPropertyValue effect)
     {
         effect = null!;
         if (expression is not ObjectCreationExpressionSyntax objectCreation
@@ -300,14 +311,10 @@ public sealed class CSharpDesignerParser
         }
 
         string typeName = objectCreation.Type.ToString();
-        bool isRipple = IsInteractionEffectType(typeName, "RippleEffect");
-        bool isPressScale = IsInteractionEffectType(typeName, "PressScaleEffect");
-        if (!isRipple && !isPressScale)
+        DesignAnimationDefinitionDescriptor? descriptor = FindEffectDescriptor(typeName);
+        if (descriptor is null)
             return false;
-
-        string[] supportedProperties = isRipple
-            ? ["Enabled", "Color", "Duration", "StartFromPointer", "RadiusMode", "FixedRadius", "Layer", "MaxConcurrentRipples", "OverflowPolicy"]
-            : ["Enabled", "PressedScale", "PressDuration", "ReleaseDuration"];
+        var byRuntimeName = descriptor.Properties.ToDictionary(item => item.RuntimePropertyName, StringComparer.Ordinal);
 
         var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
         foreach (ExpressionSyntax initializer in objectCreation.Initializer.Expressions)
@@ -325,47 +332,186 @@ public sealed class CSharpDesignerParser
                 _ => string.Empty
             };
             if (string.IsNullOrWhiteSpace(propertyName)
-                || !supportedProperties.Contains(propertyName, StringComparer.Ordinal))
+                || !byRuntimeName.TryGetValue(propertyName, out DesignAnimationPropertyDescriptor? property))
                 return false;
-
-            if (string.Equals(propertyName, "Color", StringComparison.Ordinal))
+            if (property.Kind == DesignAnimationPropertyKind.ColorArgb)
             {
                 if (!TryReadColorArgb(assignment.Right, out int argb))
                     return false;
-                if (!properties.TryAdd("ColorArgb", DesignPropertyValue.FromInt32(argb)))
+                if (!properties.TryAdd(property.Name, DesignPropertyValue.FromInt32(argb)))
+                    return false;
+                continue;
+            }
+            if (property.Kind == DesignAnimationPropertyKind.TimeSpan)
+            {
+                if (!TryReadTimeSpanMilliseconds(assignment.Right, out double milliseconds)
+                    || !IsAnimationNumberInRange(property, milliseconds))
+                    return false;
+                if (!properties.TryAdd(property.Name, DesignPropertyValue.FromDouble(milliseconds)))
+                    return false;
+                continue;
+            }
+            if (property.Kind == DesignAnimationPropertyKind.Easing)
+            {
+                if (!TryReadKnownEasing(assignment.Right, out string easing)
+                    || !properties.TryAdd(property.Name, DesignPropertyValue.FromString(easing)))
                     return false;
                 continue;
             }
 
-            string? durationProperty = propertyName switch
-            {
-                "Duration" when isRipple => "DurationMilliseconds",
-                "PressDuration" when isPressScale => "PressDurationMilliseconds",
-                "ReleaseDuration" when isPressScale => "ReleaseDurationMilliseconds",
-                _ => null
-            };
-            if (durationProperty is not null)
-            {
-                if (!TryReadTimeSpanMilliseconds(assignment.Right, out double milliseconds))
-                    return false;
-                if (!properties.TryAdd(durationProperty, DesignPropertyValue.FromDouble(milliseconds)))
-                    return false;
-                continue;
-            }
-
-            if (!TryReadDesignerValue(assignment.Right, out DesignPropertyValue value))
+            if (!TryReadDesignerValue(assignment.Right, out DesignPropertyValue value)
+                || !IsAnimationValueCompatible(property, value))
                 return false;
-            if (!properties.TryAdd(propertyName, value))
+            if (!properties.TryAdd(property.Name, value))
                 return false;
         }
 
-        effect = DesignPropertyValue.FromStructuredObject(typeName, properties);
+        effect = DesignPropertyValue.FromStructuredObject(descriptor.TypeName, properties);
         return true;
     }
 
-    private static bool IsInteractionEffectType(string typeName, string shortName)
-        => string.Equals(typeName, shortName, StringComparison.Ordinal)
-        || string.Equals(typeName, "ModernFormsNext.Animations." + shortName, StringComparison.Ordinal);
+    private static bool IsAnimationValueCompatible(
+        DesignAnimationPropertyDescriptor property,
+        DesignPropertyValue value)
+        => property.Kind switch
+        {
+            DesignAnimationPropertyKind.Boolean => value.Kind == DesignPropertyValueKind.Boolean,
+            DesignAnimationPropertyKind.Int32 => value.Kind == DesignPropertyValueKind.Int32
+                && IsAnimationNumberInRange(property, Convert.ToDouble(value.Value, CultureInfo.InvariantCulture)),
+            DesignAnimationPropertyKind.Number => value.Kind is DesignPropertyValueKind.Int32 or DesignPropertyValueKind.Double
+                && IsAnimationNumberInRange(property, Convert.ToDouble(value.Value, CultureInfo.InvariantCulture))
+                && IsRepresentableRuntimeNumber(property, Convert.ToDouble(value.Value, CultureInfo.InvariantCulture)),
+            DesignAnimationPropertyKind.Enum => value.Kind == DesignPropertyValueKind.Enum
+                && IsExpectedEnumType(value.EnumTypeName, property.EnumTypeName)
+                && property.EnumMembers.Contains(value.GetString(), StringComparer.Ordinal),
+            DesignAnimationPropertyKind.String => value.Kind == DesignPropertyValueKind.String,
+            _ => false
+        };
+
+    private static bool IsAnimationNumberInRange(
+        DesignAnimationPropertyDescriptor property,
+        double number)
+        => double.IsFinite(number) && number >= property.Minimum && number <= property.Maximum;
+
+    private static bool IsRepresentableRuntimeNumber(
+        DesignAnimationPropertyDescriptor property,
+        double number)
+    {
+        if (property.RuntimeTypeName?.Split('.').Last() is not ("float" or "Single"))
+            return true;
+        float single = (float)number;
+        return float.IsFinite(single) && (single != 0f || number == 0d);
+    }
+
+    private static bool IsExpectedEnumType(string? actual, string? expected)
+    {
+        string normalizedActual = (actual ?? string.Empty).Replace("global::", string.Empty, StringComparison.Ordinal);
+        string normalizedExpected = (expected ?? string.Empty).Replace("global::", string.Empty, StringComparison.Ordinal);
+        return string.Equals(normalizedActual, normalizedExpected, StringComparison.Ordinal)
+            || string.Equals(normalizedActual, normalizedExpected.Split('.').Last(), StringComparison.Ordinal);
+    }
+
+    private DesignAnimationDefinitionDescriptor? FindEffectDescriptor(string typeName)
+    {
+        string normalized = typeName.Replace("global::", string.Empty, StringComparison.Ordinal);
+        return BuiltInAnimationDefinitionCatalog.Definitions.Concat(animationDefinitions)
+            .FirstOrDefault(item => item.Kind == DesignAnimationDefinitionKind.InteractionEffect
+                && (string.Equals(item.TypeName, normalized, StringComparison.Ordinal)
+                    || item.IsBuiltIn && string.Equals(item.TypeName.Split('.').Last(), normalized, StringComparison.Ordinal)));
+    }
+
+    private static bool TryReadKnownEasing(ExpressionSyntax expression, out string easing)
+    {
+        easing = expression is MemberAccessExpressionSyntax member
+            ? member.Name.Identifier.ValueText
+            : string.Empty;
+        return expression is MemberAccessExpressionSyntax easingMember
+            && IsTypeReference(easingMember.Expression, "Easings", "ModernFormsNext.Animations.Easings")
+            && KnownEasingDesignValue.IsKnown(easing);
+    }
+
+    private bool TryProcessVisualStateTransitionAdd(InvocationExpressionSyntax invocation, DesignDocument document)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax addAccess
+            || !string.Equals(addAccess.Name.Identifier.ValueText, "Add", StringComparison.Ordinal)
+            || addAccess.Expression is not MemberAccessExpressionSyntax collectionAccess
+            || !string.Equals(collectionAccess.Name.Identifier.ValueText, VisualStateTransitionDesignValue.PropertyName, StringComparison.Ordinal)
+            || invocation.ArgumentList.Arguments.Count != 3)
+            return false;
+
+        string? ownerName = collectionAccess.Expression is ThisExpressionSyntax
+            ? "this"
+            : syntaxReader.GetObjectReferenceName(collectionAccess.Expression);
+        if (string.IsNullOrWhiteSpace(ownerName))
+            return true;
+        if (!TryReadVisualState(invocation.ArgumentList.Arguments[0].Expression, out string from)
+            || !TryReadVisualState(invocation.ArgumentList.Arguments[1].Expression, out string to)
+            || !TryReadVisualStateTransition(invocation.ArgumentList.Arguments[2].Expression, out double duration, out string easing))
+        {
+            AddUnsupported(invocation, $"Unsupported visual-state transition initializer for '{ownerName}'.");
+            return true;
+        }
+
+        IDictionary<string, DesignPropertyValue> properties;
+        if (string.Equals(ownerName, "this", StringComparison.Ordinal))
+            properties = document.Properties;
+        else
+        {
+            if (!TryGetNode(ownerName, invocation, out DesignControlNode node))
+                return true;
+            properties = node.Properties;
+        }
+        properties.TryGetValue(VisualStateTransitionDesignValue.PropertyName, out var existing);
+        if (!VisualStateTransitionDesignValue.TryRead(existing, out var transitions, out string? error))
+        {
+            AddUnsupported(invocation, $"Cannot append visual-state transition for '{ownerName}': {error}");
+            return true;
+        }
+        try
+        {
+            properties[VisualStateTransitionDesignValue.PropertyName] = VisualStateTransitionDesignValue.Create(
+                transitions.Append(new DesignVisualStateTransition(from, to, duration, easing)));
+        }
+        catch (ArgumentException exception)
+        {
+            AddUnsupported(invocation, exception.Message);
+        }
+        return true;
+    }
+
+    private static bool TryReadVisualState(ExpressionSyntax expression, out string state)
+    {
+        state = expression is MemberAccessExpressionSyntax member ? member.Name.Identifier.ValueText : string.Empty;
+        return expression is MemberAccessExpressionSyntax stateMember
+            && IsTypeReference(stateMember.Expression, "VisualState", "ModernFormsNext.Animations.VisualState")
+            && state is "Normal" or "Hover" or "Pressed" or "Disabled" or "Focused";
+    }
+
+    private static bool TryReadVisualStateTransition(
+        ExpressionSyntax expression,
+        out double duration,
+        out string easing)
+    {
+        duration = 150d;
+        easing = "CubicOut";
+        if (expression is not ObjectCreationExpressionSyntax creation
+            || !IsTypeReference(creation.Type, "VisualStateTransition", "ModernFormsNext.Animations.VisualStateTransition")
+            || creation.Initializer is null)
+            return false;
+        foreach (ExpressionSyntax item in creation.Initializer.Expressions)
+        {
+            if (item is not AssignmentExpressionSyntax assignment)
+                return false;
+            string name = assignment.Left.ToString();
+            if (name == "Duration" && !TryReadTimeSpanMilliseconds(assignment.Right, out duration))
+                return false;
+            if (name == "Easing" && !TryReadKnownEasing(assignment.Right, out easing))
+                return false;
+            if (name is not ("Duration" or "Easing"))
+                return false;
+        }
+        return true;
+    }
 
     private static bool TryReadTimeSpanMilliseconds(ExpressionSyntax expression, out double milliseconds)
     {
@@ -373,7 +519,7 @@ public sealed class CSharpDesignerParser
         return expression is InvocationExpressionSyntax invocation
             && invocation.Expression is MemberAccessExpressionSyntax member
             && string.Equals(member.Name.Identifier.ValueText, "FromMilliseconds", StringComparison.Ordinal)
-            && member.Expression.ToString().EndsWith("TimeSpan", StringComparison.Ordinal)
+            && IsTypeReference(member.Expression, "TimeSpan", "System.TimeSpan")
             && invocation.ArgumentList.Arguments.Count == 1
             && TryReadDouble(invocation.ArgumentList.Arguments[0].Expression, out milliseconds)
             && double.IsFinite(milliseconds)
@@ -386,7 +532,7 @@ public sealed class CSharpDesignerParser
         if (expression is not InvocationExpressionSyntax invocation
             || invocation.Expression is not MemberAccessExpressionSyntax member
             || !string.Equals(member.Name.Identifier.ValueText, "FromArgb", StringComparison.Ordinal)
-            || !member.Expression.ToString().EndsWith("Color", StringComparison.Ordinal)
+            || !IsTypeReference(member.Expression, "Color", "System.Drawing.Color")
             || invocation.ArgumentList.Arguments.Count != 4)
         {
             return false;
@@ -457,7 +603,10 @@ public sealed class CSharpDesignerParser
                 break;
 
             default:
-                if (TryReadDesignerValue(valueExpression, out var value))
+                if (propertyPath == LayoutTransitionDesignValue.PropertyName
+                    && TryReadLayoutTransition(valueExpression, out var layoutTransition))
+                    node.Properties[propertyPath] = layoutTransition;
+                else if (TryReadDesignerValue(valueExpression, out var value))
                     node.Properties[propertyPath] = value;
                 else
                     AddUnsupported(valueExpression, $"Unsupported value assigned to '{ownerName}.{propertyPath}'.");
@@ -515,12 +664,50 @@ public sealed class CSharpDesignerParser
                 break;
 
             default:
-                if (TryReadDesignerValue(valueExpression, out var value))
+                if (propertyPath == LayoutTransitionDesignValue.PropertyName
+                    && TryReadLayoutTransition(valueExpression, out var layoutTransition))
+                    document.Properties[propertyPath] = layoutTransition;
+                else if (TryReadDesignerValue(valueExpression, out var value))
                     document.Properties[propertyPath] = value;
                 else
                     AddUnsupported(syntax, $"Unsupported design root property assignment '{propertyPath}'.");
                 break;
         }
+    }
+
+    private static bool TryReadLayoutTransition(ExpressionSyntax expression, out DesignPropertyValue value)
+    {
+        bool enabled = true;
+        double duration = 250d;
+        string easing = "EaseOut";
+        value = null!;
+        if (expression is not ObjectCreationExpressionSyntax creation
+            || !IsTypeReference(creation.Type, "LayoutTransition", "ModernFormsNext.Animations.LayoutTransition")
+            || creation.Initializer is null)
+            return false;
+        foreach (ExpressionSyntax item in creation.Initializer.Expressions)
+        {
+            if (item is not AssignmentExpressionSyntax assignment)
+                return false;
+            string name = assignment.Left.ToString();
+            if (name == "Enabled" && !TryReadBoolean(assignment.Right, out enabled))
+                return false;
+            if (name == "Duration" && !TryReadTimeSpanMilliseconds(assignment.Right, out duration))
+                return false;
+            if (name == "Easing" && !TryReadKnownEasing(assignment.Right, out easing))
+                return false;
+            if (name is not ("Enabled" or "Duration" or "Easing"))
+                return false;
+        }
+        value = LayoutTransitionDesignValue.Create(enabled, duration, easing);
+        return true;
+    }
+
+    private static bool IsTypeReference(SyntaxNode syntax, string shortName, string fullName)
+    {
+        string value = syntax.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);
+        return string.Equals(value, shortName, StringComparison.Ordinal)
+            || string.Equals(value, fullName, StringComparison.Ordinal);
     }
 
     private void ProcessEventSubscription(

--- a/ModernFormsNext.Designer.Tests/AnimationEffectDefinitionDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/AnimationEffectDefinitionDesignerTests.cs
@@ -16,10 +16,8 @@ public sealed class AnimationEffectDefinitionDesignerTests
     {
         DesignerInteractionEffectEntry entry = InteractionEffectDesignerRegistry.Create(
             InteractionEffectDesignerRegistry.PressScaleTypeName);
-        Assert.True(InteractionEffectDesignerRegistry.TryApplyEditorText(
-            entry,
-            "PressDurationMilliseconds=95\nEasing=EaseInOut",
-            out string? error), error);
+        Assert.True(SetEffectProperty(entry, "PressDurationMilliseconds", DesignPropertyValue.FromDouble(95d), out string? error), error);
+        Assert.True(SetEffectProperty(entry, "Easing", DesignPropertyValue.FromString("EaseInOut"), out error), error);
         DesignDocument document = CreateDocument();
         Assert.Single(document.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
             InteractionEffectDesignerRegistry.WriteCollection([entry]);
@@ -492,19 +490,17 @@ public sealed class AnimationEffectDefinitionDesignerTests
     [Fact]
     public void TransitionResetRemovesOptionalSerializedValues()
     {
-        Assert.True(DesignerTransitionEditorModel.TryParseLayout(
-            "Enabled=true\nDurationMilliseconds=200\nEasing=EaseOut",
-            out DesignPropertyValue layout,
-            out string? error), error);
-        Assert.True(LayoutTransitionDesignValue.TryRead(layout, out _, out _, out _, out error), error);
-        Assert.False(DesignerTransitionEditorModel.TryParseLayout(
-            "DurationMilliseconds=-1",
-            out _,
-            out error));
-        Assert.Contains("not supported", error, StringComparison.OrdinalIgnoreCase);
+        var layout = new DesignerLayoutTransitionEditorModel(
+            LayoutTransitionDesignValue.Create(true, 200d, "EaseOut"));
+        layout.Reset();
+        Assert.True(layout.TryCreateValue(out DesignPropertyValue? resetLayout, out string? error), error);
+        Assert.Null(resetLayout);
 
-        Assert.True(DesignerTransitionEditorModel.TryParseVisualStates(string.Empty, out var empty, out error), error);
-        Assert.True(VisualStateTransitionDesignValue.TryRead(empty, out var transitions, out error), error);
+        var visual = new DesignerVisualStateTransitionEditorModel(
+            VisualStateTransitionDesignValue.Create([new("Normal", "Hover", 100d, "Linear")]));
+        visual.Reset();
+        Assert.True(visual.TryCreateValue(out DesignPropertyValue resetVisual, out error), error);
+        Assert.True(VisualStateTransitionDesignValue.TryRead(resetVisual, out var transitions, out error), error);
         Assert.Empty(transitions);
     }
 
@@ -520,6 +516,17 @@ public sealed class AnimationEffectDefinitionDesignerTests
                 { Minimum = 0d, RuntimeTypeName = "System.TimeSpan" },
                 new("Easing", "Easing", DesignAnimationPropertyKind.Easing, DesignPropertyValue.FromString("Linear"))
             ]);
+
+    private static bool SetEffectProperty(
+        DesignerInteractionEffectEntry entry,
+        string name,
+        DesignPropertyValue value,
+        out string? error)
+        => InteractionEffectDesignerRegistry.TrySetProperty(
+            entry,
+            entry.Descriptor!.Properties.Single(property => property.Name == name),
+            value,
+            out error);
 
     private static DesignDocument CreateDocument()
     {

--- a/ModernFormsNext.Designer.Tests/AnimationEffectDefinitionDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/AnimationEffectDefinitionDesignerTests.cs
@@ -1,0 +1,568 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using ModernFormsNext.CodeGeneration.CSharp;
+using ModernFormsNext.CodeGeneration.Reverse;
+using ModernFormsNext.Designer.Properties;
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designing;
+using Xunit;
+
+namespace ModernFormsNext.Designer.Tests;
+
+public sealed class AnimationEffectDefinitionDesignerTests
+{
+    [Fact]
+    public void BuiltInEffectEasingAndTimeSpanRoundTripThroughGeneratedCode()
+    {
+        DesignerInteractionEffectEntry entry = InteractionEffectDesignerRegistry.Create(
+            InteractionEffectDesignerRegistry.PressScaleTypeName);
+        Assert.True(InteractionEffectDesignerRegistry.TryApplyEditorText(
+            entry,
+            "PressDurationMilliseconds=95\nEasing=EaseInOut",
+            out string? error), error);
+        DesignDocument document = CreateDocument();
+        Assert.Single(document.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignerRegistry.WriteCollection([entry]);
+
+        CSharpDesignerGenerationResult generated = new CSharpDesignerGenerator().Generate(document);
+        Assert.True(generated.Succeeded, string.Join(Environment.NewLine, generated.Validation.Errors));
+        Assert.Contains("PressDuration = System.TimeSpan.FromMilliseconds(95)", generated.Code, StringComparison.Ordinal);
+        Assert.Contains("Easing = ModernFormsNext.Animations.Easings.EaseInOut", generated.Code, StringComparison.Ordinal);
+
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(generated.Code);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+        DesignPropertyValue stored = Assert.Single(parsed.Document!.Controls).Properties[InteractionEffectDesignValue.PropertyName];
+        Assert.True(InteractionEffectDesignValue.TryRead(stored, out var effects, out error), error);
+        Assert.Equal(95d, effects[0].ObjectProperties!["PressDurationMilliseconds"].Value);
+        Assert.Equal("EaseInOut", effects[0].ObjectProperties!["Easing"].Value);
+    }
+
+    [Fact]
+    public void DefaultEffectValuesStayOutOfMfdesignAndGeneratedInitializer()
+    {
+        DesignerInteractionEffectEntry entry = InteractionEffectDesignerRegistry.Create(
+            InteractionEffectDesignerRegistry.RippleTypeName);
+        Assert.Empty(entry.Properties);
+        DesignDocument document = CreateDocument();
+        Assert.Single(document.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignerRegistry.WriteCollection([entry]);
+
+        string json = DesignDocumentSerializer.Default.Serialize(document);
+        string code = new CSharpDesignerGenerator().Generate(document).Code;
+
+        Assert.DoesNotContain("DurationMilliseconds", json, StringComparison.Ordinal);
+        Assert.Contains("new ModernFormsNext.Animations.RippleEffect {}", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("Duration =", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnknownEasingProducesControlledGenerationWarning()
+    {
+        DesignDocument document = CreateDocument();
+        DesignPropertyValue effect = DesignPropertyValue.FromStructuredObject(
+            BuiltInAnimationDefinitionCatalog.RippleEffectTypeName,
+            new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            {
+                ["Easing"] = DesignPropertyValue.FromString("ApplicationDelegate")
+            });
+        Assert.Single(document.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create([effect]);
+
+        CSharpDesignerGenerationResult generated = new CSharpDesignerGenerator().Generate(document);
+
+        Assert.DoesNotContain(".InteractionEffects.Add(", generated.Code, StringComparison.Ordinal);
+        Assert.Contains(generated.Validation.Warnings, warning =>
+            warning.Contains("invalid designer value", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void OutOfRangeStoredEffectMetricsProduceControlledGenerationWarnings()
+    {
+        DesignAnimationDefinitionDescriptor descriptor = CustomEffectDescriptor();
+        DesignDocument document = CreateDocument();
+        Assert.Single(document.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create(
+            [
+                DesignPropertyValue.FromStructuredObject(
+                    descriptor.TypeName,
+                    new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+                    {
+                        ["Opacity"] = DesignPropertyValue.FromDouble(2d)
+                    }),
+                DesignPropertyValue.FromStructuredObject(
+                    descriptor.TypeName,
+                    new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+                    {
+                        ["DurationMilliseconds"] = DesignPropertyValue.FromDouble(-1d)
+                    }),
+                DesignPropertyValue.FromStructuredObject(
+                    BuiltInAnimationDefinitionCatalog.PressScaleEffectTypeName,
+                    new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+                    {
+                        ["PressedScale"] = DesignPropertyValue.FromDouble(double.Epsilon)
+                    })
+            ]);
+
+        CSharpDesignerGenerationResult generated = new CSharpDesignerGenerator().Generate(
+            document,
+            new CSharpDesignerGenerationOptions { AnimationDefinitions = [descriptor] });
+
+        Assert.DoesNotContain(".InteractionEffects.Add(", generated.Code, StringComparison.Ordinal);
+        Assert.Contains(generated.Validation.Warnings, warning => warning.Contains("Opacity", StringComparison.Ordinal));
+        Assert.Contains(generated.Validation.Warnings, warning => warning.Contains("DurationMilliseconds", StringComparison.Ordinal));
+        Assert.Contains(generated.Validation.Warnings, warning => warning.Contains("PressedScale", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void UnsafeCustomDescriptorCannotInjectGeneratedCode()
+    {
+        var descriptor = new DesignAnimationDefinitionDescriptor(
+            "Example.GlowEffect; System.Console.WriteLine(1)",
+            "Unsafe",
+            DesignAnimationDefinitionKind.InteractionEffect,
+            []);
+        DesignDocument document = CreateDocument();
+        Assert.Single(document.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create(
+            [
+                DesignPropertyValue.FromStructuredObject(
+                    descriptor.TypeName,
+                    new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal))
+            ]);
+
+        CSharpDesignerGenerationResult generated = new CSharpDesignerGenerator().Generate(
+            document,
+            new CSharpDesignerGenerationOptions { AnimationDefinitions = [descriptor] });
+
+        Assert.DoesNotContain("System.Console.WriteLine", generated.Code, StringComparison.Ordinal);
+        Assert.Contains(generated.Validation.Warnings, warning => warning.Contains("safe C# syntax", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LayoutAndVisualStateTransitionsRoundTripWithoutDelegateSerialization()
+    {
+        DesignDocument document = CreateDocument();
+        DesignControlNode button = Assert.Single(document.Controls);
+        button.Properties[LayoutTransitionDesignValue.PropertyName] =
+            LayoutTransitionDesignValue.Create(enabled: true, durationMilliseconds: 210d, easing: "EaseOut");
+        button.Properties[VisualStateTransitionDesignValue.PropertyName] =
+            VisualStateTransitionDesignValue.Create(
+            [
+                new("Normal", "Hover", 140d, "CubicOut"),
+                new("Hover", "Pressed", 80d, "Linear")
+            ]);
+
+        string code = new CSharpDesignerGenerator().Generate(document).Code;
+        AssertGeneratedCodeCompiles(code);
+        Assert.Contains("LayoutTransition = new ModernFormsNext.Animations.LayoutTransition", code, StringComparison.Ordinal);
+        Assert.Equal(2, Count(code, ".StyleTransitions.Add("));
+
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(code);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+        DesignControlNode reopened = Assert.Single(parsed.Document!.Controls);
+        Assert.True(LayoutTransitionDesignValue.TryRead(
+            reopened.Properties[LayoutTransitionDesignValue.PropertyName],
+            out bool enabled,
+            out double duration,
+            out string easing,
+            out string? error), error);
+        Assert.True(enabled);
+        Assert.Equal(210d, duration);
+        Assert.Equal("EaseOut", easing);
+        Assert.True(VisualStateTransitionDesignValue.TryRead(
+            reopened.Properties[VisualStateTransitionDesignValue.PropertyName],
+            out var transitions,
+            out error), error);
+        Assert.Equal(["Normal", "Hover"], transitions.Select(item => item.From));
+        Assert.Equal(["Hover", "Pressed"], transitions.Select(item => item.To));
+    }
+
+    [Fact]
+    public void ReverseParserDoesNotCanonicalizeSimilarlyNamedForeignAnimationApis()
+    {
+        DesignDocument document = CreateDocument();
+        DesignControlNode button = Assert.Single(document.Controls);
+        button.Properties[LayoutTransitionDesignValue.PropertyName] =
+            LayoutTransitionDesignValue.Create(enabled: true, durationMilliseconds: 210d, easing: "EaseOut");
+        button.Properties[VisualStateTransitionDesignValue.PropertyName] =
+            VisualStateTransitionDesignValue.Create([new("Normal", "Hover", 140d, "CubicOut")]);
+        button.Properties[InteractionEffectDesignValue.PropertyName] = InteractionEffectDesignValue.Create(
+        [
+            DesignPropertyValue.FromStructuredObject(
+                BuiltInAnimationDefinitionCatalog.RippleEffectTypeName,
+                new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+                {
+                    ["DurationMilliseconds"] = DesignPropertyValue.FromDouble(123d),
+                    ["RadiusMode"] = DesignPropertyValue.FromEnum(
+                        "ModernFormsNext.Animations.RippleRadiusMode",
+                        "Fixed")
+                })
+        ]);
+        string generated = new CSharpDesignerGenerator().Generate(document).Code;
+        string source = generated
+            .Replace(
+                "new ModernFormsNext.Animations.LayoutTransition",
+                "new Example.CustomLayoutTransition",
+                StringComparison.Ordinal)
+            .Replace(
+                "ModernFormsNext.Animations.VisualState.Normal",
+                "Example.CustomVisualState.Normal",
+                StringComparison.Ordinal)
+            .Replace(
+                "System.TimeSpan.FromMilliseconds(123)",
+                "Example.CustomTimeSpan.FromMilliseconds(123)",
+                StringComparison.Ordinal);
+
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(source);
+
+        Assert.True(parsed.Success);
+        DesignControlNode parsedButton = Assert.Single(parsed.Document!.Controls);
+        Assert.DoesNotContain(LayoutTransitionDesignValue.PropertyName, parsedButton.Properties.Keys);
+        Assert.DoesNotContain(VisualStateTransitionDesignValue.PropertyName, parsedButton.Properties.Keys);
+        Assert.DoesNotContain(InteractionEffectDesignValue.PropertyName, parsedButton.Properties.Keys);
+        Assert.Contains(parsed.Diagnostics, diagnostic =>
+            diagnostic.Severity == CSharpDesignerDiagnosticSeverity.Warning
+            && diagnostic.Message.Contains("Unsupported", StringComparison.OrdinalIgnoreCase));
+
+        CSharpDesignerParseResult foreignEnum = new CSharpDesignerParser().Parse(
+            generated.Replace(
+                "ModernFormsNext.Animations.RippleRadiusMode.Fixed",
+                "Example.CustomRadiusMode.Fixed",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            InteractionEffectDesignValue.PropertyName,
+            Assert.Single(foreignEnum.Document!.Controls).Properties.Keys);
+
+        CSharpDesignerParseResult foreignEasing = new CSharpDesignerParser().Parse(
+            generated.Replace(
+                "ModernFormsNext.Animations.Easings.EaseOut",
+                "Example.CustomEasings.EaseOut",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            LayoutTransitionDesignValue.PropertyName,
+            Assert.Single(foreignEasing.Document!.Controls).Properties.Keys);
+
+        CSharpDesignerParseResult foreignTransition = new CSharpDesignerParser().Parse(
+            generated.Replace(
+                "new ModernFormsNext.Animations.VisualStateTransition",
+                "new Example.CustomVisualStateTransition",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            VisualStateTransitionDesignValue.PropertyName,
+            Assert.Single(foreignTransition.Document!.Controls).Properties.Keys);
+    }
+
+    [Fact]
+    public void RootAnimationPropertiesUseSameRuntimeAndRoundTripContracts()
+    {
+        DesignDocument document = CreateDocument();
+        document.Properties[LayoutTransitionDesignValue.PropertyName] =
+            LayoutTransitionDesignValue.Create(false, 0d, "Linear");
+        document.Properties[VisualStateTransitionDesignValue.PropertyName] =
+            VisualStateTransitionDesignValue.Create([new("Normal", "Focused", 100d, "EaseIn")]);
+        document.Properties[InteractionEffectDesignValue.PropertyName] = InteractionEffectDesignValue.Create(
+        [
+            DesignPropertyValue.FromStructuredObject(
+                BuiltInAnimationDefinitionCatalog.PressScaleEffectTypeName,
+                new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal))
+        ]);
+
+        string code = new CSharpDesignerGenerator().Generate(document).Code;
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(code);
+
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+        Assert.Contains(LayoutTransitionDesignValue.PropertyName, parsed.Document!.Properties.Keys);
+        Assert.Contains(VisualStateTransitionDesignValue.PropertyName, parsed.Document.Properties.Keys);
+        Assert.Contains(InteractionEffectDesignValue.PropertyName, parsed.Document.Properties.Keys);
+    }
+
+    [Fact]
+    public void CustomEffectDescriptorGeneratesAndReverseParsesSupportedLiteralSubset()
+    {
+        DesignAnimationDefinitionDescriptor descriptor = CustomEffectDescriptor();
+        DesignDocument document = CreateDocument();
+        Assert.Single(document.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create(
+            [
+                DesignPropertyValue.FromStructuredObject(
+                    descriptor.TypeName,
+                    new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+                    {
+                        ["Opacity"] = DesignPropertyValue.FromDouble(0.65d),
+                        ["DurationMilliseconds"] = DesignPropertyValue.FromDouble(125d),
+                        ["Easing"] = DesignPropertyValue.FromString("BounceOut")
+                    })
+            ]);
+        var generationOptions = new CSharpDesignerGenerationOptions { AnimationDefinitions = [descriptor] };
+        var parseOptions = new CSharpDesignerParseOptions { AnimationDefinitions = [descriptor] };
+
+        string code = new CSharpDesignerGenerator().Generate(document, generationOptions).Code;
+        Assert.Contains("new Example.GlowEffect", code, StringComparison.Ordinal);
+        Assert.Contains("Opacity = 0.65f", code, StringComparison.Ordinal);
+        Assert.DoesNotContain(CSharpSyntaxTree.ParseText(code).GetDiagnostics(), diagnostic =>
+            diagnostic.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(code, parseOptions);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+        DesignPropertyValue stored = Assert.Single(parsed.Document!.Controls).Properties[InteractionEffectDesignValue.PropertyName];
+        Assert.True(InteractionEffectDesignValue.TryRead(stored, out var effects, out string? error), error);
+        Assert.Equal("Example.GlowEffect", Assert.Single(effects).ObjectTypeName);
+    }
+
+    [Fact]
+    public void SourceDiscoveryRequiresOptInAndNeverExecutesConstructors()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"mfn-animation-discovery-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "Effects.cs"), """
+                using EffectRoot = ModernFormsNext.Animations.InteractionEffect;
+                using DefinitionMarker = ModernFormsNext.Animations.DesignableAnimationDefinitionAttribute;
+                using PropertyMarker = ModernFormsNext.Animations.DesignableAnimationPropertyAttribute;
+                using PropertyKind = ModernFormsNext.Animations.DesignableAnimationPropertyKind;
+                namespace Example.Nested;
+                public abstract class GlowEffectBase : EffectRoot
+                {
+                    [PropertyMarker(PropertyKind.Number, DefaultValue = "0.4", Minimum = 0, Maximum = 1)]
+                    public System.Single Opacity { get; set; }
+                }
+                [DefinitionMarker("Glow")]
+                public sealed class GlowEffect : GlowEffectBase
+                {
+                    public GlowEffect() => throw new System.Exception("must not run");
+                }
+                public sealed class UnmarkedEffect : EffectRoot { }
+                public class FakeInteractionEffect { }
+                [DefinitionMarker("False positive")]
+                public sealed class NotAnEffect : FakeInteractionEffect { }
+                [DefinitionMarker("Generic")]
+                public sealed class GenericEffect<T> : EffectRoot { }
+                """);
+
+            DesignAnimationDefinitionDescriptor descriptor = Assert.Single(
+                DesignerProjectAnimationDefinitionDiscovery.Discover(directory));
+
+            Assert.Equal("Example.Nested.GlowEffect", descriptor.TypeName);
+            DesignAnimationPropertyDescriptor property = Assert.Single(descriptor.Properties);
+            Assert.Equal(0.4d, property.DefaultValue.Value);
+            Assert.Equal("System.Single", property.RuntimeTypeName);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AnimationDefinitionMetadataIsDiscoveredButNotOfferedAsInteractionEffect()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"mfn-animation-definition-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "Pulse.cs"), """
+                using ModernFormsNext.Animations;
+                namespace Example;
+                [DesignableAnimationDefinition("Pulse")]
+                public sealed class PulseDefinition : AnimationDefinition { }
+                """);
+            DesignAnimationDefinitionDescriptor descriptor = Assert.Single(
+                DesignerProjectAnimationDefinitionDiscovery.Discover(directory));
+
+            Assert.Equal(DesignAnimationDefinitionKind.AnimationDefinition, descriptor.Kind);
+            Assert.Throws<NotSupportedException>(() =>
+                InteractionEffectDesignerRegistry.Create(descriptor.TypeName, [descriptor]));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PropertyGridSeparatesEffectsLayoutAndVisualStateTransitions()
+    {
+        DesignDocument document = CreateDocument();
+        var session = new DesignerSession();
+        session.LoadDocument(document);
+        session.Host.Selection.Select(Assert.Single(document.Controls));
+        var state = new DesignerPropertyGridState(session);
+
+        Assert.Contains(state.Properties, item => item.Name == InteractionEffectDesignValue.PropertyName && item.Category == "Behavior");
+        Assert.Contains(state.Properties, item => item.Name == LayoutTransitionDesignValue.PropertyName && item.Category == "Behavior");
+        Assert.Contains(state.Properties, item => item.Name == VisualStateTransitionDesignValue.PropertyName && item.Category == "Appearance");
+        Assert.DoesNotContain(state.Properties, item => item.Name.Contains("Scheduler", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DuplicateEffectsAndDeepCopyPreserveIndependentOrderedDefinitions()
+    {
+        DesignDocument original = CreateDocument();
+        DesignPropertyValue first = DesignPropertyValue.FromStructuredObject(
+            BuiltInAnimationDefinitionCatalog.RippleEffectTypeName,
+            new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            {
+                ["DurationMilliseconds"] = DesignPropertyValue.FromDouble(200d)
+            });
+        Assert.Single(original.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create([first, first]);
+        DesignDocument copy = DesignDocumentSerializer.Default.Deserialize(
+            DesignDocumentSerializer.Default.Serialize(original));
+        Assert.Single(copy.Controls).Properties[InteractionEffectDesignValue.PropertyName] =
+            InteractionEffectDesignValue.Create([first]);
+
+        Assert.True(InteractionEffectDesignValue.TryRead(
+            Assert.Single(original.Controls).Properties[InteractionEffectDesignValue.PropertyName],
+            out var originalEffects,
+            out string? error), error);
+        Assert.True(InteractionEffectDesignValue.TryRead(
+            Assert.Single(copy.Controls).Properties[InteractionEffectDesignValue.PropertyName],
+            out var copiedEffects,
+            out error), error);
+        Assert.Equal(2, originalEffects.Count);
+        Assert.Single(copiedEffects);
+    }
+
+    [Fact]
+    public void ChangedOrMalformedCustomDescriptorDoesNotDestroyStoredDefinition()
+    {
+        DesignAnimationDefinitionDescriptor descriptor = CustomEffectDescriptor();
+        DesignPropertyValue stored = InteractionEffectDesignValue.Create(
+        [
+            DesignPropertyValue.FromStructuredObject(
+                descriptor.TypeName,
+                new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+                {
+                    ["RemovedProperty"] = DesignPropertyValue.FromDouble(1d)
+                })
+        ]);
+
+        Assert.True(InteractionEffectDesignerRegistry.TryReadCollection(
+            stored,
+            out var entries,
+            out string? error,
+            [descriptor]), error);
+        DesignerInteractionEffectEntry entry = Assert.Single(entries);
+        Assert.False(entry.IsSupported);
+        Assert.Contains("RemovedProperty", entry.ToDesignValue().ObjectProperties!.Keys);
+
+        var malformedProperties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["Count"] = DesignPropertyValue.FromInt32(0),
+            ["FutureMetadata"] = DesignPropertyValue.FromString("preserve")
+        };
+        DesignPropertyValue malformed = DesignPropertyValue.FromStructuredObject(
+            InteractionEffectDesignValue.CollectionTypeName,
+            malformedProperties);
+        Assert.False(InteractionEffectDesignerRegistry.TryReadCollection(
+            malformed,
+            out _,
+            out error,
+            [descriptor]));
+        Assert.Contains("unsupported", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("FutureMetadata", malformed.ObjectProperties!.Keys);
+    }
+
+    [Fact]
+    public void LegacyMfdesignWithoutAnimationPropertiesRemainsStable()
+    {
+        const string json = """
+            {
+              "metadata": { "formatVersion": 1, "generator": "legacy" },
+              "namespace": "Example",
+              "className": "LegacyForm",
+              "formName": "LegacyForm",
+              "size": { "width": 640, "height": 480 },
+              "properties": {},
+              "events": {},
+              "controls": []
+            }
+            """;
+
+        DesignDocument document = DesignDocumentSerializer.Default.Deserialize(json);
+        string generated = new CSharpDesignerGenerator().Generate(document).Code;
+
+        Assert.Empty(document.Properties);
+        Assert.DoesNotContain("InteractionEffects", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("LayoutTransition", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("StyleTransitions", generated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TransitionResetRemovesOptionalSerializedValues()
+    {
+        Assert.True(DesignerTransitionEditorModel.TryParseLayout(
+            "Enabled=true\nDurationMilliseconds=200\nEasing=EaseOut",
+            out DesignPropertyValue layout,
+            out string? error), error);
+        Assert.True(LayoutTransitionDesignValue.TryRead(layout, out _, out _, out _, out error), error);
+        Assert.False(DesignerTransitionEditorModel.TryParseLayout(
+            "DurationMilliseconds=-1",
+            out _,
+            out error));
+        Assert.Contains("not supported", error, StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(DesignerTransitionEditorModel.TryParseVisualStates(string.Empty, out var empty, out error), error);
+        Assert.True(VisualStateTransitionDesignValue.TryRead(empty, out var transitions, out error), error);
+        Assert.Empty(transitions);
+    }
+
+    private static DesignAnimationDefinitionDescriptor CustomEffectDescriptor()
+        => new(
+            "Example.GlowEffect",
+            "Glow",
+            DesignAnimationDefinitionKind.InteractionEffect,
+            [
+                new("Opacity", "Opacity", DesignAnimationPropertyKind.Number, DesignPropertyValue.FromDouble(0.4d))
+                { Minimum = 0d, Maximum = 1d, RuntimeTypeName = "System.Single" },
+                new("DurationMilliseconds", "Duration", DesignAnimationPropertyKind.TimeSpan, DesignPropertyValue.FromDouble(100d))
+                { Minimum = 0d, RuntimeTypeName = "System.TimeSpan" },
+                new("Easing", "Easing", DesignAnimationPropertyKind.Easing, DesignPropertyValue.FromString("Linear"))
+            ]);
+
+    private static DesignDocument CreateDocument()
+    {
+        var document = new DesignDocument
+        {
+            Namespace = "Example",
+            ClassName = "MainForm",
+            FormName = "MainForm",
+            Size = new DesignSize(640, 480)
+        };
+        document.Controls.Add(new DesignControlNode
+        {
+            TypeName = "Button",
+            Name = "button1",
+            Bounds = new DesignBounds(10, 10, 120, 36),
+            MemberVisibility = DesignerMemberVisibility.Private
+        });
+        return document;
+    }
+
+    private static int Count(string text, string value)
+        => text.Split(value, StringSplitOptions.None).Length - 1;
+
+    private static void AssertGeneratedCodeCompiles(string generatedCode)
+    {
+        string baseClass = """
+            namespace Example;
+            public partial class MainForm : ModernFormsNext.Form { }
+            """;
+        string[] trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            ?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
+        IEnumerable<MetadataReference> references = trustedAssemblies
+            .Concat(AppDomain.CurrentDomain.GetAssemblies()
+                .Where(assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+                .Select(assembly => assembly.Location))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "GeneratedDesignerValidation",
+            [CSharpSyntaxTree.ParseText(generatedCode), CSharpSyntaxTree.ParseText(baseClass)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        Assert.DoesNotContain(compilation.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+}

--- a/ModernFormsNext.Designer.Tests/AnimationEffectEditorModelTests.cs
+++ b/ModernFormsNext.Designer.Tests/AnimationEffectEditorModelTests.cs
@@ -1,0 +1,211 @@
+using ModernFormsNext.Designer.Properties;
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designing;
+using Xunit;
+
+namespace ModernFormsNext.Designer.Tests;
+
+public sealed class AnimationEffectEditorModelTests
+{
+    [Fact]
+    public void CancelLeavesInteractionEffectPropertiesUntouched()
+    {
+        var properties = StoredEffects(InteractionEffectDesignerRegistry.RippleTypeName);
+        DesignPropertyValue original = properties[InteractionEffectDesignValue.PropertyName];
+        var model = CreateEffectModel(properties);
+
+        model.Add(InteractionEffectDesignerRegistry.PressScaleTypeName);
+
+        Assert.Same(original, properties[InteractionEffectDesignValue.PropertyName]);
+        Assert.True(InteractionEffectDesignValue.TryRead(original, out var effects, out string? error), error);
+        Assert.Single(effects);
+    }
+
+    [Fact]
+    public void ApplyWritesTemporaryInteractionEffectChangesWithoutClosingModel()
+    {
+        var properties = new Dictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        var model = CreateEffectModel(properties);
+
+        model.Add(InteractionEffectDesignerRegistry.RippleTypeName);
+        model.Apply(properties);
+        model.Add(InteractionEffectDesignerRegistry.PressScaleTypeName);
+
+        Assert.True(InteractionEffectDesignValue.TryRead(
+            properties[InteractionEffectDesignValue.PropertyName],
+            out var applied,
+            out string? error), error);
+        Assert.Single(applied);
+        Assert.Equal(2, model.Entries.Count);
+    }
+
+    [Fact]
+    public void InteractionEffectReorderPreservesRuntimeOrder()
+    {
+        var properties = StoredEffects(
+            InteractionEffectDesignerRegistry.RippleTypeName,
+            InteractionEffectDesignerRegistry.PressScaleTypeName);
+        var model = CreateEffectModel(properties);
+
+        Assert.True(model.Move(1, -1));
+        model.Apply(properties);
+
+        Assert.True(InteractionEffectDesignValue.TryRead(
+            properties[InteractionEffectDesignValue.PropertyName],
+            out var reordered,
+            out string? error), error);
+        Assert.Equal(InteractionEffectDesignerRegistry.PressScaleTypeName, reordered[0].ObjectTypeName);
+        Assert.Equal(InteractionEffectDesignerRegistry.RippleTypeName, reordered[1].ObjectTypeName);
+    }
+
+    [Fact]
+    public void StructuredEffectDescriptorCommitsTypedValueAndElidesDefault()
+    {
+        DesignerInteractionEffectEntry entry = InteractionEffectDesignerRegistry.Create(
+            InteractionEffectDesignerRegistry.RippleTypeName);
+        DesignerPropertyDescriptor duration = Assert.Single(
+            DesignerInteractionEffectPropertyDescriptors.Create(entry),
+            item => item.Name == "DurationMilliseconds");
+
+        Assert.NotNull(duration.NumericMinimum);
+        Assert.True(duration.TryCommit("125.5", out string? error), error);
+        Assert.Equal(125.5d, entry.Properties["DurationMilliseconds"].Value);
+        Assert.True(duration.TryCommit("450", out error), error);
+        Assert.DoesNotContain("DurationMilliseconds", entry.Properties.Keys);
+    }
+
+    [Fact]
+    public void UnknownInteractionEffectRemainsPreservedAcrossApply()
+    {
+        DesignPropertyValue unknown = DesignPropertyValue.FromStructuredObject(
+            "Example.MissingEffect",
+            new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            {
+                ["Token"] = DesignPropertyValue.FromString("preserve-me")
+            });
+        var properties = new Dictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            [InteractionEffectDesignValue.PropertyName] = InteractionEffectDesignValue.Create([unknown])
+        };
+        var model = CreateEffectModel(properties);
+
+        model.Add(InteractionEffectDesignerRegistry.RippleTypeName);
+        model.Apply(properties);
+
+        Assert.True(InteractionEffectDesignValue.TryRead(
+            properties[InteractionEffectDesignValue.PropertyName],
+            out var effects,
+            out string? error), error);
+        Assert.Equal("Example.MissingEffect", effects[0].ObjectTypeName);
+        Assert.Equal("preserve-me", effects[0].ObjectProperties!["Token"].Value);
+    }
+
+    [Fact]
+    public void LayoutTransitionStructuredValuesRoundTripAndResetToDefault()
+    {
+        var model = new DesignerLayoutTransitionEditorModel(
+            LayoutTransitionDesignValue.Create(true, 210d, "EaseOut"));
+
+        Assert.True(model.TrySet(false, 125.5d, "CubicInOut", out string? error), error);
+        Assert.True(model.TryCreateValue(out DesignPropertyValue? value, out error), error);
+        Assert.True(LayoutTransitionDesignValue.TryRead(
+            value,
+            out bool enabled,
+            out double duration,
+            out string easing,
+            out error), error);
+        Assert.False(enabled);
+        Assert.Equal(125.5d, duration);
+        Assert.Equal("CubicInOut", easing);
+
+        model.Reset();
+        Assert.True(model.TryCreateValue(out value, out error), error);
+        Assert.Null(value);
+        Assert.True(model.Enabled);
+        Assert.Equal(250d, model.DurationMilliseconds);
+        Assert.Equal("EaseOut", model.Easing);
+    }
+
+    [Fact]
+    public void VisualStateTransitionModelAddsEditsAndRemovesEntries()
+    {
+        var model = new DesignerVisualStateTransitionEditorModel(stored: null);
+
+        Assert.True(model.TryAddDefault(out int first, out string? error), error);
+        Assert.True(model.TryUpdate(first, "Hover", "Pressed", 80d, "EaseOut", out error), error);
+        Assert.True(model.TryAdd("Pressed", "Hover", 120d, "CubicOut", out error), error);
+        Assert.True(model.RemoveAt(first));
+        Assert.True(model.TryCreateValue(out DesignPropertyValue value, out error), error);
+        Assert.True(VisualStateTransitionDesignValue.TryRead(value, out var entries, out error), error);
+        DesignVisualStateTransition remaining = Assert.Single(entries);
+        Assert.Equal("Pressed", remaining.From);
+        Assert.Equal("Hover", remaining.To);
+    }
+
+    [Fact]
+    public void InvalidTransitionStateAndEasingReturnErrorsWithoutMutation()
+    {
+        var layout = new DesignerLayoutTransitionEditorModel(stored: null);
+        var visual = new DesignerVisualStateTransitionEditorModel(stored: null);
+
+        Assert.False(layout.TrySet(true, 100d, "ApplicationDelegate", out string? layoutError));
+        Assert.Contains("not supported", layoutError, StringComparison.OrdinalIgnoreCase);
+        Assert.False(visual.TryAdd("Unknown", "Hover", 100d, "Linear", out string? stateError));
+        Assert.Contains("supported visual states", stateError, StringComparison.OrdinalIgnoreCase);
+        Assert.False(visual.TryAdd("Normal", "Hover", 100d, "ApplicationDelegate", out string? easingError));
+        Assert.Contains("not supported", easingError, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(visual.Entries);
+    }
+
+    [Fact]
+    public void VisualStateTransitionRejectsDuplicateAndSameStatePairs()
+    {
+        var model = new DesignerVisualStateTransitionEditorModel(stored: null);
+
+        Assert.False(model.TryAdd("Hover", "Hover", 100d, "Linear", out string? sameStateError));
+        Assert.Contains("different", sameStateError, StringComparison.OrdinalIgnoreCase);
+        Assert.True(model.TryAdd("Normal", "Hover", 100d, "Linear", out string? error), error);
+        Assert.False(model.TryAdd("Normal", "Hover", 200d, "EaseOut", out string? duplicateError));
+        Assert.Contains("already configured", duplicateError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DialogsConstructWithStructuredControlsInsteadOfRawMultilineEditors()
+    {
+        var session = new DesignerSession();
+        var properties = new Dictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        using var effects = new DesignerInteractionEffectCollectionDialog(session, properties);
+        using var layout = new DesignerTransitionDialog(session, properties, isLayout: true);
+        using var visual = new DesignerTransitionDialog(session, properties, isLayout: false);
+
+        Assert.Contains(effects.Controls.Cast<Control>(), control => control is DesignerPropertyGrid);
+        Assert.DoesNotContain(effects.Controls.OfType<TextBox>(), editor => editor.MultiLine);
+        Assert.Contains(layout.Controls.OfType<CheckBox>(), checkBox => checkBox.Text.Contains("Animate", StringComparison.Ordinal));
+        Assert.Single(layout.Controls.OfType<NumericUpDown>());
+        DataGridView grid = Assert.Single(visual.Controls.OfType<DataGridView>());
+        Assert.Equal(4, grid.Columns.Count);
+        Assert.Single(visual.Controls.OfType<NumericUpDown>());
+    }
+
+    private static DesignerInteractionEffectCollectionEditorModel CreateEffectModel(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties)
+    {
+        properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? stored);
+        return new DesignerInteractionEffectCollectionEditorModel(
+            stored,
+            BuiltInAnimationDefinitionCatalog.Definitions);
+    }
+
+    private static Dictionary<string, DesignPropertyValue> StoredEffects(params string[] typeNames)
+    {
+        DesignPropertyValue[] effects = typeNames
+            .Select(typeName => DesignPropertyValue.FromStructuredObject(
+                typeName,
+                new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)))
+            .ToArray();
+        return new Dictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            [InteractionEffectDesignValue.PropertyName] = InteractionEffectDesignValue.Create(effects)
+        };
+    }
+}

--- a/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
@@ -112,7 +112,7 @@ public sealed class InteractionEffectDesignerTests
     }
 
     [Fact]
-    public void UnsupportedEffectTypeIsRejectedWithoutMutation()
+    public void UnavailableEffectTypeIsPreservedWithoutInstantiation()
     {
         DesignPropertyValue unsupported = DesignPropertyValue.FromStructuredObject(
             "Example.UnsafeEffect",
@@ -121,9 +121,11 @@ public sealed class InteractionEffectDesignerTests
 
         bool success = InteractionEffectDesignerRegistry.TryReadCollection(value, out var entries, out var error);
 
-        Assert.False(success);
-        Assert.Empty(entries);
-        Assert.Contains("not supported", error, StringComparison.OrdinalIgnoreCase);
+        Assert.True(success, error);
+        DesignerInteractionEffectEntry entry = Assert.Single(entries);
+        Assert.False(entry.IsSupported);
+        Assert.Equal("Example.UnsafeEffect", entry.TypeName);
+        Assert.Equal(value.ObjectProperties!["Item0"].ObjectTypeName, entry.ToDesignValue().ObjectTypeName);
     }
 
     [Fact]
@@ -150,6 +152,13 @@ public sealed class InteractionEffectDesignerTests
     {
         DesignDocument document = CreateDocument(
             InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName));
+        DesignerInteractionEffectEntry ripple = InteractionEffectDesignerRegistry.Create(
+            InteractionEffectDesignerRegistry.RippleTypeName);
+        Assert.True(InteractionEffectDesignerRegistry.TryApplyEditorText(
+            ripple,
+            "Enabled=false",
+            out var editError), editError);
+        document = CreateDocument(ripple);
         string code = new CSharpDesignerGenerator().Generate(document).Code;
         string[] unsupportedVariants =
         [
@@ -157,7 +166,7 @@ public sealed class InteractionEffectDesignerTests
                 "ModernFormsNext.Animations.RippleEffect",
                 "Example.RippleEffect",
                 StringComparison.Ordinal),
-            code.Replace("Enabled = true", "Unsupported = true", StringComparison.Ordinal)
+            code.Replace("Enabled = false", "Unsupported = true", StringComparison.Ordinal)
         ];
 
         foreach (string unsupportedCode in unsupportedVariants)

--- a/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/InteractionEffectDesignerTests.cs
@@ -49,11 +49,11 @@ public sealed class InteractionEffectDesignerTests
     {
         DesignerInteractionEffectEntry ripple =
             InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName);
-        string edited = InteractionEffectDesignerRegistry.FormatEditorText(ripple)
-            .Replace("DurationMilliseconds=450", "DurationMilliseconds=275", StringComparison.Ordinal)
-            .Replace("OverflowPolicy=RemoveOldest", "OverflowPolicy=IgnoreNew", StringComparison.Ordinal)
-            .Replace("ColorArgb=#5AFFFFFF", "ColorArgb=#7F102030", StringComparison.Ordinal);
-        Assert.True(InteractionEffectDesignerRegistry.TryApplyEditorText(ripple, edited, out var error), error);
+        Assert.True(SetEffectProperty(ripple, "DurationMilliseconds", DesignPropertyValue.FromDouble(275d), out var error), error);
+        Assert.True(SetEffectProperty(ripple, "OverflowPolicy", DesignPropertyValue.FromEnum(
+            "ModernFormsNext.Animations.RippleOverflowPolicy",
+            "IgnoreNew"), out error), error);
+        Assert.True(SetEffectProperty(ripple, "ColorArgb", DesignPropertyValue.FromInt32(unchecked((int)0x7F102030)), out error), error);
         DesignDocument document = CreateDocument(ripple);
 
         var generated = new CSharpDesignerGenerator().Generate(document);
@@ -154,10 +154,7 @@ public sealed class InteractionEffectDesignerTests
             InteractionEffectDesignerRegistry.Create(InteractionEffectDesignerRegistry.RippleTypeName));
         DesignerInteractionEffectEntry ripple = InteractionEffectDesignerRegistry.Create(
             InteractionEffectDesignerRegistry.RippleTypeName);
-        Assert.True(InteractionEffectDesignerRegistry.TryApplyEditorText(
-            ripple,
-            "Enabled=false",
-            out var editError), editError);
+        Assert.True(SetEffectProperty(ripple, "Enabled", DesignPropertyValue.FromBoolean(false), out var editError), editError);
         document = CreateDocument(ripple);
         string code = new CSharpDesignerGenerator().Generate(document).Code;
         string[] unsupportedVariants =
@@ -325,4 +322,15 @@ public sealed class InteractionEffectDesignerTests
 
     private static int CountOccurrences(string text, string value)
         => text.Split(value, StringSplitOptions.None).Length - 1;
+
+    private static bool SetEffectProperty(
+        DesignerInteractionEffectEntry entry,
+        string name,
+        DesignPropertyValue value,
+        out string? error)
+        => InteractionEffectDesignerRegistry.TrySetProperty(
+            entry,
+            entry.Descriptor!.Properties.Single(property => property.Name == name),
+            value,
+            out error);
 }

--- a/ModernFormsNext.Designer/ModernFormsDesignerShell.cs
+++ b/ModernFormsNext.Designer/ModernFormsDesignerShell.cs
@@ -57,7 +57,10 @@ public sealed class ModernFormsDesignerShell : Panel
         this.options = options ?? new ModernFormsDesignerOptions();
         Session = new DesignerSession(environment, this.options.InitialControlRenderMode);
 
-        var files = new DesignerFileService(environment, () => Session.CurrentDocumentPath);
+        var files = new DesignerFileService(
+            environment,
+            () => Session.CurrentDocumentPath,
+            () => Session.AnimationDefinitions);
         commands = new DesignerCommandService(Session, files, this.options);
 
         Style.BackgroundColor = DesignerColors.AppBackground;

--- a/ModernFormsNext.Designer/Properties/AssemblyInfo.cs
+++ b/ModernFormsNext.Designer/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ModernFormsNext.Designer.Tests")]
+[assembly: InternalsVisibleTo("ModernFormsNext.VisualStudioExtension")]

--- a/ModernFormsNext.Designer/Properties/DesignerInteractionEffectCollectionDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerInteractionEffectCollectionDialog.cs
@@ -7,15 +7,20 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
 {
     private readonly DesignerSession session;
     private readonly IDictionary<string, DesignPropertyValue> properties;
-    private readonly List<DesignerInteractionEffectEntry> entries;
-    private readonly IReadOnlyList<DesignAnimationDefinitionDescriptor> definitions;
+    private readonly DesignerInteractionEffectCollectionEditorModel model;
     private readonly ComboBox effectType;
     private readonly ListBox effectList;
-    private readonly TextBox propertyEditor;
+    private readonly DesignerPropertyGrid propertyGrid;
+    private readonly Label unavailableLabel;
     private readonly Label errorLabel;
-    private int loadedIndex = -1;
+    private readonly Button addButton;
+    private readonly Button removeButton;
+    private readonly Button upButton;
+    private readonly Button downButton;
+    private readonly Button applyButton;
+    private readonly Button okButton;
+    private DesignerInteractionEffectEntry? selectedEntry;
     private bool changingSelection;
-    private readonly string? loadError;
 
     public DesignerInteractionEffectCollectionDialog(
         DesignerSession session,
@@ -23,171 +28,215 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
     {
         this.session = session ?? throw new ArgumentNullException(nameof(session));
         this.properties = properties ?? throw new ArgumentNullException(nameof(properties));
-        definitions = BuiltInAnimationDefinitionCatalog.Definitions
+
+        IReadOnlyList<DesignAnimationDefinitionDescriptor> definitions = BuiltInAnimationDefinitionCatalog.Definitions
             .Concat(session.AnimationDefinitions)
             .Where(item => item.Kind == DesignAnimationDefinitionKind.InteractionEffect)
             .GroupBy(item => item.TypeName, StringComparer.Ordinal)
             .Select(group => group.First())
             .ToArray();
-
         properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? stored);
-        if (!InteractionEffectDesignerRegistry.TryReadCollection(stored, out entries, out string? error, definitions))
-        {
-            entries = [];
-            loadError = error ?? "The stored interaction-effect collection is malformed.";
-        }
+        model = new DesignerInteractionEffectCollectionEditorModel(stored, definitions);
 
         Text = "Interaction Effects Collection Editor";
         Name = "DesignerInteractionEffectCollectionDialog";
-        Size = new System.Drawing.Size(760, 520);
+        Size = new System.Drawing.Size(900, 580);
+        MinimumSize = new System.Drawing.Size(760, 500);
         StartPosition = FormStartPosition.CenterParent;
 
-        Controls.Add(new Label { Left = 18, Top = 16, Width = 240, Height = 22, Text = "Members (runtime order)" });
-        effectList = Controls.Add(new ListBox { Left = 18, Top = 42, Width = 250, Height = 330 });
-
-        effectType = Controls.Add(new ComboBox { Left = 18, Top = 382, Width = 164, Height = 30 });
-        effectType.Items.AddRange(definitions.Select(item => (object)item.DisplayName).ToArray());
-        effectType.SelectedIndex = definitions.Count > 0 ? 0 : -1;
-        var add = Controls.Add(new Button { Left = 190, Top = 382, Width = 78, Height = 30, Text = "Add" });
-        var remove = Controls.Add(new Button { Left = 18, Top = 418, Width = 78, Height = 30, Text = "Remove" });
-        var up = Controls.Add(new Button { Left = 104, Top = 418, Width = 48, Height = 30, Text = "Up" });
-        var down = Controls.Add(new Button { Left = 160, Top = 418, Width = 56, Height = 30, Text = "Down" });
-
-        Controls.Add(new Label { Left = 292, Top = 16, Width = 420, Height = 22, Text = "Selected effect properties (Property=Value)" });
-        propertyEditor = Controls.Add(new TextBox
-        {
-            Left = 292,
-            Top = 42,
-            Width = 430,
-            Height = 300,
-            MultiLine = true
-        });
         Controls.Add(new Label
         {
-            Left = 292,
-            Top = 350,
-            Width = 430,
-            Height = 42,
-            Text = "Enums use member names. Colors use #AARRGGBB. Durations are milliseconds."
+            Left = 18,
+            Top = 16,
+            Width = 260,
+            Height = 22,
+            Text = "Effects (runtime order)"
         });
-        errorLabel = Controls.Add(new Label { Left = 292, Top = 396, Width = 430, Height = 44, Text = string.Empty });
+        effectList = Controls.Add(new ListBox
+        {
+            Left = 18,
+            Top = 42,
+            Width = 260,
+            Height = 386,
+            Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left
+        });
 
-        var apply = Controls.Add(new Button { Left = 450, Top = 446, Width = 80, Height = 30, Text = "Apply" });
-        var ok = Controls.Add(new Button { Left = 546, Top = 446, Width = 80, Height = 30, Text = "OK" });
-        var cancel = Controls.Add(new Button { Left = 642, Top = 446, Width = 80, Height = 30, Text = "Cancel" });
+        effectType = Controls.Add(new ComboBox
+        {
+            Left = 18,
+            Top = 440,
+            Width = 164,
+            Height = 30,
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        });
+        effectType.Items.AddRange(model.Definitions.Select(item => (object)item.DisplayName).ToArray());
+        effectType.SelectedIndex = model.Definitions.Count > 0 ? 0 : -1;
+        addButton = Controls.Add(new Button
+        {
+            Left = 190,
+            Top = 440,
+            Width = 88,
+            Height = 30,
+            Text = "Add Effect",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        });
+        removeButton = Controls.Add(new Button
+        {
+            Left = 18,
+            Top = 478,
+            Width = 80,
+            Height = 30,
+            Text = "Remove",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        });
+        upButton = Controls.Add(new Button
+        {
+            Left = 106,
+            Top = 478,
+            Width = 76,
+            Height = 30,
+            Text = "Move Up",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        });
+        downButton = Controls.Add(new Button
+        {
+            Left = 190,
+            Top = 478,
+            Width = 88,
+            Height = 30,
+            Text = "Move Down",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        });
+
+        propertyGrid = Controls.Add(new DesignerPropertyGrid(
+            session,
+            () => selectedEntry?.ToString() ?? "No effect selected",
+            () => selectedEntry?.TypeName ?? string.Empty,
+            () => DesignerInteractionEffectPropertyDescriptors.Create(selectedEntry),
+            "Selected Effect Properties")
+        {
+            Left = 300,
+            Top = 16,
+            Width = 566,
+            Height = 430,
+            Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right
+        });
+        unavailableLabel = Controls.Add(new Label
+        {
+            Left = 318,
+            Top = 92,
+            Width = 520,
+            Height = 64,
+            Text = string.Empty,
+            Visible = false,
+            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
+        });
+        unavailableLabel.BringToFront();
+        errorLabel = Controls.Add(new Label
+        {
+            Left = 300,
+            Top = 454,
+            Width = 566,
+            Height = 38,
+            Text = string.Empty,
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right
+        });
+
+        applyButton = Controls.Add(new Button
+        {
+            Left = 594,
+            Top = 500,
+            Width = 80,
+            Height = 30,
+            Text = "Apply",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+        okButton = Controls.Add(new Button
+        {
+            Left = 690,
+            Top = 500,
+            Width = 80,
+            Height = 30,
+            Text = "OK",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+        var cancelButton = Controls.Add(new Button
+        {
+            Left = 786,
+            Top = 500,
+            Width = 80,
+            Height = 30,
+            Text = "Cancel",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
 
         effectList.SelectedIndexChanged += (_, _) => ChangeSelection();
-        add.Click += (_, _) => AddSelectedType();
-        remove.Click += (_, _) => RemoveSelected();
-        up.Click += (_, _) => MoveSelected(-1);
-        down.Click += (_, _) => MoveSelected(1);
-        apply.Click += (_, _) => TryApplyLoaded();
-        ok.Click += (_, _) => Commit();
-        cancel.Click += (_, _) => DialogResult = DialogResult.Cancel;
+        addButton.Click += (_, _) => AddSelectedType();
+        removeButton.Click += (_, _) => RemoveSelected();
+        upButton.Click += (_, _) => MoveSelected(-1);
+        downButton.Click += (_, _) => MoveSelected(1);
+        applyButton.Click += (_, _) => Apply();
+        okButton.Click += (_, _) => Commit();
+        cancelButton.Click += (_, _) => DialogResult = DialogResult.Cancel;
 
-        RefreshList(selectIndex: entries.Count > 0 ? 0 : -1);
-
-        if (loadError is not null)
-        {
-            errorLabel.Text = loadError;
-            effectList.Enabled = false;
-            effectType.Enabled = false;
-            propertyEditor.Enabled = false;
-            add.Enabled = false;
-            remove.Enabled = false;
-            up.Enabled = false;
-            down.Enabled = false;
-            apply.Enabled = false;
-            ok.Enabled = false;
-            session.Log($"Interaction effect editor: {loadError}");
-        }
-
+        RefreshList(model.Entries.Count > 0 ? 0 : -1);
+        if (model.LoadError is not null)
+            DisableForLoadError(model.LoadError);
     }
 
     private void AddSelectedType()
     {
-        if (!TryApplyLoaded())
+        int definitionIndex = effectType.SelectedIndex;
+        if (definitionIndex < 0 || definitionIndex >= model.Definitions.Count)
             return;
-        int index = effectType.SelectedIndex;
-        if (index < 0 || index >= definitions.Count)
-            return;
-        entries.Add(InteractionEffectDesignerRegistry.Create(definitions[index].TypeName, definitions));
-        RefreshList(entries.Count - 1);
+        model.Add(model.Definitions[definitionIndex].TypeName);
+        RefreshList(model.Entries.Count - 1);
     }
 
     private void RemoveSelected()
     {
         int index = effectList.SelectedIndex;
-        if (index < 0 || index >= entries.Count)
+        if (!model.RemoveAt(index))
             return;
-        entries.RemoveAt(index);
-        loadedIndex = -1;
-        RefreshList(Math.Min(index, entries.Count - 1));
+        RefreshList(Math.Min(index, model.Entries.Count - 1));
     }
 
     private void MoveSelected(int delta)
     {
-        if (!TryApplyLoaded())
-            return;
         int oldIndex = effectList.SelectedIndex;
-        int newIndex = oldIndex + delta;
-        if (oldIndex < 0 || newIndex < 0 || newIndex >= entries.Count)
+        if (!model.Move(oldIndex, delta))
             return;
-        DesignerInteractionEffectEntry entry = entries[oldIndex];
-        entries.RemoveAt(oldIndex);
-        entries.Insert(newIndex, entry);
-        loadedIndex = -1;
-        RefreshList(newIndex);
+        RefreshList(oldIndex + delta);
     }
 
     private void ChangeSelection()
     {
         if (changingSelection)
             return;
-        int selected = effectList.SelectedIndex;
-        if (selected == loadedIndex)
-            return;
-        if (!TryApplyLoaded())
-        {
-            changingSelection = true;
-            effectList.SelectedIndex = loadedIndex;
-            changingSelection = false;
-            return;
-        }
-        loadedIndex = selected;
-        propertyEditor.Text = selected >= 0 && selected < entries.Count
-            ? InteractionEffectDesignerRegistry.FormatEditorText(entries[selected])
+
+        int index = effectList.SelectedIndex;
+        selectedEntry = index >= 0 && index < model.Entries.Count ? model.Entries[index] : null;
+        bool unavailable = selectedEntry is { IsSupported: false };
+        unavailableLabel.Visible = unavailable;
+        unavailableLabel.Text = unavailable
+            ? $"{selectedEntry} cannot be inspected because its detached source descriptor is unavailable. "
+                + "The serialized definition will be preserved unless you remove it."
             : string.Empty;
-        propertyEditor.Enabled = selected >= 0 && selected < entries.Count && entries[selected].IsSupported;
-        errorLabel.Text = string.Empty;
+        propertyGrid.Enabled = selectedEntry is { IsSupported: true };
+        propertyGrid.RefreshProperties();
+        UpdateButtonState();
     }
 
-    private bool TryApplyLoaded()
+    private void Apply()
     {
-        if (loadedIndex < 0 || loadedIndex >= entries.Count)
-            return true;
-        if (InteractionEffectDesignerRegistry.TryApplyEditorText(
-            entries[loadedIndex],
-            propertyEditor.Text,
-            out string? error))
-        {
-            errorLabel.Text = string.Empty;
-            return true;
-        }
-        ShowError(error ?? "The selected effect properties are invalid.");
-        return false;
+        model.Apply(properties);
+        session.NotifyDocumentChanged();
+        errorLabel.Text = "Changes applied.";
     }
 
     private void Commit()
     {
-        if (!TryApplyLoaded())
-            return;
-
-        if (entries.Count == 0)
-            properties.Remove(InteractionEffectDesignValue.PropertyName);
-        else
-            properties[InteractionEffectDesignValue.PropertyName] =
-                InteractionEffectDesignerRegistry.WriteCollection(entries);
+        model.Apply(properties);
         DialogResult = DialogResult.OK;
     }
 
@@ -195,17 +244,37 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
     {
         changingSelection = true;
         effectList.Items.Clear();
-        foreach (DesignerInteractionEffectEntry entry in entries)
+        foreach (DesignerInteractionEffectEntry entry in model.Entries)
             effectList.Items.Add(entry);
-        effectList.SelectedIndex = entries.Count == 0 ? -1 : Math.Clamp(selectIndex, 0, entries.Count - 1);
+        effectList.SelectedIndex = model.Entries.Count == 0
+            ? -1
+            : Math.Clamp(selectIndex, 0, model.Entries.Count - 1);
         changingSelection = false;
-        loadedIndex = -1;
         ChangeSelection();
     }
 
-    private void ShowError(string message)
+    private void UpdateButtonState()
     {
-        errorLabel.Text = message;
-        session.Log($"Interaction effect editor: {message}");
+        int index = effectList.SelectedIndex;
+        bool selected = index >= 0 && index < model.Entries.Count;
+        removeButton.Enabled = selected;
+        upButton.Enabled = selected && index > 0;
+        downButton.Enabled = selected && index < model.Entries.Count - 1;
+        addButton.Enabled = effectType.SelectedIndex >= 0;
+    }
+
+    private void DisableForLoadError(string error)
+    {
+        errorLabel.Text = error;
+        effectList.Enabled = false;
+        effectType.Enabled = false;
+        propertyGrid.Enabled = false;
+        addButton.Enabled = false;
+        removeButton.Enabled = false;
+        upButton.Enabled = false;
+        downButton.Enabled = false;
+        applyButton.Enabled = false;
+        okButton.Enabled = false;
+        session.Log($"Interaction effect editor: {error}");
     }
 }

--- a/ModernFormsNext.Designer/Properties/DesignerInteractionEffectCollectionDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerInteractionEffectCollectionDialog.cs
@@ -6,22 +6,36 @@ namespace ModernFormsNext.Designer.Properties;
 internal sealed class DesignerInteractionEffectCollectionDialog : Form
 {
     private readonly DesignerSession session;
-    private readonly DesignControlNode control;
+    private readonly IDictionary<string, DesignPropertyValue> properties;
     private readonly List<DesignerInteractionEffectEntry> entries;
+    private readonly IReadOnlyList<DesignAnimationDefinitionDescriptor> definitions;
+    private readonly ComboBox effectType;
     private readonly ListBox effectList;
     private readonly TextBox propertyEditor;
     private readonly Label errorLabel;
     private int loadedIndex = -1;
     private bool changingSelection;
+    private readonly string? loadError;
 
-    public DesignerInteractionEffectCollectionDialog(DesignerSession session, DesignControlNode control)
+    public DesignerInteractionEffectCollectionDialog(
+        DesignerSession session,
+        IDictionary<string, DesignPropertyValue> properties)
     {
         this.session = session ?? throw new ArgumentNullException(nameof(session));
-        this.control = control ?? throw new ArgumentNullException(nameof(control));
+        this.properties = properties ?? throw new ArgumentNullException(nameof(properties));
+        definitions = BuiltInAnimationDefinitionCatalog.Definitions
+            .Concat(session.AnimationDefinitions)
+            .Where(item => item.Kind == DesignAnimationDefinitionKind.InteractionEffect)
+            .GroupBy(item => item.TypeName, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .ToArray();
 
-        control.Properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? stored);
-        if (!InteractionEffectDesignerRegistry.TryReadCollection(stored, out entries, out string? error))
-            throw new InvalidOperationException(error);
+        properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? stored);
+        if (!InteractionEffectDesignerRegistry.TryReadCollection(stored, out entries, out string? error, definitions))
+        {
+            entries = [];
+            loadError = error ?? "The stored interaction-effect collection is malformed.";
+        }
 
         Text = "Interaction Effects Collection Editor";
         Name = "DesignerInteractionEffectCollectionDialog";
@@ -31,8 +45,10 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
         Controls.Add(new Label { Left = 18, Top = 16, Width = 240, Height = 22, Text = "Members (runtime order)" });
         effectList = Controls.Add(new ListBox { Left = 18, Top = 42, Width = 250, Height = 330 });
 
-        var addRipple = Controls.Add(new Button { Left = 18, Top = 382, Width = 116, Height = 30, Text = "Add Ripple" });
-        var addPress = Controls.Add(new Button { Left = 142, Top = 382, Width = 126, Height = 30, Text = "Add PressScale" });
+        effectType = Controls.Add(new ComboBox { Left = 18, Top = 382, Width = 164, Height = 30 });
+        effectType.Items.AddRange(definitions.Select(item => (object)item.DisplayName).ToArray());
+        effectType.SelectedIndex = definitions.Count > 0 ? 0 : -1;
+        var add = Controls.Add(new Button { Left = 190, Top = 382, Width = 78, Height = 30, Text = "Add" });
         var remove = Controls.Add(new Button { Left = 18, Top = 418, Width = 78, Height = 30, Text = "Remove" });
         var up = Controls.Add(new Button { Left = 104, Top = 418, Width = 48, Height = 30, Text = "Up" });
         var down = Controls.Add(new Button { Left = 160, Top = 418, Width = 56, Height = 30, Text = "Down" });
@@ -61,8 +77,7 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
         var cancel = Controls.Add(new Button { Left = 642, Top = 446, Width = 80, Height = 30, Text = "Cancel" });
 
         effectList.SelectedIndexChanged += (_, _) => ChangeSelection();
-        addRipple.Click += (_, _) => Add(InteractionEffectDesignerRegistry.RippleTypeName);
-        addPress.Click += (_, _) => Add(InteractionEffectDesignerRegistry.PressScaleTypeName);
+        add.Click += (_, _) => AddSelectedType();
         remove.Click += (_, _) => RemoveSelected();
         up.Click += (_, _) => MoveSelected(-1);
         down.Click += (_, _) => MoveSelected(1);
@@ -71,13 +86,32 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
         cancel.Click += (_, _) => DialogResult = DialogResult.Cancel;
 
         RefreshList(selectIndex: entries.Count > 0 ? 0 : -1);
+
+        if (loadError is not null)
+        {
+            errorLabel.Text = loadError;
+            effectList.Enabled = false;
+            effectType.Enabled = false;
+            propertyEditor.Enabled = false;
+            add.Enabled = false;
+            remove.Enabled = false;
+            up.Enabled = false;
+            down.Enabled = false;
+            apply.Enabled = false;
+            ok.Enabled = false;
+            session.Log($"Interaction effect editor: {loadError}");
+        }
+
     }
 
-    private void Add(string typeName)
+    private void AddSelectedType()
     {
         if (!TryApplyLoaded())
             return;
-        entries.Add(InteractionEffectDesignerRegistry.Create(typeName));
+        int index = effectType.SelectedIndex;
+        if (index < 0 || index >= definitions.Count)
+            return;
+        entries.Add(InteractionEffectDesignerRegistry.Create(definitions[index].TypeName, definitions));
         RefreshList(entries.Count - 1);
     }
 
@@ -124,6 +158,7 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
         propertyEditor.Text = selected >= 0 && selected < entries.Count
             ? InteractionEffectDesignerRegistry.FormatEditorText(entries[selected])
             : string.Empty;
+        propertyEditor.Enabled = selected >= 0 && selected < entries.Count && entries[selected].IsSupported;
         errorLabel.Text = string.Empty;
     }
 
@@ -149,9 +184,9 @@ internal sealed class DesignerInteractionEffectCollectionDialog : Form
             return;
 
         if (entries.Count == 0)
-            control.Properties.Remove(InteractionEffectDesignValue.PropertyName);
+            properties.Remove(InteractionEffectDesignValue.PropertyName);
         else
-            control.Properties[InteractionEffectDesignValue.PropertyName] =
+            properties[InteractionEffectDesignValue.PropertyName] =
                 InteractionEffectDesignerRegistry.WriteCollection(entries);
         DialogResult = DialogResult.OK;
     }

--- a/ModernFormsNext.Designer/Properties/DesignerInteractionEffectModel.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerInteractionEffectModel.cs
@@ -27,7 +27,7 @@ internal sealed class DesignerInteractionEffectEntry
         => DesignPropertyValue.FromStructuredObject(TypeName, Properties);
 
     public override string ToString()
-        => Descriptor?.DisplayName ?? $"{TypeName.Split('.').Last()} (unavailable)";
+        => Descriptor?.DisplayName ?? $"{TypeName.Split('.').Last()} (Unavailable)";
 
     private static SortedDictionary<string, DesignPropertyValue> Copy(
         IReadOnlyDictionary<string, DesignPropertyValue> properties)
@@ -94,65 +94,54 @@ internal static class InteractionEffectDesignerRegistry
         return InteractionEffectDesignValue.Create(entries.Select(entry => entry.ToDesignValue()));
     }
 
-    public static string FormatEditorText(DesignerInteractionEffectEntry entry)
+    public static DesignPropertyValue GetEffectiveValue(
+        DesignerInteractionEffectEntry entry,
+        DesignAnimationPropertyDescriptor definition)
     {
-        if (entry.Descriptor is null)
-            return "This effect type is unavailable. Its serialized definition is preserved.";
-
-        return string.Join(
-            Environment.NewLine,
-            entry.Descriptor.Properties.Select(definition =>
-                $"{definition.Name}={Format(definition, GetEffective(entry, definition))}"));
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(definition);
+        return GetEffective(entry, definition);
     }
 
-    public static bool TryApplyEditorText(
+    public static bool TrySetProperty(
         DesignerInteractionEffectEntry entry,
-        string text,
+        DesignAnimationPropertyDescriptor definition,
+        DesignPropertyValue value,
         out string? error)
     {
-        if (entry.Descriptor is null)
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (entry.Descriptor is null
+            || !entry.Descriptor.Properties.Any(item => ReferenceEquals(item, definition)))
         {
+            error = "The effect property descriptor is unavailable.";
+            return false;
+        }
+
+        try
+        {
+            if (!TryParse(definition, Format(definition, value), out DesignPropertyValue normalized, out error))
+                return false;
+
+            var properties = new SortedDictionary<string, DesignPropertyValue>(entry.Properties, StringComparer.Ordinal);
+            if (Equivalent(normalized, definition.DefaultValue))
+                properties.Remove(definition.Name);
+            else
+                properties[definition.Name] = normalized;
+            entry.ReplaceProperties(properties);
             error = null;
             return true;
         }
-
-        var byName = entry.Descriptor.Properties.ToDictionary(item => item.Name, StringComparer.Ordinal);
-        var parsed = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (string rawLine in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
+        catch (Exception exception) when (exception is InvalidCastException
+            or InvalidOperationException
+            or FormatException
+            or OverflowException)
         {
-            string line = rawLine.Trim();
-            if (line.Length == 0)
-                continue;
-            int separator = line.IndexOf('=');
-            if (separator <= 0)
-            {
-                error = $"'{line}' must use Property=Value syntax.";
-                return false;
-            }
-            string name = line[..separator].Trim();
-            string input = line[(separator + 1)..].Trim();
-            if (!byName.TryGetValue(name, out DesignAnimationPropertyDescriptor? definition))
-            {
-                error = $"Property '{name}' is not supported for {entry}.";
-                return false;
-            }
-            if (!seen.Add(name))
-            {
-                error = $"Property '{name}' is duplicated.";
-                return false;
-            }
-            if (!TryParse(definition, input, out DesignPropertyValue value, out error))
-                return false;
-            if (!Equivalent(value, definition.DefaultValue))
-                parsed[name] = value;
+            error = $"Value for {definition.Name} is invalid: {exception.Message}";
+            return false;
         }
-
-        // Missing lines mean reset-to-default, which keeps documents and generated code compact.
-        entry.ReplaceProperties(parsed);
-        error = null;
-        return true;
     }
 
     private static bool TryNormalizeProperties(
@@ -282,4 +271,74 @@ internal static class InteractionEffectDesignerRegistry
         => left.Kind == right.Kind
         && Equals(left.Value, right.Value)
         && string.Equals(left.EnumTypeName, right.EnumTypeName, StringComparison.Ordinal);
+}
+
+internal sealed class DesignerInteractionEffectCollectionEditorModel
+{
+    private readonly List<DesignerInteractionEffectEntry> entries;
+    private readonly IReadOnlyList<DesignAnimationDefinitionDescriptor> definitions;
+
+    public DesignerInteractionEffectCollectionEditorModel(
+        DesignPropertyValue? stored,
+        IEnumerable<DesignAnimationDefinitionDescriptor> definitions)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+        this.definitions = definitions
+            .Where(item => item.Kind == DesignAnimationDefinitionKind.InteractionEffect)
+            .GroupBy(item => item.TypeName, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .ToArray();
+
+        if (!InteractionEffectDesignerRegistry.TryReadCollection(
+            stored,
+            out entries,
+            out string? error,
+            this.definitions))
+        {
+            entries = [];
+            LoadError = error ?? "The stored interaction-effect collection is malformed.";
+        }
+    }
+
+    public IReadOnlyList<DesignerInteractionEffectEntry> Entries => entries;
+
+    public IReadOnlyList<DesignAnimationDefinitionDescriptor> Definitions => definitions;
+
+    public string? LoadError { get; }
+
+    public DesignerInteractionEffectEntry Add(string typeName)
+    {
+        DesignerInteractionEffectEntry entry = InteractionEffectDesignerRegistry.Create(typeName, definitions);
+        entries.Add(entry);
+        return entry;
+    }
+
+    public bool RemoveAt(int index)
+    {
+        if (index < 0 || index >= entries.Count)
+            return false;
+        entries.RemoveAt(index);
+        return true;
+    }
+
+    public bool Move(int index, int delta)
+    {
+        int target = index + delta;
+        if (index < 0 || index >= entries.Count || target < 0 || target >= entries.Count)
+            return false;
+        DesignerInteractionEffectEntry entry = entries[index];
+        entries.RemoveAt(index);
+        entries.Insert(target, entry);
+        return true;
+    }
+
+    public void Apply(IDictionary<string, DesignPropertyValue> properties)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+        if (entries.Count == 0)
+            properties.Remove(InteractionEffectDesignValue.PropertyName);
+        else
+            properties[InteractionEffectDesignValue.PropertyName] =
+                InteractionEffectDesignerRegistry.WriteCollection(entries);
+    }
 }

--- a/ModernFormsNext.Designer/Properties/DesignerInteractionEffectModel.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerInteractionEffectModel.cs
@@ -7,89 +7,57 @@ internal sealed class DesignerInteractionEffectEntry
 {
     public DesignerInteractionEffectEntry(
         string typeName,
-        IReadOnlyDictionary<string, DesignPropertyValue> properties)
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        DesignAnimationDefinitionDescriptor? descriptor = null)
     {
         TypeName = typeName;
-        Properties = new SortedDictionary<string, DesignPropertyValue>(
-            properties.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal),
-            StringComparer.Ordinal);
+        Descriptor = descriptor;
+        Properties = Copy(properties);
     }
 
     public string TypeName { get; }
-
+    public DesignAnimationDefinitionDescriptor? Descriptor { get; }
+    public bool IsSupported => Descriptor is not null;
     public SortedDictionary<string, DesignPropertyValue> Properties { get; private set; }
 
     public void ReplaceProperties(IReadOnlyDictionary<string, DesignPropertyValue> properties)
-        => Properties = new SortedDictionary<string, DesignPropertyValue>(
-            properties.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal),
-            StringComparer.Ordinal);
+        => Properties = Copy(properties);
 
     public DesignPropertyValue ToDesignValue()
         => DesignPropertyValue.FromStructuredObject(TypeName, Properties);
 
     public override string ToString()
-        => TypeName.Split('.').Last();
+        => Descriptor?.DisplayName ?? $"{TypeName.Split('.').Last()} (unavailable)";
+
+    private static SortedDictionary<string, DesignPropertyValue> Copy(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties)
+        => new(
+            properties.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal),
+            StringComparer.Ordinal);
 }
 
 internal static class InteractionEffectDesignerRegistry
 {
-    internal const string RippleTypeName = "ModernFormsNext.Animations.RippleEffect";
-    internal const string PressScaleTypeName = "ModernFormsNext.Animations.PressScaleEffect";
-
-    private static readonly EffectPropertyDefinition[] RippleProperties =
-    [
-        EffectPropertyDefinition.Boolean("Enabled", true),
-        EffectPropertyDefinition.ColorArgb("ColorArgb", unchecked((int)0x5AFFFFFF)),
-        EffectPropertyDefinition.Number("DurationMilliseconds", 450d, 0d, double.MaxValue),
-        EffectPropertyDefinition.Boolean("StartFromPointer", true),
-        EffectPropertyDefinition.Enum(
-            "RadiusMode",
-            "ModernFormsNext.Animations.RippleRadiusMode",
-            "CoverControl",
-            "CoverControl",
-            "Fixed"),
-        EffectPropertyDefinition.Number("FixedRadius", 48d, 0d, float.MaxValue),
-        EffectPropertyDefinition.Enum(
-            "Layer",
-            "ModernFormsNext.Animations.RippleLayer",
-            "AboveBackgroundBelowContent",
-            "AboveBackgroundBelowContent",
-            "AboveContent"),
-        EffectPropertyDefinition.Integer("MaxConcurrentRipples", 4, 1, 32),
-        EffectPropertyDefinition.Enum(
-            "OverflowPolicy",
-            "ModernFormsNext.Animations.RippleOverflowPolicy",
-            "RemoveOldest",
-            "RemoveOldest",
-            "RemoveNewest",
-            "IgnoreNew",
-            "ReplaceAll")
-    ];
-
-    private static readonly EffectPropertyDefinition[] PressScaleProperties =
-    [
-        EffectPropertyDefinition.Boolean("Enabled", true),
-        EffectPropertyDefinition.Number("PressedScale", 0.97d, double.Epsilon, float.MaxValue),
-        EffectPropertyDefinition.Number("PressDurationMilliseconds", 80d, 0d, double.MaxValue),
-        EffectPropertyDefinition.Number("ReleaseDurationMilliseconds", 120d, 0d, double.MaxValue)
-    ];
+    internal const string RippleTypeName = BuiltInAnimationDefinitionCatalog.RippleEffectTypeName;
+    internal const string PressScaleTypeName = BuiltInAnimationDefinitionCatalog.PressScaleEffectTypeName;
 
     public static IReadOnlyList<string> SupportedTypeNames { get; } =
-        [RippleTypeName, PressScaleTypeName];
+        BuiltInAnimationDefinitionCatalog.Definitions.Select(item => item.TypeName).ToArray();
 
-    public static DesignerInteractionEffectEntry Create(string typeName)
+    public static DesignerInteractionEffectEntry Create(
+        string typeName,
+        IEnumerable<DesignAnimationDefinitionDescriptor>? definitions = null)
     {
-        EffectPropertyDefinition[] definitions = GetDefinitions(typeName)
+        DesignAnimationDefinitionDescriptor descriptor = Find(typeName, definitions)
             ?? throw new NotSupportedException($"Interaction effect type '{typeName}' is not supported by the Designer.");
-        return new DesignerInteractionEffectEntry(
-            typeName,
-            definitions.ToDictionary(item => item.Name, item => item.DefaultValue, StringComparer.Ordinal));
+        return new DesignerInteractionEffectEntry(descriptor.TypeName, new Dictionary<string, DesignPropertyValue>(), descriptor);
     }
 
     public static bool TryReadCollection(
         DesignPropertyValue? value,
         out List<DesignerInteractionEffectEntry> entries,
-        out string? error)
+        out string? error,
+        IEnumerable<DesignAnimationDefinitionDescriptor>? definitions = null)
     {
         entries = [];
         if (!InteractionEffectDesignValue.TryRead(value, out IReadOnlyList<DesignPropertyValue> effects, out error))
@@ -98,19 +66,24 @@ internal static class InteractionEffectDesignerRegistry
         foreach (DesignPropertyValue effect in effects)
         {
             string typeName = NormalizeTypeName(effect.ObjectTypeName);
-            EffectPropertyDefinition[]? definitions = GetDefinitions(typeName);
-            if (definitions is null)
+            DesignAnimationDefinitionDescriptor? descriptor = Find(typeName, definitions);
+            if (descriptor is null)
             {
-                error = $"Interaction effect type '{effect.ObjectTypeName}' is not supported by the Designer.";
-                entries.Clear();
-                return false;
+                // Preserve unavailable project types so a missing/renamed source file never destroys
+                // an existing design value. The collection editor still permits remove and reorder.
+                entries.Add(new DesignerInteractionEffectEntry(typeName, effect.ObjectProperties!));
+                continue;
             }
-            if (!TryNormalizeProperties(definitions, effect.ObjectProperties!, out var properties, out error))
+
+            if (!TryNormalizeProperties(descriptor, effect.ObjectProperties!, out var properties, out error))
             {
-                entries.Clear();
-                return false;
+                // A descriptor may have changed after a project refactor. Preserve the exact
+                // detached value as unavailable instead of crashing or silently deleting it.
+                entries.Add(new DesignerInteractionEffectEntry(typeName, effect.ObjectProperties!));
+                error = null;
+                continue;
             }
-            entries.Add(new DesignerInteractionEffectEntry(typeName, properties));
+            entries.Add(new DesignerInteractionEffectEntry(descriptor.TypeName, properties, descriptor));
         }
         return true;
     }
@@ -123,11 +96,13 @@ internal static class InteractionEffectDesignerRegistry
 
     public static string FormatEditorText(DesignerInteractionEffectEntry entry)
     {
-        EffectPropertyDefinition[] definitions = GetDefinitions(entry.TypeName)!;
+        if (entry.Descriptor is null)
+            return "This effect type is unavailable. Its serialized definition is preserved.";
+
         return string.Join(
             Environment.NewLine,
-            definitions.Select(definition =>
-                $"{definition.Name}={definition.Format(entry.Properties[definition.Name])}"));
+            entry.Descriptor.Properties.Select(definition =>
+                $"{definition.Name}={Format(definition, GetEffective(entry, definition))}"));
     }
 
     public static bool TryApplyEditorText(
@@ -135,9 +110,14 @@ internal static class InteractionEffectDesignerRegistry
         string text,
         out string? error)
     {
-        EffectPropertyDefinition[] definitions = GetDefinitions(entry.TypeName)!;
-        var byName = definitions.ToDictionary(item => item.Name, StringComparer.Ordinal);
-        var parsed = definitions.ToDictionary(item => item.Name, item => item.DefaultValue, StringComparer.Ordinal);
+        if (entry.Descriptor is null)
+        {
+            error = null;
+            return true;
+        }
+
+        var byName = entry.Descriptor.Properties.ToDictionary(item => item.Name, StringComparer.Ordinal);
+        var parsed = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (string rawLine in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
@@ -152,8 +132,8 @@ internal static class InteractionEffectDesignerRegistry
                 return false;
             }
             string name = line[..separator].Trim();
-            string value = line[(separator + 1)..].Trim();
-            if (!byName.TryGetValue(name, out EffectPropertyDefinition? definition))
+            string input = line[(separator + 1)..].Trim();
+            if (!byName.TryGetValue(name, out DesignAnimationPropertyDescriptor? definition))
             {
                 error = $"Property '{name}' is not supported for {entry}.";
                 return false;
@@ -163,50 +143,73 @@ internal static class InteractionEffectDesignerRegistry
                 error = $"Property '{name}' is duplicated.";
                 return false;
             }
-            if (!definition.TryParse(value, out DesignPropertyValue parsedValue, out error))
+            if (!TryParse(definition, input, out DesignPropertyValue value, out error))
                 return false;
-            parsed[name] = parsedValue;
+            if (!Equivalent(value, definition.DefaultValue))
+                parsed[name] = value;
         }
 
+        // Missing lines mean reset-to-default, which keeps documents and generated code compact.
         entry.ReplaceProperties(parsed);
         error = null;
         return true;
     }
 
     private static bool TryNormalizeProperties(
-        EffectPropertyDefinition[] definitions,
+        DesignAnimationDefinitionDescriptor descriptor,
         IReadOnlyDictionary<string, DesignPropertyValue> source,
         out IReadOnlyDictionary<string, DesignPropertyValue> normalized,
         out string? error)
     {
-        var supported = definitions.ToDictionary(item => item.Name, StringComparer.Ordinal);
-        foreach (string name in source.Keys)
+        try
         {
-            if (!supported.ContainsKey(name))
+            var supported = descriptor.Properties.ToDictionary(item => item.Name, StringComparer.Ordinal);
+            var result = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+            foreach ((string name, DesignPropertyValue stored) in source)
             {
-                normalized = new Dictionary<string, DesignPropertyValue>();
-                error = $"Property '{name}' is not supported for this interaction effect.";
-                return false;
+                if (!supported.TryGetValue(name, out var definition))
+                {
+                    normalized = new Dictionary<string, DesignPropertyValue>();
+                    error = $"Property '{name}' is not supported for {descriptor.DisplayName}.";
+                    return false;
+                }
+                if (!TryParse(definition, Format(definition, stored), out var value, out error))
+                {
+                    normalized = new Dictionary<string, DesignPropertyValue>();
+                    return false;
+                }
+                if (!Equivalent(value, definition.DefaultValue))
+                    result[name] = value;
             }
+            normalized = result;
+            error = null;
+            return true;
         }
-
-        var result = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
-        foreach (EffectPropertyDefinition definition in definitions)
+        catch (Exception exception) when (exception is InvalidCastException
+            or InvalidOperationException
+            or FormatException
+            or OverflowException)
         {
-            DesignPropertyValue value = source.TryGetValue(definition.Name, out DesignPropertyValue? stored)
-                ? stored
-                : definition.DefaultValue;
-            if (!definition.TryParse(definition.Format(value), out DesignPropertyValue normalizedValue, out error))
-            {
-                normalized = new Dictionary<string, DesignPropertyValue>();
-                return false;
-            }
-            result[definition.Name] = normalizedValue;
+            normalized = new Dictionary<string, DesignPropertyValue>();
+            error = $"The stored definition for {descriptor.DisplayName} is invalid: {exception.Message}";
+            return false;
         }
+    }
 
-        normalized = result;
-        error = null;
-        return true;
+    private static DesignPropertyValue GetEffective(
+        DesignerInteractionEffectEntry entry,
+        DesignAnimationPropertyDescriptor definition)
+        => entry.Properties.TryGetValue(definition.Name, out var value) ? value : definition.DefaultValue;
+
+    private static DesignAnimationDefinitionDescriptor? Find(
+        string typeName,
+        IEnumerable<DesignAnimationDefinitionDescriptor>? definitions)
+    {
+        string normalized = NormalizeTypeName(typeName);
+        return BuiltInAnimationDefinitionCatalog.Definitions
+            .Concat(definitions ?? [])
+            .FirstOrDefault(item => item.Kind == DesignAnimationDefinitionKind.InteractionEffect
+                && string.Equals(NormalizeTypeName(item.TypeName), normalized, StringComparison.Ordinal));
     }
 
     private static string NormalizeTypeName(string? typeName)
@@ -214,143 +217,69 @@ internal static class InteractionEffectDesignerRegistry
         {
             "RippleEffect" => RippleTypeName,
             "PressScaleEffect" => PressScaleTypeName,
-            _ => typeName ?? string.Empty
+            _ => (typeName ?? string.Empty).Replace("global::", string.Empty, StringComparison.Ordinal).Trim()
         };
 
-    private static EffectPropertyDefinition[]? GetDefinitions(string typeName)
-        => NormalizeTypeName(typeName) switch
+    private static string Format(DesignAnimationPropertyDescriptor definition, DesignPropertyValue value)
+        => definition.Kind switch
         {
-            RippleTypeName => RippleProperties,
-            PressScaleTypeName => PressScaleProperties,
-            _ => null
+            DesignAnimationPropertyKind.Boolean => value.Value is bool boolValue && boolValue ? "true" : "false",
+            DesignAnimationPropertyKind.Int32 => Convert.ToInt32(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+            DesignAnimationPropertyKind.Number or DesignAnimationPropertyKind.TimeSpan => Convert.ToDouble(value.Value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
+            DesignAnimationPropertyKind.Easing or DesignAnimationPropertyKind.String or DesignAnimationPropertyKind.Enum => value.GetString(),
+            DesignAnimationPropertyKind.ColorArgb => $"#{unchecked((uint)Convert.ToInt32(value.Value, CultureInfo.InvariantCulture)):X8}",
+            _ => throw new ArgumentOutOfRangeException()
         };
 
-    private enum EffectPropertyKind
+    private static bool TryParse(
+        DesignAnimationPropertyDescriptor definition,
+        string text,
+        out DesignPropertyValue value,
+        out string? error)
     {
-        Boolean,
-        Integer,
-        Number,
-        Enum,
-        ColorArgb
-    }
-
-    private sealed class EffectPropertyDefinition
-    {
-        private EffectPropertyDefinition(
-            string name,
-            EffectPropertyKind kind,
-            DesignPropertyValue defaultValue,
-            double minimum = double.MinValue,
-            double maximum = double.MaxValue,
-            string? enumTypeName = null,
-            string[]? enumMembers = null)
+        switch (definition.Kind)
         {
-            Name = name;
-            Kind = kind;
-            DefaultValue = defaultValue;
-            Minimum = minimum;
-            Maximum = maximum;
-            EnumTypeName = enumTypeName;
-            EnumMembers = enumMembers ?? [];
+            case DesignAnimationPropertyKind.Boolean when bool.TryParse(text, out bool boolValue):
+                value = DesignPropertyValue.FromBoolean(boolValue);
+                error = null;
+                return true;
+            case DesignAnimationPropertyKind.Int32 when int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int intValue)
+                && intValue >= definition.Minimum && intValue <= definition.Maximum:
+                value = DesignPropertyValue.FromInt32(intValue);
+                error = null;
+                return true;
+            case DesignAnimationPropertyKind.Number or DesignAnimationPropertyKind.TimeSpan
+                when double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double number)
+                && double.IsFinite(number) && number >= definition.Minimum && number <= definition.Maximum:
+                value = DesignPropertyValue.FromDouble(number);
+                error = null;
+                return true;
+            case DesignAnimationPropertyKind.Easing when KnownEasingDesignValue.IsKnown(text):
+                value = DesignPropertyValue.FromString(text);
+                error = null;
+                return true;
+            case DesignAnimationPropertyKind.String:
+                value = DesignPropertyValue.FromString(text);
+                error = null;
+                return true;
+            case DesignAnimationPropertyKind.Enum when definition.EnumMembers.Contains(text, StringComparer.Ordinal):
+                value = DesignPropertyValue.FromEnum(definition.EnumTypeName!, text);
+                error = null;
+                return true;
+            case DesignAnimationPropertyKind.ColorArgb when text.Length == 9 && text[0] == '#'
+                && uint.TryParse(text.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint argb):
+                value = DesignPropertyValue.FromInt32(unchecked((int)argb));
+                error = null;
+                return true;
         }
 
-        public string Name { get; }
-        public EffectPropertyKind Kind { get; }
-        public DesignPropertyValue DefaultValue { get; }
-        public double Minimum { get; }
-        public double Maximum { get; }
-        public string? EnumTypeName { get; }
-        public IReadOnlyList<string> EnumMembers { get; }
-
-        public static EffectPropertyDefinition Boolean(string name, bool defaultValue)
-            => new(name, EffectPropertyKind.Boolean, DesignPropertyValue.FromBoolean(defaultValue));
-
-        public static EffectPropertyDefinition Integer(string name, int defaultValue, int minimum, int maximum)
-            => new(name, EffectPropertyKind.Integer, DesignPropertyValue.FromInt32(defaultValue), minimum, maximum);
-
-        public static EffectPropertyDefinition Number(string name, double defaultValue, double minimum, double maximum)
-            => new(name, EffectPropertyKind.Number, DesignPropertyValue.FromDouble(defaultValue), minimum, maximum);
-
-        public static EffectPropertyDefinition ColorArgb(string name, int defaultValue)
-            => new(name, EffectPropertyKind.ColorArgb, DesignPropertyValue.FromInt32(defaultValue));
-
-        public static EffectPropertyDefinition Enum(
-            string name,
-            string enumTypeName,
-            string defaultMember,
-            params string[] members)
-            => new(
-                name,
-                EffectPropertyKind.Enum,
-                DesignPropertyValue.FromEnum(enumTypeName, defaultMember),
-                enumTypeName: enumTypeName,
-                enumMembers: members);
-
-        public string Format(DesignPropertyValue value)
-            => Kind switch
-            {
-                EffectPropertyKind.Boolean => value.Value is bool boolValue && boolValue ? "true" : "false",
-                EffectPropertyKind.Integer => Convert.ToInt32(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
-                EffectPropertyKind.Number => Convert.ToDouble(value.Value, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture),
-                EffectPropertyKind.Enum => value.GetString(),
-                EffectPropertyKind.ColorArgb => $"#{unchecked((uint)Convert.ToInt32(value.Value, CultureInfo.InvariantCulture)):X8}",
-                _ => throw new ArgumentOutOfRangeException()
-            };
-
-        public bool TryParse(string text, out DesignPropertyValue value, out string? error)
-        {
-            switch (Kind)
-            {
-                case EffectPropertyKind.Boolean:
-                    if (bool.TryParse(text, out bool boolValue))
-                    {
-                        value = DesignPropertyValue.FromBoolean(boolValue);
-                        error = null;
-                        return true;
-                    }
-                    break;
-                case EffectPropertyKind.Integer:
-                    if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int intValue)
-                        && intValue >= Minimum && intValue <= Maximum)
-                    {
-                        value = DesignPropertyValue.FromInt32(intValue);
-                        error = null;
-                        return true;
-                    }
-                    break;
-                case EffectPropertyKind.Number:
-                    if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double number)
-                        && double.IsFinite(number)
-                        && number >= Minimum && number <= Maximum)
-                    {
-                        value = DesignPropertyValue.FromDouble(number);
-                        error = null;
-                        return true;
-                    }
-                    break;
-                case EffectPropertyKind.Enum:
-                    if (EnumMembers.Contains(text, StringComparer.Ordinal))
-                    {
-                        value = DesignPropertyValue.FromEnum(EnumTypeName!, text);
-                        error = null;
-                        return true;
-                    }
-                    break;
-                case EffectPropertyKind.ColorArgb:
-                    if (text.Length == 9
-                        && text[0] == '#'
-                        && uint.TryParse(text.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint argb))
-                    {
-                        value = DesignPropertyValue.FromInt32(unchecked((int)argb));
-                        error = null;
-                        return true;
-                    }
-                    break;
-            }
-
-            value = DesignPropertyValue.FromNull();
-            error = $"Value '{text}' is not valid for {Name}.";
-            return false;
-        }
+        value = DesignPropertyValue.FromNull();
+        error = $"Value '{text}' is not valid for {definition.Name}.";
+        return false;
     }
+
+    private static bool Equivalent(DesignPropertyValue left, DesignPropertyValue right)
+        => left.Kind == right.Kind
+        && Equals(left.Value, right.Value)
+        && string.Equals(left.EnumTypeName, right.EnumTypeName, StringComparison.Ordinal);
 }

--- a/ModernFormsNext.Designer/Properties/DesignerInteractionEffectPropertyDescriptors.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerInteractionEffectPropertyDescriptors.cs
@@ -1,0 +1,199 @@
+using System.Globalization;
+using ModernFormsNext.Designing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Designer.Properties;
+
+/// <summary>
+/// Builds ordinary Designer Property Grid descriptors from detached animation metadata.
+/// The resulting accessors edit only the dialog's temporary entry and never instantiate
+/// the described runtime effect type.
+/// </summary>
+internal static class DesignerInteractionEffectPropertyDescriptors
+{
+    public static IReadOnlyList<DesignerPropertyDescriptor> Create(
+        DesignerInteractionEffectEntry? entry)
+    {
+        if (entry?.Descriptor is null)
+            return [];
+
+        return entry.Descriptor.Properties
+            .Select(definition => Create(entry, definition))
+            .ToArray();
+    }
+
+    private static DesignerPropertyDescriptor Create(
+        DesignerInteractionEffectEntry entry,
+        DesignAnimationPropertyDescriptor definition)
+    {
+        Type valueType = definition.Kind switch
+        {
+            DesignAnimationPropertyKind.Boolean => typeof(bool),
+            DesignAnimationPropertyKind.Int32 => typeof(int),
+            DesignAnimationPropertyKind.Number or DesignAnimationPropertyKind.TimeSpan => typeof(double),
+            DesignAnimationPropertyKind.ColorArgb => typeof(SKColor),
+            _ => typeof(string)
+        };
+        IReadOnlyList<string>? standardValues = definition.Kind switch
+        {
+            DesignAnimationPropertyKind.Easing => KnownEasingDesignValue.Identifiers,
+            DesignAnimationPropertyKind.Enum => definition.EnumMembers,
+            _ => null
+        };
+        bool numeric = definition.Kind is DesignAnimationPropertyKind.Int32
+            or DesignAnimationPropertyKind.Number
+            or DesignAnimationPropertyKind.TimeSpan;
+        string displayName = definition.Kind == DesignAnimationPropertyKind.TimeSpan
+            ? $"{definition.RuntimePropertyName} (ms)"
+            : definition.RuntimePropertyName;
+
+        Func<DesignerPropertyDialogContext, Task<bool>>? dialogEditor =
+            definition.Kind == DesignAnimationPropertyKind.ColorArgb
+                ? DesignerPropertyDialogEditors.Color(
+                    () => GetValue(entry, definition) is SKColor color ? color : null,
+                    color => color is { } selected
+                        ? Set(entry, definition, FromColor(selected))
+                        : (false, "A color value is required."))
+                : null;
+
+        return new DesignerPropertyDescriptor
+        {
+            Name = definition.Name,
+            DisplayName = displayName,
+            Category = "Effect",
+            Description = GetDescription(definition),
+            ValueType = valueType,
+            StandardValues = standardValues,
+            NumericMinimum = numeric ? ToDecimalBound(definition.Minimum, isMinimum: true) : null,
+            NumericMaximum = numeric ? ToDecimalBound(definition.Maximum, isMinimum: false) : null,
+            NumericIncrement = definition.Kind switch
+            {
+                DesignAnimationPropertyKind.Int32 => 1m,
+                DesignAnimationPropertyKind.TimeSpan => 1m,
+                DesignAnimationPropertyKind.Number => 0.01m,
+                _ => null
+            },
+            NumericDecimalPlaces = definition.Kind == DesignAnimationPropertyKind.Number ? 3
+                : definition.Kind == DesignAnimationPropertyKind.TimeSpan ? 2
+                : 0,
+            UseBooleanCheckBox = definition.Kind == DesignAnimationPropertyKind.Boolean,
+            HasDialogEditor = dialogEditor is not null,
+            DialogEditor = dialogEditor,
+            GetValue = () => GetValue(entry, definition),
+            CommitText = text => CommitText(entry, definition, text)
+        };
+    }
+
+    private static object? GetValue(
+        DesignerInteractionEffectEntry entry,
+        DesignAnimationPropertyDescriptor definition)
+    {
+        DesignPropertyValue value = InteractionEffectDesignerRegistry.GetEffectiveValue(entry, definition);
+        return definition.Kind switch
+        {
+            DesignAnimationPropertyKind.Boolean => value.Value is bool enabled && enabled,
+            DesignAnimationPropertyKind.Int32 => Convert.ToInt32(value.Value, CultureInfo.InvariantCulture),
+            DesignAnimationPropertyKind.Number or DesignAnimationPropertyKind.TimeSpan =>
+                Convert.ToDouble(value.Value, CultureInfo.InvariantCulture),
+            DesignAnimationPropertyKind.ColorArgb => ToColor(value),
+            _ => value.GetString()
+        };
+    }
+
+    private static (bool Success, string? Error) CommitText(
+        DesignerInteractionEffectEntry entry,
+        DesignAnimationPropertyDescriptor definition,
+        string text)
+    {
+        DesignPropertyValue value;
+        switch (definition.Kind)
+        {
+            case DesignAnimationPropertyKind.Boolean:
+                if (!DesignerPropertyValueEditor.TryConvert(text, typeof(bool), out object? boolean, out string? boolError))
+                    return (false, boolError);
+                value = DesignPropertyValue.FromBoolean((bool)boolean!);
+                break;
+            case DesignAnimationPropertyKind.Int32:
+                if (!DesignerPropertyValueEditor.TryConvert(text, typeof(int), out object? integer, out string? intError))
+                    return (false, intError);
+                value = DesignPropertyValue.FromInt32((int)integer!);
+                break;
+            case DesignAnimationPropertyKind.Number:
+            case DesignAnimationPropertyKind.TimeSpan:
+                if (!DesignerPropertyValueEditor.TryConvert(text, typeof(double), out object? number, out string? numberError))
+                    return (false, numberError);
+                value = DesignPropertyValue.FromDouble((double)number!);
+                break;
+            case DesignAnimationPropertyKind.Easing:
+                value = DesignPropertyValue.FromString(text);
+                break;
+            case DesignAnimationPropertyKind.Enum:
+                value = DesignPropertyValue.FromEnum(definition.EnumTypeName!, text);
+                break;
+            case DesignAnimationPropertyKind.ColorArgb:
+                if (!DesignerPropertyValueEditor.TryConvert(text, typeof(SKColor), out object? color, out string? colorError))
+                    return (false, colorError);
+                value = FromColor((SKColor)color!);
+                break;
+            case DesignAnimationPropertyKind.String:
+                value = DesignPropertyValue.FromString(text);
+                break;
+            default:
+                return (false, "The property kind is not supported by the Designer.");
+        }
+
+        return Set(entry, definition, value);
+    }
+
+    private static (bool Success, string? Error) Set(
+        DesignerInteractionEffectEntry entry,
+        DesignAnimationPropertyDescriptor definition,
+        DesignPropertyValue value)
+        => InteractionEffectDesignerRegistry.TrySetProperty(entry, definition, value, out string? error)
+            ? (true, null)
+            : (false, error);
+
+    private static SKColor ToColor(DesignPropertyValue value)
+    {
+        uint argb = unchecked((uint)Convert.ToInt32(value.Value, CultureInfo.InvariantCulture));
+        return new SKColor(
+            (byte)(argb >> 16),
+            (byte)(argb >> 8),
+            (byte)argb,
+            (byte)(argb >> 24));
+    }
+
+    private static DesignPropertyValue FromColor(SKColor color)
+    {
+        uint argb = ((uint)color.Alpha << 24)
+            | ((uint)color.Red << 16)
+            | ((uint)color.Green << 8)
+            | color.Blue;
+        return DesignPropertyValue.FromInt32(unchecked((int)argb));
+    }
+
+    private static decimal ToDecimalBound(double value, bool isMinimum)
+    {
+        if (value <= (double)decimal.MinValue)
+            return decimal.MinValue;
+        if (value >= (double)decimal.MaxValue)
+            return decimal.MaxValue;
+        decimal converted = (decimal)value;
+        if (isMinimum && value > 0d && converted == 0m)
+            return 0.001m;
+        return converted;
+    }
+
+    private static string GetDescription(DesignAnimationPropertyDescriptor definition)
+        => definition.Kind switch
+        {
+            DesignAnimationPropertyKind.TimeSpan => "Duration in milliseconds.",
+            DesignAnimationPropertyKind.Easing => "Built-in easing used by this effect.",
+            DesignAnimationPropertyKind.ColorArgb => "ARGB color rendered by this effect.",
+            DesignAnimationPropertyKind.Enum => "Select one of the effect's supported values.",
+            DesignAnimationPropertyKind.Boolean => "Enables or disables this effect option.",
+            DesignAnimationPropertyKind.Int32 or DesignAnimationPropertyKind.Number =>
+                $"Numeric value from {definition.Minimum.ToString(CultureInfo.InvariantCulture)} through {definition.Maximum.ToString(CultureInfo.InvariantCulture)}.",
+            _ => "Value used by this effect."
+        };
+}

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyDescriptor.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyDescriptor.cs
@@ -38,6 +38,16 @@ internal sealed class DesignerPropertyDescriptor
 
     public IReadOnlyList<string>? StandardValues { get; init; }
 
+    public decimal? NumericMinimum { get; init; }
+
+    public decimal? NumericMaximum { get; init; }
+
+    public decimal? NumericIncrement { get; init; }
+
+    public int NumericDecimalPlaces { get; init; }
+
+    public bool UseBooleanCheckBox { get; init; }
+
     public Func<object?> GetValue { get; init; } = () => null;
 
     public Func<string, (bool Success, string? Error)> CommitText { get; init; } = _ => (false, "The property is read-only.");

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyDialogEditors.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyDialogEditors.cs
@@ -104,10 +104,20 @@ internal static class DesignerPropertyDialogEditors
             return await dialog.ShowDialog(context.Owner) == DialogResult.OK;
         };
 
-    public static Func<DesignerPropertyDialogContext, Task<bool>> InteractionEffects(DesignControlNode control)
+    public static Func<DesignerPropertyDialogContext, Task<bool>> InteractionEffects(
+        IDictionary<string, DesignPropertyValue> properties)
         => async context =>
         {
-            var dialog = new DesignerInteractionEffectCollectionDialog(context.Session, control);
+            var dialog = new DesignerInteractionEffectCollectionDialog(context.Session, properties);
+            return await dialog.ShowDialog(context.Owner) == DialogResult.OK;
+        };
+
+    public static Func<DesignerPropertyDialogContext, Task<bool>> Transition(
+        IDictionary<string, DesignPropertyValue> properties,
+        bool isLayout)
+        => async context =>
+        {
+            var dialog = new DesignerTransitionDialog(context.Session, properties, isLayout);
             return await dialog.ShowDialog(context.Owner) == DialogResult.OK;
         };
 

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyGrid.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyGrid.cs
@@ -15,13 +15,15 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
     private readonly DesignerFileService? fileService;
     private TextBox? textEditor;
     private ComboBox? comboEditor;
+    private CheckBox? booleanEditor;
+    private NumericUpDown? numericEditor;
     private bool committingEdit;
     private bool preserveInitialTextSelection;
     private bool replaceInitialTextSelectionOnInput;
     private int scrollOffset;
 
     public DesignerPropertyGrid(DesignerSession playgroundState, string title = "Properties")
-        : this(playgroundState, fileService: null, title)
+        : this(new DesignerPropertyGridState(playgroundState), fileService: null, title)
     {
     }
 
@@ -29,10 +31,31 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
         DesignerSession playgroundState,
         DesignerFileService? fileService,
         string title = "Properties")
+        : this(new DesignerPropertyGridState(playgroundState), fileService, title)
+    {
+    }
+
+    internal DesignerPropertyGrid(
+        DesignerSession playgroundState,
+        Func<string> headerName,
+        Func<string> headerType,
+        Func<IReadOnlyList<DesignerPropertyDescriptor>> propertyProvider,
+        string title = "Properties")
+        : this(
+            new DesignerPropertyGridState(playgroundState, headerName, headerType, propertyProvider),
+            fileService: null,
+            title)
+    {
+    }
+
+    private DesignerPropertyGrid(
+        DesignerPropertyGridState state,
+        DesignerFileService? fileService,
+        string title)
         : base(title)
     {
         this.fileService = fileService;
-        state = new DesignerPropertyGridState(playgroundState);
+        this.state = state;
         renderer = new DesignerPropertyGridRenderer();
         controller = new DesignerPropertyGridController(state, renderer);
         TabStop = true;
@@ -53,13 +76,30 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
         };
     }
 
-    internal bool IsEditingValue => textEditor is not null || comboEditor is not null || state.IsEditing;
+    internal bool IsEditingValue
+        => textEditor is not null
+        || comboEditor is not null
+        || booleanEditor is not null
+        || numericEditor is not null
+        || state.IsEditing;
+
+    internal void RefreshProperties()
+    {
+        CancelEdit();
+        state.Refresh();
+    }
 
     public void BeginEdit(DesignerPropertyGridRow row, Rectangle bounds)
     {
         CancelEdit();
         state.SelectRow(row);
         state.BeginEditing();
+
+        if (TryBeginBooleanEdit(row, bounds))
+            return;
+
+        if (TryBeginNumericEdit(row, bounds))
+            return;
 
         if (TryBeginListComboEdit(row, bounds))
             return;
@@ -118,7 +158,8 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
             if (!changed)
                 return;
 
-            state.Session.NotifyDocumentChanged();
+            if (state.SupportsEvents)
+                state.Session.NotifyDocumentChanged();
             state.Session.Log($"Updated {state.HeaderName}.{row.Property.DisplayName}.");
             state.Refresh();
             Invalidate();
@@ -201,7 +242,7 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
 
     private bool EndEdit()
     {
-        if (textEditor is null && comboEditor is null)
+        if (textEditor is null && comboEditor is null && booleanEditor is null && numericEditor is null)
             return true;
 
         committingEdit = true;
@@ -221,6 +262,16 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
             else if (comboEditor is not null)
             {
                 committed = CommitComboEdit();
+            }
+            else if (booleanEditor is not null)
+            {
+                state.UpdateEditingText(booleanEditor.Checked ? "True" : "False");
+                committed = state.CommitEditing();
+            }
+            else if (numericEditor is not null)
+            {
+                state.UpdateEditingText(numericEditor.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                committed = state.CommitEditing();
             }
         }
         finally
@@ -281,6 +332,72 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
         return true;
     }
 
+    private bool TryBeginBooleanEdit(DesignerPropertyGridRow row, Rectangle bounds)
+    {
+        if (row.Property is not { UseBooleanCheckBox: true, ValueType: var valueType } property
+            || (Nullable.GetUnderlyingType(valueType) ?? valueType) != typeof(bool))
+        {
+            return false;
+        }
+
+        booleanEditor = new CheckBox
+        {
+            Left = bounds.Left + 4,
+            Top = bounds.Top,
+            Width = Math.Max(1, bounds.Width - 8),
+            Height = bounds.Height,
+            Text = string.Empty,
+            Checked = property.GetValue() is bool value && value
+        };
+        booleanEditor.CheckedChanged += BooleanEditor_CheckedChanged;
+        booleanEditor.LostFocus += BooleanEditor_LostFocus;
+
+        Controls.Add(booleanEditor);
+        booleanEditor.BringToFront();
+        booleanEditor.Select();
+        return true;
+    }
+
+    private bool TryBeginNumericEdit(DesignerPropertyGridRow row, Rectangle bounds)
+    {
+        if (row.Property is not { NumericMinimum: { } minimum, NumericMaximum: { } maximum } property)
+            return false;
+
+        decimal current;
+        try
+        {
+            double numericValue = Convert.ToDouble(property.GetValue(), System.Globalization.CultureInfo.InvariantCulture);
+            current = numericValue <= (double)minimum ? minimum
+                : numericValue >= (double)maximum ? maximum
+                : (decimal)numericValue;
+        }
+        catch (Exception exception) when (exception is FormatException or InvalidCastException or OverflowException)
+        {
+            current = minimum;
+        }
+
+        numericEditor = new NumericUpDown
+        {
+            Left = bounds.Left,
+            Top = bounds.Top,
+            Width = bounds.Width,
+            Height = Math.Max(bounds.Height, 24),
+            AllowDecimalValues = property.NumericDecimalPlaces > 0,
+            DecimalPlaces = property.NumericDecimalPlaces,
+            Minimum = minimum,
+            Maximum = maximum,
+            Increment = property.NumericIncrement ?? (property.NumericDecimalPlaces > 0 ? 0.1m : 1m),
+            Value = Math.Clamp(current, minimum, maximum)
+        };
+        numericEditor.ValueCommitted += NumericEditor_ValueCommitted;
+        numericEditor.LostFocus += NumericEditor_LostFocus;
+
+        Controls.Add(numericEditor);
+        numericEditor.BringToFront();
+        numericEditor.Select();
+        return true;
+    }
+
     private void RemoveEditors()
     {
         if (textEditor is not null)
@@ -307,6 +424,24 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
             comboEditor.Dispose();
             comboEditor = null;
         }
+
+        if (booleanEditor is not null)
+        {
+            booleanEditor.CheckedChanged -= BooleanEditor_CheckedChanged;
+            booleanEditor.LostFocus -= BooleanEditor_LostFocus;
+            Controls.Remove(booleanEditor);
+            booleanEditor.Dispose();
+            booleanEditor = null;
+        }
+
+        if (numericEditor is not null)
+        {
+            numericEditor.ValueCommitted -= NumericEditor_ValueCommitted;
+            numericEditor.LostFocus -= NumericEditor_LostFocus;
+            Controls.Remove(numericEditor);
+            numericEditor.Dispose();
+            numericEditor = null;
+        }
     }
 
     private void ClampScrollOffset()
@@ -325,7 +460,12 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
         }
         else
         {
-            comboEditor?.Select();
+            if (comboEditor is not null)
+                comboEditor.Select();
+            else if (booleanEditor is not null)
+                booleanEditor.Select();
+            else
+                numericEditor?.Select();
         }
     }
 
@@ -418,14 +558,30 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
         EndEditOrCancelOnFocusLoss();
     }
 
+    private void BooleanEditor_CheckedChanged(object? sender, EventArgs e)
+        => EndEdit();
+
+    private void BooleanEditor_LostFocus(object? sender, EventArgs e)
+        => EndEditOrCancelOnFocusLoss();
+
+    private void NumericEditor_ValueCommitted(object? sender, EventArgs e)
+        => EndEdit();
+
+    private void NumericEditor_LostFocus(object? sender, EventArgs e)
+        => EndEditOrCancelOnFocusLoss();
+
     private void EndEditOrCancelOnFocusLoss()
     {
-        if (textEditor is null && comboEditor is null)
+        if (textEditor is null && comboEditor is null && booleanEditor is null && numericEditor is null)
             return;
 
         committingEdit = true;
         var editingEvent = state.EditingEvent;
-        var committedText = textEditor?.Text ?? GetComboValueText();
+        var committedText = textEditor?.Text
+            ?? (comboEditor is not null ? GetComboValueText() : null)
+            ?? (booleanEditor is not null ? (booleanEditor.Checked ? "True" : "False") : null)
+            ?? numericEditor?.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            ?? string.Empty;
 
         try
         {
@@ -433,6 +589,8 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
                 state.UpdateEditingText(textEditor.Text);
             else if (comboEditor is not null)
                 state.UpdateEditingText(GetComboValueText());
+            else
+                state.UpdateEditingText(committedText);
 
             if (!state.CommitEditing())
                 state.CancelEditing();
@@ -483,7 +641,7 @@ internal sealed class DesignerPropertyGrid : DesignerPanelBase
     private static bool UsesComboEditor(DesignerPropertyDescriptor property)
     {
         var type = Nullable.GetUnderlyingType(property.ValueType) ?? property.ValueType;
-        return type == typeof(bool) || type.IsEnum;
+        return property.StandardValues is not null || type.IsEnum;
     }
 
     private void EnsureEventHandlerMethod(DesignerEventDescriptor? eventDescriptor, string handlerName)

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyGridController.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyGridController.cs
@@ -136,13 +136,13 @@ internal sealed class DesignerPropertyGridController
             return true;
         }
 
-        if (Hit(x, 154, 82))
+        if (state.SupportsEvents && Hit(x, 154, 82))
         {
             state.SetMode(DesignerPropertyGridMode.Properties);
             return true;
         }
 
-        if (Hit(x, 240, Math.Max(58, width - 248)))
+        if (state.SupportsEvents && Hit(x, 240, Math.Max(58, width - 248)))
         {
             state.SetMode(DesignerPropertyGridMode.Events);
             return true;

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyGridRenderer.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyGridRenderer.cs
@@ -55,8 +55,11 @@ internal sealed class DesignerPropertyGridRenderer
 
         DrawToolbarButton(e, "Categorized", 8, top + 5, 88, state.SortMode == DesignerPropertySortMode.Categorized);
         DrawToolbarButton(e, "A-Z", 100, top + 5, 44, state.SortMode == DesignerPropertySortMode.Alphabetical);
-        DrawToolbarButton(e, "Properties", 154, top + 5, 82, state.Mode == DesignerPropertyGridMode.Properties);
-        DrawToolbarButton(e, "Events", 240, top + 5, Math.Max(58, width - 248), state.Mode == DesignerPropertyGridMode.Events);
+        if (state.SupportsEvents)
+        {
+            DrawToolbarButton(e, "Properties", 154, top + 5, 82, state.Mode == DesignerPropertyGridMode.Properties);
+            DrawToolbarButton(e, "Events", 240, top + 5, Math.Max(58, width - 248), state.Mode == DesignerPropertyGridMode.Events);
+        }
     }
 
     private static void DrawToolbarButton(PaintEventArgs e, string text, int x, int y, int width, bool selected)

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
@@ -623,6 +623,8 @@ internal sealed class DesignerPropertyGridState
         descriptors.Add(ReadOnly("X", "X", "Layout", originDescription, typeof(int), () => 0));
         descriptors.Add(ReadOnly("Y", "Y", "Layout", originDescription, typeof(int), () => 0));
         descriptors.Add(DesignerPropertyDescriptorFactory.CreateDocumentSize(playgroundState.Document));
+        descriptors.Add(InteractionEffectsProperty(playgroundState.Document.Properties));
+        AddAnimationDescriptors(descriptors, playgroundState.Document.Properties);
         descriptors.Add(FormSize("Width", "Width", size => size.Width, (width, height) => new DesignSize(width, height)));
         descriptors.Add(FormSize("Height", "Height", size => size.Height, (width, height) => new DesignSize(width, height)));
     }
@@ -697,7 +699,8 @@ internal sealed class DesignerPropertyGridState
 
     private void AddSpecialContainerDescriptors(List<DesignerPropertyDescriptor> descriptors, DesignControlNode node)
     {
-        descriptors.Add(InteractionEffectsProperty(node));
+        descriptors.Add(InteractionEffectsProperty(node.Properties));
+        AddAnimationDescriptors(descriptors, node.Properties);
 
         if (DesignerSpecialContainers.IsTabControl(node))
             descriptors.Add(TabPagesProperty(node));
@@ -737,20 +740,64 @@ internal sealed class DesignerPropertyGridState
         }
     }
 
-    private static DesignerPropertyDescriptor InteractionEffectsProperty(DesignControlNode control)
+    private static void AddAnimationDescriptors(
+        List<DesignerPropertyDescriptor> descriptors,
+        IDictionary<string, DesignPropertyValue> properties)
+    {
+        descriptors.Add(TransitionProperty(properties, isLayout: true));
+        descriptors.Add(TransitionProperty(properties, isLayout: false));
+    }
+
+    private static DesignerPropertyDescriptor TransitionProperty(
+        IDictionary<string, DesignPropertyValue> properties,
+        bool isLayout)
+    {
+        string name = isLayout
+            ? LayoutTransitionDesignValue.PropertyName
+            : VisualStateTransitionDesignValue.PropertyName;
+        return new DesignerPropertyDescriptor
+        {
+            Name = name,
+            DisplayName = isLayout ? "Layout Transition" : "Visual State Transitions",
+            Category = isLayout ? "Behavior" : "Appearance",
+            Description = isLayout
+                ? "Configures logical-to-presentation bounds animation using the runtime LayoutTransition API."
+                : "Configures ordered runtime visual-state transition pairs.",
+            ValueType = typeof(string),
+            IsReadOnly = true,
+            HasDialogEditor = true,
+            DialogEditor = DesignerPropertyDialogEditors.Transition(properties, isLayout),
+            GetValue = () =>
+            {
+                if (!properties.TryGetValue(name, out var value))
+                    return "(none)";
+                if (isLayout)
+                {
+                    return LayoutTransitionDesignValue.TryRead(value, out bool enabled, out double duration, out _, out _)
+                        ? enabled ? $"{duration:0.##} ms" : "Disabled"
+                        : "(invalid)";
+                }
+                return VisualStateTransitionDesignValue.TryRead(value, out var transitions, out _)
+                    ? $"{transitions.Count} transition{(transitions.Count == 1 ? string.Empty : "s")}" : "(invalid)";
+            }
+        };
+    }
+
+    private static DesignerPropertyDescriptor InteractionEffectsProperty(
+        IDictionary<string, DesignPropertyValue> properties)
         => new()
         {
             Name = InteractionEffectDesignValue.PropertyName,
             DisplayName = "InteractionEffects",
             Category = "Behavior",
-            Description = "Edits the ordered RippleEffect and PressScaleEffect collection without running effects in the Designer.",
+            Description = "Edits ordered built-in and explicitly source-described interaction effects without running project code in the Designer.",
             ValueType = typeof(string),
             IsReadOnly = true,
             HasDialogEditor = true,
-            DialogEditor = DesignerPropertyDialogEditors.InteractionEffects(control),
+            DialogEditor = DesignerPropertyDialogEditors.InteractionEffects(properties),
             GetValue = () =>
             {
-                control.Properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? value);
+                properties.TryGetValue(InteractionEffectDesignValue.PropertyName, out DesignPropertyValue? value);
                 return InteractionEffectDesignValue.TryRead(value, out IReadOnlyList<DesignPropertyValue> effects, out _)
                     ? $"{effects.Count} effect{(effects.Count == 1 ? string.Empty : "s")}"
                     : "(invalid)";

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
@@ -36,6 +36,9 @@ internal sealed class DesignerPropertyGridState
     ];
 
     private readonly DesignerSession playgroundState;
+    private readonly Func<IReadOnlyList<DesignerPropertyDescriptor>>? detachedPropertyProvider;
+    private readonly Func<string>? detachedHeaderName;
+    private readonly Func<string>? detachedHeaderType;
     private readonly DesignMetadataReader metadataReader = new();
     private readonly HashSet<string> expandedProperties = new(StringComparer.Ordinal)
     {
@@ -55,6 +58,19 @@ internal sealed class DesignerPropertyGridState
         Refresh();
     }
 
+    internal DesignerPropertyGridState(
+        DesignerSession playgroundState,
+        Func<string> headerName,
+        Func<string> headerType,
+        Func<IReadOnlyList<DesignerPropertyDescriptor>> propertyProvider)
+    {
+        this.playgroundState = playgroundState ?? throw new ArgumentNullException(nameof(playgroundState));
+        detachedHeaderName = headerName ?? throw new ArgumentNullException(nameof(headerName));
+        detachedHeaderType = headerType ?? throw new ArgumentNullException(nameof(headerType));
+        detachedPropertyProvider = propertyProvider ?? throw new ArgumentNullException(nameof(propertyProvider));
+        Refresh();
+    }
+
     public event EventHandler? Changed;
 
     public DesignerPropertyGridMode Mode { get; private set; } = DesignerPropertyGridMode.Properties;
@@ -64,6 +80,8 @@ internal sealed class DesignerPropertyGridState
     public string HeaderName { get; private set; } = "No selection";
 
     public DesignerSession Session => playgroundState;
+
+    public bool SupportsEvents => detachedPropertyProvider is null;
 
     public string HeaderType { get; private set; } = string.Empty;
 
@@ -103,6 +121,9 @@ internal sealed class DesignerPropertyGridState
 
     public void SetMode(DesignerPropertyGridMode mode)
     {
+        if (mode == DesignerPropertyGridMode.Events && !SupportsEvents)
+            return;
+
         if (Mode == mode)
             return;
 
@@ -280,6 +301,12 @@ internal sealed class DesignerPropertyGridState
 
     public void Refresh()
     {
+        if (detachedPropertyProvider is not null)
+        {
+            RefreshDetachedProperties();
+            return;
+        }
+
         var document = playgroundState.Document;
         var selectedNode = playgroundState.SelectedNode;
         var selectedObjectChanged = hasSelectionSnapshot
@@ -321,6 +348,34 @@ internal sealed class DesignerPropertyGridState
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
+    private void RefreshDetachedProperties()
+    {
+        string? selectedPropertyName = SelectedProperty?.Identity;
+        string? editingPropertyName = EditingProperty?.Identity;
+
+        HeaderName = detachedHeaderName!();
+        HeaderType = detachedHeaderType!();
+        Properties = detachedPropertyProvider!()
+            .Where(property => property.IsVisible)
+            .ToArray();
+        Events = [];
+        ApplyExpansionState(Properties);
+        SelectedProperty = FindPropertyByIdentity(selectedPropertyName)
+            ?? Properties.FirstOrDefault();
+        SelectedEvent = null;
+        EditingProperty = IsEditing && editingPropertyName is not null
+            ? FindPropertyByIdentity(editingPropertyName)
+            : null;
+        EditingEvent = null;
+
+        if (IsEditing && EditingProperty is null)
+            ClearEditingState();
+
+        Mode = DesignerPropertyGridMode.Properties;
+        RebuildRows();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
     private void ClearEditingState()
     {
         EditingProperty = null;
@@ -344,7 +399,8 @@ internal sealed class DesignerPropertyGridState
         }
 
         var propertyName = SelectedProperty.DisplayName;
-        playgroundState.NotifyDocumentChanged();
+        if (detachedPropertyProvider is null)
+            playgroundState.NotifyDocumentChanged();
         playgroundState.Log($"Updated {HeaderName}.{propertyName}.");
         return true;
     }

--- a/ModernFormsNext.Designer/Properties/DesignerTransitionDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerTransitionDialog.cs
@@ -1,0 +1,106 @@
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designing;
+
+namespace ModernFormsNext.Designer.Properties;
+
+internal sealed class DesignerTransitionDialog : Form
+{
+    private readonly DesignerSession session;
+    private readonly IDictionary<string, DesignPropertyValue> properties;
+    private readonly string propertyName;
+    private readonly bool isLayout;
+    private readonly TextBox editor;
+    private readonly Label errorLabel;
+
+    public DesignerTransitionDialog(
+        DesignerSession session,
+        IDictionary<string, DesignPropertyValue> properties,
+        bool isLayout)
+    {
+        this.session = session;
+        this.properties = properties;
+        this.isLayout = isLayout;
+        propertyName = isLayout ? LayoutTransitionDesignValue.PropertyName : VisualStateTransitionDesignValue.PropertyName;
+        properties.TryGetValue(propertyName, out var stored);
+        string? loadError = null;
+        if (stored is not null)
+        {
+            bool valid = isLayout
+                ? LayoutTransitionDesignValue.TryRead(stored, out _, out _, out _, out loadError)
+                : VisualStateTransitionDesignValue.TryRead(stored, out _, out loadError);
+            if (valid)
+                loadError = null;
+        }
+
+        Text = isLayout ? "Layout Transition Editor" : "Visual State Transitions Editor";
+        Name = "DesignerTransitionDialog";
+        Size = new System.Drawing.Size(660, 430);
+        StartPosition = FormStartPosition.CenterParent;
+        Controls.Add(new Label
+        {
+            Left = 18,
+            Top = 16,
+            Width = 610,
+            Height = 42,
+            Text = isLayout
+                ? "Edit Enabled, DurationMilliseconds and a built-in Easing identifier."
+                : "One ordered transition per line: Normal->Hover; DurationMilliseconds=150; Easing=CubicOut"
+        });
+        editor = Controls.Add(new TextBox
+        {
+            Left = 18,
+            Top = 66,
+            Width = 610,
+            Height = 240,
+            MultiLine = true,
+            Text = isLayout
+                ? DesignerTransitionEditorModel.FormatLayout(stored)
+                : DesignerTransitionEditorModel.FormatVisualStates(stored)
+        });
+        errorLabel = Controls.Add(new Label { Left = 18, Top = 314, Width = 610, Height = 34 });
+        var reset = Controls.Add(new Button { Left = 352, Top = 350, Width = 84, Height = 30, Text = "Reset" });
+        var ok = Controls.Add(new Button { Left = 448, Top = 350, Width = 84, Height = 30, Text = "OK" });
+        var cancel = Controls.Add(new Button { Left = 544, Top = 350, Width = 84, Height = 30, Text = "Cancel" });
+        reset.Click += (_, _) => Reset();
+        ok.Click += (_, _) => Commit();
+        cancel.Click += (_, _) => DialogResult = DialogResult.Cancel;
+        if (loadError is not null)
+        {
+            editor.Enabled = false;
+            ok.Enabled = false;
+            errorLabel.Text = loadError + " Use Reset to remove the invalid optional value.";
+            session.Log($"Transition editor: {loadError}");
+        }
+    }
+
+    private void Commit()
+    {
+        bool success = isLayout
+            ? DesignerTransitionEditorModel.TryParseLayout(editor.Text, out var value, out string? error)
+            : DesignerTransitionEditorModel.TryParseVisualStates(editor.Text, out value, out error);
+        if (!success)
+        {
+            errorLabel.Text = error ?? "The transition definition is invalid.";
+            session.Log($"Transition editor: {error}");
+            return;
+        }
+
+        if (!isLayout
+            && VisualStateTransitionDesignValue.TryRead(value, out var transitions, out _)
+            && transitions.Count == 0)
+        {
+            properties.Remove(propertyName);
+        }
+        else
+        {
+            properties[propertyName] = value;
+        }
+        DialogResult = DialogResult.OK;
+    }
+
+    private void Reset()
+    {
+        properties.Remove(propertyName);
+        DialogResult = DialogResult.OK;
+    }
+}

--- a/ModernFormsNext.Designer/Properties/DesignerTransitionDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerTransitionDialog.cs
@@ -9,98 +9,520 @@ internal sealed class DesignerTransitionDialog : Form
     private readonly IDictionary<string, DesignPropertyValue> properties;
     private readonly string propertyName;
     private readonly bool isLayout;
-    private readonly TextBox editor;
     private readonly Label errorLabel;
+    private DesignerLayoutTransitionEditorModel? layoutModel;
+    private DesignerVisualStateTransitionEditorModel? visualModel;
+    private CheckBox? layoutEnabled;
+    private NumericUpDown? layoutDuration;
+    private ComboBox? layoutEasing;
+    private DataGridView? transitionGrid;
+    private ComboBox? fromState;
+    private ComboBox? toState;
+    private NumericUpDown? visualDuration;
+    private ComboBox? visualEasing;
+    private Button? addTransitionButton;
+    private Button? removeButton;
+    private Button? okButton;
+    private int loadedTransitionIndex = -1;
+    private bool loadingControls;
 
     public DesignerTransitionDialog(
         DesignerSession session,
         IDictionary<string, DesignPropertyValue> properties,
         bool isLayout)
     {
-        this.session = session;
-        this.properties = properties;
+        this.session = session ?? throw new ArgumentNullException(nameof(session));
+        this.properties = properties ?? throw new ArgumentNullException(nameof(properties));
         this.isLayout = isLayout;
-        propertyName = isLayout ? LayoutTransitionDesignValue.PropertyName : VisualStateTransitionDesignValue.PropertyName;
-        properties.TryGetValue(propertyName, out var stored);
-        string? loadError = null;
-        if (stored is not null)
-        {
-            bool valid = isLayout
-                ? LayoutTransitionDesignValue.TryRead(stored, out _, out _, out _, out loadError)
-                : VisualStateTransitionDesignValue.TryRead(stored, out _, out loadError);
-            if (valid)
-                loadError = null;
-        }
+        propertyName = isLayout
+            ? LayoutTransitionDesignValue.PropertyName
+            : VisualStateTransitionDesignValue.PropertyName;
+        properties.TryGetValue(propertyName, out DesignPropertyValue? stored);
 
         Text = isLayout ? "Layout Transition Editor" : "Visual State Transitions Editor";
         Name = "DesignerTransitionDialog";
-        Size = new System.Drawing.Size(660, 430);
         StartPosition = FormStartPosition.CenterParent;
+
+        if (isLayout)
+        {
+            Size = new System.Drawing.Size(470, 300);
+            MinimumSize = new System.Drawing.Size(430, 280);
+            errorLabel = Controls.Add(new Label
+            {
+                Left = 18,
+                Top = 166,
+                Width = 418,
+                Height = 38,
+                Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right
+            });
+            BuildLayoutEditor(stored);
+        }
+        else
+        {
+            Size = new System.Drawing.Size(780, 580);
+            MinimumSize = new System.Drawing.Size(780, 520);
+            errorLabel = Controls.Add(new Label
+            {
+                Left = 18,
+                Top = 476,
+                Width = 728,
+                Height = 34,
+                Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right
+            });
+            BuildVisualStateEditor(stored);
+        }
+    }
+
+    private void BuildLayoutEditor(DesignPropertyValue? stored)
+    {
+        layoutModel = new DesignerLayoutTransitionEditorModel(stored);
+        Controls.Add(new Label { Left = 18, Top = 24, Width = 120, Height = 24, Text = "Enabled" });
+        layoutEnabled = Controls.Add(new CheckBox
+        {
+            Left = 154,
+            Top = 20,
+            Width = 220,
+            Height = 28,
+            Text = "Animate layout changes"
+        });
+        Controls.Add(new Label { Left = 18, Top = 64, Width = 120, Height = 24, Text = "Duration" });
+        layoutDuration = Controls.Add(CreateDurationEditor(154, 60, 180));
+        layoutDuration.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+        Controls.Add(new Label { Left = 342, Top = 64, Width = 32, Height = 24, Text = "ms" });
+        Controls.Add(new Label { Left = 18, Top = 104, Width = 120, Height = 24, Text = "Easing" });
+        layoutEasing = Controls.Add(CreateEasingEditor(154, 100, 220));
+        layoutEasing.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+
+        var resetButton = Controls.Add(new Button
+        {
+            Left = 162,
+            Top = 218,
+            Width = 84,
+            Height = 30,
+            Text = "Reset",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+        okButton = Controls.Add(new Button
+        {
+            Left = 258,
+            Top = 218,
+            Width = 84,
+            Height = 30,
+            Text = "OK",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+        var cancelButton = Controls.Add(new Button
+        {
+            Left = 354,
+            Top = 218,
+            Width = 84,
+            Height = 30,
+            Text = "Cancel",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+
+        layoutEnabled.CheckedChanged += (_, _) => UpdateLayoutModel();
+        layoutDuration.ValueChanged += (_, _) => UpdateLayoutModel();
+        layoutEasing.SelectedIndexChanged += (_, _) => UpdateLayoutModel();
+        resetButton.Click += (_, _) => ResetLayout();
+        okButton.Click += (_, _) => CommitLayout();
+        cancelButton.Click += (_, _) => DialogResult = DialogResult.Cancel;
+
+        LoadLayoutControls();
+        if (layoutModel.LoadError is not null)
+            DisableInvalidLayout(layoutModel.LoadError);
+    }
+
+    private void BuildVisualStateEditor(DesignPropertyValue? stored)
+    {
+        visualModel = new DesignerVisualStateTransitionEditorModel(stored);
         Controls.Add(new Label
         {
             Left = 18,
             Top = 16,
-            Width = 610,
-            Height = 42,
-            Text = isLayout
-                ? "Edit Enabled, DurationMilliseconds and a built-in Easing identifier."
-                : "One ordered transition per line: Normal->Hover; DurationMilliseconds=150; Easing=CubicOut"
+            Width = 300,
+            Height = 22,
+            Text = "Directional visual-state transitions"
         });
-        editor = Controls.Add(new TextBox
+        transitionGrid = Controls.Add(new DataGridView
         {
             Left = 18,
-            Top = 66,
-            Width = 610,
-            Height = 240,
-            MultiLine = true,
-            Text = isLayout
-                ? DesignerTransitionEditorModel.FormatLayout(stored)
-                : DesignerTransitionEditorModel.FormatVisualStates(stored)
+            Top = 42,
+            Width = 728,
+            Height = 280,
+            ReadOnly = true,
+            RowHeadersVisible = false,
+            SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+            Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right
         });
-        errorLabel = Controls.Add(new Label { Left = 18, Top = 314, Width = 610, Height = 34 });
-        var reset = Controls.Add(new Button { Left = 352, Top = 350, Width = 84, Height = 30, Text = "Reset" });
-        var ok = Controls.Add(new Button { Left = 448, Top = 350, Width = 84, Height = 30, Text = "OK" });
-        var cancel = Controls.Add(new Button { Left = 544, Top = 350, Width = 84, Height = 30, Text = "Cancel" });
-        reset.Click += (_, _) => Reset();
-        ok.Click += (_, _) => Commit();
-        cancel.Click += (_, _) => DialogResult = DialogResult.Cancel;
-        if (loadError is not null)
+        transitionGrid.Columns.Add("From", 150);
+        transitionGrid.Columns.Add("To", 150);
+        transitionGrid.Columns.Add("Duration", 170);
+        transitionGrid.Columns.Add("Easing", 210);
+
+        addTransitionButton = Controls.Add(new Button
         {
-            editor.Enabled = false;
-            ok.Enabled = false;
-            errorLabel.Text = loadError + " Use Reset to remove the invalid optional value.";
-            session.Log($"Transition editor: {loadError}");
-        }
+            Left = 18,
+            Top = 332,
+            Width = 84,
+            Height = 30,
+            Text = "Add",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        });
+        removeButton = Controls.Add(new Button
+        {
+            Left = 114,
+            Top = 332,
+            Width = 84,
+            Height = 30,
+            Text = "Remove",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        });
+
+        Controls.Add(new Label { Left = 18, Top = 382, Width = 64, Height = 24, Text = "From", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        fromState = Controls.Add(CreateStateEditor(82, 378));
+        Controls.Add(new Label { Left = 274, Top = 382, Width = 38, Height = 24, Text = "To", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        toState = Controls.Add(CreateStateEditor(316, 378));
+        Controls.Add(new Label { Left = 508, Top = 382, Width = 68, Height = 24, Text = "Duration", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        visualDuration = Controls.Add(CreateDurationEditor(580, 378, 126));
+        Controls.Add(new Label { Left = 712, Top = 382, Width = 28, Height = 24, Text = "ms", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        Controls.Add(new Label { Left = 18, Top = 426, Width = 64, Height = 24, Text = "Easing", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        visualEasing = Controls.Add(CreateEasingEditor(82, 422, 188));
+
+        var resetButton = Controls.Add(new Button
+        {
+            Left = 470,
+            Top = 518,
+            Width = 84,
+            Height = 30,
+            Text = "Reset",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+        okButton = Controls.Add(new Button
+        {
+            Left = 566,
+            Top = 518,
+            Width = 84,
+            Height = 30,
+            Text = "OK",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+        var cancelButton = Controls.Add(new Button
+        {
+            Left = 662,
+            Top = 518,
+            Width = 84,
+            Height = 30,
+            Text = "Cancel",
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        });
+
+        transitionGrid.SelectionChanged += (_, _) => ChangeTransitionSelection();
+        addTransitionButton.Click += (_, _) => AddTransition();
+        removeButton.Click += (_, _) => RemoveTransition();
+        resetButton.Click += (_, _) => ResetVisualStates();
+        okButton.Click += (_, _) => CommitVisualStates();
+        cancelButton.Click += (_, _) => DialogResult = DialogResult.Cancel;
+
+        RefreshTransitionGrid(visualModel.Entries.Count > 0 ? 0 : -1);
+        if (visualModel.LoadError is not null)
+            DisableInvalidVisualStates(visualModel.LoadError);
     }
 
-    private void Commit()
-    {
-        bool success = isLayout
-            ? DesignerTransitionEditorModel.TryParseLayout(editor.Text, out var value, out string? error)
-            : DesignerTransitionEditorModel.TryParseVisualStates(editor.Text, out value, out error);
-        if (!success)
+    private static NumericUpDown CreateDurationEditor(int left, int top, int width)
+        => new()
         {
-            errorLabel.Text = error ?? "The transition definition is invalid.";
-            session.Log($"Transition editor: {error}");
+            Left = left,
+            Top = top,
+            Width = width,
+            Height = 30,
+            Minimum = 0m,
+            Maximum = decimal.MaxValue,
+            AllowDecimalValues = true,
+            DecimalPlaces = 2,
+            Increment = 1m,
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        };
+
+    private static ComboBox CreateEasingEditor(int left, int top, int width)
+    {
+        var combo = new ComboBox
+        {
+            Left = left,
+            Top = top,
+            Width = width,
+            Height = 30,
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        };
+        combo.Items.AddRange(KnownEasingDesignValue.Identifiers.Cast<object>().ToArray());
+        return combo;
+    }
+
+    private static ComboBox CreateStateEditor(int left, int top)
+    {
+        var combo = new ComboBox
+        {
+            Left = left,
+            Top = top,
+            Width = 170,
+            Height = 30,
+            Anchor = AnchorStyles.Bottom | AnchorStyles.Left
+        };
+        combo.Items.AddRange(DesignerVisualStateTransitionEditorModel.States.Cast<object>().ToArray());
+        return combo;
+    }
+
+    private void UpdateLayoutModel()
+    {
+        if (loadingControls || layoutModel is null || layoutEnabled is null || layoutDuration is null || layoutEasing is null)
+            return;
+
+        string easing = SelectedText(layoutEasing);
+        if (!layoutModel.TrySet(layoutEnabled.Checked, (double)layoutDuration.Value, easing, out string? error))
+            ShowError(error ?? "The layout transition is invalid.");
+        else
+            errorLabel.Text = string.Empty;
+    }
+
+    private void LoadLayoutControls()
+    {
+        loadingControls = true;
+        layoutEnabled!.Checked = layoutModel!.Enabled;
+        layoutDuration!.Value = ClampToDecimal(layoutModel.DurationMilliseconds);
+        SelectText(layoutEasing!, layoutModel.Easing);
+        loadingControls = false;
+    }
+
+    private void ResetLayout()
+    {
+        layoutModel!.Reset();
+        LoadLayoutControls();
+        SetLayoutControlsEnabled(true);
+        errorLabel.Text = "Default restored: no explicit LayoutTransition will be stored.";
+    }
+
+    private void CommitLayout()
+    {
+        if (!layoutModel!.TryCreateValue(out DesignPropertyValue? value, out string? error))
+        {
+            ShowError(error ?? "The layout transition is invalid.");
             return;
         }
 
-        if (!isLayout
-            && VisualStateTransitionDesignValue.TryRead(value, out var transitions, out _)
-            && transitions.Count == 0)
-        {
+        if (value is null)
             properties.Remove(propertyName);
-        }
         else
-        {
             properties[propertyName] = value;
-        }
         DialogResult = DialogResult.OK;
     }
 
-    private void Reset()
+    private void AddTransition()
     {
-        properties.Remove(propertyName);
+        if (!TryCommitLoadedTransition())
+            return;
+        if (!visualModel!.TryAddDefault(out int index, out string? error))
+        {
+            ShowError(error ?? "A transition could not be added.");
+            return;
+        }
+        RefreshTransitionGrid(index);
+    }
+
+    private void RemoveTransition()
+    {
+        int index = transitionGrid!.SelectedRowIndex;
+        if (!visualModel!.RemoveAt(index))
+            return;
+        loadedTransitionIndex = -1;
+        RefreshTransitionGrid(Math.Min(index, visualModel.Entries.Count - 1));
+    }
+
+    private void ChangeTransitionSelection()
+    {
+        if (loadingControls)
+            return;
+
+        int selectedIndex = transitionGrid!.SelectedRowIndex;
+        if (selectedIndex == loadedTransitionIndex)
+            return;
+        if (!TryCommitLoadedTransition())
+        {
+            loadingControls = true;
+            transitionGrid.SelectedRowIndex = loadedTransitionIndex;
+            loadingControls = false;
+            return;
+        }
+
+        loadedTransitionIndex = selectedIndex;
+        LoadSelectedTransition();
+    }
+
+    private bool TryCommitLoadedTransition()
+    {
+        if (loadedTransitionIndex < 0 || loadedTransitionIndex >= visualModel!.Entries.Count)
+            return true;
+
+        if (!visualModel.TryUpdate(
+            loadedTransitionIndex,
+            SelectedText(fromState!),
+            SelectedText(toState!),
+            (double)visualDuration!.Value,
+            SelectedText(visualEasing!),
+            out string? error))
+        {
+            ShowError(error ?? "The selected transition is invalid.");
+            return false;
+        }
+
+        UpdateTransitionGridRow(loadedTransitionIndex);
+        errorLabel.Text = string.Empty;
+        return true;
+    }
+
+    private void LoadSelectedTransition()
+    {
+        loadingControls = true;
+        DesignerVisualStateTransitionEditorModel model = visualModel!;
+        bool selected = loadedTransitionIndex >= 0 && loadedTransitionIndex < model.Entries.Count;
+        if (selected)
+        {
+            DesignVisualStateTransition entry = model.Entries[loadedTransitionIndex];
+            SelectText(fromState!, entry.From);
+            SelectText(toState!, entry.To);
+            visualDuration!.Value = ClampToDecimal(entry.DurationMilliseconds);
+            SelectText(visualEasing!, entry.Easing);
+        }
+        else
+        {
+            fromState!.SelectedIndex = -1;
+            toState!.SelectedIndex = -1;
+            visualDuration!.Value = 0m;
+            visualEasing!.SelectedIndex = -1;
+        }
+        SetVisualEditorsEnabled(selected);
+        loadingControls = false;
+    }
+
+    private void RefreshTransitionGrid(int selectIndex)
+    {
+        loadingControls = true;
+        transitionGrid!.Rows.Clear();
+        foreach (DesignVisualStateTransition entry in visualModel!.Entries)
+        {
+            transitionGrid.Rows.Add(
+                entry.From,
+                entry.To,
+                $"{entry.DurationMilliseconds:0.##} ms",
+                entry.Easing);
+        }
+        transitionGrid.SelectedRowIndex = visualModel.Entries.Count == 0
+            ? -1
+            : Math.Clamp(selectIndex, 0, visualModel.Entries.Count - 1);
+        loadedTransitionIndex = transitionGrid.SelectedRowIndex;
+        loadingControls = false;
+        LoadSelectedTransition();
+    }
+
+    private void UpdateTransitionGridRow(int index)
+    {
+        DesignVisualStateTransition entry = visualModel!.Entries[index];
+        DataGridViewRow row = transitionGrid!.Rows[index];
+        row.Cells[0].Value = entry.From;
+        row.Cells[1].Value = entry.To;
+        row.Cells[2].Value = $"{entry.DurationMilliseconds:0.##} ms";
+        row.Cells[3].Value = entry.Easing;
+        transitionGrid.Invalidate();
+    }
+
+    private void ResetVisualStates()
+    {
+        visualModel!.Reset();
+        SetVisualCollectionEnabled(true);
+        RefreshTransitionGrid(-1);
+        errorLabel.Text = "Default restored: no visual-state transitions will be stored.";
+    }
+
+    private void CommitVisualStates()
+    {
+        if (!TryCommitLoadedTransition())
+            return;
+        if (!visualModel!.TryCreateValue(out DesignPropertyValue value, out string? error))
+        {
+            ShowError(error ?? "The visual-state transition collection is invalid.");
+            return;
+        }
+
+        if (visualModel.Entries.Count == 0)
+            properties.Remove(propertyName);
+        else
+            properties[propertyName] = value;
         DialogResult = DialogResult.OK;
+    }
+
+    private void DisableInvalidLayout(string error)
+    {
+        SetLayoutControlsEnabled(false);
+        okButton!.Enabled = false;
+        ShowError(error + " Use Reset to restore the default.");
+    }
+
+    private void DisableInvalidVisualStates(string error)
+    {
+        SetVisualCollectionEnabled(false);
+        okButton!.Enabled = false;
+        ShowError(error + " Use Reset to remove the invalid optional value.");
+    }
+
+    private void SetLayoutControlsEnabled(bool enabled)
+    {
+        layoutEnabled!.Enabled = enabled;
+        layoutDuration!.Enabled = enabled;
+        layoutEasing!.Enabled = enabled;
+        okButton!.Enabled = enabled;
+    }
+
+    private void SetVisualCollectionEnabled(bool enabled)
+    {
+        transitionGrid!.Enabled = enabled;
+        addTransitionButton!.Enabled = enabled;
+        removeButton!.Enabled = enabled && transitionGrid.SelectedRowIndex >= 0;
+        okButton!.Enabled = enabled;
+        SetVisualEditorsEnabled(enabled && transitionGrid.SelectedRowIndex >= 0);
+    }
+
+    private void SetVisualEditorsEnabled(bool enabled)
+    {
+        fromState!.Enabled = enabled;
+        toState!.Enabled = enabled;
+        visualDuration!.Enabled = enabled;
+        visualEasing!.Enabled = enabled;
+        removeButton!.Enabled = enabled;
+    }
+
+    private void ShowError(string message)
+    {
+        errorLabel.Text = message;
+        session.Log($"Transition editor: {message}");
+    }
+
+    private static string SelectedText(ComboBox comboBox)
+        => comboBox.SelectedItem?.ToString()
+            ?? (comboBox.SelectedIndex >= 0 ? comboBox.Items[comboBox.SelectedIndex]?.ToString() : null)
+            ?? string.Empty;
+
+    private static void SelectText(ComboBox comboBox, string value)
+    {
+        comboBox.SelectedIndex = comboBox.Items
+            .Select((item, index) => new { Text = item?.ToString(), Index = index })
+            .FirstOrDefault(item => string.Equals(item.Text, value, StringComparison.Ordinal))?.Index ?? -1;
+    }
+
+    private static decimal ClampToDecimal(double value)
+    {
+        if (value <= (double)decimal.MinValue)
+            return decimal.MinValue;
+        if (value >= (double)decimal.MaxValue)
+            return decimal.MaxValue;
+        return (decimal)value;
     }
 }

--- a/ModernFormsNext.Designer/Properties/DesignerTransitionEditorModel.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerTransitionEditorModel.cs
@@ -1,114 +1,217 @@
-using System.Globalization;
 using ModernFormsNext.Designing;
 
 namespace ModernFormsNext.Designer.Properties;
 
-internal static class DesignerTransitionEditorModel
+internal sealed class DesignerLayoutTransitionEditorModel
 {
-    private static readonly string[] States = ["Normal", "Hover", "Pressed", "Disabled", "Focused"];
-
-    public static string FormatLayout(DesignPropertyValue? value)
+    public DesignerLayoutTransitionEditorModel(DesignPropertyValue? stored)
     {
-        if (!LayoutTransitionDesignValue.TryRead(value, out bool enabled, out double duration, out string easing, out _))
-            return string.Empty;
-        return $"Enabled={enabled.ToString().ToLowerInvariant()}{Environment.NewLine}DurationMilliseconds={duration.ToString("R", CultureInfo.InvariantCulture)}{Environment.NewLine}Easing={easing}";
+        IsExplicit = stored is not null;
+        if (!LayoutTransitionDesignValue.TryRead(
+            stored,
+            out bool enabled,
+            out double duration,
+            out string easing,
+            out string? error))
+        {
+            LoadError = error ?? "The stored layout transition is malformed.";
+            enabled = true;
+            duration = 250d;
+            easing = "EaseOut";
+        }
+
+        Enabled = enabled;
+        DurationMilliseconds = duration;
+        Easing = easing;
     }
 
-    public static bool TryParseLayout(string text, out DesignPropertyValue value, out string? error)
+    public bool Enabled { get; private set; }
+
+    public double DurationMilliseconds { get; private set; }
+
+    public string Easing { get; private set; }
+
+    public bool IsExplicit { get; private set; }
+
+    public string? LoadError { get; private set; }
+
+    public bool TrySet(bool enabled, double durationMilliseconds, string easing, out string? error)
     {
-        bool enabled = true;
-        double duration = 250d;
-        string easing = "EaseOut";
-        if (!TryReadAssignments(text, out var assignments, out error))
+        if (!double.IsFinite(durationMilliseconds) || durationMilliseconds < 0d)
         {
-            value = null!;
+            error = "Duration must be a finite non-negative number of milliseconds.";
+            return false;
+        }
+        if (!KnownEasingDesignValue.IsKnown(easing))
+        {
+            error = $"Easing '{easing}' is not supported by the Designer.";
             return false;
         }
 
-        foreach ((string name, string input) in assignments)
-        {
-            switch (name)
-            {
-                case "Enabled" when bool.TryParse(input, out bool parsed):
-                    enabled = parsed;
-                    break;
-                case "DurationMilliseconds" when double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
-                    && double.IsFinite(parsed) && parsed >= 0d:
-                    duration = parsed;
-                    break;
-                case "Easing" when KnownEasingDesignValue.IsKnown(input):
-                    easing = input;
-                    break;
-                default:
-                    value = null!;
-                    error = $"Layout transition value '{name}={input}' is not supported.";
-                    return false;
-            }
-        }
-        value = LayoutTransitionDesignValue.Create(enabled, duration, easing);
+        Enabled = enabled;
+        DurationMilliseconds = durationMilliseconds;
+        Easing = easing;
+        IsExplicit = true;
+        LoadError = null;
         error = null;
         return true;
     }
 
-    public static string FormatVisualStates(DesignPropertyValue? value)
+    public void Reset()
     {
-        if (!VisualStateTransitionDesignValue.TryRead(value, out var transitions, out _))
-            return string.Empty;
-        return string.Join(Environment.NewLine, transitions.Select(item =>
-            $"{item.From}->{item.To}; DurationMilliseconds={item.DurationMilliseconds.ToString("R", CultureInfo.InvariantCulture)}; Easing={item.Easing}"));
+        Enabled = true;
+        DurationMilliseconds = 250d;
+        Easing = "EaseOut";
+        IsExplicit = false;
+        LoadError = null;
     }
 
-    public static bool TryParseVisualStates(string text, out DesignPropertyValue value, out string? error)
+    public bool TryCreateValue(out DesignPropertyValue? value, out string? error)
     {
-        var transitions = new List<DesignVisualStateTransition>();
-        foreach (string rawLine in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
+        if (LoadError is not null)
         {
-            string line = rawLine.Trim();
-            if (line.Length == 0)
-                continue;
-            string[] segments = line.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-            string[] endpoints = segments[0].Split("->", StringSplitOptions.TrimEntries);
-            if (endpoints.Length != 2
-                || !States.Contains(endpoints[0], StringComparer.Ordinal)
-                || !States.Contains(endpoints[1], StringComparer.Ordinal))
-            {
-                value = null!;
-                error = $"'{segments[0]}' must be a known From->To visual-state pair.";
-                return false;
-            }
-
-            double duration = 150d;
-            string easing = "CubicOut";
-            if (!TryReadAssignments(string.Join(Environment.NewLine, segments.Skip(1)), out var assignments, out error, separator: '='))
-            {
-                value = null!;
-                return false;
-            }
-            foreach ((string name, string input) in assignments)
-            {
-                if (name == "DurationMilliseconds"
-                    && double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
-                    && double.IsFinite(parsed) && parsed >= 0d)
-                {
-                    duration = parsed;
-                }
-                else if (name == "Easing" && KnownEasingDesignValue.IsKnown(input))
-                {
-                    easing = input;
-                }
-                else
-                {
-                    value = null!;
-                    error = $"Visual-state transition value '{name}={input}' is not supported.";
-                    return false;
-                }
-            }
-            transitions.Add(new DesignVisualStateTransition(endpoints[0], endpoints[1], duration, easing));
+            value = null;
+            error = LoadError;
+            return false;
+        }
+        if (!IsExplicit)
+        {
+            value = null;
+            error = null;
+            return true;
         }
 
         try
         {
-            value = VisualStateTransitionDesignValue.Create(transitions);
+            value = LayoutTransitionDesignValue.Create(Enabled, DurationMilliseconds, Easing);
+            error = null;
+            return true;
+        }
+        catch (ArgumentException exception)
+        {
+            value = null;
+            error = exception.Message;
+            return false;
+        }
+    }
+}
+
+internal sealed class DesignerVisualStateTransitionEditorModel
+{
+    internal static IReadOnlyList<string> States { get; } =
+        ["Normal", "Hover", "Pressed", "Disabled", "Focused"];
+
+    private readonly List<DesignVisualStateTransition> entries = [];
+
+    public DesignerVisualStateTransitionEditorModel(DesignPropertyValue? stored)
+    {
+        if (!VisualStateTransitionDesignValue.TryRead(stored, out var loaded, out string? error))
+        {
+            LoadError = error ?? "The stored visual-state transition collection is malformed.";
+            return;
+        }
+        entries.AddRange(loaded);
+    }
+
+    public IReadOnlyList<DesignVisualStateTransition> Entries => entries;
+
+    public string? LoadError { get; private set; }
+
+    public bool TryAddDefault(out int index, out string? error)
+    {
+        foreach (string from in States)
+        {
+            foreach (string to in States)
+            {
+                if (from == to || entries.Any(item => item.From == from && item.To == to))
+                    continue;
+
+                entries.Add(new DesignVisualStateTransition(from, to, 150d, "CubicOut"));
+                index = entries.Count - 1;
+                error = null;
+                return true;
+            }
+        }
+
+        index = -1;
+        error = "Every supported visual-state pair is already configured.";
+        return false;
+    }
+
+    public bool TryAdd(
+        string from,
+        string to,
+        double durationMilliseconds,
+        string easing,
+        out string? error)
+    {
+        if (!TryValidate(from, to, durationMilliseconds, easing, ignoredIndex: -1, out error))
+            return false;
+        entries.Add(new DesignVisualStateTransition(from, to, durationMilliseconds, easing));
+        return true;
+    }
+
+    public bool TryUpdate(
+        int index,
+        string from,
+        string to,
+        double durationMilliseconds,
+        string easing,
+        out string? error)
+    {
+        if (index < 0 || index >= entries.Count)
+        {
+            error = "Select a transition to edit.";
+            return false;
+        }
+        if (!TryValidate(from, to, durationMilliseconds, easing, index, out error))
+            return false;
+        entries[index] = new DesignVisualStateTransition(from, to, durationMilliseconds, easing);
+        return true;
+    }
+
+    public bool RemoveAt(int index)
+    {
+        if (index < 0 || index >= entries.Count)
+            return false;
+        entries.RemoveAt(index);
+        return true;
+    }
+
+    public void Reset()
+    {
+        entries.Clear();
+        LoadError = null;
+    }
+
+    public bool TryCreateValue(out DesignPropertyValue value, out string? error)
+    {
+        if (LoadError is not null)
+        {
+            value = null!;
+            error = LoadError;
+            return false;
+        }
+
+        for (int index = 0; index < entries.Count; index++)
+        {
+            DesignVisualStateTransition entry = entries[index];
+            if (!TryValidate(
+                entry.From,
+                entry.To,
+                entry.DurationMilliseconds,
+                entry.Easing,
+                index,
+                out error))
+            {
+                value = null!;
+                return false;
+            }
+        }
+
+        try
+        {
+            value = VisualStateTransitionDesignValue.Create(entries);
             error = null;
             return true;
         }
@@ -120,25 +223,41 @@ internal static class DesignerTransitionEditorModel
         }
     }
 
-    private static bool TryReadAssignments(
-        string text,
-        out Dictionary<string, string> assignments,
-        out string? error,
-        char separator = '=')
+    private bool TryValidate(
+        string from,
+        string to,
+        double durationMilliseconds,
+        string easing,
+        int ignoredIndex,
+        out string? error)
     {
-        assignments = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (string rawLine in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
+        if (!States.Contains(from, StringComparer.Ordinal) || !States.Contains(to, StringComparer.Ordinal))
         {
-            string line = rawLine.Trim();
-            if (line.Length == 0)
-                continue;
-            int index = line.IndexOf(separator);
-            if (index <= 0 || !assignments.TryAdd(line[..index].Trim(), line[(index + 1)..].Trim()))
-            {
-                error = $"'{line}' must be a unique Property=Value entry.";
-                return false;
-            }
+            error = "From and To must be supported visual states.";
+            return false;
         }
+        if (string.Equals(from, to, StringComparison.Ordinal))
+        {
+            error = "From and To must identify different visual states.";
+            return false;
+        }
+        if (!double.IsFinite(durationMilliseconds) || durationMilliseconds < 0d)
+        {
+            error = "Duration must be a finite non-negative number of milliseconds.";
+            return false;
+        }
+        if (!KnownEasingDesignValue.IsKnown(easing))
+        {
+            error = $"Easing '{easing}' is not supported by the Designer.";
+            return false;
+        }
+        if (entries.Where((_, index) => index != ignoredIndex)
+            .Any(item => item.From == from && item.To == to))
+        {
+            error = $"The {from} -> {to} transition is already configured.";
+            return false;
+        }
+
         error = null;
         return true;
     }

--- a/ModernFormsNext.Designer/Properties/DesignerTransitionEditorModel.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerTransitionEditorModel.cs
@@ -1,0 +1,145 @@
+using System.Globalization;
+using ModernFormsNext.Designing;
+
+namespace ModernFormsNext.Designer.Properties;
+
+internal static class DesignerTransitionEditorModel
+{
+    private static readonly string[] States = ["Normal", "Hover", "Pressed", "Disabled", "Focused"];
+
+    public static string FormatLayout(DesignPropertyValue? value)
+    {
+        if (!LayoutTransitionDesignValue.TryRead(value, out bool enabled, out double duration, out string easing, out _))
+            return string.Empty;
+        return $"Enabled={enabled.ToString().ToLowerInvariant()}{Environment.NewLine}DurationMilliseconds={duration.ToString("R", CultureInfo.InvariantCulture)}{Environment.NewLine}Easing={easing}";
+    }
+
+    public static bool TryParseLayout(string text, out DesignPropertyValue value, out string? error)
+    {
+        bool enabled = true;
+        double duration = 250d;
+        string easing = "EaseOut";
+        if (!TryReadAssignments(text, out var assignments, out error))
+        {
+            value = null!;
+            return false;
+        }
+
+        foreach ((string name, string input) in assignments)
+        {
+            switch (name)
+            {
+                case "Enabled" when bool.TryParse(input, out bool parsed):
+                    enabled = parsed;
+                    break;
+                case "DurationMilliseconds" when double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
+                    && double.IsFinite(parsed) && parsed >= 0d:
+                    duration = parsed;
+                    break;
+                case "Easing" when KnownEasingDesignValue.IsKnown(input):
+                    easing = input;
+                    break;
+                default:
+                    value = null!;
+                    error = $"Layout transition value '{name}={input}' is not supported.";
+                    return false;
+            }
+        }
+        value = LayoutTransitionDesignValue.Create(enabled, duration, easing);
+        error = null;
+        return true;
+    }
+
+    public static string FormatVisualStates(DesignPropertyValue? value)
+    {
+        if (!VisualStateTransitionDesignValue.TryRead(value, out var transitions, out _))
+            return string.Empty;
+        return string.Join(Environment.NewLine, transitions.Select(item =>
+            $"{item.From}->{item.To}; DurationMilliseconds={item.DurationMilliseconds.ToString("R", CultureInfo.InvariantCulture)}; Easing={item.Easing}"));
+    }
+
+    public static bool TryParseVisualStates(string text, out DesignPropertyValue value, out string? error)
+    {
+        var transitions = new List<DesignVisualStateTransition>();
+        foreach (string rawLine in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+                continue;
+            string[] segments = line.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            string[] endpoints = segments[0].Split("->", StringSplitOptions.TrimEntries);
+            if (endpoints.Length != 2
+                || !States.Contains(endpoints[0], StringComparer.Ordinal)
+                || !States.Contains(endpoints[1], StringComparer.Ordinal))
+            {
+                value = null!;
+                error = $"'{segments[0]}' must be a known From->To visual-state pair.";
+                return false;
+            }
+
+            double duration = 150d;
+            string easing = "CubicOut";
+            if (!TryReadAssignments(string.Join(Environment.NewLine, segments.Skip(1)), out var assignments, out error, separator: '='))
+            {
+                value = null!;
+                return false;
+            }
+            foreach ((string name, string input) in assignments)
+            {
+                if (name == "DurationMilliseconds"
+                    && double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
+                    && double.IsFinite(parsed) && parsed >= 0d)
+                {
+                    duration = parsed;
+                }
+                else if (name == "Easing" && KnownEasingDesignValue.IsKnown(input))
+                {
+                    easing = input;
+                }
+                else
+                {
+                    value = null!;
+                    error = $"Visual-state transition value '{name}={input}' is not supported.";
+                    return false;
+                }
+            }
+            transitions.Add(new DesignVisualStateTransition(endpoints[0], endpoints[1], duration, easing));
+        }
+
+        try
+        {
+            value = VisualStateTransitionDesignValue.Create(transitions);
+            error = null;
+            return true;
+        }
+        catch (ArgumentException exception)
+        {
+            value = null!;
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    private static bool TryReadAssignments(
+        string text,
+        out Dictionary<string, string> assignments,
+        out string? error,
+        char separator = '=')
+    {
+        assignments = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string rawLine in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+                continue;
+            int index = line.IndexOf(separator);
+            if (index <= 0 || !assignments.TryAdd(line[..index].Trim(), line[(index + 1)..].Trim()))
+            {
+                error = $"'{line}' must be a unique Property=Value entry.";
+                return false;
+            }
+        }
+        error = null;
+        return true;
+    }
+}

--- a/ModernFormsNext.Designer/Services/DesignerFileService.cs
+++ b/ModernFormsNext.Designer/Services/DesignerFileService.cs
@@ -10,12 +10,17 @@ internal sealed class DesignerFileService
 {
     private readonly IDesignerHostEnvironment? environment;
     private readonly Func<string?>? currentDocumentPathProvider;
+    private readonly Func<IReadOnlyList<DesignAnimationDefinitionDescriptor>>? animationDefinitionsProvider;
     private readonly CSharpDesignerRoundTripService roundTrip = new();
 
-    public DesignerFileService(IDesignerHostEnvironment? environment = null, Func<string?>? currentDocumentPathProvider = null)
+    public DesignerFileService(
+        IDesignerHostEnvironment? environment = null,
+        Func<string?>? currentDocumentPathProvider = null,
+        Func<IReadOnlyList<DesignAnimationDefinitionDescriptor>>? animationDefinitionsProvider = null)
     {
         this.environment = environment;
         this.currentDocumentPathProvider = currentDocumentPathProvider;
+        this.animationDefinitionsProvider = animationDefinitionsProvider;
     }
 
     public DesignDocument LoadDesignDocument(string path)
@@ -39,7 +44,8 @@ internal sealed class DesignerFileService
             new CSharpDesignerGenerationOptions
             {
                 SourceFilePath = Path.GetFileName(designDocumentPath),
-                DesignHash = roundTrip.ComputeDesignHash(document)
+                DesignHash = roundTrip.ComputeDesignHash(document),
+                AnimationDefinitions = animationDefinitionsProvider?.Invoke() ?? []
             });
 
         if (!result.Succeeded)

--- a/ModernFormsNext.Designer/Services/DesignerProjectAnimationDefinitionDiscovery.cs
+++ b/ModernFormsNext.Designer/Services/DesignerProjectAnimationDefinitionDiscovery.cs
@@ -1,0 +1,572 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using ModernFormsNext.Designing;
+
+namespace ModernFormsNext.Designer.Services;
+
+/// <summary>
+/// Discovers explicitly opted-in project animation definitions from C# source without loading assemblies.
+/// </summary>
+internal static class DesignerProjectAnimationDefinitionDiscovery
+{
+    private const string AnimationNamespace = "ModernFormsNext.Animations";
+    private const string DefinitionAttributeName = "DesignableAnimationDefinition";
+    private const string PropertyAttributeName = "DesignableAnimationProperty";
+
+    /// <summary>Reads explicitly attributed animation descriptors from project C# source.</summary>
+    /// <param name="projectPath">A project file or project directory path.</param>
+    /// <returns>Detached descriptors in deterministic display order.</returns>
+    public static IReadOnlyList<DesignAnimationDefinitionDescriptor> Discover(string? projectPath)
+    {
+        string? directory = DesignerProjectUserControlDiscovery.GetProjectDirectory(projectPath);
+        if (directory is null)
+            return [];
+
+        try
+        {
+            ProjectAnimationDeclaration[] declarations = DesignerProjectUserControlDiscovery
+                .EnumerateProjectFiles(directory, "*.cs")
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .SelectMany(ReadDeclarations)
+                .GroupBy(item => item.FullName, StringComparer.Ordinal)
+                .Select(MergePartialDeclarations)
+                .ToArray();
+            IReadOnlyDictionary<string, DesignAnimationDefinitionKind> kinds = ResolveKinds(declarations);
+
+            return declarations
+                .Where(item => item.DisplayName is not null
+                    && item.IsPublic
+                    && !item.IsAbstract
+                    && !item.IsGeneric
+                    && (!item.HasAnyConstructor || item.HasPublicParameterlessConstructor)
+                    && kinds.ContainsKey(item.FullName))
+                .Select(item => new DesignAnimationDefinitionDescriptor(
+                    item.FullName,
+                    item.DisplayName!,
+                    kinds[item.FullName],
+                    ReadInheritedProperties(item, declarations)))
+                .OrderBy(item => item.DisplayName, StringComparer.Ordinal)
+                .ThenBy(item => item.TypeName, StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    private static IEnumerable<ProjectAnimationDeclaration> ReadDeclarations(string path)
+    {
+        CompilationUnitSyntax root;
+        try
+        {
+            root = CSharpSyntaxTree.ParseText(File.ReadAllText(path)).GetCompilationUnitRoot();
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            yield break;
+        }
+
+        foreach (ClassDeclarationSyntax type in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+        {
+            // Nested runtime types require '+' metadata names and are intentionally outside the
+            // current document/generator contract. Top-level abstract and generic declarations stay
+            // in the graph so concrete derived definitions can inherit their metadata safely.
+            if (type.Ancestors().OfType<TypeDeclarationSyntax>().Any())
+                continue;
+
+            string name = type.Identifier.ValueText;
+            string namespaceName = ReadNamespace(type);
+            string fullName = string.IsNullOrWhiteSpace(namespaceName) ? name : $"{namespaceName}.{name}";
+            UsingDirectiveSyntax[] usings = ReadUsings(type).ToArray();
+            bool hasAnimationUsing = HasNamespaceUsing(usings, AnimationNamespace);
+            AttributeSyntax? marker = FindAttribute(
+                type.AttributeLists,
+                DefinitionAttributeName,
+                usings,
+                hasAnimationUsing);
+            ConstructorDeclarationSyntax[] constructors = type.Members
+                .OfType<ConstructorDeclarationSyntax>()
+                .ToArray();
+
+            yield return new ProjectAnimationDeclaration(
+                name,
+                namespaceName,
+                fullName,
+                ResolveAliases(type.BaseList?.Types.FirstOrDefault()?.Type.ToString(), usings),
+                marker is null ? null : ReadStringArgument(marker, 0) ?? name,
+                ReadProperties(type, usings, hasAnimationUsing).ToArray(),
+                type.Modifiers.Any(SyntaxKind.PublicKeyword),
+                type.Modifiers.Any(SyntaxKind.AbstractKeyword),
+                type.TypeParameterList is not null,
+                constructors.Length > 0,
+                constructors.Any(constructor => constructor.ParameterList.Parameters.Count == 0
+                    && constructor.Modifiers.Any(SyntaxKind.PublicKeyword)),
+                hasAnimationUsing);
+        }
+    }
+
+    private static IReadOnlyDictionary<string, DesignAnimationDefinitionKind> ResolveKinds(
+        IReadOnlyList<ProjectAnimationDeclaration> declarations)
+    {
+        var kinds = new Dictionary<string, DesignAnimationDefinitionKind>(StringComparer.Ordinal);
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (ProjectAnimationDeclaration declaration in declarations)
+            {
+                if (kinds.ContainsKey(declaration.FullName)
+                    || !TryReadKind(declaration, declarations, kinds, out DesignAnimationDefinitionKind kind))
+                {
+                    continue;
+                }
+
+                kinds.Add(declaration.FullName, kind);
+                changed = true;
+            }
+        }
+        while (changed);
+
+        return kinds;
+    }
+
+    private static bool TryReadKind(
+        ProjectAnimationDeclaration declaration,
+        IReadOnlyList<ProjectAnimationDeclaration> declarations,
+        IReadOnlyDictionary<string, DesignAnimationDefinitionKind> knownKinds,
+        out DesignAnimationDefinitionKind kind)
+    {
+        string baseTypeName = RemoveGenericArguments(
+            DesignerProjectUserControlDiscovery.NormalizeTypeName(declaration.BaseTypeName ?? string.Empty));
+        ProjectAnimationDeclaration? projectBase = FindProjectBase(declaration, baseTypeName, declarations);
+        if (projectBase is not null)
+            return knownKinds.TryGetValue(projectBase.FullName, out kind);
+
+        if (string.Equals(baseTypeName, $"{AnimationNamespace}.InteractionEffect", StringComparison.Ordinal)
+            || declaration.HasAnimationNamespaceUsing
+                && string.Equals(baseTypeName, "InteractionEffect", StringComparison.Ordinal))
+        {
+            kind = DesignAnimationDefinitionKind.InteractionEffect;
+            return true;
+        }
+
+        if (string.Equals(baseTypeName, $"{AnimationNamespace}.AnimationDefinition", StringComparison.Ordinal)
+            || declaration.HasAnimationNamespaceUsing
+                && string.Equals(baseTypeName, "AnimationDefinition", StringComparison.Ordinal))
+        {
+            kind = DesignAnimationDefinitionKind.AnimationDefinition;
+            return true;
+        }
+
+        kind = default;
+        return false;
+    }
+
+    private static IReadOnlyList<DesignAnimationPropertyDescriptor> ReadInheritedProperties(
+        ProjectAnimationDeclaration declaration,
+        IReadOnlyList<ProjectAnimationDeclaration> declarations)
+    {
+        var properties = new List<DesignAnimationPropertyDescriptor>();
+        var indexes = new Dictionary<string, int>(StringComparer.Ordinal);
+        var visiting = new HashSet<string>(StringComparer.Ordinal);
+
+        Append(declaration);
+        return properties;
+
+        void Append(ProjectAnimationDeclaration current)
+        {
+            if (!visiting.Add(current.FullName))
+                return;
+
+            string baseTypeName = RemoveGenericArguments(
+                DesignerProjectUserControlDiscovery.NormalizeTypeName(current.BaseTypeName ?? string.Empty));
+            ProjectAnimationDeclaration? projectBase = FindProjectBase(current, baseTypeName, declarations);
+            if (projectBase is not null)
+                Append(projectBase);
+
+            foreach (DesignAnimationPropertyDescriptor property in current.DeclaredProperties)
+            {
+                if (indexes.TryGetValue(property.Name, out int index))
+                    properties[index] = property;
+                else
+                {
+                    indexes.Add(property.Name, properties.Count);
+                    properties.Add(property);
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<DesignAnimationPropertyDescriptor> ReadProperties(
+        ClassDeclarationSyntax type,
+        IReadOnlyList<UsingDirectiveSyntax> usings,
+        bool hasAnimationUsing)
+    {
+        foreach (PropertyDeclarationSyntax property in type.Members.OfType<PropertyDeclarationSyntax>())
+        {
+            AttributeSyntax? marker = FindAttribute(
+                property.AttributeLists,
+                PropertyAttributeName,
+                usings,
+                hasAnimationUsing);
+            if (marker is null
+                || !property.Modifiers.Any(SyntaxKind.PublicKeyword)
+                || property.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.SetAccessorDeclaration)
+                    && !accessor.Modifiers.Any(SyntaxKind.PrivateKeyword)) != true)
+            {
+                continue;
+            }
+
+            DesignAnimationPropertyKind? kind = ReadPropertyKind(marker);
+            if (kind is null)
+                continue;
+
+            string name = property.Identifier.ValueText;
+            string? defaultText = ReadNamedString(marker, "DefaultValue");
+            string? enumTypeName = ReadNamedString(marker, "EnumTypeName");
+            string[] enumMembers = ReadNamedStringArray(marker, "EnumMembers");
+            double declaredMinimum = ReadNamedDouble(marker, "Minimum") ?? double.MinValue;
+            double minimum = kind == DesignAnimationPropertyKind.TimeSpan
+                ? Math.Max(0d, declaredMinimum)
+                : declaredMinimum;
+            double maximum = ReadNamedDouble(marker, "Maximum") ?? double.MaxValue;
+            string runtimeTypeName = property.Type.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);
+            if (minimum > maximum
+                || !IsCompatiblePropertyType(kind.Value, runtimeTypeName, enumTypeName)
+                || kind == DesignAnimationPropertyKind.Enum
+                    && (!IsQualifiedIdentifier(enumTypeName)
+                        || enumMembers.Length == 0
+                        || enumMembers.Any(member => !DesignDocumentValidator.IsValidCSharpIdentifier(member)))
+                || !TryCreateDefault(
+                    kind.Value,
+                    defaultText,
+                    enumTypeName,
+                    enumMembers,
+                    minimum,
+                    maximum,
+                    out DesignPropertyValue defaultValue))
+            {
+                continue;
+            }
+
+            yield return new DesignAnimationPropertyDescriptor(name, name, kind.Value, defaultValue)
+            {
+                Minimum = minimum,
+                Maximum = maximum,
+                EnumTypeName = enumTypeName,
+                EnumMembers = enumMembers,
+                RuntimeTypeName = runtimeTypeName
+            };
+        }
+    }
+
+    private static DesignAnimationPropertyKind? ReadPropertyKind(AttributeSyntax marker)
+    {
+        string text = marker.ArgumentList?.Arguments.FirstOrDefault()?.Expression.ToString() ?? string.Empty;
+        string member = text.Split('.').Last();
+        return Enum.TryParse(member, ignoreCase: false, out DesignAnimationPropertyKind result) ? result : null;
+    }
+
+    private static bool TryCreateDefault(
+        DesignAnimationPropertyKind kind,
+        string? text,
+        string? enumTypeName,
+        IReadOnlyList<string> enumMembers,
+        double minimum,
+        double maximum,
+        out DesignPropertyValue value)
+    {
+        text ??= kind switch
+        {
+            DesignAnimationPropertyKind.Boolean => "false",
+            DesignAnimationPropertyKind.Easing => "Linear",
+            DesignAnimationPropertyKind.Enum => enumMembers.FirstOrDefault() ?? string.Empty,
+            DesignAnimationPropertyKind.String => string.Empty,
+            DesignAnimationPropertyKind.ColorArgb => "#00000000",
+            _ => "0"
+        };
+
+        switch (kind)
+        {
+            case DesignAnimationPropertyKind.Boolean when bool.TryParse(text, out bool boolean):
+                value = DesignPropertyValue.FromBoolean(boolean);
+                return true;
+            case DesignAnimationPropertyKind.Int32 when int.TryParse(
+                    text,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out int integer)
+                && integer >= minimum && integer <= maximum:
+                value = DesignPropertyValue.FromInt32(integer);
+                return true;
+            case DesignAnimationPropertyKind.Number or DesignAnimationPropertyKind.TimeSpan
+                when double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double number)
+                && double.IsFinite(number) && number >= minimum && number <= maximum:
+                value = DesignPropertyValue.FromDouble(number);
+                return true;
+            case DesignAnimationPropertyKind.Easing when KnownEasingDesignValue.IsKnown(text):
+                value = DesignPropertyValue.FromString(text);
+                return true;
+            case DesignAnimationPropertyKind.Enum when enumMembers.Contains(text, StringComparer.Ordinal):
+                value = DesignPropertyValue.FromEnum(enumTypeName!, text);
+                return true;
+            case DesignAnimationPropertyKind.ColorArgb when TryReadArgb(text, out int argb):
+                value = DesignPropertyValue.FromInt32(argb);
+                return true;
+            case DesignAnimationPropertyKind.String:
+                value = DesignPropertyValue.FromString(text);
+                return true;
+            default:
+                value = DesignPropertyValue.FromNull();
+                return false;
+        }
+    }
+
+    private static AttributeSyntax? FindAttribute(
+        SyntaxList<AttributeListSyntax> lists,
+        string shortName,
+        IReadOnlyList<UsingDirectiveSyntax> usings,
+        bool hasAnimationUsing)
+        => lists.SelectMany(list => list.Attributes).FirstOrDefault(attribute =>
+        {
+            string name = ResolveAliases(attribute.Name.ToString(), usings) ?? string.Empty;
+            return string.Equals(name, $"{AnimationNamespace}.{shortName}", StringComparison.Ordinal)
+                || string.Equals(name, $"{AnimationNamespace}.{shortName}Attribute", StringComparison.Ordinal)
+                || hasAnimationUsing && (string.Equals(name, shortName, StringComparison.Ordinal)
+                    || string.Equals(name, shortName + "Attribute", StringComparison.Ordinal));
+        });
+
+    private static string? ReadStringArgument(AttributeSyntax attribute, int index)
+        => attribute.ArgumentList?.Arguments.ElementAtOrDefault(index)?.Expression is LiteralExpressionSyntax literal
+            && literal.IsKind(SyntaxKind.StringLiteralExpression)
+                ? literal.Token.ValueText
+                : null;
+
+    private static string? ReadNamedString(AttributeSyntax attribute, string name)
+        => attribute.ArgumentList?.Arguments.FirstOrDefault(argument =>
+                string.Equals(argument.NameEquals?.Name.Identifier.ValueText, name, StringComparison.Ordinal))
+            ?.Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression)
+                ? literal.Token.ValueText
+                : null;
+
+    private static double? ReadNamedDouble(AttributeSyntax attribute, string name)
+    {
+        ExpressionSyntax? expression = attribute.ArgumentList?.Arguments.FirstOrDefault(argument =>
+            string.Equals(argument.NameEquals?.Name.Identifier.ValueText, name, StringComparison.Ordinal))?.Expression;
+        if (expression is PrefixUnaryExpressionSyntax prefix && prefix.IsKind(SyntaxKind.UnaryMinusExpression))
+        {
+            return double.TryParse(
+                prefix.Operand.ToString().TrimEnd('d', 'D', 'f', 'F'),
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out double negative)
+                    ? -negative
+                    : null;
+        }
+
+        return expression is not null && double.TryParse(
+            expression.ToString().TrimEnd('d', 'D', 'f', 'F'),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out double value)
+                ? value
+                : null;
+    }
+
+    private static string[] ReadNamedStringArray(AttributeSyntax attribute, string name)
+    {
+        ExpressionSyntax? expression = attribute.ArgumentList?.Arguments.FirstOrDefault(argument =>
+            string.Equals(argument.NameEquals?.Name.Identifier.ValueText, name, StringComparison.Ordinal))?.Expression;
+        InitializerExpressionSyntax? initializer = expression switch
+        {
+            ArrayCreationExpressionSyntax array => array.Initializer,
+            ImplicitArrayCreationExpressionSyntax array => array.Initializer,
+            CollectionExpressionSyntax collection => SyntaxFactory.InitializerExpression(
+                SyntaxKind.ArrayInitializerExpression,
+                SyntaxFactory.SeparatedList(collection.Elements.OfType<ExpressionElementSyntax>().Select(item => item.Expression))),
+            _ => null
+        };
+        return initializer?.Expressions.OfType<LiteralExpressionSyntax>()
+            .Where(item => item.IsKind(SyntaxKind.StringLiteralExpression))
+            .Select(item => item.Token.ValueText)
+            .ToArray() ?? [];
+    }
+
+    private static bool TryReadArgb(string text, out int value)
+    {
+        value = 0;
+        return text.Length == 9 && text[0] == '#'
+            && uint.TryParse(text.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint argb)
+            && (value = unchecked((int)argb)) == unchecked((int)argb);
+    }
+
+    private static bool IsCompatiblePropertyType(
+        DesignAnimationPropertyKind kind,
+        string typeName,
+        string? enumTypeName)
+    {
+        string normalized = typeName.Replace(" ", string.Empty, StringComparison.Ordinal);
+        string simpleName = normalized.Split('.').Last();
+        return kind switch
+        {
+            DesignAnimationPropertyKind.Boolean => simpleName is "bool" or "Boolean",
+            DesignAnimationPropertyKind.Int32 => simpleName is "int" or "Int32",
+            DesignAnimationPropertyKind.Number => simpleName is "float" or "Single" or "double" or "Double",
+            DesignAnimationPropertyKind.TimeSpan => simpleName == "TimeSpan",
+            DesignAnimationPropertyKind.Easing => normalized
+                is "Func<float,float>" or "System.Func<float,float>" or "Func<System.Single,System.Single>" or "System.Func<System.Single,System.Single>",
+            DesignAnimationPropertyKind.Enum => !string.IsNullOrWhiteSpace(enumTypeName)
+                && string.Equals(simpleName, enumTypeName.Split('.').Last(), StringComparison.Ordinal),
+            DesignAnimationPropertyKind.ColorArgb => simpleName == "Color",
+            DesignAnimationPropertyKind.String => simpleName is "string" or "String",
+            _ => false
+        };
+    }
+
+    private static bool IsQualifiedIdentifier(string? value)
+        => !string.IsNullOrWhiteSpace(value)
+        && value.Split('.').All(DesignDocumentValidator.IsValidCSharpIdentifier);
+
+    private static ProjectAnimationDeclaration MergePartialDeclarations(
+        IGrouping<string, ProjectAnimationDeclaration> declarations)
+    {
+        ProjectAnimationDeclaration declaration = declarations
+            .FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate.BaseTypeName))
+            ?? declarations.First();
+        return declaration with
+        {
+            BaseTypeName = declarations.Select(candidate => candidate.BaseTypeName)
+                .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)),
+            DisplayName = declarations.Select(candidate => candidate.DisplayName)
+                .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)),
+            DeclaredProperties = declarations.SelectMany(candidate => candidate.DeclaredProperties).ToArray(),
+            IsPublic = declarations.Any(candidate => candidate.IsPublic),
+            IsAbstract = declarations.Any(candidate => candidate.IsAbstract),
+            IsGeneric = declarations.Any(candidate => candidate.IsGeneric),
+            HasAnyConstructor = declarations.Any(candidate => candidate.HasAnyConstructor),
+            HasPublicParameterlessConstructor = declarations.Any(candidate => candidate.HasPublicParameterlessConstructor),
+            HasAnimationNamespaceUsing = declarations.Any(candidate => candidate.HasAnimationNamespaceUsing)
+        };
+    }
+
+    private static ProjectAnimationDeclaration? FindProjectBase(
+        ProjectAnimationDeclaration declaration,
+        string typeName,
+        IReadOnlyList<ProjectAnimationDeclaration> declarations)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return null;
+
+        if (!typeName.Contains('.'))
+        {
+            string relativeName = string.IsNullOrWhiteSpace(declaration.Namespace)
+                ? typeName
+                : $"{declaration.Namespace}.{typeName}";
+            return declarations.FirstOrDefault(candidate =>
+                string.Equals(candidate.FullName, relativeName, StringComparison.Ordinal));
+        }
+
+        if (!string.IsNullOrWhiteSpace(declaration.Namespace))
+        {
+            string relativeName = $"{declaration.Namespace}.{typeName}";
+            ProjectAnimationDeclaration? relative = declarations.FirstOrDefault(candidate =>
+                string.Equals(candidate.FullName, relativeName, StringComparison.Ordinal));
+            if (relative is not null)
+                return relative;
+        }
+
+        return declarations.FirstOrDefault(candidate =>
+            string.Equals(candidate.FullName, typeName, StringComparison.Ordinal));
+    }
+
+    private static IEnumerable<UsingDirectiveSyntax> ReadUsings(ClassDeclarationSyntax declaration)
+        => declaration.Ancestors().SelectMany(node => node switch
+        {
+            CompilationUnitSyntax compilationUnit => compilationUnit.Usings,
+            BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.Usings,
+            _ => []
+        });
+
+    private static bool HasNamespaceUsing(IEnumerable<UsingDirectiveSyntax> usings, string namespaceName)
+        => usings.Any(usingDirective => usingDirective.Alias is null
+            && string.Equals(
+                DesignerProjectUserControlDiscovery.NormalizeTypeName(usingDirective.Name?.ToString() ?? string.Empty),
+                namespaceName,
+                StringComparison.Ordinal));
+
+    private static string? ResolveAliases(
+        string? typeName,
+        IEnumerable<UsingDirectiveSyntax> usings)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return typeName;
+
+        string normalized = DesignerProjectUserControlDiscovery.NormalizeTypeName(typeName);
+        foreach (UsingDirectiveSyntax usingDirective in usings)
+        {
+            string? alias = usingDirective.Alias?.Name.Identifier.ValueText;
+            string? target = usingDirective.Name?.ToString();
+            if (string.IsNullOrWhiteSpace(alias) || string.IsNullOrWhiteSpace(target))
+                continue;
+
+            target = DesignerProjectUserControlDiscovery.NormalizeTypeName(target);
+            if (string.Equals(normalized, alias, StringComparison.Ordinal))
+                return target;
+            if (normalized.StartsWith(alias + ".", StringComparison.Ordinal))
+                return target + normalized[alias.Length..];
+        }
+
+        return normalized;
+    }
+
+    private static string RemoveGenericArguments(string typeName)
+    {
+        var result = new StringBuilder(typeName.Length);
+        int depth = 0;
+        foreach (char character in typeName)
+        {
+            if (character == '<')
+            {
+                depth++;
+                continue;
+            }
+            if (character == '>')
+            {
+                depth = Math.Max(0, depth - 1);
+                continue;
+            }
+            if (depth == 0 && !char.IsWhiteSpace(character))
+                result.Append(character);
+        }
+        return result.ToString();
+    }
+
+    private static string ReadNamespace(ClassDeclarationSyntax declaration)
+    {
+        var segments = new Stack<string>();
+        for (SyntaxNode? node = declaration.Parent; node is not null; node = node.Parent)
+        {
+            if (node is BaseNamespaceDeclarationSyntax namespaceDeclaration)
+                segments.Push(namespaceDeclaration.Name.ToString());
+        }
+        return string.Join(".", segments);
+    }
+
+    private sealed record ProjectAnimationDeclaration(
+        string Name,
+        string Namespace,
+        string FullName,
+        string? BaseTypeName,
+        string? DisplayName,
+        IReadOnlyList<DesignAnimationPropertyDescriptor> DeclaredProperties,
+        bool IsPublic,
+        bool IsAbstract,
+        bool IsGeneric,
+        bool HasAnyConstructor,
+        bool HasPublicParameterlessConstructor,
+        bool HasAnimationNamespaceUsing);
+}

--- a/ModernFormsNext.Designer/Services/DesignerSession.cs
+++ b/ModernFormsNext.Designer/Services/DesignerSession.cs
@@ -117,6 +117,9 @@ public sealed class DesignerSession
 
     internal IReadOnlyList<DesignerProjectUserControlInfo> ProjectUserControls => projectUserControls;
 
+    internal IReadOnlyList<DesignAnimationDefinitionDescriptor> AnimationDefinitions
+        => DesignerProjectAnimationDefinitionDiscovery.Discover(CurrentProjectPath);
+
     internal IReadOnlyList<DesignerOpenDocument> OpenDocuments => openDocuments;
 
     internal int ActiveDocumentIndex => activeDocument is null ? -1 : openDocuments.IndexOf(activeDocument);

--- a/ModernFormsNext.Designing/Metadata/BuiltInAnimationDefinitionCatalog.cs
+++ b/ModernFormsNext.Designing/Metadata/BuiltInAnimationDefinitionCatalog.cs
@@ -1,0 +1,71 @@
+namespace ModernFormsNext.Designing;
+
+/// <summary>Provides the authoritative detached descriptors for built-in interaction effects.</summary>
+public static class BuiltInAnimationDefinitionCatalog
+{
+    /// <summary>Gets the namespace-qualified RippleEffect type name.</summary>
+    public const string RippleEffectTypeName = "ModernFormsNext.Animations.RippleEffect";
+    /// <summary>Gets the namespace-qualified PressScaleEffect type name.</summary>
+    public const string PressScaleEffectTypeName = "ModernFormsNext.Animations.PressScaleEffect";
+
+    /// <summary>Gets built-in effect descriptors in Designer display order.</summary>
+    public static IReadOnlyList<DesignAnimationDefinitionDescriptor> Definitions { get; } =
+    [
+        new(
+            RippleEffectTypeName,
+            "RippleEffect",
+            DesignAnimationDefinitionKind.InteractionEffect,
+            [
+                Boolean("Enabled", true),
+                Color("ColorArgb", "Color", unchecked((int)0x5AFFFFFF)),
+                TimeSpan("DurationMilliseconds", "Duration", 450d),
+                Easing("Easing", "CubicOut"),
+                Boolean("StartFromPointer", true),
+                Enum("RadiusMode", "ModernFormsNext.Animations.RippleRadiusMode", "CoverControl", "CoverControl", "Fixed"),
+                Number("FixedRadius", 48d, 0d, float.MaxValue),
+                Enum("Layer", "ModernFormsNext.Animations.RippleLayer", "AboveBackgroundBelowContent", "AboveBackgroundBelowContent", "AboveContent"),
+                Integer("MaxConcurrentRipples", 4, 1, 32),
+                Enum("OverflowPolicy", "ModernFormsNext.Animations.RippleOverflowPolicy", "RemoveOldest", "RemoveOldest", "RemoveNewest", "IgnoreNew", "ReplaceAll")
+            ]) { IsBuiltIn = true },
+        new(
+            PressScaleEffectTypeName,
+            "PressScaleEffect",
+            DesignAnimationDefinitionKind.InteractionEffect,
+            [
+                Boolean("Enabled", true),
+                Number("PressedScale", 0.97d, float.Epsilon, float.MaxValue),
+                TimeSpan("PressDurationMilliseconds", "PressDuration", 80d),
+                TimeSpan("ReleaseDurationMilliseconds", "ReleaseDuration", 120d),
+                Easing("Easing", "CubicOut")
+            ]) { IsBuiltIn = true }
+    ];
+
+    private static DesignAnimationPropertyDescriptor Boolean(string name, bool value)
+        => new(name, name, DesignAnimationPropertyKind.Boolean, DesignPropertyValue.FromBoolean(value));
+
+    private static DesignAnimationPropertyDescriptor Integer(string name, int value, int minimum, int maximum)
+        => new(name, name, DesignAnimationPropertyKind.Int32, DesignPropertyValue.FromInt32(value))
+        { Minimum = minimum, Maximum = maximum };
+
+    private static DesignAnimationPropertyDescriptor Number(string name, double value, double minimum, double maximum)
+        => new(name, name, DesignAnimationPropertyKind.Number, DesignPropertyValue.FromDouble(value))
+        { Minimum = minimum, Maximum = maximum, RuntimeTypeName = "float" };
+
+    private static DesignAnimationPropertyDescriptor TimeSpan(string name, string runtimeName, double milliseconds)
+        => new(name, runtimeName, DesignAnimationPropertyKind.TimeSpan, DesignPropertyValue.FromDouble(milliseconds))
+        { Minimum = 0d };
+
+    private static DesignAnimationPropertyDescriptor Easing(string name, string value)
+        => new(name, name, DesignAnimationPropertyKind.Easing, DesignPropertyValue.FromString(value));
+
+    private static DesignAnimationPropertyDescriptor Color(string name, string runtimeName, int value)
+        => new(name, runtimeName, DesignAnimationPropertyKind.ColorArgb, DesignPropertyValue.FromInt32(value));
+
+    private static DesignAnimationPropertyDescriptor Enum(
+        string name,
+        string typeName,
+        string defaultMember,
+        params string[] members)
+        => new(name, name, DesignAnimationPropertyKind.Enum, DesignPropertyValue.FromEnum(typeName, defaultMember))
+        { EnumTypeName = typeName, EnumMembers = members };
+}

--- a/ModernFormsNext.Designing/Metadata/DesignAnimationDefinitionDescriptor.cs
+++ b/ModernFormsNext.Designing/Metadata/DesignAnimationDefinitionDescriptor.cs
@@ -1,0 +1,108 @@
+namespace ModernFormsNext.Designing;
+
+/// <summary>Identifies the runtime animation concept described by design-time metadata.</summary>
+public enum DesignAnimationDefinitionKind
+{
+    /// <summary>A definition derived from <c>InteractionEffect</c> and attachable to a control.</summary>
+    InteractionEffect,
+
+    /// <summary>A code-first definition derived from <c>AnimationDefinition</c>.</summary>
+    AnimationDefinition
+}
+
+/// <summary>Identifies a safely serializable property shape exposed by an animation descriptor.</summary>
+public enum DesignAnimationPropertyKind
+{
+    /// <summary>A Boolean value.</summary>
+    Boolean,
+    /// <summary>A signed 32-bit integer.</summary>
+    Int32,
+    /// <summary>A finite floating-point number.</summary>
+    Number,
+    /// <summary>A non-negative <c>TimeSpan</c>, persisted as milliseconds.</summary>
+    TimeSpan,
+    /// <summary>A stable identifier from <see cref="KnownEasingDesignValue"/>.</summary>
+    Easing,
+    /// <summary>An enum member with an explicitly declared member set.</summary>
+    Enum,
+    /// <summary>An ARGB color persisted as a signed 32-bit value.</summary>
+    ColorArgb,
+    /// <summary>A string value.</summary>
+    String
+}
+
+/// <summary>Describes one designer-safe property of an animation or interaction effect.</summary>
+public sealed class DesignAnimationPropertyDescriptor
+{
+    /// <summary>Initializes a property descriptor.</summary>
+    public DesignAnimationPropertyDescriptor(
+        string name,
+        string runtimePropertyName,
+        DesignAnimationPropertyKind kind,
+        DesignPropertyValue defaultValue)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(runtimePropertyName);
+        Name = name;
+        RuntimePropertyName = runtimePropertyName;
+        Kind = kind;
+        DefaultValue = defaultValue ?? throw new ArgumentNullException(nameof(defaultValue));
+    }
+
+    /// <summary>Gets the stable design-document property name.</summary>
+    public string Name { get; }
+    /// <summary>Gets the corresponding runtime CLR property name.</summary>
+    public string RuntimePropertyName { get; }
+    /// <summary>Gets the serialized property shape.</summary>
+    public DesignAnimationPropertyKind Kind { get; }
+    /// <summary>Gets the runtime-compatible default represented as a detached value.</summary>
+    public DesignPropertyValue DefaultValue { get; }
+    /// <summary>Gets or initializes the inclusive numeric minimum.</summary>
+    public double Minimum { get; init; } = double.MinValue;
+    /// <summary>Gets or initializes the inclusive numeric maximum.</summary>
+    public double Maximum { get; init; } = double.MaxValue;
+    /// <summary>Gets or initializes the runtime enum type name.</summary>
+    public string? EnumTypeName { get; init; }
+    /// <summary>Gets or initializes the explicitly allowed enum members.</summary>
+    public IReadOnlyList<string> EnumMembers { get; init; } = [];
+    /// <summary>Gets or initializes the source runtime type used to choose numeric literal syntax.</summary>
+    public string? RuntimeTypeName { get; init; }
+}
+
+/// <summary>
+/// Provides detached, non-executable metadata for a runtime animation or interaction-effect type.
+/// </summary>
+/// <remarks>
+/// A descriptor contains no delegates, constructors, instances, or assembly references. Designer
+/// hosts may obtain custom descriptors from source analysis, then pass the same descriptors to the
+/// editor, generator, and conservative reverse parser.
+/// </remarks>
+public sealed class DesignAnimationDefinitionDescriptor
+{
+    /// <summary>Initializes a definition descriptor.</summary>
+    public DesignAnimationDefinitionDescriptor(
+        string typeName,
+        string displayName,
+        DesignAnimationDefinitionKind kind,
+        IEnumerable<DesignAnimationPropertyDescriptor> properties)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(typeName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        ArgumentNullException.ThrowIfNull(properties);
+        TypeName = typeName;
+        DisplayName = displayName;
+        Kind = kind;
+        Properties = properties.ToArray();
+    }
+
+    /// <summary>Gets the namespace-qualified, assembly-independent runtime type name.</summary>
+    public string TypeName { get; }
+    /// <summary>Gets the user-facing display name.</summary>
+    public string DisplayName { get; }
+    /// <summary>Gets the described runtime concept.</summary>
+    public DesignAnimationDefinitionKind Kind { get; }
+    /// <summary>Gets properties in deterministic editor display order.</summary>
+    public IReadOnlyList<DesignAnimationPropertyDescriptor> Properties { get; }
+    /// <summary>Gets or initializes whether the type is supplied by ModernFormsNext itself.</summary>
+    public bool IsBuiltIn { get; init; }
+}

--- a/ModernFormsNext.Designing/Properties/InteractionEffectDesignValue.cs
+++ b/ModernFormsNext.Designing/Properties/InteractionEffectDesignValue.cs
@@ -77,6 +77,13 @@ public static class InteractionEffectDesignValue
             error = "InteractionEffects.Count must be an integer from 0 through 64.";
             return false;
         }
+        if (value.ObjectProperties.Count != count + 1
+            || value.ObjectProperties.Keys.Any(name => name != "Count"
+                && !Enumerable.Range(0, count).Any(index => name == $"Item{index}")))
+        {
+            error = "InteractionEffects contains unsupported collection properties.";
+            return false;
+        }
 
         var result = new List<DesignPropertyValue>(count);
         for (int index = 0; index < count; index++)

--- a/ModernFormsNext.Designing/Properties/KnownEasingDesignValue.cs
+++ b/ModernFormsNext.Designing/Properties/KnownEasingDesignValue.cs
@@ -1,0 +1,33 @@
+namespace ModernFormsNext.Designing;
+
+/// <summary>
+/// Defines stable design-document identifiers for easing functions supplied by ModernFormsNext.
+/// </summary>
+/// <remarks>
+/// Designer documents persist one of these identifiers instead of attempting to serialize the
+/// runtime <c>Func&lt;float, float&gt;</c> delegate. Code generation maps the identifier back to the
+/// corresponding member of <c>ModernFormsNext.Animations.Easings</c>.
+/// </remarks>
+public static class KnownEasingDesignValue
+{
+    /// <summary>Gets all easing identifiers accepted by the Designer, in display order.</summary>
+    public static IReadOnlyList<string> Identifiers { get; } =
+    [
+        "Linear",
+        "EaseIn",
+        "EaseOut",
+        "EaseInOut",
+        "EaseOutCubic",
+        "CubicIn",
+        "CubicOut",
+        "CubicInOut",
+        "BounceOut",
+        "EaseInOutCubic"
+    ];
+
+    /// <summary>Determines whether a value is a supported stable easing identifier.</summary>
+    /// <param name="identifier">The identifier to validate.</param>
+    /// <returns><see langword="true"/> when the identifier is known.</returns>
+    public static bool IsKnown(string? identifier)
+        => identifier is not null && Identifiers.Contains(identifier, StringComparer.Ordinal);
+}

--- a/ModernFormsNext.Designing/Properties/LayoutTransitionDesignValue.cs
+++ b/ModernFormsNext.Designing/Properties/LayoutTransitionDesignValue.cs
@@ -1,0 +1,118 @@
+namespace ModernFormsNext.Designing;
+
+/// <summary>Encodes a detached <c>LayoutTransition</c> configuration in a design document.</summary>
+public static class LayoutTransitionDesignValue
+{
+    /// <summary>Gets the design-document property name.</summary>
+    public const string PropertyName = "LayoutTransition";
+
+    /// <summary>Gets the structured runtime type name.</summary>
+    public const string TypeName = "ModernFormsNext.Animations.LayoutTransition";
+
+    /// <summary>Creates a validated layout-transition value.</summary>
+    /// <param name="enabled">Whether animated layout is enabled.</param>
+    /// <param name="durationMilliseconds">Duration in milliseconds.</param>
+    /// <param name="easing">Stable built-in easing identifier.</param>
+    /// <returns>The detached structured value.</returns>
+    public static DesignPropertyValue Create(bool enabled, double durationMilliseconds, string easing)
+    {
+        Validate(durationMilliseconds, easing);
+        return DesignPropertyValue.FromStructuredObject(
+            TypeName,
+            new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            {
+                ["DurationMilliseconds"] = DesignPropertyValue.FromDouble(durationMilliseconds),
+                ["Easing"] = DesignPropertyValue.FromString(easing),
+                ["Enabled"] = DesignPropertyValue.FromBoolean(enabled)
+            });
+    }
+
+    /// <summary>Reads and validates a detached layout-transition value.</summary>
+    public static bool TryRead(
+        DesignPropertyValue? value,
+        out bool enabled,
+        out double durationMilliseconds,
+        out string easing,
+        out string? error)
+    {
+        enabled = true;
+        durationMilliseconds = 250d;
+        easing = "EaseOut";
+        error = null;
+
+        if (value is null)
+            return true;
+        if (value.Kind != DesignPropertyValueKind.Object
+            || value.ObjectProperties is null
+            || !IsType(value.ObjectTypeName))
+        {
+            error = "LayoutTransition must be a structured LayoutTransition value.";
+            return false;
+        }
+
+        foreach (string name in value.ObjectProperties.Keys)
+        {
+            if (name is not ("Enabled" or "DurationMilliseconds" or "Easing"))
+            {
+                error = $"LayoutTransition property '{name}' is not supported.";
+                return false;
+            }
+        }
+
+        if (value.ObjectProperties.TryGetValue("Enabled", out var enabledValue))
+        {
+            if (enabledValue.Kind != DesignPropertyValueKind.Boolean || enabledValue.Value is not bool parsedEnabled)
+            {
+                error = "LayoutTransition.Enabled must be a Boolean.";
+                return false;
+            }
+            enabled = parsedEnabled;
+        }
+
+        if (value.ObjectProperties.TryGetValue("DurationMilliseconds", out var durationValue))
+        {
+            if (!TryReadNumber(durationValue, out durationMilliseconds) || durationMilliseconds < 0d)
+            {
+                error = "LayoutTransition.DurationMilliseconds must be a finite non-negative number.";
+                return false;
+            }
+        }
+
+        if (value.ObjectProperties.TryGetValue("Easing", out var easingValue))
+        {
+            if (easingValue.Kind != DesignPropertyValueKind.String
+                || easingValue.Value is not string parsedEasing
+                || !KnownEasingDesignValue.IsKnown(parsedEasing))
+            {
+                error = "LayoutTransition.Easing must be a known built-in easing identifier.";
+                return false;
+            }
+            easing = parsedEasing;
+        }
+
+        return true;
+    }
+
+    private static void Validate(double durationMilliseconds, string easing)
+    {
+        if (!double.IsFinite(durationMilliseconds) || durationMilliseconds < 0d)
+            throw new ArgumentOutOfRangeException(nameof(durationMilliseconds));
+        if (!KnownEasingDesignValue.IsKnown(easing))
+            throw new ArgumentException("The easing identifier is not supported by the Designer.", nameof(easing));
+    }
+
+    private static bool TryReadNumber(DesignPropertyValue value, out double number)
+    {
+        number = value.Kind switch
+        {
+            DesignPropertyValueKind.Int32 => Convert.ToDouble(value.Value, System.Globalization.CultureInfo.InvariantCulture),
+            DesignPropertyValueKind.Double => Convert.ToDouble(value.Value, System.Globalization.CultureInfo.InvariantCulture),
+            _ => double.NaN
+        };
+        return double.IsFinite(number);
+    }
+
+    private static bool IsType(string? typeName)
+        => string.Equals(typeName, TypeName, StringComparison.Ordinal)
+        || string.Equals(typeName, "LayoutTransition", StringComparison.Ordinal);
+}

--- a/ModernFormsNext.Designing/Properties/VisualStateTransitionDesignValue.cs
+++ b/ModernFormsNext.Designing/Properties/VisualStateTransitionDesignValue.cs
@@ -1,0 +1,176 @@
+namespace ModernFormsNext.Designing;
+
+/// <summary>Represents one detached visual-state transition entry.</summary>
+/// <param name="From">Source visual-state member name.</param>
+/// <param name="To">Target visual-state member name.</param>
+/// <param name="DurationMilliseconds">Transition duration in milliseconds.</param>
+/// <param name="Easing">Stable built-in easing identifier.</param>
+public sealed record DesignVisualStateTransition(
+    string From,
+    string To,
+    double DurationMilliseconds,
+    string Easing);
+
+/// <summary>Encodes the ordered visual-state transition collection in one designer value.</summary>
+public static class VisualStateTransitionDesignValue
+{
+    /// <summary>Gets the design-document property name mapped to <c>Control.StyleTransitions</c>.</summary>
+    public const string PropertyName = "StyleTransitions";
+
+    /// <summary>Gets the structured collection type name.</summary>
+    public const string CollectionTypeName = "ModernFormsNext.Animations.VisualStateTransitionCollection";
+
+    private const string EntryTypeName = "ModernFormsNext.Animations.VisualStateTransition";
+
+    /// <summary>Creates a deterministic ordered collection value.</summary>
+    public static DesignPropertyValue Create(IEnumerable<DesignVisualStateTransition> transitions)
+    {
+        ArgumentNullException.ThrowIfNull(transitions);
+        DesignVisualStateTransition[] items = transitions.ToArray();
+        if (items.Length > 64)
+            throw new ArgumentOutOfRangeException(nameof(transitions), "At most 64 transitions can be stored.");
+
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["Count"] = DesignPropertyValue.FromInt32(items.Length)
+        };
+        var pairs = new HashSet<string>(StringComparer.Ordinal);
+
+        for (int index = 0; index < items.Length; index++)
+        {
+            DesignVisualStateTransition item = items[index];
+            Validate(item);
+            if (!pairs.Add(item.From + "\0" + item.To))
+                throw new ArgumentException($"The {item.From} -> {item.To} transition is duplicated.", nameof(transitions));
+
+            properties[$"Item{index}"] = DesignPropertyValue.FromStructuredObject(
+                EntryTypeName,
+                new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+                {
+                    ["DurationMilliseconds"] = DesignPropertyValue.FromDouble(item.DurationMilliseconds),
+                    ["Easing"] = DesignPropertyValue.FromString(item.Easing),
+                    ["From"] = DesignPropertyValue.FromEnum("ModernFormsNext.Animations.VisualState", item.From),
+                    ["To"] = DesignPropertyValue.FromEnum("ModernFormsNext.Animations.VisualState", item.To)
+                });
+        }
+
+        return DesignPropertyValue.FromStructuredObject(CollectionTypeName, properties);
+    }
+
+    /// <summary>Reads and validates an ordered transition collection.</summary>
+    public static bool TryRead(
+        DesignPropertyValue? value,
+        out IReadOnlyList<DesignVisualStateTransition> transitions,
+        out string? error)
+    {
+        transitions = [];
+        error = null;
+        if (value is null)
+            return true;
+        if (value.Kind != DesignPropertyValueKind.Object
+            || value.ObjectProperties is null
+            || !IsCollectionType(value.ObjectTypeName))
+        {
+            error = "StyleTransitions must be a structured visual-state transition collection.";
+            return false;
+        }
+        if (!value.ObjectProperties.TryGetValue("Count", out var countValue)
+            || countValue.Kind != DesignPropertyValueKind.Int32
+            || countValue.Value is not int count
+            || count is < 0 or > 64)
+        {
+            error = "StyleTransitions.Count must be an integer from 0 through 64.";
+            return false;
+        }
+        if (value.ObjectProperties.Count != count + 1
+            || value.ObjectProperties.Keys.Any(name => name != "Count"
+                && !Enumerable.Range(0, count).Any(index => name == $"Item{index}")))
+        {
+            error = "StyleTransitions contains unsupported collection properties.";
+            return false;
+        }
+
+        var result = new List<DesignVisualStateTransition>(count);
+        var pairs = new HashSet<string>(StringComparer.Ordinal);
+        for (int index = 0; index < count; index++)
+        {
+            if (!value.ObjectProperties.TryGetValue($"Item{index}", out var item)
+                || item.Kind != DesignPropertyValueKind.Object
+                || item.ObjectProperties is null
+                || !string.Equals(item.ObjectTypeName, EntryTypeName, StringComparison.Ordinal)
+                || item.ObjectProperties.Keys.Any(name => name is not ("From" or "To" or "DurationMilliseconds" or "Easing")))
+            {
+                error = $"StyleTransitions.Item{index} is missing or malformed.";
+                return false;
+            }
+
+            if (!TryReadState(item.ObjectProperties, "From", out string from)
+                || !TryReadState(item.ObjectProperties, "To", out string to)
+                || !TryReadDuration(item.ObjectProperties, out double duration)
+                || !TryReadEasing(item.ObjectProperties, out string easing))
+            {
+                error = $"StyleTransitions.Item{index} contains an invalid state, duration, or easing.";
+                return false;
+            }
+            if (!pairs.Add(from + "\0" + to))
+            {
+                error = $"StyleTransitions contains duplicate {from} -> {to} entries.";
+                return false;
+            }
+            result.Add(new DesignVisualStateTransition(from, to, duration, easing));
+        }
+
+        transitions = result;
+        return true;
+    }
+
+    private static readonly string[] States = ["Normal", "Hover", "Pressed", "Disabled", "Focused"];
+
+    private static void Validate(DesignVisualStateTransition item)
+    {
+        if (!States.Contains(item.From, StringComparer.Ordinal) || !States.Contains(item.To, StringComparer.Ordinal))
+            throw new ArgumentException("Visual-state transition endpoints must be known VisualState members.");
+        if (!double.IsFinite(item.DurationMilliseconds) || item.DurationMilliseconds < 0d)
+            throw new ArgumentOutOfRangeException(nameof(item), "Transition duration must be non-negative and finite.");
+        if (!KnownEasingDesignValue.IsKnown(item.Easing))
+            throw new ArgumentException("Transition easing must be a known built-in easing identifier.");
+    }
+
+    private static bool TryReadState(IReadOnlyDictionary<string, DesignPropertyValue> properties, string name, out string value)
+    {
+        value = string.Empty;
+        if (!properties.TryGetValue(name, out var stored)
+            || stored.Kind != DesignPropertyValueKind.Enum
+            || stored.Value is not string member
+            || !States.Contains(member, StringComparer.Ordinal))
+            return false;
+        value = member;
+        return true;
+    }
+
+    private static bool TryReadDuration(IReadOnlyDictionary<string, DesignPropertyValue> properties, out double value)
+    {
+        value = 150d;
+        if (!properties.TryGetValue("DurationMilliseconds", out var stored))
+            return true;
+        if (stored.Kind is not (DesignPropertyValueKind.Int32 or DesignPropertyValueKind.Double))
+            return false;
+        value = Convert.ToDouble(stored.Value, System.Globalization.CultureInfo.InvariantCulture);
+        return double.IsFinite(value) && value >= 0d;
+    }
+
+    private static bool TryReadEasing(IReadOnlyDictionary<string, DesignPropertyValue> properties, out string value)
+    {
+        value = "CubicOut";
+        if (!properties.TryGetValue("Easing", out var stored))
+            return true;
+        if (stored.Kind != DesignPropertyValueKind.String || stored.Value is not string identifier)
+            return false;
+        value = identifier;
+        return KnownEasingDesignValue.IsKnown(value);
+    }
+
+    private static bool IsCollectionType(string? typeName)
+        => string.Equals(typeName, CollectionTypeName, StringComparison.Ordinal)
+        || string.Equals(typeName, "VisualStateTransitionCollection", StringComparison.Ordinal);
+}

--- a/ModernFormsNext.VisualStudioExtension/Editors/MfDesignFileGenerator.cs
+++ b/ModernFormsNext.VisualStudioExtension/Editors/MfDesignFileGenerator.cs
@@ -28,8 +28,12 @@ public sealed class MfDesignFileGenerator
     /// </summary>
     /// <param name="document">The design document to generate from.</param>
     /// <param name="designDocumentPath">The source <c>.mfdesign</c> path.</param>
+    /// <param name="animationDefinitions">Optional source-discovered project effect descriptors.</param>
     /// <returns>The generated code and validation result.</returns>
-    public CSharpDesignerGenerationResult Generate(DesignDocument document, string designDocumentPath)
+    public CSharpDesignerGenerationResult Generate(
+        DesignDocument document,
+        string designDocumentPath,
+        IReadOnlyList<DesignAnimationDefinitionDescriptor>? animationDefinitions = null)
     {
         ArgumentNullException.ThrowIfNull(document);
         ArgumentException.ThrowIfNullOrWhiteSpace(designDocumentPath);
@@ -39,7 +43,8 @@ public sealed class MfDesignFileGenerator
             new CSharpDesignerGenerationOptions
             {
                 SourceFilePath = Path.GetFileName(designDocumentPath),
-                DesignHash = roundTrip.ComputeDesignHash(document)
+                DesignHash = roundTrip.ComputeDesignHash(document),
+                AnimationDefinitions = animationDefinitions ?? []
             });
     }
 

--- a/ModernFormsNext.VisualStudioExtension/Hosting/VisualStudioDesignerFileService.cs
+++ b/ModernFormsNext.VisualStudioExtension/Hosting/VisualStudioDesignerFileService.cs
@@ -1,5 +1,6 @@
 using ModernFormsNext.Designing;
 using ModernFormsNext.VisualStudioExtension.Editors;
+using ModernFormsNext.Designer.Services;
 
 namespace ModernFormsNext.VisualStudioExtension.Hosting;
 
@@ -24,7 +25,10 @@ public sealed class VisualStudioDesignerFileService
 
         documentAdapter.Save(designDocumentPath, document);
 
-        var generation = fileGenerator.Generate(document, designDocumentPath);
+        var generation = fileGenerator.Generate(
+            document,
+            designDocumentPath,
+            DesignerProjectAnimationDefinitionDiscovery.Discover(FindProjectPath(designDocumentPath)));
 
         if (!generation.Succeeded)
             throw new InvalidOperationException("Designer code generation failed: " + string.Join("; ", generation.Validation.Errors));
@@ -32,5 +36,18 @@ public sealed class VisualStudioDesignerFileService
         var generatedCodePath = fileGenerator.GetGeneratedCodePath(designDocumentPath);
         File.WriteAllText(generatedCodePath, generation.Code);
         return generatedCodePath;
+    }
+
+    private static string FindProjectPath(string designDocumentPath)
+    {
+        string? directory = Path.GetDirectoryName(Path.GetFullPath(designDocumentPath));
+        while (!string.IsNullOrWhiteSpace(directory))
+        {
+            string? project = Directory.GetFiles(directory, "*.csproj", SearchOption.TopDirectoryOnly).FirstOrDefault();
+            if (project is not null)
+                return project;
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+        return Path.GetDirectoryName(Path.GetFullPath(designDocumentPath)) ?? string.Empty;
     }
 }

--- a/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
+++ b/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
@@ -336,7 +336,9 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
                     NamespaceOverride = fileInfo.Namespace,
                     ClassNameOverride = fileInfo.ClassName,
                     FormNameOverride = fileInfo.ClassName,
-                    RootKind = fileInfo.RootKind
+                    RootKind = fileInfo.RootKind,
+                    AnimationDefinitions = ModernFormsNext.Designer.Services.DesignerProjectAnimationDefinitionDiscovery.Discover(
+                        FindNearestProjectPath(fileInfo.CodeFilePath))
                 });
 
             if (parseResult.Success && parseResult.Document is not null)
@@ -356,5 +358,18 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
         };
 
         DesignDocumentSerializer.Default.Save(fileInfo.DesignFilePath, document);
+    }
+
+    private static string? FindNearestProjectPath(string path)
+    {
+        string? directory = File.Exists(path) ? Path.GetDirectoryName(path) : path;
+        while (!string.IsNullOrWhiteSpace(directory))
+        {
+            string? project = Directory.GetFiles(directory, "*.csproj", SearchOption.TopDirectoryOnly).FirstOrDefault();
+            if (project is not null)
+                return project;
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+        return null;
     }
 }

--- a/ModernFormsNext/Animations/DesignableAnimationDefinitionAttribute.cs
+++ b/ModernFormsNext/Animations/DesignableAnimationDefinitionAttribute.cs
@@ -1,0 +1,80 @@
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Marks a project-owned animation definition or interaction effect for safe source-based Designer discovery.
+/// </summary>
+/// <remarks>
+/// The Designer reads this attribute from C# syntax and does not load the project assembly or invoke
+/// the attributed type. Custom <see cref="AnimationDefinition"/> types remain code-first because
+/// controls currently expose no general animation-definition attachment collection. Custom
+/// <see cref="InteractionEffect"/> types can be configured when every exposed property also carries
+/// <see cref="DesignableAnimationPropertyAttribute"/>.
+/// </remarks>
+/// <example>
+/// <code>
+/// [DesignableAnimationDefinition("Glow")]
+/// public sealed class GlowEffect : InteractionEffect
+/// {
+///     [DesignableAnimationProperty(DesignableAnimationPropertyKind.Number, DefaultValue = "0.5")]
+///     public float Opacity { get; set; } = 0.5f;
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class DesignableAnimationDefinitionAttribute : Attribute
+{
+    /// <summary>Initializes the marker with a user-facing display name.</summary>
+    /// <param name="displayName">The non-empty name shown by Designer editors.</param>
+    public DesignableAnimationDefinitionAttribute(string displayName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        DisplayName = displayName;
+    }
+
+    /// <summary>Gets the name shown by Designer editors.</summary>
+    public string DisplayName { get; }
+}
+
+/// <summary>Identifies the source-serializable shape of a custom animation property.</summary>
+public enum DesignableAnimationPropertyKind
+{
+    /// <summary>A Boolean value.</summary>
+    Boolean,
+    /// <summary>A signed 32-bit integer.</summary>
+    Int32,
+    /// <summary>A finite <see cref="float"/> or <see cref="double"/> value.</summary>
+    Number,
+    /// <summary>A non-negative <see cref="TimeSpan"/> persisted as milliseconds.</summary>
+    TimeSpan,
+    /// <summary>A built-in easing identifier mapped to an <see cref="Easings"/> member.</summary>
+    Easing,
+    /// <summary>An enum whose allowed members are declared by the attribute.</summary>
+    Enum,
+    /// <summary>A <see cref="System.Drawing.Color"/> persisted as ARGB.</summary>
+    ColorArgb,
+    /// <summary>A string value.</summary>
+    String
+}
+
+/// <summary>Marks a public settable custom animation property as safe for detached Designer editing.</summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+public sealed class DesignableAnimationPropertyAttribute : Attribute
+{
+    /// <summary>Initializes property metadata.</summary>
+    /// <param name="kind">The explicitly supported serialized property shape.</param>
+    public DesignableAnimationPropertyAttribute(DesignableAnimationPropertyKind kind)
+        => Kind = kind;
+
+    /// <summary>Gets the serialized property shape.</summary>
+    public DesignableAnimationPropertyKind Kind { get; }
+    /// <summary>Gets or sets the invariant default text used by the Designer.</summary>
+    public string? DefaultValue { get; set; }
+    /// <summary>Gets or sets the inclusive numeric minimum.</summary>
+    public double Minimum { get; set; } = double.MinValue;
+    /// <summary>Gets or sets the inclusive numeric maximum.</summary>
+    public double Maximum { get; set; } = double.MaxValue;
+    /// <summary>Gets or sets the namespace-qualified enum type name for <see cref="DesignableAnimationPropertyKind.Enum"/>.</summary>
+    public string? EnumTypeName { get; set; }
+    /// <summary>Gets or sets the allowed enum member names.</summary>
+    public string[] EnumMembers { get; set; } = [];
+}

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -675,8 +675,9 @@ stops when no runnable work remains.
   and border widths. Other layout-aware state metrics remain discrete.
 - Brush cross-kind geometry, `GlassBrush`, `NoBrush`, null, empty-to-populated gradients, and
   custom/derived brush types switch discretely.
-- The Designer collection editor supports the built-in `RippleEffect` and `PressScaleEffect` only;
-  custom effects and easing delegates remain code-first, and Designer undo/redo is not available.
+- The Designer supports built-in effects, explicitly source-described project effects, layout
+  transitions, visual-state transitions, and built-in easing identifiers. Custom easing delegates,
+  general `AnimationDefinition` activation, and Designer undo/redo remain code-first/unavailable.
 - Android platform preference refresh occurs on startup/foreground or explicit refresh; there is no
   live `ContentObserver` in this experimental stage.
 - Android is experimental; physical-device frame pacing, multi-touch rendering,
@@ -688,5 +689,6 @@ See [the scheduler architecture](architecture/ui-animation-scheduler.md), the
 [scheduler architecture decision](architecture/decisions/ADR-UI-Animation-Scheduler.md), the
 [composable-animation architecture decision](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md),
 the [animation platform polish decision](architecture/decisions/ADR-Animation-Platform-Polish.md),
+the [Designer animation/effect contract](designer-animation-effects.md),
 and **Animations and Interaction Effects** in `samples/ControlGallery` for implementation rationale
 and interactive checks.

--- a/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
+++ b/docs/architecture/decisions/ADR-Animation-Platform-Polish.md
@@ -91,7 +91,9 @@ shared scheduler; disposal and cancellation clear their handles and visual state
 
 The runtime `InteractionEffectCollection` remains the owner-attached collection. Designer-only
 editing lives in `ModernFormsNext.Designer` and supports the built-in `RippleEffect` and
-`PressScaleEffect`. Unsupported effect types are not offered and are rejected when imported.
+`PressScaleEffect`. Issue #28 extends the same detached contract to explicitly attributed project
+effects discovered from source. Missing or changed project types are retained as unavailable
+definitions and never instantiated by Designer.
 
 The `.mfdesign` value is a deterministic structured object containing `Count` and ordered `ItemN`
 entries. Each entry stores a type discriminator and supported serializable properties. Generated

--- a/docs/composable-animations.md
+++ b/docs/composable-animations.md
@@ -21,8 +21,10 @@ ModernFormsNext 1.9.0. It does not change the release status or authorize public
   or replace all active waves. The existing eviction property remains source-compatible.
 - Windows observes the native client-area animation preference without polling. Experimental
   Android reads the global animator and transition scales on startup/foreground entry.
-- The Designer Property Grid has a detached, scheduler-free collection editor for ordered built-in
-  ripple and press-scale effects with stable `.mfdesign` and generated-code round trips.
+- The Designer Property Grid has detached, scheduler-free editors for ordered interaction effects,
+  layout transitions, and visual-state transitions with stable `.mfdesign` and generated-code
+  round trips. Explicitly attributed project effects are discovered from source without loading
+  the application assembly.
 - The common render order is background, effects below content, content, effects above content,
   then the focus ring. Built-in clipping respects control bounds and corner radius.
 - One application visual-invalidation batch wraps every scheduler tick, coalescing repaint per
@@ -49,9 +51,12 @@ device/emulator validation for frame pacing, background/foreground transitions, 
 rendering, platform setting changes, and orientation changes. Android refreshes platform animation
 scales on foreground entry rather than maintaining a live settings observer. Visual-state layout
 metrics switch immediately rather than interpolate and incompatible Brush structures switch
-discretely. The Designer editor currently supports only the built-in ripple and press-scale effect
-descriptions; custom effects and easing remain code-first, and the Designer has no undo/redo stack.
+discretely. Designer documents serialize only built-in easing identifiers; custom delegate easing
+and general `AnimationDefinition` activation remain code-first. The Designer still has no global
+undo/redo stack and does not execute or preview project effect code.
 
 See [UI animations](animations.md) and the
 [composable-animation ADR](architecture/decisions/ADR-Composable-Animations-And-Interaction-Effects.md),
 plus the [animation platform polish ADR](architecture/decisions/ADR-Animation-Platform-Polish.md).
+Designer serialization and isolation are detailed in
+[Designer animation and interaction-effect definitions](designer-animation-effects.md).

--- a/docs/designer-animation-effects.md
+++ b/docs/designer-animation-effects.md
@@ -1,0 +1,124 @@
+# Designer animation and interaction-effect definitions
+
+ModernFormsNext Designer edits animation configuration as detached document data. Opening a
+Property Grid editor does not construct an `InteractionEffect`, load the application assembly,
+invoke a custom constructor, start the animation scheduler, or preview executable project code.
+Generated application code remains the only place where configured effects are instantiated.
+
+## Property Grid surface
+
+The design root and ordinary controls expose three separate concepts:
+
+- **Interaction Effects** is an ordered collection. The editor can add built-in `RippleEffect`
+  and `PressScaleEffect` entries, keep duplicates when runtime permits them, remove entries, and
+  move entries up or down. The selected entry displays its supported properties as detached
+  `Property=Value` fields.
+- **Layout Transition** maps to the public `Control.LayoutTransition` API. It exposes `Enabled`,
+  `DurationMilliseconds`, and a built-in easing identifier. Reset removes the optional value.
+- **Visual State Transitions** maps directional `VisualState` pairs to the existing
+  `Control.StyleTransitions` collection. Each line identifies `From`, `To`, duration, and easing.
+
+The editors keep private working copies until **OK**. **Cancel** leaves the document unchanged.
+There is no independent runtime animation model in Designer and these definitions never appear as
+control children in Document Outline. Existing JSON-based control copy/paste deep-copies their
+structured values.
+
+## Stable `.mfdesign` representation
+
+Animation configuration uses the existing `DesignPropertyValue` structured-object shape. No
+document-format version bump is required, and documents that omit these optional properties retain
+their historical behavior.
+
+Interaction effects are stored in `InteractionEffects` with `Count` plus ordered `ItemN` values.
+Each item carries a namespace-qualified, assembly-independent runtime type name and only explicitly
+changed properties. Transition collections use the same deterministic `Count`/`ItemN` convention.
+`LayoutTransition` is one structured value. Default effect properties are omitted so resetting a
+field does not create unnecessary generated assignments.
+
+`TimeSpan` properties are stored as finite, non-negative milliseconds. This matches the existing
+effect document convention and is displayed as `DurationMilliseconds`. The generator emits
+`TimeSpan.FromMilliseconds(...)` and the reverse parser recognizes that exact supported shape.
+
+Runtime easing values remain `Func<float, float>` delegates. `.mfdesign` never serializes a
+delegate. It stores a stable identifier such as `Linear`, `EaseOut`, or `CubicOut`, which generation
+maps to `ModernFormsNext.Animations.Easings.<identifier>`. An unknown identifier produces a
+controlled diagnostic and is not executed or guessed.
+
+## Built-in and project-owned effects
+
+Built-in descriptors are defined once in the neutral Designing layer and are shared by the editor,
+generator, and conservative reverse parser. Project effects are opt-in source metadata:
+
+```csharp
+[DesignableAnimationDefinition("Glow")]
+public sealed class GlowEffect : InteractionEffect
+{
+    [DesignableAnimationProperty(
+        DesignableAnimationPropertyKind.Number,
+        DefaultValue = "0.5",
+        Minimum = 0,
+        Maximum = 1)]
+    public float Opacity { get; set; } = 0.5f;
+}
+```
+
+Discovery parses project-owned `.cs` files with Roslyn. It requires an explicit marker, a public,
+non-abstract, non-generic, top-level type and an accessible parameterless constructor. Only public
+settable properties with explicit designer metadata are exposed. Discovery excludes build and
+repository artifact directories. It performs no `Type.GetType`, reflection, assembly loading, or
+constructor invocation. C# aliases and project-owned base classes are resolved from syntax; marked
+properties declared on a project base class are inherited by an opted-in concrete definition.
+
+Supported detached custom property shapes are Boolean, Int32, finite number, TimeSpan, known
+easing, explicitly described enum, ARGB color, and string. Arbitrary nested CLR objects, delegates,
+services, Brushes, and factory expressions are deliberately not deserialized. A missing or renamed
+custom effect type stays in `.mfdesign` as an unavailable entry that can be kept, reordered, or
+removed; generation reports it and skips unsafe code rather than destroying the definition.
+
+`AnimationDefinition` subclasses can carry the same source metadata, but remain code-first because
+the current runtime has no general control-level definition collection or activation contract.
+Designer therefore does not offer them in the Interaction Effects list and does not invent a
+parallel attachment API.
+
+## Generation and reverse synchronization
+
+Generation preserves interaction-effect order and emits the actual runtime APIs:
+
+```csharp
+button1.InteractionEffects.Add(new ModernFormsNext.Animations.PressScaleEffect {
+    PressedScale = 0.96f,
+    Easing = ModernFormsNext.Animations.Easings.EaseOut
+});
+```
+
+Layout and visual-state transitions similarly emit `LayoutTransition` and
+`StyleTransitions.Add(...)`. The reverse parser supports the complete subset emitted by the
+generator. It does not evaluate factories, locals, arbitrary method calls, or user expressions;
+unsupported syntax produces diagnostics.
+
+The Visual Studio host passes the same source-discovered descriptors into save/generation and
+reverse import. The existing Designer, Designing, and CodeGeneration project references are already
+included in the VSIX; no application assembly is added to the extension process.
+
+## Current limitations
+
+- Custom delegate easing remains code-first.
+- General custom `AnimationDefinition` activation remains code-first.
+- There is no automatic design-surface effect preview; this avoids interfering with selection,
+  drag, resize, and custom-code isolation.
+- Designer-wide undo/redo does not exist yet. Editors use atomic OK/Cancel semantics so a future
+  transaction service can wrap one committed definition change.
+- Android runtime animation integration and device validation remain part of issue #29.
+
+## Manual Visual Studio smoke test
+
+For a host-level check, open a Form `.mfdesign`, select a Button, add `PressScaleEffect` and
+`RippleEffect`, change their order and easing, configure a 200 ms Layout Transition and one
+Normal-to-Hover Visual State Transition, then save. Inspect the sibling `.Designer.cs`, close and
+reopen the designer, and run the application. Confirm the order and values survive, the generated
+file alone changes, and runtime behavior begins only after the application starts. A project-owned
+effect can be checked with the explicit attributes shown above; its throwing constructor must not
+run while the designer or editor is open.
+
+See [Designer architecture](designer-architecture.md), [Animations](animations.md), and
+[Composable animations](composable-animations.md).

--- a/docs/designer-architecture.md
+++ b/docs/designer-architecture.md
@@ -1,5 +1,9 @@
 # ModernFormsNext Designer Architecture
 
+Animation/effect Property Grid editing, source-only custom-effect discovery, stable easing IDs,
+and round-trip boundaries are documented separately in
+[Designer animation and interaction-effect definitions](designer-animation-effects.md).
+
 ModernFormsNext designer support is split into small projects with separate responsibilities.
 The goal is to keep the document model, code generation, reusable designer UI, standalone test
 host, and Visual Studio integration independent from each other.


### PR DESCRIPTION
## Summary

- add Designer support for `InteractionEffects` with Add/Remove/Reorder collection editing and a Property Grid for effect properties
- support `RippleEffect` and `PressScaleEffect`, plus source-first Roslyn discovery of custom effects without assembly loading or executing user code
- add structured editors for `LayoutTransition` and `VisualStateTransition`
- serialize stable built-in easing identifiers and `TimeSpan` values
- persist definitions in `.mfdesign`, generate them in `.Designer.cs`, and recover them through the reverse parser
- preserve unavailable custom effect definitions and keep copy/paste values isolated
- integrate the feature with the VSIX and improve the dialogs with typed controls and structured editing
- add regression coverage for serialization, ordering, discovery, generation, reverse parsing, preservation, copy/paste, Form/UserControl Designer paths, and VSIX integration

## Safety

Custom effect discovery is source-first and Roslyn-based. The Designer does not load project assemblies or execute custom user code.

## Validation

- 994/994 tests passed
- Debug and Release builds passed with 0 errors and 0 warnings
- VSIX Debug and Release validation passed
- `git diff --check` passed
- manual smoke-test passed in Visual Studio Experimental Instance

Closes #28