### PR TITLE
Add Shape controls and vector geometry

### DIFF
--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
@@ -1171,11 +1171,8 @@ public sealed class CSharpDesignerParser
     {
         value = null!;
 
-        if (expression is not ObjectCreationExpressionSyntax objectCreation
-            || objectCreation.ArgumentList is null)
-        {
+        if (expression is not ObjectCreationExpressionSyntax objectCreation)
             return false;
-        }
 
         var typeName = objectCreation.Type.ToString();
         var propertyValues = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
@@ -1196,6 +1193,24 @@ public sealed class CSharpDesignerParser
             return true;
         }
 
+        if ((IsType(typeName, "PointF") || IsType(typeName, "SKPoint"))
+            && TryReadDoubleObjectArguments(objectCreation, 2, out double[] floatPoint))
+        {
+            propertyValues["X"] = DesignPropertyValue.FromDouble(floatPoint[0]);
+            propertyValues["Y"] = DesignPropertyValue.FromDouble(floatPoint[1]);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
+        if (IsType(typeName, "SKSize")
+            && TryReadDoubleObjectArguments(objectCreation, 2, out double[] floatSize))
+        {
+            propertyValues["Width"] = DesignPropertyValue.FromDouble(floatSize[0]);
+            propertyValues["Height"] = DesignPropertyValue.FromDouble(floatSize[1]);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
         if ((IsType(typeName, "Rectangle") || IsType(typeName, "Bounds"))
             && TryReadObjectArguments(expression, 4, out var rectangle))
         {
@@ -1207,10 +1222,32 @@ public sealed class CSharpDesignerParser
             return true;
         }
 
-        if (IsType(typeName, "SKColor")
-            && objectCreation.ArgumentList.Arguments.Count is 3 or 4)
+        if ((IsType(typeName, "RectangleF") || IsType(typeName, "SKRect"))
+            && TryReadDoubleObjectArguments(objectCreation, 4, out double[] floatRectangle))
         {
-            var arguments = objectCreation.ArgumentList.Arguments;
+            string[] names = IsType(typeName, "SKRect")
+                ? ["Left", "Top", "Right", "Bottom"]
+                : ["X", "Y", "Width", "Height"];
+            for (int index = 0; index < names.Length; index++)
+                propertyValues[names[index]] = DesignPropertyValue.FromDouble(floatRectangle[index]);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
+        if (IsType(typeName, "Matrix3x2")
+            && TryReadDoubleObjectArguments(objectCreation, 6, out double[] matrix))
+        {
+            string[] names = ["M11", "M12", "M21", "M22", "M31", "M32"];
+            for (int index = 0; index < names.Length; index++)
+                propertyValues[names[index]] = DesignPropertyValue.FromDouble(matrix[index]);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
+        if (IsType(typeName, "SKColor")
+            && objectCreation.ArgumentList is { Arguments.Count: 3 or 4 } colorArgumentList)
+        {
+            var arguments = colorArgumentList.Arguments;
             if (!TryReadInt32(arguments[0].Expression, out var r)
                 || !TryReadInt32(arguments[1].Expression, out var g)
                 || !TryReadInt32(arguments[2].Expression, out var b))
@@ -1233,7 +1270,270 @@ public sealed class CSharpDesignerParser
             return true;
         }
 
+        if (IsType(typeName, "PointCollection"))
+            return TryReadPointCollection(objectCreation, typeName, out value);
+
+        if (IsType(typeName, "GradientStop")
+            && TryReadStructuredArgument(objectCreation, 0, out DesignPropertyValue stopColor)
+            && objectCreation.ArgumentList?.Arguments.Count == 2
+            && TryReadDouble(objectCreation.ArgumentList.Arguments[1].Expression, out double stopOffset))
+        {
+            propertyValues["Color"] = stopColor;
+            propertyValues["Offset"] = DesignPropertyValue.FromDouble(stopOffset);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
+        if (IsType(typeName, "LineGeometry"))
+            return TryReadLineGeometry(objectCreation, typeName, out value);
+
+        if (IsType(typeName, "RectangleGeometry") || IsType(typeName, "EllipseGeometry"))
+            return TryReadRectangleGeometry(objectCreation, typeName, out value);
+
+        if (IsType(typeName, "PathGeometry"))
+            return TryReadPathGeometry(objectCreation, typeName, out value);
+
+        if (IsType(typeName, "SolidColorBrush"))
+        {
+            if (!TryReadStructuredArgument(objectCreation, 0, out DesignPropertyValue color))
+                return false;
+            propertyValues["Color"] = color;
+            ReadSimpleInitializerAssignments(objectCreation, propertyValues);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
+        if (IsType(typeName, "GlassBrush")
+            || IsType(typeName, "LinearGradientBrush")
+            || IsType(typeName, "RadialGradientBrush")
+            || IsType(typeName, "SweepGradientBrush"))
+        {
+            ReadSimpleInitializerAssignments(objectCreation, propertyValues, "GradientStops");
+            ReadCollectionInitializer(objectCreation, "GradientStops", "GradientStop", propertyValues);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
         return false;
+    }
+
+    private static bool TryReadDoubleObjectArguments(
+        ObjectCreationExpressionSyntax objectCreation,
+        int count,
+        out double[] values)
+    {
+        values = [];
+        if (objectCreation.ArgumentList?.Arguments.Count != count)
+            return false;
+
+        values = new double[count];
+        for (int index = 0; index < count; index++)
+        {
+            if (!TryReadDouble(objectCreation.ArgumentList.Arguments[index].Expression, out values[index]))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool TryReadStructuredArgument(
+        ObjectCreationExpressionSyntax objectCreation,
+        int index,
+        out DesignPropertyValue value)
+    {
+        value = null!;
+        return objectCreation.ArgumentList is not null
+            && objectCreation.ArgumentList.Arguments.Count > index
+            && TryReadDesignerValue(objectCreation.ArgumentList.Arguments[index].Expression, out value);
+    }
+
+    private static bool TryReadPointCollection(
+        ObjectCreationExpressionSyntax objectCreation,
+        string typeName,
+        out DesignPropertyValue value)
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        int count = 0;
+        if (objectCreation.Initializer is not null)
+        {
+            foreach (ExpressionSyntax expression in objectCreation.Initializer.Expressions)
+            {
+                if (TryReadDesignerValue(expression, out DesignPropertyValue point))
+                    properties[$"Point{count++}"] = point;
+                else
+                {
+                    value = null!;
+                    return false;
+                }
+            }
+        }
+        properties["Count"] = DesignPropertyValue.FromInt32(count);
+        value = DesignPropertyValue.FromStructuredObject(typeName, properties);
+        return true;
+    }
+
+    private static bool TryReadLineGeometry(
+        ObjectCreationExpressionSyntax objectCreation,
+        string typeName,
+        out DesignPropertyValue value)
+    {
+        value = null!;
+        if (!TryReadStructuredArgument(objectCreation, 0, out DesignPropertyValue start)
+            || !TryReadStructuredArgument(objectCreation, 1, out DesignPropertyValue end))
+            return false;
+
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["StartPoint"] = start,
+            ["EndPoint"] = end
+        };
+        ReadSimpleInitializerAssignments(objectCreation, properties);
+        value = DesignPropertyValue.FromStructuredObject(typeName, properties);
+        return true;
+    }
+
+    private static bool TryReadRectangleGeometry(
+        ObjectCreationExpressionSyntax objectCreation,
+        string typeName,
+        out DesignPropertyValue value)
+    {
+        value = null!;
+        if (!TryReadStructuredArgument(objectCreation, 0, out DesignPropertyValue rectangle))
+            return false;
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["Rect"] = rectangle
+        };
+        ReadSimpleInitializerAssignments(objectCreation, properties);
+        value = DesignPropertyValue.FromStructuredObject(typeName, properties);
+        return true;
+    }
+
+    private static bool TryReadPathGeometry(
+        ObjectCreationExpressionSyntax objectCreation,
+        string typeName,
+        out DesignPropertyValue value)
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        ReadSimpleInitializerAssignments(objectCreation, properties, "Figures");
+        ReadCollectionInitializer(objectCreation, "Figures", "Figure", properties);
+        value = DesignPropertyValue.FromStructuredObject(typeName, properties);
+        return true;
+    }
+
+    private static void ReadSimpleInitializerAssignments(
+        ObjectCreationExpressionSyntax objectCreation,
+        SortedDictionary<string, DesignPropertyValue> properties,
+        params string[] excludedNames)
+    {
+        if (objectCreation.Initializer is null)
+            return;
+
+        foreach (ExpressionSyntax expression in objectCreation.Initializer.Expressions)
+        {
+            if (expression is AssignmentExpressionSyntax assignment
+                && assignment.Left is IdentifierNameSyntax name
+                && !excludedNames.Contains(name.Identifier.ValueText, StringComparer.Ordinal)
+                && TryReadDesignerValue(assignment.Right, out DesignPropertyValue propertyValue))
+            {
+                properties[name.Identifier.ValueText] = propertyValue;
+            }
+        }
+    }
+
+    private static void ReadCollectionInitializer(
+        ObjectCreationExpressionSyntax objectCreation,
+        string propertyName,
+        string itemPrefix,
+        SortedDictionary<string, DesignPropertyValue> properties)
+    {
+        int count = 0;
+        if (objectCreation.Initializer is not null)
+        {
+            foreach (AssignmentExpressionSyntax assignment in objectCreation.Initializer.Expressions.OfType<AssignmentExpressionSyntax>())
+            {
+                if (assignment.Left is not IdentifierNameSyntax name
+                    || !string.Equals(name.Identifier.ValueText, propertyName, StringComparison.Ordinal)
+                    || assignment.Right is not InitializerExpressionSyntax collection)
+                    continue;
+
+                foreach (ExpressionSyntax item in collection.Expressions)
+                {
+                    if (TryReadPathInitializerItem(item, itemPrefix, out DesignPropertyValue itemValue))
+                        properties[$"{itemPrefix}{count++}"] = itemValue;
+                }
+            }
+        }
+        properties[$"{propertyName.TrimEnd('s')}Count"] = DesignPropertyValue.FromInt32(count);
+    }
+
+    private static bool TryReadPathInitializerItem(
+        ExpressionSyntax expression,
+        string itemPrefix,
+        out DesignPropertyValue value)
+    {
+        if (string.Equals(itemPrefix, "Figure", StringComparison.Ordinal))
+            return TryReadPathFigure(expression, out value);
+        if (string.Equals(itemPrefix, "Segment", StringComparison.Ordinal))
+            return TryReadPathSegment(expression, out value);
+        return TryReadDesignerValue(expression, out value);
+    }
+
+    private static bool TryReadPathFigure(ExpressionSyntax expression, out DesignPropertyValue value)
+    {
+        value = null!;
+        if (expression is not ObjectCreationExpressionSyntax creation
+            || !IsType(creation.Type.ToString(), "PathFigure")
+            || !TryReadStructuredArgument(creation, 0, out DesignPropertyValue start)
+            || creation.ArgumentList?.Arguments.Count != 2
+            || !TryReadBoolean(creation.ArgumentList.Arguments[1].Expression, out bool isClosed))
+            return false;
+
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["StartPoint"] = start,
+            ["IsClosed"] = DesignPropertyValue.FromBoolean(isClosed)
+        };
+        ReadCollectionInitializer(creation, "Segments", "Segment", properties);
+        value = DesignPropertyValue.FromStructuredObject(creation.Type.ToString(), properties);
+        return true;
+    }
+
+    private static bool TryReadPathSegment(ExpressionSyntax expression, out DesignPropertyValue value)
+    {
+        value = null!;
+        if (expression is not ObjectCreationExpressionSyntax creation)
+            return false;
+
+        string typeName = creation.Type.ToString();
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        if (IsType(typeName, "LineSegment")
+            && TryReadStructuredArgument(creation, 0, out DesignPropertyValue point))
+        {
+            properties["Point"] = point;
+        }
+        else if (IsType(typeName, "QuadraticBezierSegment")
+            && TryReadStructuredArgument(creation, 0, out DesignPropertyValue control)
+            && TryReadStructuredArgument(creation, 1, out point))
+        {
+            properties["ControlPoint"] = control;
+            properties["Point"] = point;
+        }
+        else if (IsType(typeName, "BezierSegment")
+            && TryReadStructuredArgument(creation, 0, out DesignPropertyValue control1)
+            && TryReadStructuredArgument(creation, 1, out DesignPropertyValue control2)
+            && TryReadStructuredArgument(creation, 2, out point))
+        {
+            properties["ControlPoint1"] = control1;
+            properties["ControlPoint2"] = control2;
+            properties["Point"] = point;
+        }
+        else
+        {
+            return false;
+        }
+
+        value = DesignPropertyValue.FromStructuredObject(typeName, properties);
+        return true;
     }
 
     private static bool IsType(string typeName, string expectedSuffix)

--- a/ModernFormsNext.CodeGeneration/Utilities/CSharpLiteralWriter.cs
+++ b/ModernFormsNext.CodeGeneration/Utilities/CSharpLiteralWriter.cs
@@ -124,6 +124,11 @@ public static class CSharpLiteralWriter
             return $"new System.Drawing.Rectangle({ReadInt(properties, "X")}, {ReadInt(properties, "Y")}, {ReadInt(properties, "Width")}, {ReadInt(properties, "Height")})";
         }
 
+        if (IsType(typeName, "System.Drawing.RectangleF"))
+        {
+            return $"new System.Drawing.RectangleF({ReadFloat(properties, "X")}, {ReadFloat(properties, "Y")}, {ReadFloat(properties, "Width")}, {ReadFloat(properties, "Height")})";
+        }
+
         if (IsType(typeName, "ModernFormsNext.Padding"))
         {
             return $"new Padding({ReadInt(properties, "Left")}, {ReadInt(properties, "Top")}, {ReadInt(properties, "Right")}, {ReadInt(properties, "Bottom")})";
@@ -156,6 +161,34 @@ public static class CSharpLiteralWriter
             var style = WriteFontStyle(properties);
             return $"new Font({name}, {size}, {style})";
         }
+
+        if (IsType(typeName, "ModernFormsNext.Drawing.PointCollection"))
+            return WritePointCollection(properties);
+
+        if (IsType(typeName, "ModernFormsNext.Drawing.LineGeometry"))
+        {
+            return "new ModernFormsNext.Drawing.LineGeometry("
+                + ReadValue(properties, "StartPoint", "System.Drawing.PointF.Empty") + ", "
+                + ReadValue(properties, "EndPoint", "System.Drawing.PointF.Empty") + ")"
+                + WriteGeometryInitializer(properties);
+        }
+
+        if (IsType(typeName, "ModernFormsNext.Drawing.RectangleGeometry"))
+        {
+            return "new ModernFormsNext.Drawing.RectangleGeometry("
+                + ReadValue(properties, "Rect", "System.Drawing.RectangleF.Empty") + ")"
+                + WriteGeometryInitializer(properties);
+        }
+
+        if (IsType(typeName, "ModernFormsNext.Drawing.EllipseGeometry"))
+        {
+            return "new ModernFormsNext.Drawing.EllipseGeometry("
+                + ReadValue(properties, "Rect", "System.Drawing.RectangleF.Empty") + ")"
+                + WriteGeometryInitializer(properties);
+        }
+
+        if (IsType(typeName, "ModernFormsNext.Drawing.PathGeometry"))
+            return WritePathGeometry(properties);
 
         if (IsType(typeName, "ModernFormsNext.Drawing.SolidColorBrush"))
         {
@@ -294,6 +327,88 @@ public static class CSharpLiteralWriter
         return stops.Count == 0
             ? string.Empty
             : $", GradientStops = {{ {string.Join(", ", stops)} }}";
+    }
+
+    private static string WritePointCollection(IReadOnlyDictionary<string, DesignPropertyValue> properties)
+    {
+        var points = new List<string>();
+        int count = ReadInt(properties, "Count");
+        for (int index = 0; index < count; index++)
+        {
+            if (properties.TryGetValue($"Point{index}", out DesignPropertyValue? point))
+                points.Add(WriteValue(point));
+        }
+        return points.Count == 0
+            ? "new ModernFormsNext.Drawing.PointCollection()"
+            : $"new ModernFormsNext.Drawing.PointCollection {{ {string.Join(", ", points)} }}";
+    }
+
+    private static string WriteGeometryInitializer(IReadOnlyDictionary<string, DesignPropertyValue> properties)
+        => properties.TryGetValue("Transform", out DesignPropertyValue? transform)
+            ? $" {{ Transform = {WriteValue(transform)} }}"
+            : string.Empty;
+
+    private static string WritePathGeometry(IReadOnlyDictionary<string, DesignPropertyValue> properties)
+    {
+        var figures = new List<string>();
+        int count = ReadInt(properties, "FigureCount");
+        for (int index = 0; index < count; index++)
+        {
+            if (properties.TryGetValue($"Figure{index}", out DesignPropertyValue? figure))
+                figures.Add(WritePathFigure(figure));
+        }
+
+        var assignments = new List<string>
+        {
+            "FillRule = " + ReadValue(properties, "FillRule", "ModernFormsNext.Drawing.GeometryFillRule.Winding"),
+            "Transform = " + ReadValue(properties, "Transform", "System.Numerics.Matrix3x2.Identity")
+        };
+        if (figures.Count > 0)
+            assignments.Add($"Figures = {{ {string.Join(", ", figures)} }}");
+        return $"new ModernFormsNext.Drawing.PathGeometry {{ {string.Join(", ", assignments)} }}";
+    }
+
+    private static string WritePathFigure(DesignPropertyValue value)
+    {
+        IReadOnlyDictionary<string, DesignPropertyValue> properties = value.ObjectProperties
+            ?? new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        var segments = new List<string>();
+        int count = ReadInt(properties, "SegmentCount");
+        for (int index = 0; index < count; index++)
+        {
+            if (properties.TryGetValue($"Segment{index}", out DesignPropertyValue? segment))
+                segments.Add(WritePathSegment(segment));
+        }
+
+        string result = "new ModernFormsNext.Drawing.PathFigure("
+            + ReadValue(properties, "StartPoint", "System.Drawing.PointF.Empty") + ", "
+            + ReadBoolLiteral(properties, "IsClosed") + ")";
+        return segments.Count == 0
+            ? result
+            : result + $" {{ Segments = {{ {string.Join(", ", segments)} }} }}";
+    }
+
+    private static string WritePathSegment(DesignPropertyValue value)
+    {
+        string typeName = value.ObjectTypeName ?? string.Empty;
+        IReadOnlyDictionary<string, DesignPropertyValue> properties = value.ObjectProperties
+            ?? new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        if (IsType(typeName, "ModernFormsNext.Drawing.LineSegment"))
+            return $"new ModernFormsNext.Drawing.LineSegment({ReadValue(properties, "Point", "System.Drawing.PointF.Empty")})";
+        if (IsType(typeName, "ModernFormsNext.Drawing.QuadraticBezierSegment"))
+        {
+            return "new ModernFormsNext.Drawing.QuadraticBezierSegment("
+                + ReadValue(properties, "ControlPoint", "System.Drawing.PointF.Empty") + ", "
+                + ReadValue(properties, "Point", "System.Drawing.PointF.Empty") + ")";
+        }
+        if (IsType(typeName, "ModernFormsNext.Drawing.BezierSegment"))
+        {
+            return "new ModernFormsNext.Drawing.BezierSegment("
+                + ReadValue(properties, "ControlPoint1", "System.Drawing.PointF.Empty") + ", "
+                + ReadValue(properties, "ControlPoint2", "System.Drawing.PointF.Empty") + ", "
+                + ReadValue(properties, "Point", "System.Drawing.PointF.Empty") + ")";
+        }
+        throw new NotSupportedException($"Unsupported path segment type '{typeName}'.");
     }
 
     private static string WriteFontStyle(IReadOnlyDictionary<string, DesignPropertyValue> properties)

--- a/ModernFormsNext.CrossPlatform.Sample.Tests/AndroidProjectConfigurationTests.cs
+++ b/ModernFormsNext.CrossPlatform.Sample.Tests/AndroidProjectConfigurationTests.cs
@@ -65,7 +65,7 @@ public sealed class AndroidProjectConfigurationTests
         Assert.Equal("apk", Property(project, "AndroidPackageFormats").Value);
         Assert.Equal("23.0", Property(project, "SupportedOSPlatformVersion").Value);
 
-        var mainActivity = File.ReadAllText(Path.Combine(SampleDirectory, "Platforms", "Android", "MainActivity.cs"));
+        var mainActivity = File.ReadAllText(IOPath.Combine(SampleDirectory, "Platforms", "Android", "MainActivity.cs"));
         Assert.Contains($"Name = \"{ActivityName}\"", mainActivity, StringComparison.Ordinal);
         Assert.Contains("MainLauncher = true", mainActivity, StringComparison.Ordinal);
         Assert.Contains("Exported = true", mainActivity, StringComparison.Ordinal);
@@ -74,7 +74,7 @@ public sealed class AndroidProjectConfigurationTests
     [Fact]
     public void ManifestDeclaresOnlyTheOptionalCameraPermission()
     {
-        var manifest = XDocument.Load(Path.Combine(SampleDirectory, "Platforms", "Android", "AndroidManifest.xml"));
+        var manifest = XDocument.Load(IOPath.Combine(SampleDirectory, "Platforms", "Android", "AndroidManifest.xml"));
         XNamespace android = "http://schemas.android.com/apk/res/android";
         XNamespace tools = "http://schemas.android.com/tools";
 
@@ -89,7 +89,7 @@ public sealed class AndroidProjectConfigurationTests
         Assert.DoesNotContain("android.permission.WRITE_EXTERNAL_STORAGE", effectivePermissions);
     }
 
-    private static string SampleDirectory => Path.Combine(
+    private static string SampleDirectory => IOPath.Combine(
         RepositoryRoot,
         "samples",
         "ModernFormsNext.CrossPlatform.Sample");
@@ -99,7 +99,7 @@ public sealed class AndroidProjectConfigurationTests
         get
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);
-            while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "ModernFormsNext.slnx")))
+            while (directory is not null && !File.Exists(IOPath.Combine(directory.FullName, "ModernFormsNext.slnx")))
                 directory = directory.Parent;
 
             return directory?.FullName
@@ -108,7 +108,7 @@ public sealed class AndroidProjectConfigurationTests
     }
 
     private static XDocument LoadProject()
-        => XDocument.Load(Path.Combine(SampleDirectory, "ModernFormsNext.CrossPlatform.Sample.csproj"));
+        => XDocument.Load(IOPath.Combine(SampleDirectory, "ModernFormsNext.CrossPlatform.Sample.csproj"));
 
     private static XElement Property(XContainer container, string name)
         => Assert.Single(container.Descendants(), element => element.Name.LocalName == name);

--- a/ModernFormsNext.CrossPlatform.Sample.Tests/AndroidToolingContractTests.cs
+++ b/ModernFormsNext.CrossPlatform.Sample.Tests/AndroidToolingContractTests.cs
@@ -24,7 +24,7 @@ public sealed class AndroidToolingContractTests
     public void RepositoryContainsTheCompleteAndroidCommandLineWorkflow()
     {
         foreach (var script in RequiredScripts)
-            Assert.True(File.Exists(Path.Combine(AndroidScriptsDirectory, script)), $"Missing Android script: {script}");
+            Assert.True(File.Exists(IOPath.Combine(AndroidScriptsDirectory, script)), $"Missing Android script: {script}");
     }
 
     [Fact]
@@ -51,7 +51,7 @@ public sealed class AndroidToolingContractTests
     [Fact]
     public void ToolingHasPureParsersTimeoutCancellationAndNoUserSpecificPath()
     {
-        var module = File.ReadAllText(Path.Combine(AndroidScriptsDirectory, "AndroidTools.psm1"));
+        var module = File.ReadAllText(IOPath.Combine(AndroidScriptsDirectory, "AndroidTools.psm1"));
 
         Assert.Contains("ConvertFrom-AdbDevicesOutput", module, StringComparison.Ordinal);
         Assert.Contains("ConvertFrom-AvdListOutput", module, StringComparison.Ordinal);
@@ -74,8 +74,8 @@ public sealed class AndroidToolingContractTests
     [Fact]
     public void AndroidHostUsesTheSharedImePipelineWithoutNativeEditText()
     {
-        var host = File.ReadAllText(Path.Combine(SampleDirectory, "Platforms", "Android", "AndroidAppHost.cs"));
-        var page = File.ReadAllText(Path.Combine(SampleDirectory, "MainPage.cs"));
+        var host = File.ReadAllText(IOPath.Combine(SampleDirectory, "Platforms", "Android", "AndroidAppHost.cs"));
+        var page = File.ReadAllText(IOPath.Combine(SampleDirectory, "MainPage.cs"));
 
         Assert.Contains("controlSurface.SetComposingText", host, StringComparison.Ordinal);
         Assert.Contains("controlSurface.DeleteSurroundingText", host, StringComparison.Ordinal);
@@ -86,11 +86,11 @@ public sealed class AndroidToolingContractTests
     }
 
     private static string ReadScript(string name)
-        => File.ReadAllText(Path.Combine(AndroidScriptsDirectory, name));
+        => File.ReadAllText(IOPath.Combine(AndroidScriptsDirectory, name));
 
-    private static string AndroidScriptsDirectory => Path.Combine(RepositoryRoot, "scripts", "android");
+    private static string AndroidScriptsDirectory => IOPath.Combine(RepositoryRoot, "scripts", "android");
 
-    private static string SampleDirectory => Path.Combine(
+    private static string SampleDirectory => IOPath.Combine(
         RepositoryRoot,
         "samples",
         "ModernFormsNext.CrossPlatform.Sample");
@@ -100,7 +100,7 @@ public sealed class AndroidToolingContractTests
         get
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);
-            while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "ModernFormsNext.slnx")))
+            while (directory is not null && !File.Exists(IOPath.Combine(directory.FullName, "ModernFormsNext.slnx")))
                 directory = directory.Parent;
 
             return directory?.FullName

--- a/ModernFormsNext.CrossPlatform.Sample.Tests/GlobalUsings.ShapeCompatibility.cs
+++ b/ModernFormsNext.CrossPlatform.Sample.Tests/GlobalUsings.ShapeCompatibility.cs
@@ -1,0 +1,2 @@
+// ModernFormsNext.Path is a public vector control; keep file-system test paths explicit.
+global using IOPath = System.IO.Path;

--- a/ModernFormsNext.Designer.Tests/AnimationEffectDefinitionDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/AnimationEffectDefinitionDesignerTests.cs
@@ -310,11 +310,11 @@ public sealed class AnimationEffectDefinitionDesignerTests
     [Fact]
     public void SourceDiscoveryRequiresOptInAndNeverExecutesConstructors()
     {
-        string directory = Path.Combine(Path.GetTempPath(), $"mfn-animation-discovery-{Guid.NewGuid():N}");
+        string directory = IOPath.Combine(IOPath.GetTempPath(), $"mfn-animation-discovery-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         try
         {
-            File.WriteAllText(Path.Combine(directory, "Effects.cs"), """
+            File.WriteAllText(IOPath.Combine(directory, "Effects.cs"), """
                 using EffectRoot = ModernFormsNext.Animations.InteractionEffect;
                 using DefinitionMarker = ModernFormsNext.Animations.DesignableAnimationDefinitionAttribute;
                 using PropertyMarker = ModernFormsNext.Animations.DesignableAnimationPropertyAttribute;
@@ -355,11 +355,11 @@ public sealed class AnimationEffectDefinitionDesignerTests
     [Fact]
     public void AnimationDefinitionMetadataIsDiscoveredButNotOfferedAsInteractionEffect()
     {
-        string directory = Path.Combine(Path.GetTempPath(), $"mfn-animation-definition-{Guid.NewGuid():N}");
+        string directory = IOPath.Combine(IOPath.GetTempPath(), $"mfn-animation-definition-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         try
         {
-            File.WriteAllText(Path.Combine(directory, "Pulse.cs"), """
+            File.WriteAllText(IOPath.Combine(directory, "Pulse.cs"), """
                 using ModernFormsNext.Animations;
                 namespace Example;
                 [DesignableAnimationDefinition("Pulse")]
@@ -557,7 +557,7 @@ public sealed class AnimationEffectDefinitionDesignerTests
             public partial class MainForm : ModernFormsNext.Form { }
             """;
         string[] trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
-            ?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
+            ?.Split(IOPath.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
         IEnumerable<MetadataReference> references = trustedAssemblies
             .Concat(AppDomain.CurrentDomain.GetAssemblies()
                 .Where(assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))

--- a/ModernFormsNext.Designer.Tests/CustomUserControlPreviewTests.cs
+++ b/ModernFormsNext.Designer.Tests/CustomUserControlPreviewTests.cs
@@ -42,7 +42,7 @@ public sealed class CustomUserControlPreviewTests
         Assert.Single(parent.Controls);
         Assert.Empty(parent.Controls[0].Children);
 
-        var parentPath = Path.Combine(project.DirectoryPath, "MainForm.mfdesign");
+        var parentPath = IOPath.Combine(project.DirectoryPath, "MainForm.mfdesign");
         var files = new DesignerFileService(new TestDesignerEnvironment(project.ProjectFilePath, parentPath));
         files.SaveDesignDocument(parent);
 
@@ -146,7 +146,7 @@ public sealed class CustomUserControlPreviewTests
         project.AddUserControlSource(sourceDocument.Namespace, sourceDocument.ClassName);
 
         if (invalidDocument)
-            File.WriteAllText(Path.Combine(project.DirectoryPath, "Sidebar.mfdesign"), "{ invalid json");
+            File.WriteAllText(IOPath.Combine(project.DirectoryPath, "Sidebar.mfdesign"), "{ invalid json");
 
         var session = CreateSession(project, CreateParentDocument("Example.Sidebar", 40, 50, 300, 200));
         var exception = Record.Exception(() => Render(new DesignerSurfaceRenderer(), session));
@@ -160,7 +160,7 @@ public sealed class CustomUserControlPreviewTests
     {
         using var project = new TemporaryPreviewProject();
         project.AddUserControlSource("Example", "Sidebar");
-        File.WriteAllText(Path.Combine(project.DirectoryPath, "Sidebar.mfdesign"), string.Empty);
+        File.WriteAllText(IOPath.Combine(project.DirectoryPath, "Sidebar.mfdesign"), string.Empty);
         var session = CreateSession(project, CreateParentDocument("Example.Sidebar", 40, 50, 300, 200));
 
         var exception = Record.Exception(() => Render(new DesignerSurfaceRenderer(), session));
@@ -174,7 +174,7 @@ public sealed class CustomUserControlPreviewTests
     {
         using var project = new TemporaryPreviewProject();
         project.AddUserControlSource("Example", "Sidebar");
-        var path = Path.Combine(project.DirectoryPath, "Sidebar.mfdesign");
+        var path = IOPath.Combine(project.DirectoryPath, "Sidebar.mfdesign");
         File.WriteAllText(path, "{ invalid json");
         var cache = new DesignerEmbeddedPreviewCache(
             project.ProjectFilePath,
@@ -200,7 +200,7 @@ public sealed class CustomUserControlPreviewTests
         using var project = new TemporaryPreviewProject();
         project.AddUserControlSource("Example", "Sidebar");
         File.WriteAllText(
-            Path.Combine(project.DirectoryPath, "Sidebar.mfdesign"),
+            IOPath.Combine(project.DirectoryPath, "Sidebar.mfdesign"),
             """
             {
               "namespace": "Example",
@@ -237,7 +237,7 @@ public sealed class CustomUserControlPreviewTests
         var staleDocument = CreateUserControlDocument(documentNamespace, documentClassName, 300, 200);
         staleDocument.Controls.Add(CreateNode("Label", "staleLabel", 10, 10, 100, 24, "Stale"));
         DesignDocumentSerializer.Default.Save(
-            Path.Combine(project.DirectoryPath, "Sidebar.mfdesign"),
+            IOPath.Combine(project.DirectoryPath, "Sidebar.mfdesign"),
             staleDocument);
         var session = CreateSession(project, CreateParentDocument("Example.Sidebar", 40, 50, 300, 200));
 
@@ -255,7 +255,7 @@ public sealed class CustomUserControlPreviewTests
         var formDocument = CreateUserControlDocument("Example", "Sidebar", 300, 200);
         formDocument.RootKind = DesignRootKind.Form;
         DesignDocumentSerializer.Default.Save(
-            Path.Combine(project.DirectoryPath, "Sidebar.mfdesign"),
+            IOPath.Combine(project.DirectoryPath, "Sidebar.mfdesign"),
             formDocument);
         var session = CreateSession(project, CreateParentDocument("Example.Sidebar", 40, 50, 300, 200));
 
@@ -514,9 +514,9 @@ public sealed class CustomUserControlPreviewTests
     {
         public TemporaryPreviewProject()
         {
-            DirectoryPath = Path.Combine(Path.GetTempPath(), $"ModernFormsNextPreviewTests-{Guid.NewGuid():N}");
+            DirectoryPath = IOPath.Combine(IOPath.GetTempPath(), $"ModernFormsNextPreviewTests-{Guid.NewGuid():N}");
             Directory.CreateDirectory(DirectoryPath);
-            ProjectFilePath = Path.Combine(DirectoryPath, "Example.csproj");
+            ProjectFilePath = IOPath.Combine(DirectoryPath, "Example.csproj");
             File.WriteAllText(ProjectFilePath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
         }
 
@@ -527,7 +527,7 @@ public sealed class CustomUserControlPreviewTests
         public string AddUserControl(DesignDocument document)
         {
             AddUserControlSource(document.Namespace, document.ClassName);
-            var path = Path.Combine(DirectoryPath, $"{document.ClassName}.mfdesign");
+            var path = IOPath.Combine(DirectoryPath, $"{document.ClassName}.mfdesign");
             DesignDocumentSerializer.Default.Save(path, document);
             return path;
         }
@@ -535,7 +535,7 @@ public sealed class CustomUserControlPreviewTests
         public void AddUserControlSource(string namespaceName, string className)
         {
             File.WriteAllText(
-                Path.Combine(DirectoryPath, $"{className}.cs"),
+                IOPath.Combine(DirectoryPath, $"{className}.cs"),
                 $$"""
                 using ModernFormsNext;
 

--- a/ModernFormsNext.Designer.Tests/GlobalUsings.ShapeCompatibility.cs
+++ b/ModernFormsNext.Designer.Tests/GlobalUsings.ShapeCompatibility.cs
@@ -1,0 +1,2 @@
+// ModernFormsNext.Path is a public vector control. Keep existing file-system test code unambiguous.
+global using IOPath = System.IO.Path;

--- a/ModernFormsNext.Designer.Tests/ShapeDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/ShapeDesignerTests.cs
@@ -1,0 +1,421 @@
+using System.Drawing;
+using System.Globalization;
+using System.Numerics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using ModernFormsNext.CodeGeneration.CSharp;
+using ModernFormsNext.CodeGeneration.Reverse;
+using ModernFormsNext.CodeGeneration.Utilities;
+using ModernFormsNext.Designer.Properties;
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designer.Surface;
+using ModernFormsNext.Designing;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Designer.Tests;
+
+public sealed class ShapeDesignerTests
+{
+    [Fact]
+    public void ConcreteShapesAppearInDedicatedToolboxCategory()
+    {
+        IReadOnlyList<DesignerToolboxItem> items = new DesignerToolboxService().GetItems();
+
+        foreach (string type in ShapeTypes)
+            Assert.Contains(items, item => item.TypeName == type && item.Category == "Shapes");
+        Assert.DoesNotContain(items, item => item.TypeName == nameof(Shape));
+    }
+
+    [Theory]
+    [MemberData(nameof(GetShapeTypes))]
+    public void ShapeCanBeAddedToFormWithVisibleDefaults(string typeName)
+    {
+        DesignerSession session = CreateBlankSession();
+
+        DesignControlNode node = session.AddControl(typeName);
+
+        Assert.Equal(typeName, node.TypeName);
+        Assert.True(node.Bounds.Width >= 120);
+        Assert.True(node.Properties.ContainsKey("Stroke"));
+        Assert.False(node.Properties.ContainsKey("Text"));
+    }
+
+    [Fact]
+    public void ShapePropertyGridShowsAppearanceAndGeometryProperties()
+    {
+        DesignerSession session = CreateBlankSession();
+        session.AddControl(nameof(Polygon));
+        var state = new DesignerPropertyGridState(session);
+
+        foreach (string name in new[] { "Fill", "Stroke", "StrokeThickness", "StrokeLineCap", "StrokeLineJoin", "MiterLimit", "Points" })
+            Assert.Contains(state.Properties, property => property.Name == name);
+    }
+
+    [Fact]
+    public void LinePropertyGridHidesMeaninglessFill()
+    {
+        DesignerSession session = CreateBlankSession();
+        session.AddControl(nameof(Line));
+        var state = new DesignerPropertyGridState(session);
+
+        Assert.DoesNotContain(state.Properties, property => property.Name == "Fill");
+        Assert.Contains(state.Properties, property => property.Name == "StartPoint");
+        Assert.Contains(state.Properties, property => property.Name == "EndPoint");
+    }
+
+    [Fact]
+    public void PolylinePropertyGridHidesFillAndComplexValuesHaveDialogEditors()
+    {
+        DesignerSession session = CreateBlankSession();
+        session.AddControl(nameof(Polyline));
+        var polylineState = new DesignerPropertyGridState(session);
+        DesignerPropertyDescriptor points = Assert.Single(polylineState.Properties, property => property.Name == "Points");
+
+        Assert.DoesNotContain(polylineState.Properties, property => property.Name == "Fill");
+        Assert.True(points.HasDialogEditor);
+
+        session.SelectForm();
+        session.AddControl(nameof(ModernFormsNext.Path));
+        var pathState = new DesignerPropertyGridState(session);
+        DesignerPropertyDescriptor data = Assert.Single(pathState.Properties, property => property.Name == "Data");
+        Assert.True(data.HasDialogEditor);
+    }
+
+    [Fact]
+    public void PointCollectionTextAndStructuredValueRoundTrip()
+    {
+        var source = new PointCollection([new(1.25f, -2), new(8, 9.5f), new(40, 3)]);
+        string text = DesignerPropertyValueEditor.ToDisplayString(source);
+
+        Assert.True(DesignerPropertyValueEditor.TryConvert(text, typeof(PointCollection), out object? parsed, out string? error), error);
+        Assert.Equal(source, Assert.IsType<PointCollection>(parsed));
+        DesignPropertyValue stored = DesignerPropertyValueEditor.ToDesignPropertyValue(source, typeof(PointCollection));
+        Assert.Equal(source, Assert.IsType<PointCollection>(DesignerPropertyValueEditor.FromDesignPropertyValue(stored, typeof(PointCollection))));
+    }
+
+    [Fact]
+    public void PathGeometryTextAndStructuredValueRoundTrip()
+    {
+        PathGeometry source = CreatePathGeometry();
+        string text = DesignerPropertyValueEditor.ToDisplayString(source);
+
+        Assert.True(DesignerPropertyValueEditor.TryConvert(text, typeof(Geometry), out object? textResult, out string? error), error);
+        PathGeometry parsedText = Assert.IsType<PathGeometry>(textResult);
+        Assert.Equal(2, parsedText.Figures[0].Segments.Count);
+        DesignPropertyValue stored = DesignerPropertyValueEditor.ToDesignPropertyValue(source, typeof(Geometry));
+        PathGeometry restored = Assert.IsType<PathGeometry>(DesignerPropertyValueEditor.FromDesignPropertyValue(stored, typeof(Geometry)));
+        Assert.Equal(source.FillRule, restored.FillRule);
+        Assert.Equal(source.Transform, restored.Transform);
+        Assert.Equal(source.Figures[0].Segments.Count, restored.Figures[0].Segments.Count);
+    }
+
+    [Fact]
+    public void ShapeMfdesignSaveLoadPreservesStructuredValues()
+    {
+        DesignDocument document = CreateShapeDocument();
+
+        string json = DesignDocumentSerializer.Default.Serialize(document);
+        DesignDocument restored = DesignDocumentSerializer.Default.Deserialize(json);
+
+        DesignControlNode polygon = Assert.Single(restored.Controls, node => node.TypeName == nameof(Polygon));
+        Assert.True(polygon.Properties.ContainsKey("Points"));
+        DesignControlNode path = Assert.Single(restored.Controls, node => node.TypeName == nameof(ModernFormsNext.Path));
+        Assert.True(path.Properties.ContainsKey("Data"));
+        Assert.Contains("ModernFormsNext.Drawing.PathGeometry", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GeneratorEmitsReadablePublicShapeApi()
+    {
+        CSharpDesignerGenerationResult result = new CSharpDesignerGenerator().Generate(CreateShapeDocument());
+
+        Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Validation.Errors));
+        Assert.Contains("new Polygon()", result.Code, StringComparison.Ordinal);
+        Assert.Contains("new ModernFormsNext.Drawing.PointCollection", result.Code, StringComparison.Ordinal);
+        Assert.Contains("new ModernFormsNext.Drawing.PathGeometry", result.Code, StringComparison.Ordinal);
+        Assert.Contains("StrokeThickness = 2", result.Code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GeneratedShapeCodeCompiles()
+    {
+        string code = new CSharpDesignerGenerator().Generate(CreateShapeDocument()).Code;
+
+        AssertGeneratedCodeCompiles(code);
+    }
+
+    [Fact]
+    public void ReverseParserRestoresGeneratedShapesAndGeometry()
+    {
+        string code = new CSharpDesignerGenerator().Generate(CreateShapeDocument()).Code;
+
+        CSharpDesignerParseResult result = new CSharpDesignerParser().Parse(code);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics.Select(item => item.Message)));
+        DesignDocument document = Assert.IsType<DesignDocument>(result.Document);
+        DesignControlNode polygon = Assert.Single(document.Controls, node => node.TypeName.EndsWith(nameof(Polygon), StringComparison.Ordinal));
+        Assert.True(polygon.Properties.ContainsKey("Points"));
+        DesignControlNode path = Assert.Single(document.Controls, node => node.TypeName.EndsWith(nameof(ModernFormsNext.Path), StringComparison.Ordinal));
+        Assert.True(path.Properties.ContainsKey("Data"));
+    }
+
+    [Fact]
+    public void MfdesignCodeParserRoundTripIsStableForShapes()
+    {
+        var serializer = DesignDocumentSerializer.Default;
+        var generator = new CSharpDesignerGenerator();
+        DesignDocument document = serializer.Deserialize(serializer.Serialize(CreateShapeDocument()));
+        string firstCode = generator.Generate(document).Code;
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(firstCode);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+
+        string secondCode = generator.Generate(Assert.IsType<DesignDocument>(parsed.Document)).Code;
+
+        Assert.Equal(firstCode, secondCode);
+    }
+
+    [Fact]
+    public void ComplexPathRoundTripPreservesBrushTransformFiguresAndEverySegmentKind()
+    {
+        DesignerSession session = CreateBlankSession();
+        DesignControlNode path = session.AddControl(nameof(ModernFormsNext.Path));
+        var fill = new LinearGradientBrush
+        {
+            Start = new PointF(0.125f, 0.25f),
+            End = new PointF(0.875f, 0.75f),
+            Transform = Matrix3x2.CreateTranslation(1.5f, -2.25f)
+        };
+        fill.GradientStops.AddRange([
+            new GradientStop(Color.CornflowerBlue, 0.125f),
+            new GradientStop(Color.Gold, 0.625f),
+            new GradientStop(Color.DarkRed, 1f)
+        ]);
+        path.Properties["Fill"] = DesignerPropertyValueEditor.ToDesignPropertyValue(fill, typeof(ModernFormsNext.Drawing.Brush));
+        path.Properties["Stroke"] = DesignerPropertyValueEditor.ToDesignPropertyValue(new SolidColorBrush(Color.Navy), typeof(ModernFormsNext.Drawing.Brush));
+        path.Properties["StrokeThickness"] = DesignPropertyValue.FromDouble(2.75);
+        path.Properties["Data"] = DesignerPropertyValueEditor.ToDesignPropertyValue(CreateComplexPathGeometry(), typeof(Geometry));
+
+        var serializer = DesignDocumentSerializer.Default;
+        var generator = new CSharpDesignerGenerator();
+        DesignDocument stored = serializer.Deserialize(serializer.Serialize(session.Document));
+        string firstCode = generator.Generate(stored).Code;
+        CSharpDesignerParseResult parsed = new CSharpDesignerParser().Parse(firstCode);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(item => item.Message)));
+        DesignDocument reversed = Assert.IsType<DesignDocument>(parsed.Document);
+        string secondCode = generator.Generate(reversed).Code;
+
+        Assert.Equal(firstCode, secondCode);
+        DesignControlNode restoredNode = Assert.Single(reversed.Controls);
+        PathGeometry restored = Assert.IsType<PathGeometry>(DesignerPropertyValueEditor.FromDesignPropertyValue(restoredNode.Properties["Data"], typeof(Geometry)));
+        Assert.Equal(2, restored.Figures.Count);
+        Assert.IsType<LineSegment>(restored.Figures[0].Segments[0]);
+        Assert.IsType<QuadraticBezierSegment>(restored.Figures[0].Segments[1]);
+        Assert.IsType<BezierSegment>(restored.Figures[0].Segments[2]);
+        Assert.True(restored.Figures[0].IsClosed);
+        Assert.False(restored.Figures[1].IsClosed);
+        Assert.Equal(GeometryFillRule.EvenOdd, restored.FillRule);
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("de-DE")]
+    [InlineData("pl-PL")]
+    public void GeometryEditingAndCodeGenerationAreCultureInvariant(string cultureName)
+    {
+        CultureInfo previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo previousUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+            var points = new PointCollection([new(1.5f, -2.25f), new(3.75f, 4.125f)]);
+            PathGeometry geometry = CreateComplexPathGeometry();
+
+            string pointText = DesignerPropertyValueEditor.ToDisplayString(points);
+            string geometryText = DesignerPropertyValueEditor.ToDisplayString(geometry);
+            Assert.True(DesignerPropertyValueEditor.TryConvert(pointText, typeof(PointCollection), out object? restoredPoints, out string? pointError), pointError);
+            Assert.True(DesignerPropertyValueEditor.TryConvert(geometryText, typeof(Geometry), out object? restoredGeometry, out string? geometryError), geometryError);
+            Assert.True(DesignerPropertyValueEditor.TryConvert("2.75", typeof(float), out object? thickness, out string? thicknessError), thicknessError);
+
+            Assert.Equal(points, Assert.IsType<PointCollection>(restoredPoints));
+            Assert.Equal(geometry.Transform, Assert.IsType<PathGeometry>(restoredGeometry).Transform);
+            Assert.Equal(2.75f, Assert.IsType<float>(thickness));
+            string generated = CSharpLiteralWriter.WriteValue(DesignerPropertyValueEditor.ToDesignPropertyValue(geometry, typeof(Geometry)));
+            Assert.Contains("1.5f", generated, StringComparison.Ordinal);
+            Assert.DoesNotContain("1,5f", generated, StringComparison.Ordinal);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
+    }
+
+    [Fact]
+    public void RuntimeDesignerPainterRendersActualEllipse()
+    {
+        using var target = new SKBitmap(100, 80);
+        target.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(target);
+        using var ellipse = new Ellipse
+        {
+            Size = new Size(80, 60),
+            Fill = new SolidColorBrush(Color.CornflowerBlue)
+        };
+
+        bool painted = RuntimeControlPainter.TryPaint(
+            new PaintEventArgs(target.Info, canvas, 1),
+            ellipse,
+            ellipse.Size,
+            new Rectangle(10, 10, 80, 60),
+            out _,
+            out string? error);
+        canvas.Flush();
+
+        Assert.True(painted, error);
+        Assert.Equal(new SKColor(100, 149, 237), target.GetPixel(50, 40));
+    }
+
+    [Fact]
+    public void LegacyDocumentWithoutShapesStillRoundTrips()
+    {
+        const string json = """
+            {"schemaVersion":1,"namespace":"Example","className":"MainForm","formName":"Form1","size":{"width":640,"height":480},"controls":[]}
+            """;
+
+        DesignDocument document = DesignDocumentSerializer.Default.Deserialize(json);
+        CSharpDesignerGenerationResult generated = new CSharpDesignerGenerator().Generate(document);
+
+        Assert.True(generated.Succeeded, string.Join(Environment.NewLine, generated.Validation.Errors));
+        Assert.Empty(document.Controls);
+    }
+
+    [Theory]
+    [InlineData(DesignRootKind.Form)]
+    [InlineData(DesignRootKind.UserControl)]
+    public void ExistingRootKindsGenerateWithoutShapeRegression(DesignRootKind rootKind)
+    {
+        DesignDocument document = BlankDocument();
+        document.RootKind = rootKind;
+        document.Controls.Add(new DesignControlNode
+        {
+            TypeName = nameof(Button),
+            Name = "button1",
+            Bounds = new DesignBounds(10, 10, 100, 30)
+        });
+
+        CSharpDesignerGenerationResult result = new CSharpDesignerGenerator().Generate(document);
+
+        Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Validation.Errors));
+        Assert.DoesNotContain("PathGeometry", result.Code, StringComparison.Ordinal);
+    }
+
+    public static TheoryData<string> GetShapeTypes()
+    {
+        var result = new TheoryData<string>();
+        foreach (string type in ShapeTypes)
+            result.Add(type);
+        return result;
+    }
+
+    private static readonly string[] ShapeTypes =
+    [
+        nameof(Ellipse), nameof(Circle), nameof(Line), nameof(Polygon), nameof(Polyline), nameof(ModernFormsNext.Path)
+    ];
+
+    private static DesignerSession CreateBlankSession()
+    {
+        var session = new DesignerSession();
+        session.LoadDocument(BlankDocument());
+        session.SelectForm();
+        return session;
+    }
+
+    private static DesignDocument CreateShapeDocument()
+    {
+        DesignerSession session = CreateBlankSession();
+        DesignControlNode ellipse = session.AddControl(nameof(Ellipse));
+        var gradient = new LinearGradientBrush { Start = new PointF(0, 0), End = new PointF(1, 1) };
+        gradient.GradientStops.AddRange([
+            new GradientStop(Color.CornflowerBlue, 0),
+            new GradientStop(Color.MidnightBlue, 1)
+        ]);
+        ellipse.Properties["Fill"] = DesignerPropertyValueEditor.ToDesignPropertyValue(gradient, typeof(ModernFormsNext.Drawing.Brush));
+        session.SelectForm();
+        session.AddControl(nameof(Line));
+        session.SelectForm();
+        session.AddControl(nameof(Polygon));
+        session.SelectForm();
+        session.AddControl(nameof(Polyline));
+        session.SelectForm();
+        session.AddControl(nameof(ModernFormsNext.Path));
+        return session.Document;
+    }
+
+    private static DesignDocument BlankDocument()
+        => new()
+        {
+            Namespace = "Example",
+            ClassName = "MainForm",
+            FormName = "Form1",
+            Size = new DesignSize(640, 480)
+        };
+
+    private static PathGeometry CreatePathGeometry()
+    {
+        var geometry = new PathGeometry
+        {
+            FillRule = GeometryFillRule.EvenOdd,
+            Transform = System.Numerics.Matrix3x2.CreateTranslation(3, 4)
+        };
+        var figure = new PathFigure(new PointF(1, 2), true);
+        figure.Segments.Add(new QuadraticBezierSegment(new PointF(4, 5), new PointF(8, 9)));
+        figure.Segments.Add(new BezierSegment(new PointF(10, 11), new PointF(12, 13), new PointF(14, 15)));
+        geometry.Figures.Add(figure);
+        return geometry;
+    }
+
+    private static PathGeometry CreateComplexPathGeometry()
+    {
+        var geometry = new PathGeometry
+        {
+            FillRule = GeometryFillRule.EvenOdd,
+            Transform = new Matrix3x2(1.25f, 0.125f, -0.25f, 0.875f, 1.5f, -2.25f)
+        };
+        var first = new PathFigure(new PointF(1.5f, 2.25f), isClosed: true);
+        first.Segments.Add(new LineSegment(new PointF(10.5f, 3.25f)));
+        first.Segments.Add(new QuadraticBezierSegment(new PointF(12.5f, 5.75f), new PointF(16.25f, 9.5f)));
+        first.Segments.Add(new BezierSegment(new PointF(18.5f, 11.25f), new PointF(21.75f, 13.5f), new PointF(24.25f, 17.75f)));
+        var second = new PathFigure(new PointF(-3.5f, 4.25f));
+        second.Segments.Add(new LineSegment(new PointF(5.5f, 8.75f)));
+        geometry.Figures.Add(first);
+        geometry.Figures.Add(second);
+        return geometry;
+    }
+
+    private static void AssertGeneratedCodeCompiles(string generatedCode)
+    {
+        const string baseClass = """
+            namespace Example;
+            public partial class MainForm : ModernFormsNext.Form { }
+            """;
+        string[] trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            ?.Split(System.IO.Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
+        IEnumerable<MetadataReference> references = trustedAssemblies
+            .Concat(AppDomain.CurrentDomain.GetAssemblies()
+                .Where(assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+                .Select(assembly => assembly.Location))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "GeneratedShapeDesignerValidation",
+            [CSharpSyntaxTree.ParseText(generatedCode), CSharpSyntaxTree.ParseText(baseClass)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        Assert.DoesNotContain(compilation.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+}

--- a/ModernFormsNext.Designer.Tests/UserControlDesignerTests.cs
+++ b/ModernFormsNext.Designer.Tests/UserControlDesignerTests.cs
@@ -127,7 +127,7 @@ public sealed class UserControlDesignerTests
     public void ImportDesignerCodePreservesActiveUserControlRootKind()
     {
         using var project = TemporaryDesignerProject.Create("namespace Example; public class Placeholder { }");
-        var designerPath = Path.Combine(project.DirectoryPath, "NavigationPanel.Designer.cs");
+        var designerPath = IOPath.Combine(project.DirectoryPath, "NavigationPanel.Designer.cs");
         File.WriteAllText(
             designerPath,
             """
@@ -365,7 +365,7 @@ public sealed class UserControlDesignerTests
             Name = "controlA1",
             Bounds = new DesignBounds(0, 0, 100, 100)
         });
-        DesignDocumentSerializer.Default.Save(Path.Combine(project.DirectoryPath, "ControlB.mfdesign"), controlB);
+        DesignDocumentSerializer.Default.Save(IOPath.Combine(project.DirectoryPath, "ControlB.mfdesign"), controlB);
 
         var allowed = DesignerControlReferenceGuard.CanReference(
             controlA,
@@ -415,10 +415,10 @@ public sealed class UserControlDesignerTests
             """);
         foreach (var excludedDirectoryName in new[] { "bin", "obj", "artifacts", ".git", ".vs" })
         {
-            var excludedDirectory = Path.Combine(project.DirectoryPath, excludedDirectoryName);
+            var excludedDirectory = IOPath.Combine(project.DirectoryPath, excludedDirectoryName);
             Directory.CreateDirectory(excludedDirectory);
             File.WriteAllText(
-                Path.Combine(excludedDirectory, $"Hidden{excludedDirectoryName.TrimStart('.')}Control.cs"),
+                IOPath.Combine(excludedDirectory, $"Hidden{excludedDirectoryName.TrimStart('.')}Control.cs"),
                 $"using ModernFormsNext; public class Hidden{excludedDirectoryName.TrimStart('.')}Control : UserControl {{ }}");
         }
 
@@ -449,9 +449,9 @@ public sealed class UserControlDesignerTests
             public class ControlA : UserControl { }
             public class ControlB : UserControl { }
             """);
-        File.WriteAllText(Path.Combine(project.DirectoryPath, "Empty.mfdesign"), string.Empty);
+        File.WriteAllText(IOPath.Combine(project.DirectoryPath, "Empty.mfdesign"), string.Empty);
         File.WriteAllText(
-            Path.Combine(project.DirectoryPath, "StructurallyBroken.mfdesign"),
+            IOPath.Combine(project.DirectoryPath, "StructurallyBroken.mfdesign"),
             """{ "className": "Broken", "controls": null }""");
         var controlA = CreateUserControlDocument("ControlA");
 
@@ -483,8 +483,8 @@ public sealed class UserControlDesignerTests
         var controlC = CreateUserControlDocument("ControlC");
         controlB.Controls.Add(CreateControlReference("Example.ControlC", "controlC1"));
         controlC.Controls.Add(CreateControlReference("Example.ControlA", "controlA1"));
-        DesignDocumentSerializer.Default.Save(Path.Combine(project.DirectoryPath, "ControlB.mfdesign"), controlB);
-        DesignDocumentSerializer.Default.Save(Path.Combine(project.DirectoryPath, "ControlC.mfdesign"), controlC);
+        DesignDocumentSerializer.Default.Save(IOPath.Combine(project.DirectoryPath, "ControlB.mfdesign"), controlB);
+        DesignDocumentSerializer.Default.Save(IOPath.Combine(project.DirectoryPath, "ControlC.mfdesign"), controlC);
 
         var allowed = DesignerControlReferenceGuard.CanReference(
             controlA,
@@ -517,7 +517,7 @@ public sealed class UserControlDesignerTests
         File.WriteAllText(
             project.ProjectFilePath,
             """<Project Sdk="Microsoft.NET.Sdk"><ItemGroup><PackageReference Include="ModernFormsNext" Version="1.9.0" /></ItemGroup></Project>""");
-        var sourcePath = Path.Combine(project.DirectoryPath, "Controls.cs");
+        var sourcePath = IOPath.Combine(project.DirectoryPath, "Controls.cs");
 
         var result = new ModernFormsDesignableFileDetector().Inspect(sourcePath);
 
@@ -549,7 +549,7 @@ public sealed class UserControlDesignerTests
             """<Project Sdk="Microsoft.NET.Sdk"><ItemGroup><PackageReference Include="ModernFormsNext" Version="1.9.0" /></ItemGroup></Project>""");
 
         var result = new ModernFormsDesignableFileDetector().Inspect(
-            Path.Combine(project.DirectoryPath, "Controls.cs"));
+            IOPath.Combine(project.DirectoryPath, "Controls.cs"));
 
         Assert.False(Assert.IsType<ModernFormsDesignableFileInfo>(result).IsDesignable);
     }
@@ -565,7 +565,7 @@ public sealed class UserControlDesignerTests
 
             public partial class RenamedControl : UserControl { }
             """);
-        var designPath = Path.Combine(project.DirectoryPath, "Controls.mfdesign");
+        var designPath = IOPath.Combine(project.DirectoryPath, "Controls.mfdesign");
         var environment = new TestDesignerEnvironment(project.ProjectFilePath, designPath);
         var session = new DesignerSession(environment);
         var document = CreateUserControlDocument("OldControl");
@@ -591,14 +591,14 @@ public sealed class UserControlDesignerTests
         Assert.Contains(firstSession.ProjectUserControls, control => control.FullName == "OldNamespace.OldControl");
 
         File.WriteAllText(
-            Path.Combine(project.DirectoryPath, "Controls.cs"),
+            IOPath.Combine(project.DirectoryPath, "Controls.cs"),
             "using ModernFormsNext; namespace NewNamespace; public class RenamedControl : UserControl { }");
         var reopenedSession = new DesignerSession(new TestDesignerEnvironment(project.ProjectFilePath));
 
         Assert.DoesNotContain(reopenedSession.ProjectUserControls, control => control.FullName == "OldNamespace.OldControl");
         Assert.Contains(reopenedSession.ProjectUserControls, control => control.FullName == "NewNamespace.RenamedControl");
 
-        File.Delete(Path.Combine(project.DirectoryPath, "Controls.cs"));
+        File.Delete(IOPath.Combine(project.DirectoryPath, "Controls.cs"));
         var afterDeletion = new DesignerSession(new TestDesignerEnvironment(project.ProjectFilePath));
         var parent = new DesignDocument
         {
@@ -623,8 +623,8 @@ public sealed class UserControlDesignerTests
     public void DesignerGenerationDoesNotModifyUserCodeFile()
     {
         using var project = TemporaryDesignerProject.Create("namespace Example; public class Placeholder { }");
-        var designPath = Path.Combine(project.DirectoryPath, "NavigationPanel.mfdesign");
-        var userCodePath = Path.Combine(project.DirectoryPath, "NavigationPanel.cs");
+        var designPath = IOPath.Combine(project.DirectoryPath, "NavigationPanel.mfdesign");
+        var userCodePath = IOPath.Combine(project.DirectoryPath, "NavigationPanel.cs");
         const string userCode = """
             using ModernFormsNext;
 
@@ -647,7 +647,7 @@ public sealed class UserControlDesignerTests
 
         Assert.Equal(designPath, savedPath);
         Assert.True(generated.Succeeded, string.Join(Environment.NewLine, generated.Errors));
-        Assert.Equal(Path.Combine(project.DirectoryPath, "NavigationPanel.Designer.cs"), generated.Path);
+        Assert.Equal(IOPath.Combine(project.DirectoryPath, "NavigationPanel.Designer.cs"), generated.Path);
         Assert.Equal(userCode, File.ReadAllText(userCodePath));
     }
 
@@ -703,11 +703,11 @@ public sealed class UserControlDesignerTests
 
         public static TemporaryDesignerProject Create(string source)
         {
-            var directory = Path.Combine(Path.GetTempPath(), $"ModernFormsNextDesignerTests-{Guid.NewGuid():N}");
+            var directory = IOPath.Combine(IOPath.GetTempPath(), $"ModernFormsNextDesignerTests-{Guid.NewGuid():N}");
             Directory.CreateDirectory(directory);
-            var projectPath = Path.Combine(directory, "Example.csproj");
+            var projectPath = IOPath.Combine(directory, "Example.csproj");
             File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
-            File.WriteAllText(Path.Combine(directory, "Controls.cs"), source);
+            File.WriteAllText(IOPath.Combine(directory, "Controls.cs"), source);
             return new TemporaryDesignerProject(directory, projectPath);
         }
 

--- a/ModernFormsNext.Designer/GlobalUsings.ShapeCompatibility.cs
+++ b/ModernFormsNext.Designer/GlobalUsings.ShapeCompatibility.cs
@@ -1,0 +1,3 @@
+// ModernFormsNext.Path is a public vector control. Keep existing file-system code unambiguous
+// inside the designer project, whose namespaces are nested below ModernFormsNext.
+global using IOPath = System.IO.Path;

--- a/ModernFormsNext.Designer/Panels/SolutionExplorerPanel.cs
+++ b/ModernFormsNext.Designer/Panels/SolutionExplorerPanel.cs
@@ -143,7 +143,7 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
         if (root is null)
             return;
 
-        rows.Add(new SolutionExplorerRow(Path.GetFileName(root), "S", 0, false, root));
+        rows.Add(new SolutionExplorerRow(IOPath.GetFileName(root), "S", 0, false, root));
         AddDirectoryRows(root, root, depth: 1);
     }
 
@@ -153,10 +153,10 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
             return;
 
         foreach (var childDirectory in Directory.EnumerateDirectories(directory)
-                     .Where(path => !SkippedDirectories.Contains(Path.GetFileName(path)))
+                     .Where(path => !SkippedDirectories.Contains(IOPath.GetFileName(path)))
                      .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
         {
-            rows.Add(new SolutionExplorerRow(Path.GetFileName(childDirectory), "[]", depth, false, childDirectory));
+            rows.Add(new SolutionExplorerRow(IOPath.GetFileName(childDirectory), "[]", depth, false, childDirectory));
             AddDirectoryRows(root, childDirectory, depth + 1);
 
             if (rows.Count >= MaxRows)
@@ -167,7 +167,7 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
                      .OrderBy(path => GetFileRank(path))
                      .ThenBy(path => path, StringComparer.OrdinalIgnoreCase))
         {
-            rows.Add(new SolutionExplorerRow(Path.GetFileName(file), GetFileGlyph(file), depth, IsDocumentRelated(file), file));
+            rows.Add(new SolutionExplorerRow(IOPath.GetFileName(file), GetFileGlyph(file), depth, IsDocumentRelated(file), file));
 
             if (rows.Count >= MaxRows)
                 return;
@@ -179,11 +179,11 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
         if (string.IsNullOrWhiteSpace(row.Path) || !File.Exists(row.Path))
             return;
 
-        var extension = Path.GetExtension(row.Path);
+        var extension = IOPath.GetExtension(row.Path);
         var designPath = string.Equals(extension, ".mfdesign", StringComparison.OrdinalIgnoreCase)
             ? row.Path
             : string.Equals(extension, ".cs", StringComparison.OrdinalIgnoreCase)
-                ? Path.ChangeExtension(row.Path, ".mfdesign")
+                ? IOPath.ChangeExtension(row.Path, ".mfdesign")
                 : null;
 
         if (designPath is null)
@@ -191,7 +191,7 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
 
         if (!File.Exists(designPath))
         {
-            state.Log($"No ModernFormsNext design file exists for {Path.GetFileName(row.Path)}.");
+            state.Log($"No ModernFormsNext design file exists for {IOPath.GetFileName(row.Path)}.");
             return;
         }
 
@@ -199,11 +199,11 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
         {
             var document = DesignDocumentSerializer.Default.Load(designPath);
             state.OpenDocument(document, designPath);
-            state.Log($"Opened {Path.GetFileName(designPath)} from Solution Explorer.");
+            state.Log($"Opened {IOPath.GetFileName(designPath)} from Solution Explorer.");
         }
         catch (Exception ex)
         {
-            state.Log($"Could not open {Path.GetFileName(designPath)}: {ex.Message}");
+            state.Log($"Could not open {IOPath.GetFileName(designPath)}: {ex.Message}");
         }
     }
 
@@ -212,8 +212,8 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
         if (state.CurrentDocumentPath is null)
             return false;
 
-        var currentBase = Path.GetFileNameWithoutExtension(state.CurrentDocumentPath);
-        return string.Equals(Path.GetFileNameWithoutExtension(file), currentBase, StringComparison.OrdinalIgnoreCase);
+        var currentBase = IOPath.GetFileNameWithoutExtension(state.CurrentDocumentPath);
+        return string.Equals(IOPath.GetFileNameWithoutExtension(file), currentBase, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? GetProjectRoot(string? projectPath, string? documentPath)
@@ -221,7 +221,7 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
         if (!string.IsNullOrWhiteSpace(projectPath))
         {
             if (File.Exists(projectPath))
-                return Path.GetDirectoryName(projectPath);
+                return IOPath.GetDirectoryName(projectPath);
 
             if (Directory.Exists(projectPath))
                 return projectPath;
@@ -229,23 +229,23 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
 
         var directory = string.IsNullOrWhiteSpace(documentPath)
             ? null
-            : Path.GetDirectoryName(documentPath);
+            : IOPath.GetDirectoryName(documentPath);
 
         while (!string.IsNullOrWhiteSpace(directory))
         {
             if (Directory.EnumerateFiles(directory, "*.csproj").Any())
                 return directory;
 
-            directory = Path.GetDirectoryName(directory);
+            directory = IOPath.GetDirectoryName(directory);
         }
 
         return string.IsNullOrWhiteSpace(documentPath)
             ? null
-            : Path.GetDirectoryName(documentPath);
+            : IOPath.GetDirectoryName(documentPath);
     }
 
     private static int GetFileRank(string path)
-        => Path.GetExtension(path).ToLowerInvariant() switch
+        => IOPath.GetExtension(path).ToLowerInvariant() switch
         {
             ".csproj" => 0,
             ".cs" => 1,
@@ -254,7 +254,7 @@ internal sealed class SolutionExplorerPanel : DesignerPanelBase
         };
 
     private static string GetFileGlyph(string path)
-        => Path.GetExtension(path).ToLowerInvariant() switch
+        => IOPath.GetExtension(path).ToLowerInvariant() switch
         {
             ".csproj" => "C#",
             ".cs" => "C#",

--- a/ModernFormsNext.Designer/Properties/DesignerImagePickerDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerImagePickerDialog.cs
@@ -120,12 +120,12 @@ internal sealed class DesignerImagePickerDialog : Form
         }
 
         foreach (var path in Directory.EnumerateFiles(projectDirectory, "*.*", SearchOption.AllDirectories)
-                     .Where(path => ImageExtensions.Contains(Path.GetExtension(path), StringComparer.OrdinalIgnoreCase))
+                     .Where(path => ImageExtensions.Contains(IOPath.GetExtension(path), StringComparer.OrdinalIgnoreCase))
                      .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
                      .Take(500))
         {
             imagePaths.Add(path);
-            imageList.Items.Add(Path.GetRelativePath(projectDirectory, path));
+            imageList.Items.Add(IOPath.GetRelativePath(projectDirectory, path));
         }
 
         if (imagePaths.Count == 0)
@@ -151,7 +151,7 @@ internal sealed class DesignerImagePickerDialog : Form
         if (string.IsNullOrWhiteSpace(designDocumentPath))
             return null;
 
-        var directory = Path.GetDirectoryName(designDocumentPath);
+        var directory = IOPath.GetDirectoryName(designDocumentPath);
         return string.IsNullOrWhiteSpace(directory) ? null : directory;
     }
 }

--- a/ModernFormsNext.Designer/Properties/DesignerPathGeometryDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPathGeometryDialog.cs
@@ -1,0 +1,384 @@
+using System.Drawing;
+using System.Globalization;
+using System.Numerics;
+using ModernFormsNext.Drawing;
+
+namespace ModernFormsNext.Designer.Properties;
+
+/// <summary>Provides structured editing for PathGeometry figures and supported segment types.</summary>
+internal sealed class DesignerPathGeometryDialog : Form
+{
+    private readonly PathGeometry geometry;
+    private readonly ComboBox fillRuleCombo;
+    private readonly TextBox transformTextBox;
+    private readonly ListBox figureList;
+    private readonly TextBox startXTextBox;
+    private readonly TextBox startYTextBox;
+    private readonly CheckBox isClosedCheckBox;
+    private readonly ListBox segmentList;
+    private readonly ComboBox segmentTypeCombo;
+    private readonly TextBox control1XTextBox;
+    private readonly TextBox control1YTextBox;
+    private readonly TextBox control2XTextBox;
+    private readonly TextBox control2YTextBox;
+    private readonly TextBox endXTextBox;
+    private readonly TextBox endYTextBox;
+    private readonly Label errorLabel;
+    private bool changingSelection;
+
+    public DesignerPathGeometryDialog(PathGeometry? source)
+    {
+        geometry = Clone(source ?? new PathGeometry());
+
+        Text = "PathGeometry Editor";
+        Name = nameof(DesignerPathGeometryDialog);
+        Size = new Size(930, 610);
+        MinimumSize = new Size(860, 560);
+        StartPosition = FormStartPosition.CenterParent;
+
+        Controls.Add(new Label { Left = 18, Top = 16, Width = 70, Height = 22, Text = "Fill rule" });
+        fillRuleCombo = Controls.Add(new ComboBox { Left = 92, Top = 12, Width = 120, Height = 28 });
+        fillRuleCombo.Items.AddRange(Enum.GetNames<GeometryFillRule>().Cast<object>().ToArray());
+        fillRuleCombo.SelectedItem = geometry.FillRule.ToString();
+        Controls.Add(new Label { Left = 232, Top = 16, Width = 76, Height = 22, Text = "Transform" });
+        transformTextBox = Controls.Add(new TextBox { Left = 312, Top = 12, Width = 566, Height = 28, Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right });
+        transformTextBox.Text = FormatMatrix(geometry.Transform);
+
+        Controls.Add(new Label { Left = 18, Top = 56, Width = 230, Height = 22, Text = "Figures (rendering order)" });
+        figureList = Controls.Add(new ListBox { Left = 18, Top = 82, Width = 250, Height = 190 });
+        var addFigureButton = Controls.Add(new Button { Left = 18, Top = 280, Width = 54, Height = 30, Text = "Add" });
+        var removeFigureButton = Controls.Add(new Button { Left = 80, Top = 280, Width = 70, Height = 30, Text = "Remove" });
+        var upFigureButton = Controls.Add(new Button { Left = 158, Top = 280, Width = 50, Height = 30, Text = "Up" });
+        var downFigureButton = Controls.Add(new Button { Left = 216, Top = 280, Width = 52, Height = 30, Text = "Down" });
+
+        Controls.Add(new Label { Left = 290, Top = 56, Width = 180, Height = 22, Text = "Selected figure" });
+        Controls.Add(new Label { Left = 290, Top = 88, Width = 52, Height = 22, Text = "Start X" });
+        startXTextBox = Controls.Add(new TextBox { Left = 350, Top = 84, Width = 100, Height = 28 });
+        Controls.Add(new Label { Left = 466, Top = 88, Width = 52, Height = 22, Text = "Start Y" });
+        startYTextBox = Controls.Add(new TextBox { Left = 526, Top = 84, Width = 100, Height = 28 });
+        isClosedCheckBox = Controls.Add(new CheckBox { Left = 646, Top = 86, Width = 110, Height = 26, Text = "IsClosed" });
+        var applyFigureButton = Controls.Add(new Button { Left = 770, Top = 82, Width = 108, Height = 30, Text = "Apply Figure", Anchor = AnchorStyles.Top | AnchorStyles.Right });
+
+        Controls.Add(new Label { Left = 290, Top = 126, Width = 230, Height = 22, Text = "Segments (figure order)" });
+        segmentList = Controls.Add(new ListBox { Left = 290, Top = 152, Width = 336, Height = 160 });
+        segmentTypeCombo = Controls.Add(new ComboBox { Left = 646, Top = 152, Width = 138, Height = 28 });
+        segmentTypeCombo.Items.AddRange(["Line", "Quadratic", "Cubic"]);
+        segmentTypeCombo.SelectedIndex = 0;
+        var addSegmentButton = Controls.Add(new Button { Left = 792, Top = 150, Width = 86, Height = 30, Text = "Add", Anchor = AnchorStyles.Top | AnchorStyles.Right });
+        var removeSegmentButton = Controls.Add(new Button { Left = 646, Top = 190, Width = 86, Height = 30, Text = "Remove" });
+        var upSegmentButton = Controls.Add(new Button { Left = 740, Top = 190, Width = 64, Height = 30, Text = "Up" });
+        var downSegmentButton = Controls.Add(new Button { Left = 812, Top = 190, Width = 66, Height = 30, Text = "Down", Anchor = AnchorStyles.Top | AnchorStyles.Right });
+
+        int editorTop = 334;
+        Controls.Add(new Label { Left = 18, Top = editorTop, Width = 300, Height = 22, Text = "Selected segment coordinates" });
+        control1XTextBox = AddCoordinateEditor("Control 1 X", 18, editorTop + 32);
+        control1YTextBox = AddCoordinateEditor("Control 1 Y", 310, editorTop + 32);
+        control2XTextBox = AddCoordinateEditor("Control 2 X", 18, editorTop + 70);
+        control2YTextBox = AddCoordinateEditor("Control 2 Y", 310, editorTop + 70);
+        endXTextBox = AddCoordinateEditor("End X", 18, editorTop + 108);
+        endYTextBox = AddCoordinateEditor("End Y", 310, editorTop + 108);
+        var applySegmentButton = Controls.Add(new Button { Left = 646, Top = editorTop + 106, Width = 126, Height = 30, Text = "Apply Segment" });
+
+        errorLabel = Controls.Add(new Label { Left = 18, Top = 492, Width = 620, Height = 48, Text = string.Empty, Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right });
+        var okButton = Controls.Add(new Button { Left = 710, Top = 510, Width = 78, Height = 30, Text = "OK", Anchor = AnchorStyles.Bottom | AnchorStyles.Right });
+        var cancelButton = Controls.Add(new Button { Left = 800, Top = 510, Width = 78, Height = 30, Text = "Cancel", Anchor = AnchorStyles.Bottom | AnchorStyles.Right });
+
+        figureList.SelectedIndexChanged += (_, _) => { if (!changingSelection) { RefreshSegments(0); LoadFigure(); } };
+        segmentList.SelectedIndexChanged += (_, _) => { if (!changingSelection) LoadSegment(); };
+        addFigureButton.Click += (_, _) => { geometry.Figures.Add(new PathFigure()); RefreshFigures(geometry.Figures.Count - 1); };
+        removeFigureButton.Click += (_, _) => RemoveFigure();
+        upFigureButton.Click += (_, _) => MoveFigure(-1);
+        downFigureButton.Click += (_, _) => MoveFigure(1);
+        applyFigureButton.Click += (_, _) => ApplyFigure();
+        addSegmentButton.Click += (_, _) => AddSegment();
+        removeSegmentButton.Click += (_, _) => RemoveSegment();
+        upSegmentButton.Click += (_, _) => MoveSegment(-1);
+        downSegmentButton.Click += (_, _) => MoveSegment(1);
+        applySegmentButton.Click += (_, _) => ApplySegment();
+        okButton.Click += (_, _) => Commit();
+        cancelButton.Click += (_, _) => DialogResult = DialogResult.Cancel;
+
+        RefreshFigures(geometry.Figures.Count > 0 ? 0 : -1);
+    }
+
+    public PathGeometry Geometry => Clone(geometry);
+
+    private TextBox AddCoordinateEditor(string label, int left, int top)
+    {
+        Controls.Add(new Label { Left = left, Top = top + 4, Width = 84, Height = 22, Text = label });
+        return Controls.Add(new TextBox { Left = left + 90, Top = top, Width = 170, Height = 28 });
+    }
+
+    private void RemoveFigure()
+    {
+        int index = figureList.SelectedIndex;
+        if (index < 0 || index >= geometry.Figures.Count)
+            return;
+        geometry.Figures.RemoveAt(index);
+        RefreshFigures(Math.Min(index, geometry.Figures.Count - 1));
+    }
+
+    private void MoveFigure(int delta)
+    {
+        int oldIndex = figureList.SelectedIndex;
+        int newIndex = oldIndex + delta;
+        if (oldIndex < 0 || newIndex < 0 || newIndex >= geometry.Figures.Count)
+            return;
+        geometry.Figures.Move(oldIndex, newIndex);
+        RefreshFigures(newIndex);
+    }
+
+    private bool ApplyFigure()
+    {
+        PathFigure? figure = SelectedFigure();
+        if (figure is null)
+            return true;
+        if (!TryPoint(startXTextBox, startYTextBox, out PointF start))
+            return Fail("StartPoint must contain finite invariant X and Y values.");
+        figure.StartPoint = start;
+        figure.IsClosed = isClosedCheckBox.Checked;
+        errorLabel.Text = string.Empty;
+        RefreshFigures(figureList.SelectedIndex);
+        return true;
+    }
+
+    private void AddSegment()
+    {
+        PathFigure? figure = SelectedFigure();
+        if (figure is null)
+            return;
+        PathSegment segment = segmentTypeCombo.SelectedIndex switch
+        {
+            1 => new QuadraticBezierSegment(),
+            2 => new BezierSegment(),
+            _ => new LineSegment()
+        };
+        figure.Segments.Add(segment);
+        RefreshSegments(figure.Segments.Count - 1);
+    }
+
+    private void RemoveSegment()
+    {
+        PathFigure? figure = SelectedFigure();
+        int index = segmentList.SelectedIndex;
+        if (figure is null || index < 0 || index >= figure.Segments.Count)
+            return;
+        figure.Segments.RemoveAt(index);
+        RefreshSegments(Math.Min(index, figure.Segments.Count - 1));
+    }
+
+    private void MoveSegment(int delta)
+    {
+        PathFigure? figure = SelectedFigure();
+        int oldIndex = segmentList.SelectedIndex;
+        int newIndex = oldIndex + delta;
+        if (figure is null || oldIndex < 0 || newIndex < 0 || newIndex >= figure.Segments.Count)
+            return;
+        figure.Segments.Move(oldIndex, newIndex);
+        RefreshSegments(newIndex);
+    }
+
+    private bool ApplySegment()
+    {
+        PathSegment? segment = SelectedSegment();
+        if (segment is null)
+            return true;
+        if (!TryPoint(endXTextBox, endYTextBox, out PointF end))
+            return Fail("End point must contain finite invariant X and Y values.");
+        switch (segment)
+        {
+            case LineSegment line:
+                line.Point = end;
+                break;
+            case QuadraticBezierSegment quadratic:
+                if (!TryPoint(control1XTextBox, control1YTextBox, out PointF quadraticControl))
+                    return Fail("Quadratic control point must contain finite invariant X and Y values.");
+                quadratic.ControlPoint = quadraticControl;
+                quadratic.Point = end;
+                break;
+            case BezierSegment cubic:
+                if (!TryPoint(control1XTextBox, control1YTextBox, out PointF control1)
+                    || !TryPoint(control2XTextBox, control2YTextBox, out PointF control2))
+                    return Fail("Cubic control points must contain finite invariant X and Y values.");
+                cubic.ControlPoint1 = control1;
+                cubic.ControlPoint2 = control2;
+                cubic.Point = end;
+                break;
+        }
+        errorLabel.Text = string.Empty;
+        RefreshSegments(segmentList.SelectedIndex);
+        return true;
+    }
+
+    private void Commit()
+    {
+        // Persist the selected segment before refreshing the figure list; refreshing a figure also
+        // reloads its segment selection and would otherwise discard pending coordinate edits.
+        if (!ApplySegment() || !ApplyFigure())
+            return;
+        if (!Enum.TryParse(fillRuleCombo.SelectedItem?.ToString(), out GeometryFillRule fillRule))
+        {
+            Fail("Select a valid fill rule.");
+            return;
+        }
+        if (!TryParseMatrix(transformTextBox.Text, out Matrix3x2 transform))
+        {
+            Fail("Transform must contain six finite invariant values: m11,m12,m21,m22,m31,m32.");
+            return;
+        }
+        geometry.FillRule = fillRule;
+        geometry.Transform = transform;
+        DialogResult = DialogResult.OK;
+    }
+
+    private void RefreshFigures(int selectedIndex)
+    {
+        changingSelection = true;
+        figureList.Items.Clear();
+        for (int index = 0; index < geometry.Figures.Count; index++)
+        {
+            PathFigure figure = geometry.Figures[index];
+            figureList.Items.Add($"Figure {index + 1}: {FormatPoint(figure.StartPoint)}, {figure.Segments.Count} segments{(figure.IsClosed ? ", closed" : string.Empty)}");
+        }
+        figureList.SelectedIndex = geometry.Figures.Count == 0 ? -1 : Math.Clamp(selectedIndex, 0, geometry.Figures.Count - 1);
+        changingSelection = false;
+        LoadFigure();
+        RefreshSegments(0);
+    }
+
+    private void RefreshSegments(int selectedIndex)
+    {
+        changingSelection = true;
+        segmentList.Items.Clear();
+        PathFigure? figure = SelectedFigure();
+        if (figure is not null)
+        {
+            for (int index = 0; index < figure.Segments.Count; index++)
+                segmentList.Items.Add($"{index + 1}: {Describe(figure.Segments[index])}");
+            segmentList.SelectedIndex = figure.Segments.Count == 0 ? -1 : Math.Clamp(selectedIndex, 0, figure.Segments.Count - 1);
+        }
+        changingSelection = false;
+        LoadSegment();
+    }
+
+    private void LoadFigure()
+    {
+        PathFigure? figure = SelectedFigure();
+        bool enabled = figure is not null;
+        startXTextBox.Enabled = enabled;
+        startYTextBox.Enabled = enabled;
+        isClosedCheckBox.Enabled = enabled;
+        if (figure is null)
+        {
+            startXTextBox.Text = startYTextBox.Text = string.Empty;
+            isClosedCheckBox.Checked = false;
+            return;
+        }
+        startXTextBox.Text = FormatFloat(figure.StartPoint.X);
+        startYTextBox.Text = FormatFloat(figure.StartPoint.Y);
+        isClosedCheckBox.Checked = figure.IsClosed;
+    }
+
+    private void LoadSegment()
+    {
+        PathSegment? segment = SelectedSegment();
+        SetPointEditors(control1XTextBox, control1YTextBox, null, false);
+        SetPointEditors(control2XTextBox, control2YTextBox, null, false);
+        SetPointEditors(endXTextBox, endYTextBox, null, segment is not null);
+        switch (segment)
+        {
+            case LineSegment line:
+                SetPointEditors(endXTextBox, endYTextBox, line.Point, true);
+                break;
+            case QuadraticBezierSegment quadratic:
+                SetPointEditors(control1XTextBox, control1YTextBox, quadratic.ControlPoint, true);
+                SetPointEditors(endXTextBox, endYTextBox, quadratic.Point, true);
+                break;
+            case BezierSegment cubic:
+                SetPointEditors(control1XTextBox, control1YTextBox, cubic.ControlPoint1, true);
+                SetPointEditors(control2XTextBox, control2YTextBox, cubic.ControlPoint2, true);
+                SetPointEditors(endXTextBox, endYTextBox, cubic.Point, true);
+                break;
+        }
+    }
+
+    private PathFigure? SelectedFigure()
+        => figureList.SelectedIndex >= 0 && figureList.SelectedIndex < geometry.Figures.Count
+            ? geometry.Figures[figureList.SelectedIndex]
+            : null;
+
+    private PathSegment? SelectedSegment()
+    {
+        PathFigure? figure = SelectedFigure();
+        return figure is not null && segmentList.SelectedIndex >= 0 && segmentList.SelectedIndex < figure.Segments.Count
+            ? figure.Segments[segmentList.SelectedIndex]
+            : null;
+    }
+
+    private bool TryPoint(TextBox xTextBox, TextBox yTextBox, out PointF point)
+    {
+        bool validX = TryFloat(xTextBox.Text, out float x);
+        bool validY = TryFloat(yTextBox.Text, out float y);
+        bool valid = validX && validY;
+        point = valid ? new PointF(x, y) : default;
+        return valid;
+    }
+
+    private bool Fail(string message)
+    {
+        errorLabel.Text = message;
+        return false;
+    }
+
+    private static PathGeometry Clone(PathGeometry source)
+        => (PathGeometry)DesignerPropertyValueEditor.FromDesignPropertyValue(
+            DesignerPropertyValueEditor.ToDesignPropertyValue(source, typeof(Geometry)),
+            typeof(Geometry))!;
+
+    private static string Describe(PathSegment segment)
+        => segment switch
+        {
+            LineSegment line => $"Line to {FormatPoint(line.Point)}",
+            QuadraticBezierSegment quadratic => $"Quadratic via {FormatPoint(quadratic.ControlPoint)} to {FormatPoint(quadratic.Point)}",
+            BezierSegment cubic => $"Cubic via {FormatPoint(cubic.ControlPoint1)}, {FormatPoint(cubic.ControlPoint2)} to {FormatPoint(cubic.Point)}",
+            _ => segment.GetType().Name
+        };
+
+    private static void SetPointEditors(TextBox x, TextBox y, PointF? point, bool enabled)
+    {
+        x.Enabled = y.Enabled = enabled;
+        x.Text = point is { } value ? FormatFloat(value.X) : string.Empty;
+        y.Text = point is { } value2 ? FormatFloat(value2.Y) : string.Empty;
+    }
+
+    private static bool TryParseMatrix(string text, out Matrix3x2 matrix)
+    {
+        string[] parts = text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var values = new float[6];
+        if (parts.Length != values.Length)
+        {
+            matrix = default;
+            return false;
+        }
+        for (int index = 0; index < values.Length; index++)
+        {
+            if (!TryFloat(parts[index], out values[index]))
+            {
+                matrix = default;
+                return false;
+            }
+        }
+        matrix = new Matrix3x2(values[0], values[1], values[2], values[3], values[4], values[5]);
+        return true;
+    }
+
+    private static bool TryFloat(string text, out float value)
+        => float.TryParse(text.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out value) && float.IsFinite(value);
+
+    private static string FormatFloat(float value) => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static string FormatPoint(PointF point) => $"{FormatFloat(point.X)},{FormatFloat(point.Y)}";
+
+    private static string FormatMatrix(Matrix3x2 matrix)
+        => string.Join(',', new[] { matrix.M11, matrix.M12, matrix.M21, matrix.M22, matrix.M31, matrix.M32 }.Select(FormatFloat));
+}

--- a/ModernFormsNext.Designer/Properties/DesignerPointCollectionDialog.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPointCollectionDialog.cs
@@ -1,0 +1,168 @@
+using System.Drawing;
+using System.Globalization;
+using ModernFormsNext.Drawing;
+
+namespace ModernFormsNext.Designer.Properties;
+
+/// <summary>Provides ordered, structured editing for Polygon and Polyline point collections.</summary>
+internal sealed class DesignerPointCollectionDialog : Form
+{
+    private readonly List<PointF> points;
+    private readonly ListBox pointList;
+    private readonly TextBox xTextBox;
+    private readonly TextBox yTextBox;
+    private readonly Button removeButton;
+    private readonly Button upButton;
+    private readonly Button downButton;
+    private readonly Button applyPointButton;
+    private readonly Label errorLabel;
+    private bool changingSelection;
+
+    public DesignerPointCollectionDialog(PointCollection? source)
+    {
+        points = source is null ? [] : [.. source];
+
+        Text = "Point Collection Editor";
+        Name = nameof(DesignerPointCollectionDialog);
+        Size = new Size(610, 430);
+        MinimumSize = new Size(560, 390);
+        StartPosition = FormStartPosition.CenterParent;
+
+        Controls.Add(new Label { Left = 18, Top = 16, Width = 250, Height = 22, Text = "Points (rendering order)" });
+        pointList = Controls.Add(new ListBox
+        {
+            Left = 18,
+            Top = 42,
+            Width = 270,
+            Height = 280,
+            Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left
+        });
+
+        var addButton = Controls.Add(new Button { Left = 18, Top = 332, Width = 58, Height = 30, Text = "Add", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        removeButton = Controls.Add(new Button { Left = 84, Top = 332, Width = 72, Height = 30, Text = "Remove", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        upButton = Controls.Add(new Button { Left = 164, Top = 332, Width = 56, Height = 30, Text = "Up", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+        downButton = Controls.Add(new Button { Left = 228, Top = 332, Width = 60, Height = 30, Text = "Down", Anchor = AnchorStyles.Bottom | AnchorStyles.Left });
+
+        Controls.Add(new Label { Left = 316, Top = 16, Width = 230, Height = 22, Text = "Selected point" });
+        Controls.Add(new Label { Left = 316, Top = 54, Width = 36, Height = 24, Text = "X" });
+        xTextBox = Controls.Add(new TextBox { Left = 360, Top = 50, Width = 190, Height = 28, Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right });
+        Controls.Add(new Label { Left = 316, Top = 92, Width = 36, Height = 24, Text = "Y" });
+        yTextBox = Controls.Add(new TextBox { Left = 360, Top = 88, Width = 190, Height = 28, Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right });
+        applyPointButton = Controls.Add(new Button { Left = 430, Top = 128, Width = 120, Height = 30, Text = "Apply Point", Anchor = AnchorStyles.Top | AnchorStyles.Right });
+        errorLabel = Controls.Add(new Label { Left = 316, Top = 170, Width = 234, Height = 72, Text = string.Empty, Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right });
+
+        var okButton = Controls.Add(new Button { Left = 398, Top = 332, Width = 72, Height = 30, Text = "OK", Anchor = AnchorStyles.Bottom | AnchorStyles.Right });
+        var cancelButton = Controls.Add(new Button { Left = 478, Top = 332, Width = 72, Height = 30, Text = "Cancel", Anchor = AnchorStyles.Bottom | AnchorStyles.Right });
+
+        pointList.SelectedIndexChanged += (_, _) => LoadSelectedPoint();
+        addButton.Click += (_, _) => AddPoint();
+        removeButton.Click += (_, _) => RemovePoint();
+        upButton.Click += (_, _) => MovePoint(-1);
+        downButton.Click += (_, _) => MovePoint(1);
+        applyPointButton.Click += (_, _) => ApplySelectedPoint();
+        okButton.Click += (_, _) => Commit();
+        cancelButton.Click += (_, _) => DialogResult = DialogResult.Cancel;
+
+        RefreshList(points.Count > 0 ? 0 : -1);
+    }
+
+    public PointCollection Points => new(points);
+
+    private void AddPoint()
+    {
+        points.Add(PointF.Empty);
+        RefreshList(points.Count - 1);
+    }
+
+    private void RemovePoint()
+    {
+        int index = pointList.SelectedIndex;
+        if (index < 0 || index >= points.Count)
+            return;
+
+        points.RemoveAt(index);
+        RefreshList(Math.Min(index, points.Count - 1));
+    }
+
+    private void MovePoint(int delta)
+    {
+        int oldIndex = pointList.SelectedIndex;
+        int newIndex = oldIndex + delta;
+        if (oldIndex < 0 || newIndex < 0 || newIndex >= points.Count)
+            return;
+
+        PointF point = points[oldIndex];
+        points.RemoveAt(oldIndex);
+        points.Insert(newIndex, point);
+        RefreshList(newIndex);
+    }
+
+    private bool ApplySelectedPoint()
+    {
+        int index = pointList.SelectedIndex;
+        if (index < 0 || index >= points.Count)
+            return true;
+
+        if (!TryReadFiniteFloat(xTextBox.Text, out float x) || !TryReadFiniteFloat(yTextBox.Text, out float y))
+        {
+            errorLabel.Text = "X and Y must be finite invariant numbers, for example 12.5.";
+            return false;
+        }
+
+        points[index] = new PointF(x, y);
+        errorLabel.Text = string.Empty;
+        RefreshList(index);
+        return true;
+    }
+
+    private void Commit()
+    {
+        if (ApplySelectedPoint())
+            DialogResult = DialogResult.OK;
+    }
+
+    private void LoadSelectedPoint()
+    {
+        if (changingSelection)
+            return;
+
+        int index = pointList.SelectedIndex;
+        bool selected = index >= 0 && index < points.Count;
+        if (selected)
+        {
+            PointF point = points[index];
+            xTextBox.Text = point.X.ToString("R", CultureInfo.InvariantCulture);
+            yTextBox.Text = point.Y.ToString("R", CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            xTextBox.Text = string.Empty;
+            yTextBox.Text = string.Empty;
+        }
+
+        xTextBox.Enabled = selected;
+        yTextBox.Enabled = selected;
+        applyPointButton.Enabled = selected;
+        removeButton.Enabled = selected;
+        upButton.Enabled = selected && index > 0;
+        downButton.Enabled = selected && index < points.Count - 1;
+    }
+
+    private void RefreshList(int selectedIndex)
+    {
+        changingSelection = true;
+        pointList.Items.Clear();
+        for (int index = 0; index < points.Count; index++)
+        {
+            PointF point = points[index];
+            pointList.Items.Add($"{index + 1} | {point.X.ToString("R", CultureInfo.InvariantCulture)} | {point.Y.ToString("R", CultureInfo.InvariantCulture)}");
+        }
+        pointList.SelectedIndex = points.Count == 0 ? -1 : Math.Clamp(selectedIndex, 0, points.Count - 1);
+        changingSelection = false;
+        LoadSelectedPoint();
+    }
+
+    private static bool TryReadFiniteFloat(string text, out float value)
+        => float.TryParse(text.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+            && float.IsFinite(value);
+}

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyDescriptorFactory.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyDescriptorFactory.cs
@@ -207,6 +207,12 @@ internal static class DesignerPropertyDescriptorFactory
             return true;
         }
 
+        if (type == typeof(System.Drawing.PointF))
+        {
+            descriptor = CreateStoredPointFDescriptor(node, name, displayName, category, description, propertyType, fallbackValue, canEdit, isAdvanced);
+            return true;
+        }
+
         if (type == typeof(Padding))
         {
             descriptor = CreateStoredPaddingDescriptor(node, name, displayName, category, description, propertyType, fallbackValue, canEdit, isAdvanced);
@@ -252,6 +258,54 @@ internal static class DesignerPropertyDescriptorFactory
         if (typeof(ModernFormsNext.Drawing.Brush).IsAssignableFrom(type))
         {
             descriptor = CreateStoredBrushDescriptor(node, name, displayName, category, description, propertyType, fallbackValue as ModernFormsNext.Drawing.Brush, canEdit, isAdvanced);
+            return true;
+        }
+
+        if (type == typeof(ModernFormsNext.Drawing.PointCollection))
+        {
+            Func<ModernFormsNext.Drawing.PointCollection?> getPoints = () =>
+                GetStoredValue(node, name, propertyType, fallbackValue) as ModernFormsNext.Drawing.PointCollection;
+            descriptor = CreateStoredRoot(
+                node,
+                name,
+                displayName,
+                category,
+                description,
+                propertyType,
+                fallbackValue,
+                canEdit,
+                isAdvanced,
+                DesignerPropertyDialogEditors.PointCollection(
+                    getPoints,
+                    points =>
+                    {
+                        SetStoredValue(node, name, points, propertyType);
+                        return (true, null);
+                    }));
+            return true;
+        }
+
+        if (typeof(ModernFormsNext.Drawing.Geometry).IsAssignableFrom(type))
+        {
+            Func<ModernFormsNext.Drawing.Geometry?> getGeometry = () =>
+                GetStoredValue(node, name, propertyType, fallbackValue) as ModernFormsNext.Drawing.Geometry;
+            descriptor = CreateStoredRoot(
+                node,
+                name,
+                displayName,
+                category,
+                description,
+                propertyType,
+                fallbackValue,
+                canEdit,
+                isAdvanced,
+                DesignerPropertyDialogEditors.PathGeometry(
+                    getGeometry,
+                    geometry =>
+                    {
+                        SetStoredValue(node, name, geometry, propertyType);
+                        return (true, null);
+                    }));
             return true;
         }
 
@@ -335,6 +389,23 @@ internal static class DesignerPropertyDescriptorFactory
         var root = CreateStoredRoot(node, path, displayName, category, description, valueType, fallbackValue, canEdit, isAdvanced);
         root.Children.Add(CreateStoredPointChild(node, path, "X", "X", "Horizontal position.", valueType, fallbackValue, point => point.X, (point, value) => new System.Drawing.Point(value, point.Y), 1, canEdit, category));
         root.Children.Add(CreateStoredPointChild(node, path, "Y", "Y", "Vertical position.", valueType, fallbackValue, point => point.Y, (point, value) => new System.Drawing.Point(point.X, value), 1, canEdit, category));
+        return root;
+    }
+
+    private static DesignerPropertyDescriptor CreateStoredPointFDescriptor(
+        DesignControlNode node,
+        string path,
+        string displayName,
+        string category,
+        string description,
+        Type valueType,
+        object? fallbackValue,
+        bool canEdit,
+        bool isAdvanced)
+    {
+        var root = CreateStoredRoot(node, path, displayName, category, description, valueType, fallbackValue, canEdit, isAdvanced);
+        root.Children.Add(CreateStoredPointFChild(node, path, "X", "X", "Horizontal position in logical pixels.", valueType, fallbackValue, point => point.X, (point, value) => new System.Drawing.PointF(value, point.Y), 1, canEdit, category));
+        root.Children.Add(CreateStoredPointFChild(node, path, "Y", "Y", "Vertical position in logical pixels.", valueType, fallbackValue, point => point.Y, (point, value) => new System.Drawing.PointF(point.X, value), 1, canEdit, category));
         return root;
     }
 
@@ -518,7 +589,8 @@ internal static class DesignerPropertyDescriptorFactory
         Type valueType,
         object? fallbackValue,
         bool canEdit,
-        bool isAdvanced)
+        bool isAdvanced,
+        Func<DesignerPropertyDialogContext, Task<bool>>? dialogEditor = null)
         => new()
         {
             Name = path,
@@ -530,6 +602,8 @@ internal static class DesignerPropertyDescriptorFactory
             IsReadOnly = !canEdit,
             IsAdvanced = isAdvanced,
             ShouldSerialize = canEdit,
+            HasDialogEditor = canEdit && dialogEditor is not null,
+            DialogEditor = canEdit ? dialogEditor : null,
             GetValue = () => GetStoredValue(node, path, valueType, fallbackValue),
             CommitText = text =>
             {
@@ -1461,6 +1535,34 @@ internal static class DesignerPropertyDescriptorFactory
             depth,
             isReadOnly: !canEdit);
 
+    private static DesignerPropertyDescriptor CreateStoredPointFChild(
+        DesignControlNode node,
+        string path,
+        string name,
+        string displayName,
+        string description,
+        Type valueType,
+        object? fallbackValue,
+        Func<System.Drawing.PointF, float> getValue,
+        Func<System.Drawing.PointF, float, System.Drawing.PointF> update,
+        int depth,
+        bool canEdit,
+        string category)
+        => CreateFloatChild(
+            name,
+            $"{path}.{name}",
+            displayName,
+            category,
+            description,
+            () => getValue(GetStoredPointF(node, path, valueType, fallbackValue)),
+            value =>
+            {
+                SetStoredValue(node, path, update(GetStoredPointF(node, path, valueType, fallbackValue), value), valueType);
+                return (true, null);
+            },
+            depth,
+            isReadOnly: !canEdit);
+
     private static DesignerPropertyDescriptor CreateStoredSkPointChild(
         DesignControlNode node,
         string path,
@@ -1770,6 +1872,11 @@ internal static class DesignerPropertyDescriptorFactory
         => GetStoredValue(node, path, valueType, fallbackValue) is System.Drawing.Point point
             ? point
             : System.Drawing.Point.Empty;
+
+    private static System.Drawing.PointF GetStoredPointF(DesignControlNode node, string path, Type valueType, object? fallbackValue)
+        => GetStoredValue(node, path, valueType, fallbackValue) is System.Drawing.PointF point
+            ? point
+            : System.Drawing.PointF.Empty;
 
     private static Padding GetStoredPadding(DesignControlNode node, string path, Type valueType, object? fallbackValue)
         => GetStoredValue(node, path, valueType, fallbackValue) is Padding padding

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyDialogEditors.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyDialogEditors.cs
@@ -80,6 +80,51 @@ internal static class DesignerPropertyDialogEditors
             return true;
         };
 
+    public static Func<DesignerPropertyDialogContext, Task<bool>> PointCollection(
+        Func<ModernFormsNext.Drawing.PointCollection?> getPoints,
+        Func<ModernFormsNext.Drawing.PointCollection, (bool Success, string? Error)> setPoints)
+        => async context =>
+        {
+            var dialog = new DesignerPointCollectionDialog(getPoints());
+            if (await dialog.ShowDialog(context.Owner) != DialogResult.OK)
+                return false;
+
+            var result = setPoints(dialog.Points);
+            if (!result.Success)
+            {
+                context.Session.Log($"Point collection editor failed: {result.Error}");
+                return false;
+            }
+
+            return true;
+        };
+
+    public static Func<DesignerPropertyDialogContext, Task<bool>> PathGeometry(
+        Func<ModernFormsNext.Drawing.Geometry?> getGeometry,
+        Func<ModernFormsNext.Drawing.Geometry, (bool Success, string? Error)> setGeometry)
+        => async context =>
+        {
+            ModernFormsNext.Drawing.Geometry? current = getGeometry();
+            if (current is not null and not ModernFormsNext.Drawing.PathGeometry)
+            {
+                context.Session.Log("The structured geometry dialog edits PathGeometry. Use the inline editor for LineGeometry, RectangleGeometry, or EllipseGeometry.");
+                return false;
+            }
+
+            var dialog = new DesignerPathGeometryDialog(current as ModernFormsNext.Drawing.PathGeometry);
+            if (await dialog.ShowDialog(context.Owner) != DialogResult.OK)
+                return false;
+
+            var result = setGeometry(dialog.Geometry);
+            if (!result.Success)
+            {
+                context.Session.Log($"Path geometry editor failed: {result.Error}");
+                return false;
+            }
+
+            return true;
+        };
+
     public static Func<DesignerPropertyDialogContext, Task<bool>> ImageLocation(DesignControlNode node)
         => async context =>
         {

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyGridState.cs
@@ -945,8 +945,11 @@ internal sealed class DesignerPropertyGridState
             var description = GetPropertyDescription(
                 metadata.Description ?? "Designer metadata does not provide a description for this property.",
                 unsupported);
-            var complexCanEdit = metadata.Serialize
-                && !unsupported
+            // TryCreateRuntimeDescriptor below is the allow-list for complex values that have a
+            // deterministic editor and serializer. Do not require the primitive-only metadata
+            // Serialize flag for those values, otherwise Brush, PointCollection, and Geometry
+            // appear read-only despite their dedicated structured support.
+            var complexCanEdit = !unsupported
                 && (!metadata.ReadOnly || (Nullable.GetUnderlyingType(metadata.PropertyType) ?? metadata.PropertyType) == typeof(ControlStyle));
 
             if (DesignerPropertyDescriptorFactory.TryCreateRuntimeDescriptor(

--- a/ModernFormsNext.Designer/Properties/DesignerPropertyValueEditor.cs
+++ b/ModernFormsNext.Designer/Properties/DesignerPropertyValueEditor.cs
@@ -29,6 +29,7 @@ internal static class DesignerPropertyValueEditor
             System.Drawing.Point point => $"{point.X}, {point.Y}",
             System.Drawing.PointF point => $"{point.X.ToString("R", CultureInfo.InvariantCulture)}, {point.Y.ToString("R", CultureInfo.InvariantCulture)}",
             System.Drawing.Rectangle rectangle => $"{rectangle.X}, {rectangle.Y}, {rectangle.Width}, {rectangle.Height}",
+            System.Drawing.RectangleF rectangle => $"{rectangle.X.ToString("R", CultureInfo.InvariantCulture)}, {rectangle.Y.ToString("R", CultureInfo.InvariantCulture)}, {rectangle.Width.ToString("R", CultureInfo.InvariantCulture)}, {rectangle.Height.ToString("R", CultureInfo.InvariantCulture)}",
             SKPoint point => $"{point.X.ToString("R", CultureInfo.InvariantCulture)}, {point.Y.ToString("R", CultureInfo.InvariantCulture)}",
             SKSize size => $"{size.Width.ToString("R", CultureInfo.InvariantCulture)}, {size.Height.ToString("R", CultureInfo.InvariantCulture)}",
             SKRect rect => $"{rect.Left.ToString("R", CultureInfo.InvariantCulture)}, {rect.Top.ToString("R", CultureInfo.InvariantCulture)}, {rect.Right.ToString("R", CultureInfo.InvariantCulture)}, {rect.Bottom.ToString("R", CultureInfo.InvariantCulture)}",
@@ -40,6 +41,8 @@ internal static class DesignerPropertyValueEditor
             ModernFormsNext.Drawing.RadialGradientBrush radialBrush => $"RadialGradientBrush ({radialBrush.GradientStops.Count} stops)",
             ModernFormsNext.Drawing.SweepGradientBrush sweepBrush => $"SweepGradientBrush ({sweepBrush.GradientStops.Count} stops)",
             ModernFormsNext.Drawing.Brush => "<custom brush>",
+            ModernFormsNext.Drawing.PointCollection points => WritePointCollectionText(points),
+            ModernFormsNext.Drawing.Geometry geometry => WriteGeometryText(geometry),
             ModernFormsNext.Font font => $"{font.FamilyName}, {font.SizeInPoints.ToString("G", CultureInfo.InvariantCulture)}pt",
             float floatValue => floatValue.ToString("R", CultureInfo.InvariantCulture),
             double doubleValue => doubleValue.ToString("R", CultureInfo.InvariantCulture),
@@ -142,8 +145,14 @@ internal static class DesignerPropertyValueEditor
         if (targetType == typeof(System.Drawing.Point))
             return TryParsePoint(trimmed, out value, out error);
 
+        if (targetType == typeof(System.Drawing.PointF))
+            return TryParsePointF(trimmed, out value, out error);
+
         if (targetType == typeof(System.Drawing.Rectangle))
             return TryParseRectangle(trimmed, out value, out error);
+
+        if (targetType == typeof(System.Drawing.RectangleF))
+            return TryParseRectangleF(trimmed, out value, out error);
 
         if (targetType == typeof(DesignSize))
             return TryParseDesignSize(trimmed, out value, out error);
@@ -184,6 +193,12 @@ internal static class DesignerPropertyValueEditor
 
         if (targetType == typeof(ModernFormsNext.Font))
             return TryParseFont(trimmed, out value, out error);
+
+        if (targetType == typeof(ModernFormsNext.Drawing.PointCollection))
+            return TryParsePointCollection(trimmed, out value, out error);
+
+        if (typeof(ModernFormsNext.Drawing.Geometry).IsAssignableFrom(targetType))
+            return TryParseGeometry(trimmed, out value, out error);
 
         error = $"Values of type '{targetType.Name}' are not editable yet.";
         value = null;
@@ -255,6 +270,15 @@ internal static class DesignerPropertyValueEditor
                 ["Height"] = DesignPropertyValue.FromInt32(rectangle.Height)
             });
 
+        if (value is System.Drawing.RectangleF rectangleF)
+            return DesignPropertyValue.FromStructuredObject(typeof(System.Drawing.RectangleF).FullName!, new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+            {
+                ["X"] = DesignPropertyValue.FromDouble(rectangleF.X),
+                ["Y"] = DesignPropertyValue.FromDouble(rectangleF.Y),
+                ["Width"] = DesignPropertyValue.FromDouble(rectangleF.Width),
+                ["Height"] = DesignPropertyValue.FromDouble(rectangleF.Height)
+            });
+
         if (value is DesignBounds designBounds)
             return DesignPropertyValue.FromStructuredObject(typeof(DesignBounds).FullName!, new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
             {
@@ -320,6 +344,12 @@ internal static class DesignerPropertyValueEditor
 
         if (value is ModernFormsNext.Drawing.SweepGradientBrush sweepGradientBrush)
             return ToSweepGradientBrushPropertyValue(sweepGradientBrush);
+
+        if (value is ModernFormsNext.Drawing.PointCollection points)
+            return ToPointCollectionPropertyValue(points);
+
+        if (value is ModernFormsNext.Drawing.Geometry geometry)
+            return ToGeometryPropertyValue(geometry);
 
         if (value is ModernFormsNext.Font font)
             return ToFontPropertyValue(font);
@@ -459,6 +489,83 @@ internal static class DesignerPropertyValueEditor
         }
     }
 
+    private static DesignPropertyValue ToPointCollectionPropertyValue(ModernFormsNext.Drawing.PointCollection points)
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["Count"] = DesignPropertyValue.FromInt32(points.Count)
+        };
+        for (int index = 0; index < points.Count; index++)
+            properties[$"Point{index}"] = ToDesignPropertyValue(points[index], typeof(System.Drawing.PointF));
+        return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.PointCollection).FullName!, properties);
+    }
+
+    private static DesignPropertyValue ToGeometryPropertyValue(ModernFormsNext.Drawing.Geometry geometry)
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["Transform"] = ToDesignPropertyValue(geometry.Transform, typeof(Matrix3x2))
+        };
+
+        switch (geometry)
+        {
+            case ModernFormsNext.Drawing.LineGeometry line:
+                properties["StartPoint"] = ToDesignPropertyValue(line.StartPoint, typeof(System.Drawing.PointF));
+                properties["EndPoint"] = ToDesignPropertyValue(line.EndPoint, typeof(System.Drawing.PointF));
+                break;
+            case ModernFormsNext.Drawing.RectangleGeometry rectangle:
+                properties["Rect"] = ToDesignPropertyValue(rectangle.Rect, typeof(System.Drawing.RectangleF));
+                break;
+            case ModernFormsNext.Drawing.EllipseGeometry ellipse:
+                properties["Rect"] = ToDesignPropertyValue(ellipse.Rect, typeof(System.Drawing.RectangleF));
+                break;
+            case ModernFormsNext.Drawing.PathGeometry path:
+                properties["FillRule"] = DesignPropertyValue.FromEnum(
+                    typeof(ModernFormsNext.Drawing.GeometryFillRule).FullName!,
+                    path.FillRule.ToString());
+                properties["FigureCount"] = DesignPropertyValue.FromInt32(path.Figures.Count);
+                for (int index = 0; index < path.Figures.Count; index++)
+                    properties[$"Figure{index}"] = ToPathFigurePropertyValue(path.Figures[index]);
+                break;
+        }
+
+        return DesignPropertyValue.FromStructuredObject(geometry.GetType().FullName!, properties);
+    }
+
+    private static DesignPropertyValue ToPathFigurePropertyValue(ModernFormsNext.Drawing.PathFigure figure)
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal)
+        {
+            ["StartPoint"] = ToDesignPropertyValue(figure.StartPoint, typeof(System.Drawing.PointF)),
+            ["IsClosed"] = DesignPropertyValue.FromBoolean(figure.IsClosed),
+            ["SegmentCount"] = DesignPropertyValue.FromInt32(figure.Segments.Count)
+        };
+        for (int index = 0; index < figure.Segments.Count; index++)
+            properties[$"Segment{index}"] = ToPathSegmentPropertyValue(figure.Segments[index]);
+        return DesignPropertyValue.FromStructuredObject(typeof(ModernFormsNext.Drawing.PathFigure).FullName!, properties);
+    }
+
+    private static DesignPropertyValue ToPathSegmentPropertyValue(ModernFormsNext.Drawing.PathSegment segment)
+    {
+        var properties = new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        switch (segment)
+        {
+            case ModernFormsNext.Drawing.LineSegment line:
+                properties["Point"] = ToDesignPropertyValue(line.Point, typeof(System.Drawing.PointF));
+                break;
+            case ModernFormsNext.Drawing.QuadraticBezierSegment quadratic:
+                properties["ControlPoint"] = ToDesignPropertyValue(quadratic.ControlPoint, typeof(System.Drawing.PointF));
+                properties["Point"] = ToDesignPropertyValue(quadratic.Point, typeof(System.Drawing.PointF));
+                break;
+            case ModernFormsNext.Drawing.BezierSegment cubic:
+                properties["ControlPoint1"] = ToDesignPropertyValue(cubic.ControlPoint1, typeof(System.Drawing.PointF));
+                properties["ControlPoint2"] = ToDesignPropertyValue(cubic.ControlPoint2, typeof(System.Drawing.PointF));
+                properties["Point"] = ToDesignPropertyValue(cubic.Point, typeof(System.Drawing.PointF));
+                break;
+        }
+        return DesignPropertyValue.FromStructuredObject(segment.GetType().FullName!, properties);
+    }
+
     public static string ToHex(SKColor color)
         => color.Alpha == byte.MaxValue
             ? $"#{color.Red:X2}{color.Green:X2}{color.Blue:X2}"
@@ -479,6 +586,13 @@ internal static class DesignerPropertyValueEditor
 
         if (targetType == typeof(System.Drawing.PointF))
             return new System.Drawing.PointF((float)ReadDouble(properties, "X"), (float)ReadDouble(properties, "Y"));
+
+        if (targetType == typeof(System.Drawing.RectangleF))
+            return new System.Drawing.RectangleF(
+                (float)ReadDouble(properties, "X"),
+                (float)ReadDouble(properties, "Y"),
+                (float)ReadDouble(properties, "Width"),
+                (float)ReadDouble(properties, "Height"));
 
         if (targetType == typeof(Matrix3x2))
             return new Matrix3x2(
@@ -599,7 +713,391 @@ internal static class DesignerPropertyValueEditor
             return new ModernFormsNext.Font(ReadString(properties, "Name", "Segoe UI"), (float)ReadDouble(properties, "Size", 9), style);
         }
 
+        if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.PointCollection))
+            || targetType == typeof(ModernFormsNext.Drawing.PointCollection))
+        {
+            var result = new ModernFormsNext.Drawing.PointCollection();
+            int count = ReadInt(properties, "Count");
+            for (int index = 0; index < count; index++)
+            {
+                if (properties.TryGetValue($"Point{index}", out DesignPropertyValue? pointValue)
+                    && FromDesignPropertyValue(pointValue, typeof(System.Drawing.PointF)) is System.Drawing.PointF point)
+                {
+                    result.Add(point);
+                }
+            }
+            return result;
+        }
+
+        if (typeof(ModernFormsNext.Drawing.Geometry).IsAssignableFrom(targetType)
+            || IsGeometryTypeName(value.ObjectTypeName))
+        {
+            return FromGeometryPropertyValue(value, properties);
+        }
+
         return value;
+    }
+
+    private static ModernFormsNext.Drawing.Geometry FromGeometryPropertyValue(
+        DesignPropertyValue value,
+        IReadOnlyDictionary<string, DesignPropertyValue> properties)
+    {
+        ModernFormsNext.Drawing.Geometry geometry;
+        if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.LineGeometry)))
+        {
+            geometry = new ModernFormsNext.Drawing.LineGeometry(
+                ReadPointF(properties, "StartPoint"),
+                ReadPointF(properties, "EndPoint"));
+        }
+        else if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.RectangleGeometry)))
+        {
+            geometry = new ModernFormsNext.Drawing.RectangleGeometry(ReadRectangleF(properties, "Rect"));
+        }
+        else if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.EllipseGeometry)))
+        {
+            geometry = new ModernFormsNext.Drawing.EllipseGeometry(ReadRectangleF(properties, "Rect"));
+        }
+        else
+        {
+            var path = new ModernFormsNext.Drawing.PathGeometry();
+            if (properties.TryGetValue("FillRule", out DesignPropertyValue? fillRuleValue)
+                && FromDesignPropertyValue(fillRuleValue, typeof(ModernFormsNext.Drawing.GeometryFillRule)) is ModernFormsNext.Drawing.GeometryFillRule fillRule)
+            {
+                path.FillRule = fillRule;
+            }
+
+            int count = ReadInt(properties, "FigureCount");
+            for (int index = 0; index < count; index++)
+            {
+                if (properties.TryGetValue($"Figure{index}", out DesignPropertyValue? figureValue))
+                    path.Figures.Add(FromPathFigurePropertyValue(figureValue));
+            }
+            geometry = path;
+        }
+
+        if (properties.TryGetValue("Transform", out DesignPropertyValue? transformValue)
+            && FromDesignPropertyValue(transformValue, typeof(Matrix3x2)) is Matrix3x2 transform)
+        {
+            geometry.Transform = transform;
+        }
+        return geometry;
+    }
+
+    private static ModernFormsNext.Drawing.PathFigure FromPathFigurePropertyValue(DesignPropertyValue value)
+    {
+        IReadOnlyDictionary<string, DesignPropertyValue> properties = value.ObjectProperties
+            ?? new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        var figure = new ModernFormsNext.Drawing.PathFigure(
+            ReadPointF(properties, "StartPoint"),
+            ReadBool(properties, "IsClosed"));
+        int count = ReadInt(properties, "SegmentCount");
+        for (int index = 0; index < count; index++)
+        {
+            if (properties.TryGetValue($"Segment{index}", out DesignPropertyValue? segmentValue)
+                && FromPathSegmentPropertyValue(segmentValue) is { } segment)
+            {
+                figure.Segments.Add(segment);
+            }
+        }
+        return figure;
+    }
+
+    private static ModernFormsNext.Drawing.PathSegment? FromPathSegmentPropertyValue(DesignPropertyValue value)
+    {
+        IReadOnlyDictionary<string, DesignPropertyValue> properties = value.ObjectProperties
+            ?? new SortedDictionary<string, DesignPropertyValue>(StringComparer.Ordinal);
+        if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.LineSegment)))
+            return new ModernFormsNext.Drawing.LineSegment(ReadPointF(properties, "Point"));
+        if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.QuadraticBezierSegment)))
+        {
+            return new ModernFormsNext.Drawing.QuadraticBezierSegment(
+                ReadPointF(properties, "ControlPoint"),
+                ReadPointF(properties, "Point"));
+        }
+        if (IsStructuredType(value, typeof(ModernFormsNext.Drawing.BezierSegment)))
+        {
+            return new ModernFormsNext.Drawing.BezierSegment(
+                ReadPointF(properties, "ControlPoint1"),
+                ReadPointF(properties, "ControlPoint2"),
+                ReadPointF(properties, "Point"));
+        }
+        return null;
+    }
+
+    private static string WritePointCollectionText(ModernFormsNext.Drawing.PointCollection points)
+        => string.Join("; ", points.Select(FormatPoint));
+
+    private static string WriteGeometryText(ModernFormsNext.Drawing.Geometry geometry)
+    {
+        string transform = geometry.Transform == Matrix3x2.Identity
+            ? string.Empty
+            : $"transform({FormatMatrix(geometry.Transform)}) ";
+
+        return geometry switch
+        {
+            ModernFormsNext.Drawing.LineGeometry line =>
+                $"{transform}line {FormatPoint(line.StartPoint)} {FormatPoint(line.EndPoint)}",
+            ModernFormsNext.Drawing.RectangleGeometry rectangle =>
+                $"{transform}rectangle {FormatRectangle(rectangle.Rect)}",
+            ModernFormsNext.Drawing.EllipseGeometry ellipse =>
+                $"{transform}ellipse {FormatRectangle(ellipse.Rect)}",
+            ModernFormsNext.Drawing.PathGeometry path =>
+                $"{transform}path {path.FillRule.ToString().ToLowerInvariant()} {WritePathFigures(path)}".TrimEnd(),
+            _ => geometry.GetType().Name
+        };
+    }
+
+    private static string WritePathFigures(ModernFormsNext.Drawing.PathGeometry path)
+    {
+        var parts = new List<string>();
+        foreach (ModernFormsNext.Drawing.PathFigure figure in path.Figures)
+        {
+            parts.Add("M");
+            parts.Add(FormatPoint(figure.StartPoint));
+            foreach (ModernFormsNext.Drawing.PathSegment segment in figure.Segments)
+            {
+                switch (segment)
+                {
+                    case ModernFormsNext.Drawing.LineSegment line:
+                        parts.Add("L");
+                        parts.Add(FormatPoint(line.Point));
+                        break;
+                    case ModernFormsNext.Drawing.QuadraticBezierSegment quadratic:
+                        parts.Add("Q");
+                        parts.Add(FormatPoint(quadratic.ControlPoint));
+                        parts.Add(FormatPoint(quadratic.Point));
+                        break;
+                    case ModernFormsNext.Drawing.BezierSegment cubic:
+                        parts.Add("C");
+                        parts.Add(FormatPoint(cubic.ControlPoint1));
+                        parts.Add(FormatPoint(cubic.ControlPoint2));
+                        parts.Add(FormatPoint(cubic.Point));
+                        break;
+                }
+            }
+
+            if (figure.IsClosed)
+                parts.Add("Z");
+        }
+        return string.Join(' ', parts);
+    }
+
+    private static string FormatPoint(System.Drawing.PointF point)
+        => $"{point.X.ToString("R", CultureInfo.InvariantCulture)},{point.Y.ToString("R", CultureInfo.InvariantCulture)}";
+
+    private static string FormatRectangle(System.Drawing.RectangleF rectangle)
+        => $"{rectangle.X.ToString("R", CultureInfo.InvariantCulture)},{rectangle.Y.ToString("R", CultureInfo.InvariantCulture)},{rectangle.Width.ToString("R", CultureInfo.InvariantCulture)},{rectangle.Height.ToString("R", CultureInfo.InvariantCulture)}";
+
+    private static string FormatMatrix(Matrix3x2 matrix)
+        => string.Join(',', new[] { matrix.M11, matrix.M12, matrix.M21, matrix.M22, matrix.M31, matrix.M32 }
+            .Select(value => value.ToString("R", CultureInfo.InvariantCulture)));
+
+    private static bool TryParsePointF(string text, out object? value, out string? error)
+    {
+        if (TryReadFloatList(text, 2, out float[] parts, out error))
+        {
+            value = new System.Drawing.PointF(parts[0], parts[1]);
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryParseRectangleF(string text, out object? value, out string? error)
+    {
+        if (TryReadFloatList(text, 4, out float[] parts, out error))
+        {
+            if (parts[2] < 0 || parts[3] < 0)
+            {
+                value = null;
+                error = "Rectangle width and height cannot be negative.";
+                return false;
+            }
+
+            value = new System.Drawing.RectangleF(parts[0], parts[1], parts[2], parts[3]);
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryParsePointCollection(string text, out object? value, out string? error)
+    {
+        var points = new ModernFormsNext.Drawing.PointCollection();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            value = points;
+            error = null;
+            return true;
+        }
+
+        foreach (string token in text.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!TryParsePointF(token, out object? pointValue, out error)
+                || pointValue is not System.Drawing.PointF point)
+            {
+                value = null;
+                error = "Expected points as 'x,y; x,y; ...'.";
+                return false;
+            }
+            points.Add(point);
+        }
+
+        value = points;
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseGeometry(string text, out object? value, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(text) || string.Equals(text, "null", StringComparison.OrdinalIgnoreCase))
+        {
+            value = null;
+            error = null;
+            return true;
+        }
+
+        string[] tokens = text.Split((char[]?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        int index = 0;
+        Matrix3x2 transform = Matrix3x2.Identity;
+        if (tokens[index].StartsWith("transform(", StringComparison.OrdinalIgnoreCase))
+        {
+            string token = tokens[index++];
+            if (!token.EndsWith(')'))
+                return FailGeometry("Expected transform(m11,m12,m21,m22,m31,m32).", out value, out error);
+            if (!TryReadFloatList(token[10..^1], 6, out float[] matrix, out _))
+                return FailGeometry("Expected six finite transform components.", out value, out error);
+            transform = new Matrix3x2(matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]);
+        }
+
+        if (index >= tokens.Length)
+            return FailGeometry("Expected line, rectangle, ellipse, or path geometry.", out value, out error);
+
+        string kind = tokens[index++].ToLowerInvariant();
+        ModernFormsNext.Drawing.Geometry? geometry;
+        switch (kind)
+        {
+            case "line":
+                if (!TryReadPointToken(tokens, ref index, out System.Drawing.PointF start)
+                    || !TryReadPointToken(tokens, ref index, out System.Drawing.PointF end)
+                    || index != tokens.Length)
+                {
+                    return FailGeometry("Expected 'line x1,y1 x2,y2'.", out value, out error);
+                }
+                geometry = new ModernFormsNext.Drawing.LineGeometry(start, end);
+                break;
+            case "rectangle":
+            case "ellipse":
+                if (index >= tokens.Length
+                    || !TryParseRectangleF(tokens[index++], out object? rectangleValue, out _)
+                    || rectangleValue is not System.Drawing.RectangleF rectangle
+                    || index != tokens.Length)
+                {
+                    return FailGeometry($"Expected '{kind} x,y,width,height'.", out value, out error);
+                }
+                geometry = kind == "rectangle"
+                    ? new ModernFormsNext.Drawing.RectangleGeometry(rectangle)
+                    : new ModernFormsNext.Drawing.EllipseGeometry(rectangle);
+                break;
+            case "path":
+                geometry = ParsePathGeometry(tokens, ref index, out error);
+                if (geometry is null)
+                {
+                    value = null;
+                    return false;
+                }
+                break;
+            default:
+                return FailGeometry("Expected line, rectangle, ellipse, or path geometry.", out value, out error);
+        }
+
+        geometry.Transform = transform;
+        value = geometry;
+        error = null;
+        return true;
+    }
+
+    private static ModernFormsNext.Drawing.PathGeometry? ParsePathGeometry(
+        string[] tokens,
+        ref int index,
+        out string? error)
+    {
+        var path = new ModernFormsNext.Drawing.PathGeometry();
+        if (index < tokens.Length
+            && Enum.TryParse(tokens[index], ignoreCase: true, out ModernFormsNext.Drawing.GeometryFillRule fillRule))
+        {
+            path.FillRule = fillRule;
+            index++;
+        }
+
+        ModernFormsNext.Drawing.PathFigure? figure = null;
+        while (index < tokens.Length)
+        {
+            string command = tokens[index++].ToUpperInvariant();
+            switch (command)
+            {
+                case "M":
+                    if (!TryReadPointToken(tokens, ref index, out System.Drawing.PointF start))
+                        return FailPath("Command M requires one point.", out error);
+                    figure = new ModernFormsNext.Drawing.PathFigure(start);
+                    path.Figures.Add(figure);
+                    break;
+                case "L" when figure is not null:
+                    if (!TryReadPointToken(tokens, ref index, out System.Drawing.PointF linePoint))
+                        return FailPath("Command L requires one point.", out error);
+                    figure.Segments.Add(new ModernFormsNext.Drawing.LineSegment(linePoint));
+                    break;
+                case "Q" when figure is not null:
+                    if (!TryReadPointToken(tokens, ref index, out System.Drawing.PointF control)
+                        || !TryReadPointToken(tokens, ref index, out System.Drawing.PointF quadraticPoint))
+                        return FailPath("Command Q requires a control point and an end point.", out error);
+                    figure.Segments.Add(new ModernFormsNext.Drawing.QuadraticBezierSegment(control, quadraticPoint));
+                    break;
+                case "C" when figure is not null:
+                    if (!TryReadPointToken(tokens, ref index, out System.Drawing.PointF control1)
+                        || !TryReadPointToken(tokens, ref index, out System.Drawing.PointF control2)
+                        || !TryReadPointToken(tokens, ref index, out System.Drawing.PointF cubicPoint))
+                        return FailPath("Command C requires two control points and an end point.", out error);
+                    figure.Segments.Add(new ModernFormsNext.Drawing.BezierSegment(control1, control2, cubicPoint));
+                    break;
+                case "Z" when figure is not null:
+                    figure.IsClosed = true;
+                    break;
+                default:
+                    return FailPath("Path commands must start with M and use M, L, Q, C, or Z.", out error);
+            }
+        }
+
+        error = null;
+        return path;
+    }
+
+    private static bool TryReadPointToken(string[] tokens, ref int index, out System.Drawing.PointF point)
+    {
+        point = default;
+        if (index >= tokens.Length
+            || !TryParsePointF(tokens[index++], out object? pointValue, out _)
+            || pointValue is not System.Drawing.PointF parsed)
+        {
+            return false;
+        }
+        point = parsed;
+        return true;
+    }
+
+    private static bool FailGeometry(string message, out object? value, out string? error)
+    {
+        value = null;
+        error = message;
+        return false;
+    }
+
+    private static ModernFormsNext.Drawing.PathGeometry? FailPath(string message, out string? error)
+    {
+        error = message;
+        return null;
     }
 
     private static bool TryParseSize(string text, out object? value, out string? error)
@@ -839,9 +1337,10 @@ internal static class DesignerPropertyValueEditor
 
         for (var i = 0; i < tokens.Length; i++)
         {
-            if (!float.TryParse(tokens[i], NumberStyles.Float, CultureInfo.InvariantCulture, out parts[i]))
+            if (!float.TryParse(tokens[i], NumberStyles.Float, CultureInfo.InvariantCulture, out parts[i])
+                || !float.IsFinite(parts[i]))
             {
-                error = "Expected numeric values.";
+                error = "Expected finite numeric values.";
                 return false;
             }
         }
@@ -900,6 +1399,35 @@ internal static class DesignerPropertyValueEditor
     private static bool IsStructuredType(DesignPropertyValue value, Type type)
         => string.Equals(value.ObjectTypeName, type.FullName, StringComparison.Ordinal)
         || string.Equals(value.ObjectTypeName, type.Name, StringComparison.Ordinal);
+
+    private static bool IsGeometryTypeName(string? typeName)
+        => typeName is not null
+        && new[]
+        {
+            typeof(ModernFormsNext.Drawing.LineGeometry),
+            typeof(ModernFormsNext.Drawing.RectangleGeometry),
+            typeof(ModernFormsNext.Drawing.EllipseGeometry),
+            typeof(ModernFormsNext.Drawing.PathGeometry)
+        }.Any(type => string.Equals(typeName, type.FullName, StringComparison.Ordinal)
+            || string.Equals(typeName, type.Name, StringComparison.Ordinal));
+
+    private static System.Drawing.PointF ReadPointF(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name,
+        System.Drawing.PointF fallback = default)
+        => properties.TryGetValue(name, out DesignPropertyValue? value)
+            && FromDesignPropertyValue(value, typeof(System.Drawing.PointF)) is System.Drawing.PointF point
+                ? point
+                : fallback;
+
+    private static System.Drawing.RectangleF ReadRectangleF(
+        IReadOnlyDictionary<string, DesignPropertyValue> properties,
+        string name,
+        System.Drawing.RectangleF fallback = default)
+        => properties.TryGetValue(name, out DesignPropertyValue? value)
+            && FromDesignPropertyValue(value, typeof(System.Drawing.RectangleF)) is System.Drawing.RectangleF rectangle
+                ? rectangle
+                : fallback;
 
     private static SKColor ReadColor(
         IReadOnlyDictionary<string, DesignPropertyValue> properties,

--- a/ModernFormsNext.Designer/Services/DesignerDocumentPath.cs
+++ b/ModernFormsNext.Designer/Services/DesignerDocumentPath.cs
@@ -9,8 +9,8 @@ internal static class DesignerDocumentPath
 
         try
         {
-            var fullPath = Path.GetFullPath(path);
-            var extension = Path.GetExtension(fullPath);
+            var fullPath = IOPath.GetFullPath(path);
+            var extension = IOPath.GetExtension(fullPath);
 
             if (string.Equals(extension, ".mfdesign", StringComparison.OrdinalIgnoreCase))
                 return fullPath;
@@ -18,13 +18,13 @@ internal static class DesignerDocumentPath
             if (!string.Equals(extension, ".cs", StringComparison.OrdinalIgnoreCase))
                 return fullPath;
 
-            var directory = Path.GetDirectoryName(fullPath) ?? string.Empty;
-            var fileName = Path.GetFileNameWithoutExtension(fullPath);
+            var directory = IOPath.GetDirectoryName(fullPath) ?? string.Empty;
+            var fileName = IOPath.GetFileNameWithoutExtension(fullPath);
 
             if (fileName.EndsWith(".Designer", StringComparison.OrdinalIgnoreCase))
                 fileName = fileName[..^".Designer".Length];
 
-            return Path.Combine(directory, $"{fileName}.mfdesign");
+            return IOPath.Combine(directory, $"{fileName}.mfdesign");
         }
         catch
         {

--- a/ModernFormsNext.Designer/Services/DesignerFileService.cs
+++ b/ModernFormsNext.Designer/Services/DesignerFileService.cs
@@ -43,7 +43,7 @@ internal sealed class DesignerFileService
             document,
             new CSharpDesignerGenerationOptions
             {
-                SourceFilePath = Path.GetFileName(designDocumentPath),
+                SourceFilePath = IOPath.GetFileName(designDocumentPath),
                 DesignHash = roundTrip.ComputeDesignHash(document),
                 AnimationDefinitions = animationDefinitionsProvider?.Invoke() ?? []
             });
@@ -94,7 +94,7 @@ internal sealed class DesignerFileService
             .OfType<MethodDeclarationSyntax>()
             .Any(method => string.Equals(method.Identifier.ValueText, handlerName, StringComparison.Ordinal)))
         {
-            return new DesignerEventHandlerFileResult(true, codePath, $"Event handler {handlerName} already exists in {Path.GetFileName(codePath)}.");
+            return new DesignerEventHandlerFileResult(true, codePath, $"Event handler {handlerName} already exists in {IOPath.GetFileName(codePath)}.");
         }
 
         var lineEnding = sourceText.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
@@ -108,7 +108,7 @@ internal sealed class DesignerFileService
         var updatedText = sourceText.Insert(insertionIndex, methodText);
         File.WriteAllText(codePath, updatedText);
 
-        return new DesignerEventHandlerFileResult(true, codePath, $"Added event handler {handlerName} to {Path.GetFileName(codePath)}.");
+        return new DesignerEventHandlerFileResult(true, codePath, $"Added event handler {handlerName} to {IOPath.GetFileName(codePath)}.");
     }
 
     private string GetDesignDocumentPath(DesignDocument document)
@@ -121,7 +121,7 @@ internal sealed class DesignerFileService
         if (!string.IsNullOrWhiteSpace(environment?.CurrentDocumentPath))
             return DesignerDocumentPath.NormalizeDesignPath(environment.CurrentDocumentPath)!;
 
-        return Path.Combine(AppContext.BaseDirectory, $"{document.ClassName}.mfdesign");
+        return IOPath.Combine(AppContext.BaseDirectory, $"{document.ClassName}.mfdesign");
     }
 
     private string GetGeneratedCodePath(DesignDocument document)
@@ -131,24 +131,24 @@ internal sealed class DesignerFileService
         if (!string.IsNullOrWhiteSpace(activeDocumentPath))
         {
             var designPath = DesignerDocumentPath.NormalizeDesignPath(activeDocumentPath)!;
-            var directory = Path.GetDirectoryName(designPath);
-            var fileName = Path.GetFileNameWithoutExtension(designPath);
+            var directory = IOPath.GetDirectoryName(designPath);
+            var fileName = IOPath.GetFileNameWithoutExtension(designPath);
 
             if (!string.IsNullOrWhiteSpace(directory) && !string.IsNullOrWhiteSpace(fileName))
-                return Path.Combine(directory, $"{fileName}.Designer.cs");
+                return IOPath.Combine(directory, $"{fileName}.Designer.cs");
         }
 
         if (!string.IsNullOrWhiteSpace(environment?.CurrentDocumentPath))
         {
             var designPath = DesignerDocumentPath.NormalizeDesignPath(environment.CurrentDocumentPath)!;
-            var directory = Path.GetDirectoryName(designPath);
-            var fileName = Path.GetFileNameWithoutExtension(designPath);
+            var directory = IOPath.GetDirectoryName(designPath);
+            var fileName = IOPath.GetFileNameWithoutExtension(designPath);
 
             if (!string.IsNullOrWhiteSpace(directory) && !string.IsNullOrWhiteSpace(fileName))
-                return Path.Combine(directory, $"{fileName}.Designer.cs");
+                return IOPath.Combine(directory, $"{fileName}.Designer.cs");
         }
 
-        return Path.Combine(AppContext.BaseDirectory, $"{document.ClassName}.Designer.cs");
+        return IOPath.Combine(AppContext.BaseDirectory, $"{document.ClassName}.Designer.cs");
     }
 
     private string? GetFormCodePath(DesignDocument document)
@@ -156,16 +156,16 @@ internal sealed class DesignerFileService
         var activeDocumentPath = currentDocumentPathProvider?.Invoke();
 
         if (!string.IsNullOrWhiteSpace(activeDocumentPath))
-            return Path.Combine(
-                Path.GetDirectoryName(DesignerDocumentPath.NormalizeDesignPath(activeDocumentPath)!) ?? string.Empty,
-                $"{Path.GetFileNameWithoutExtension(DesignerDocumentPath.NormalizeDesignPath(activeDocumentPath)!)}.cs");
+            return IOPath.Combine(
+                IOPath.GetDirectoryName(DesignerDocumentPath.NormalizeDesignPath(activeDocumentPath)!) ?? string.Empty,
+                $"{IOPath.GetFileNameWithoutExtension(DesignerDocumentPath.NormalizeDesignPath(activeDocumentPath)!)}.cs");
 
         if (!string.IsNullOrWhiteSpace(environment?.CurrentDocumentPath))
-            return Path.Combine(
-                Path.GetDirectoryName(DesignerDocumentPath.NormalizeDesignPath(environment.CurrentDocumentPath)!) ?? string.Empty,
-                $"{Path.GetFileNameWithoutExtension(DesignerDocumentPath.NormalizeDesignPath(environment.CurrentDocumentPath)!)}.cs");
+            return IOPath.Combine(
+                IOPath.GetDirectoryName(DesignerDocumentPath.NormalizeDesignPath(environment.CurrentDocumentPath)!) ?? string.Empty,
+                $"{IOPath.GetFileNameWithoutExtension(DesignerDocumentPath.NormalizeDesignPath(environment.CurrentDocumentPath)!)}.cs");
 
-        return Path.Combine(AppContext.BaseDirectory, $"{document.ClassName}.cs");
+        return IOPath.Combine(AppContext.BaseDirectory, $"{document.ClassName}.cs");
     }
 
     private static string WriteEventHandlerParameters(Type? eventHandlerType)

--- a/ModernFormsNext.Designer/Services/DesignerProjectUserControlDiscovery.cs
+++ b/ModernFormsNext.Designer/Services/DesignerProjectUserControlDiscovery.cs
@@ -95,10 +95,10 @@ internal static class DesignerProjectUserControlDiscovery
             return null;
 
         if (Directory.Exists(projectPath))
-            return Path.GetFullPath(projectPath);
+            return IOPath.GetFullPath(projectPath);
 
         return File.Exists(projectPath)
-            ? Path.GetDirectoryName(Path.GetFullPath(projectPath))
+            ? IOPath.GetDirectoryName(IOPath.GetFullPath(projectPath))
             : null;
     }
 
@@ -189,9 +189,9 @@ internal static class DesignerProjectUserControlDiscovery
 
     internal static bool IsExcludedProjectArtifact(string path, string projectDirectory)
     {
-        var relative = Path.GetRelativePath(projectDirectory, path);
+        var relative = IOPath.GetRelativePath(projectDirectory, path);
         return relative
-            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Split(IOPath.DirectorySeparatorChar, IOPath.AltDirectorySeparatorChar)
             .Any(segment => segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
                 || segment.Equals("obj", StringComparison.OrdinalIgnoreCase)
                 || segment.Equals("artifacts", StringComparison.OrdinalIgnoreCase)

--- a/ModernFormsNext.Designer/Services/DesignerSession.cs
+++ b/ModernFormsNext.Designer/Services/DesignerSession.cs
@@ -1,6 +1,9 @@
 using ModernFormsNext;
+using ModernFormsNext.Designer.Properties;
 using ModernFormsNext.Designer.Surface;
 using ModernFormsNext.Designing;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
 
 namespace ModernFormsNext.Designer.Services;
 
@@ -184,11 +187,11 @@ public sealed class DesignerSession
         if (string.IsNullOrWhiteSpace(designPath))
             return false;
 
-        var sourcePath = Path.ChangeExtension(designPath, ".cs");
+        var sourcePath = IOPath.ChangeExtension(designPath, ".cs");
         var matchingControls = projectUserControls
             .Where(control => string.Equals(
-                Path.GetFullPath(control.SourceFilePath),
-                Path.GetFullPath(sourcePath),
+                IOPath.GetFullPath(control.SourceFilePath),
+                IOPath.GetFullPath(sourcePath),
                 StringComparison.OrdinalIgnoreCase))
             .Take(2)
             .ToArray();
@@ -403,6 +406,8 @@ public sealed class DesignerSession
 
         if (shortTypeName == "Panel")
             node.Properties["Text"] = DesignPropertyValue.FromString(string.Empty);
+
+        InitializeShapeDefaults(node, shortTypeName);
 
         DesignerSpecialContainers.InitializeNewNode(node);
 
@@ -1479,8 +1484,53 @@ public sealed class DesignerSession
             "Label" => new DesignBounds(originX + offset, originY + offset, 100, 24),
             "TextBox" => new DesignBounds(originX + offset, originY + offset, 150, 25),
             "RichTextBox" => new DesignBounds(originX + offset, originY + offset, 220, 96),
+            "Line" => new DesignBounds(originX + offset, originY + offset, 120, 40),
+            "Ellipse" or "Circle" or "Polygon" or "Polyline" or "Path" => new DesignBounds(originX + offset, originY + offset, 120, 90),
             _ => new DesignBounds(originX + offset, originY + offset, 90, 28)
         };
+    }
+
+    private static void InitializeShapeDefaults(DesignControlNode node, string shortTypeName)
+    {
+        if (shortTypeName is not ("Ellipse" or "Circle" or "Line" or "Polygon" or "Polyline" or "Path"))
+            return;
+
+        node.Properties.Remove("Text");
+        var stroke = new SolidColorBrush(new SKColor(0x31, 0x5B, 0xA6));
+        node.Properties["Stroke"] = DesignerPropertyValueEditor.ToDesignPropertyValue(stroke, typeof(Brush));
+        node.Properties["StrokeThickness"] = DesignPropertyValue.FromDouble(2);
+
+        if (shortTypeName is "Ellipse" or "Circle" or "Polygon" or "Path")
+        {
+            var fill = new SolidColorBrush(new SKColor(0x70, 0xA1, 0xF5, 0x88));
+            node.Properties["Fill"] = DesignerPropertyValueEditor.ToDesignPropertyValue(fill, typeof(Brush));
+        }
+
+        switch (shortTypeName)
+        {
+            case "Line":
+                node.Properties["StartPoint"] = DesignerPropertyValueEditor.ToDesignPropertyValue(new System.Drawing.PointF(8, 20), typeof(System.Drawing.PointF));
+                node.Properties["EndPoint"] = DesignerPropertyValueEditor.ToDesignPropertyValue(new System.Drawing.PointF(112, 20), typeof(System.Drawing.PointF));
+                break;
+            case "Polygon":
+                node.Properties["Points"] = DesignerPropertyValueEditor.ToDesignPropertyValue(
+                    new PointCollection([new(60, 6), new(114, 82), new(6, 82)]),
+                    typeof(PointCollection));
+                break;
+            case "Polyline":
+                node.Properties["Points"] = DesignerPropertyValueEditor.ToDesignPropertyValue(
+                    new PointCollection([new(6, 68), new(32, 24), new(62, 62), new(88, 18), new(114, 50)]),
+                    typeof(PointCollection));
+                break;
+            case "Path":
+                var geometry = new PathGeometry();
+                var figure = new PathFigure(new System.Drawing.PointF(8, 72), isClosed: true);
+                figure.Segments.Add(new QuadraticBezierSegment(new System.Drawing.PointF(30, 4), new System.Drawing.PointF(60, 34)));
+                figure.Segments.Add(new BezierSegment(new System.Drawing.PointF(78, 4), new System.Drawing.PointF(110, 20), new System.Drawing.PointF(112, 72)));
+                geometry.Figures.Add(figure);
+                node.Properties["Data"] = DesignerPropertyValueEditor.ToDesignPropertyValue(geometry, typeof(Geometry));
+                break;
+        }
     }
 
     private static string GetDefaultText(string typeName, int index)

--- a/ModernFormsNext.Designer/Services/DesignerToolboxService.cs
+++ b/ModernFormsNext.Designer/Services/DesignerToolboxService.cs
@@ -120,7 +120,8 @@ internal sealed class DesignerToolboxService
         {
             "Common" => 0,
             "Containers" => 1,
-            "Components" => 2,
+            "Shapes" => 2,
+            "Components" => 3,
             _ => 10
         };
 

--- a/ModernFormsNext.Designer/Surface/DesignerEmbeddedPreviewCache.cs
+++ b/ModernFormsNext.Designer/Surface/DesignerEmbeddedPreviewCache.cs
@@ -167,17 +167,17 @@ internal sealed class DesignerEmbeddedPreviewCache
         documentIndexBuilt = true;
 
         foreach (var sourceGroup in projectUserControls.GroupBy(
-            control => Path.GetFullPath(control.SourceFilePath),
+            control => IOPath.GetFullPath(control.SourceFilePath),
             StringComparer.OrdinalIgnoreCase))
         {
             var controls = sourceGroup.ToArray();
-            var siblingPath = Path.ChangeExtension(sourceGroup.Key, ".mfdesign");
+            var siblingPath = IOPath.ChangeExtension(sourceGroup.Key, ".mfdesign");
 
             // A sibling path is the strongest source-level association and also lets the caller
             // report malformed or stale identity data precisely. TryGetPreview still validates the
             // document identity and root kind before exposing a projection.
             if (controls.Length == 1 && File.Exists(siblingPath))
-                documentPathsByType[controls[0].FullName] = Path.GetFullPath(siblingPath);
+                documentPathsByType[controls[0].FullName] = IOPath.GetFullPath(siblingPath);
         }
 
         var unresolvedControls = projectUserControls
@@ -219,7 +219,7 @@ internal sealed class DesignerEmbeddedPreviewCache
 
     private CachedPreviewSource GetOrRefreshSource(string path)
     {
-        var normalizedPath = Path.GetFullPath(path);
+        var normalizedPath = IOPath.GetFullPath(path);
         sourcesByPath.TryGetValue(normalizedPath, out var cached);
         var observedLastWriteTimeUtc = default(DateTime);
         var observedLength = -1L;

--- a/ModernFormsNext.Tests/GlobalUsings.ShapeCompatibility.cs
+++ b/ModernFormsNext.Tests/GlobalUsings.ShapeCompatibility.cs
@@ -1,0 +1,2 @@
+// ModernFormsNext.Path is a public vector control. Keep existing file-system test code unambiguous.
+global using IOPath = System.IO.Path;

--- a/ModernFormsNext.Tests/MarkdownImageAssetWorkflowTests.cs
+++ b/ModernFormsNext.Tests/MarkdownImageAssetWorkflowTests.cs
@@ -20,7 +20,7 @@ public class MarkdownImageAssetWorkflowTests
         Assert.Equal("assets/images/source.png", result.MarkdownSource);
         Assert.True(File.Exists(result.DestinationPath));
         Assert.DoesNotContain('\\', result.MarkdownSource!);
-        Assert.False(Path.IsPathFullyQualified(result.MarkdownSource!));
+        Assert.False(IOPath.IsPathFullyQualified(result.MarkdownSource!));
     }
 
     [Fact]
@@ -229,7 +229,7 @@ public class MarkdownImageAssetWorkflowTests
     {
         public TemporaryImageFiles()
         {
-            Root = Path.Combine(Path.GetTempPath(), "ModernFormsNext.Tests", Guid.NewGuid().ToString("N"));
+            Root = IOPath.Combine(IOPath.GetTempPath(), "ModernFormsNext.Tests", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(Root);
         }
 
@@ -238,20 +238,20 @@ public class MarkdownImageAssetWorkflowTests
         public MarkdownImageAssetOptions CreateOptions(string relativeDestination)
             => new()
             {
-                DestinationDirectory = Path.Combine(Root, relativeDestination.Replace('/', Path.DirectorySeparatorChar)),
+                DestinationDirectory = IOPath.Combine(Root, relativeDestination.Replace('/', IOPath.DirectorySeparatorChar)),
                 MarkdownBaseDirectory = Root
             };
 
         public string CreateBytes(string name, byte[] bytes)
         {
-            var path = Path.Combine(Root, name);
+            var path = IOPath.Combine(Root, name);
             File.WriteAllBytes(path, bytes);
             return path;
         }
 
         public string CreatePng(string name, SKColor color, bool overwrite = false)
         {
-            var path = Path.Combine(Root, name);
+            var path = IOPath.Combine(Root, name);
             if (File.Exists(path) && !overwrite)
                 throw new IOException("The test image already exists.");
 

--- a/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
+++ b/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
@@ -36,7 +36,7 @@ public sealed class ReleaseVersionConsistencyTests
             .EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories)
             .Where(path => !ContainsGeneratedDirectory(path))
             .Where(path => string.Equals(ElementValue(XDocument.Load(path), "IsPackable"), "true", StringComparison.OrdinalIgnoreCase))
-            .Select(path => Path.GetRelativePath(root, path).Replace('\\', '/'))
+            .Select(path => IOPath.GetRelativePath(root, path).Replace('\\', '/'))
             .Order(StringComparer.Ordinal)
             .ToArray();
 
@@ -113,14 +113,14 @@ public sealed class ReleaseVersionConsistencyTests
 
     private static void AssertRegistrationVersion(string relativePath)
     {
-        string text = File.ReadAllText(Path.Combine(FindRepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        string text = File.ReadAllText(IOPath.Combine(FindRepositoryRoot(), relativePath.Replace('/', IOPath.DirectorySeparatorChar)));
         Assert.Contains($"InstalledProductRegistration", text, StringComparison.Ordinal);
         Assert.Contains($"\"{ExpectedVersion}\"", text, StringComparison.Ordinal);
         Assert.DoesNotContain("\"1.8.0\"", text, StringComparison.Ordinal);
     }
 
     private static XDocument LoadXml(string relativePath)
-        => XDocument.Load(Path.Combine(FindRepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        => XDocument.Load(IOPath.Combine(FindRepositoryRoot(), relativePath.Replace('/', IOPath.DirectorySeparatorChar)));
 
     private static string? ElementValue(XDocument document, string name)
         => document.Descendants().FirstOrDefault(element => element.Name.LocalName == name)?.Value.Trim();
@@ -136,8 +136,8 @@ public sealed class ReleaseVersionConsistencyTests
     {
         for (DirectoryInfo? directory = new(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
         {
-            if (File.Exists(Path.Combine(directory.FullName, "Directory.Build.props"))
-                && File.Exists(Path.Combine(directory.FullName, "ModernFormsNext.slnx")))
+            if (File.Exists(IOPath.Combine(directory.FullName, "Directory.Build.props"))
+                && File.Exists(IOPath.Combine(directory.FullName, "ModernFormsNext.slnx")))
                 return directory.FullName;
         }
 

--- a/ModernFormsNext.Tests/ShapeGeometryTests.cs
+++ b/ModernFormsNext.Tests/ShapeGeometryTests.cs
@@ -1,0 +1,622 @@
+using System.Drawing;
+using System.Numerics;
+using ModernFormsNext.Drawing;
+using ModernFormsNext.Rendering.Skia;
+using SkiaSharp;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class ShapeGeometryTests
+{
+    [Fact]
+    public void EllipseFollowsCurrentBoundsAndRejectsCornerHits()
+    {
+        using var shape = Filled(new Ellipse { Size = new Size(100, 60) });
+
+        Assert.True(shape.HitTestClient(new PointF(50, 30)));
+        Assert.False(shape.HitTestClient(new PointF(2, 2)));
+    }
+
+    [Fact]
+    public void CircleUsesTheSmallerCenteredDimension()
+    {
+        using var shape = Filled(new Circle { Size = new Size(120, 80) });
+
+        Assert.False(shape.HitTestClient(new PointF(5, 40)));
+        Assert.True(shape.HitTestClient(new PointF(60, 40)));
+
+        shape.Size = new Size(80, 120);
+        Assert.False(shape.HitTestClient(new PointF(40, 5)));
+        Assert.True(shape.HitTestClient(new PointF(40, 60)));
+
+        shape.Size = new Size(45, 20);
+        Assert.False(shape.HitTestClient(new PointF(3, 10)));
+        Assert.True(shape.HitTestClient(new PointF(22.5f, 10)));
+
+        using var stroked = Stroked(new Circle { Size = new Size(120, 80), StrokeThickness = 6 });
+        Assert.True(Render(stroked, 60, 5).Alpha > 0);
+    }
+
+    [Fact]
+    public void LineGeometryPreservesEndpoints()
+    {
+        var geometry = new LineGeometry(new PointF(-3, 7), new PointF(41, 19));
+        using SKPath path = SkiaGeometryConverter.CreatePath(geometry, new SizeF(1, 1));
+
+        Assert.Equal(new SKRect(-3, 7, 41, 19), path.Bounds);
+    }
+
+    [Fact]
+    public void PolygonClosesItsStrokeButPolylineDoesNot()
+    {
+        PointCollection points = [new(10, 10), new(90, 10), new(90, 90)];
+        using var polygon = Stroked(new Polygon { Size = new Size(100, 100), Points = points });
+        using var polyline = Stroked(new Polyline { Size = new Size(100, 100), Points = new PointCollection(points) });
+
+        Assert.True(polygon.HitTestClient(new PointF(50, 50)));
+        Assert.False(polyline.HitTestClient(new PointF(50, 50)));
+    }
+
+    [Fact]
+    public void PolylineIgnoresFillInsteadOfCreatingAnImplicitlyClosedHitArea()
+    {
+        using var shape = new Polyline
+        {
+            Size = new Size(100, 100),
+            Points = [new(10, 10), new(90, 10), new(90, 90)],
+            Fill = new SolidColorBrush(Color.CornflowerBlue)
+        };
+
+        Assert.Null(shape.Fill);
+        Assert.False(shape.HitTestClient(new PointF(60, 40)));
+        Assert.Equal(0, Render(shape, 60, 40).Alpha);
+    }
+
+    [Fact]
+    public void PointCollectionPreservesOrderAndRaisesOneAddRangeChange()
+    {
+        var points = new PointCollection();
+        int changed = 0;
+        points.Changed += (_, _) => changed++;
+
+        points.AddRange([new(9, 2), new(4, 8), new(-1, 3)]);
+
+        Assert.Equal(1, changed);
+        Assert.Equal([new PointF(9, 2), new PointF(4, 8), new PointF(-1, 3)], points);
+    }
+
+    [Fact]
+    public void PathRendersReusableGeometry()
+    {
+        var geometry = TriangleGeometry();
+        using var shape = Filled(new ModernFormsNext.Path { Size = new Size(100, 100), Data = geometry });
+
+        Assert.True(shape.HitTestClient(new PointF(50, 40)));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void NullAndNoBrushFillLeaveDestinationTransparent(bool useNull)
+    {
+        using var shape = new Ellipse
+        {
+            Size = new Size(40, 40),
+            Fill = useNull ? null : new NoBrush()
+        };
+
+        Assert.Equal(0, Render(shape, 20, 20).Alpha);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void NullAndNoBrushStrokeLeaveDestinationTransparent(bool useNull)
+    {
+        using var shape = new Ellipse
+        {
+            Size = new Size(40, 40),
+            Stroke = useNull ? null : new NoBrush(),
+            StrokeThickness = 8
+        };
+
+        Assert.Equal(0, Render(shape, 20, 2).Alpha);
+    }
+
+    [Fact]
+    public void StrokeThicknessChangesLineHitArea()
+    {
+        using var thin = Stroked(new Line { Size = new Size(120, 40) });
+        using var thick = Stroked(new Line { Size = new Size(120, 40), StrokeThickness = 16 });
+
+        Assert.False(thin.HitTestClient(new PointF(60, 29)));
+        Assert.True(thick.HitTestClient(new PointF(60, 29)));
+    }
+
+    [Theory]
+    [InlineData(StrokeLineCap.Flat, SKStrokeCap.Butt)]
+    [InlineData(StrokeLineCap.Round, SKStrokeCap.Round)]
+    [InlineData(StrokeLineCap.Square, SKStrokeCap.Square)]
+    public void LineCapsMapWithoutLeakingSkia(StrokeLineCap source, SKStrokeCap expected)
+        => Assert.Equal(expected, SkiaShapeRenderer.MapLineCap(source));
+
+    [Theory]
+    [InlineData(StrokeLineJoin.Miter, SKStrokeJoin.Miter)]
+    [InlineData(StrokeLineJoin.Round, SKStrokeJoin.Round)]
+    [InlineData(StrokeLineJoin.Bevel, SKStrokeJoin.Bevel)]
+    public void LineJoinsMapWithoutLeakingSkia(StrokeLineJoin source, SKStrokeJoin expected)
+        => Assert.Equal(expected, SkiaShapeRenderer.MapLineJoin(source));
+
+    [Fact]
+    public void SolidBrushFillUsesSharedBrushRendering()
+    {
+        using var shape = new Ellipse
+        {
+            Size = new Size(40, 40),
+            Fill = new SolidColorBrush(Color.CornflowerBlue)
+        };
+
+        Assert.Equal(new SKColor(100, 149, 237), Render(shape, 20, 20));
+    }
+
+    [Fact]
+    public void GradientFillRendersAcrossGeometryBounds()
+    {
+        var fill = Gradient(new LinearGradientBrush { Start = new PointF(0, 0), End = new PointF(1, 0) });
+        using var shape = new Ellipse { Size = new Size(80, 40), Fill = fill };
+
+        Assert.True(Render(shape, 12, 20).Red > Render(shape, 68, 20).Red);
+    }
+
+    [Fact]
+    public void GradientStrokeRendersThroughTheSamePipeline()
+    {
+        var stroke = Gradient(new SweepGradientBrush());
+        using var shape = new Ellipse { Size = new Size(80, 80), Stroke = stroke, StrokeThickness = 8 };
+
+        Assert.True(Render(shape, 40, 6).Alpha > 0);
+
+        shape.StrokeThickness = 12;
+        Assert.True(Render(shape, 40, 10).Alpha > 0);
+    }
+
+    [Fact]
+    public void GeometryTransformAffectsRenderingAndHitTesting()
+    {
+        var geometry = new EllipseGeometry(new RectangleF(0, 0, 20, 20))
+        {
+            Transform = Matrix3x2.CreateTranslation(40, 10)
+        };
+        using var shape = Filled(new GeometryProbe { Size = new Size(100, 60), Geometry = geometry });
+
+        Assert.False(shape.HitTestClient(new PointF(10, 10)));
+        Assert.True(shape.HitTestClient(new PointF(50, 20)));
+        Assert.True(Render(shape, 50, 20).Alpha > 0);
+    }
+
+    [Fact]
+    public void ControlRenderTransformAffectsPointerHitTesting()
+    {
+        using var shape = Filled(new Ellipse
+        {
+            Bounds = new Rectangle(0, 0, 60, 40),
+            TranslationX = 40
+        });
+
+        Assert.False(shape.PresentationContains(new Point(5, 20)));
+        Assert.True(shape.PresentationContains(new Point(70, 20)));
+    }
+
+    [Fact]
+    public void GeometryAndControlTransformsUseTheSameOrderForRenderingAndHitTesting()
+    {
+        var geometry = new EllipseGeometry(new RectangleF(0, 0, 24, 16))
+        {
+            Transform = Matrix3x2.CreateTranslation(28, 18)
+        };
+        using var shape = Filled(new GeometryProbe
+        {
+            Bounds = new Rectangle(12, 8, 100, 70),
+            Geometry = geometry,
+            TranslationX = 17,
+            ScaleX = 1.25f,
+            ScaleY = 0.8f,
+            Rotation = 19
+        });
+
+        Point transformedHit = shape.ClientPointToParentPresentation(new Point(40, 26));
+        Point transformedMiss = shape.ClientPointToParentPresentation(new Point(8, 8));
+
+        Assert.True(shape.PresentationContains(transformedHit));
+        Assert.False(shape.PresentationContains(transformedMiss));
+    }
+
+    [Fact]
+    public void SingularAndMirroredControlTransformsHaveSafeHitTesting()
+    {
+        using var shape = Filled(new Ellipse { Bounds = new Rectangle(10, 20, 60, 40) });
+
+        shape.ScaleX = 0;
+        Assert.False(shape.PresentationContains(new Point(40, 40)));
+
+        shape.ScaleX = 0.0000001f;
+        Assert.False(shape.PresentationContains(new Point(40, 40)));
+
+        shape.ScaleX = -1;
+        Point mirroredCenter = shape.ClientPointToParentPresentation(new Point(30, 20));
+        Assert.True(shape.PresentationContains(mirroredCenter));
+    }
+
+    [Fact]
+    public void PolygonFillHitTestingUsesFillRule()
+    {
+        using var shape = Filled(new Polygon
+        {
+            Size = new Size(100, 100),
+            Points = [new(10, 10), new(90, 10), new(90, 90), new(10, 90)]
+        });
+
+        Assert.True(shape.HitTestClient(new PointF(50, 50)));
+        Assert.False(shape.HitTestClient(new PointF(3, 3)));
+    }
+
+    [Fact]
+    public void SelfIntersectingPolygonUsesItsSelectedFillRule()
+    {
+        PointCollection doubleWoundSquare =
+        [
+            new(10, 10), new(90, 10), new(90, 90), new(10, 90),
+            new(10, 10), new(90, 10), new(90, 90), new(10, 90)
+        ];
+        using var winding = Filled(new Polygon { Size = new Size(100, 100), Points = doubleWoundSquare });
+        using var evenOdd = Filled(new Polygon
+        {
+            Size = new Size(100, 100),
+            Points = new PointCollection(doubleWoundSquare),
+            FillRule = GeometryFillRule.EvenOdd
+        });
+
+        Assert.True(winding.HitTestClient(new PointF(50, 50)));
+        Assert.False(evenOdd.HitTestClient(new PointF(50, 50)));
+    }
+
+    [Fact]
+    public void LineHitTestingIncludesReasonableTolerance()
+    {
+        using var shape = Stroked(new Line { Size = new Size(120, 40), StrokeThickness = 1 });
+
+        Assert.True(shape.HitTestClient(new PointF(60, 22)));
+        Assert.False(shape.HitTestClient(new PointF(60, 28)));
+    }
+
+    [Fact]
+    public void ShapeRenderingIsHardClippedToItsControlBuffer()
+    {
+        using var shape = Filled(new GeometryProbe
+        {
+            Size = new Size(30, 30),
+            Geometry = new EllipseGeometry(new RectangleF(-40, -40, 110, 110))
+        });
+        using var bitmap = new SKBitmap(60, 60);
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.ClipRect(new SKRect(0, 0, 30, 30));
+        shape.RaisePaint(new PaintEventArgs(bitmap.Info, canvas, 1));
+        canvas.Flush();
+
+        Assert.True(bitmap.GetPixel(15, 15).Alpha > 0);
+        Assert.Equal(0, bitmap.GetPixel(45, 45).Alpha);
+    }
+
+    [Fact]
+    public void TransformedPathAndThickStrokeRemainClippedToTheControlBuffer()
+    {
+        var geometry = new PathGeometry { Transform = Matrix3x2.CreateTranslation(12.5f, -3.25f) };
+        var figure = new PathFigure(new PointF(-20, 15));
+        figure.Segments.Add(new BezierSegment(new PointF(5, -15), new PointF(35, 45), new PointF(60, 12)));
+        geometry.Figures.Add(figure);
+        using var shape = new ModernFormsNext.Path
+        {
+            Size = new Size(30, 30),
+            Data = geometry,
+            Stroke = new SolidColorBrush(Color.DarkRed),
+            StrokeThickness = 11.5f,
+            StrokeLineCap = StrokeLineCap.Round
+        };
+        using var bitmap = new SKBitmap(60, 60);
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.ClipRect(new SKRect(0, 0, 30, 30));
+
+        shape.RaisePaint(new PaintEventArgs(bitmap.Info, canvas, 1));
+        canvas.Flush();
+
+        int paintedPixelCount = 0;
+        for (int x = 0; x < 30; x++)
+        {
+            for (int y = 0; y < 30; y++)
+            {
+                if (bitmap.GetPixel(x, y).Alpha > 0)
+                    paintedPixelCount++;
+            }
+        }
+        Assert.NotEqual(0, paintedPixelCount);
+        Assert.Equal(0, bitmap.GetPixel(45, 15).Alpha);
+        Assert.False(shape.HitTestClient(new PointF(45, 15)));
+    }
+
+    [Fact]
+    public void ResizeRebuildsEllipseGeometryCache()
+    {
+        using var shape = Filled(new Ellipse { Size = new Size(30, 30) });
+        Assert.False(shape.HitTestClient(new PointF(55, 30)));
+
+        shape.Size = new Size(70, 60);
+
+        Assert.True(shape.HitTestClient(new PointF(55, 30)));
+    }
+
+    [Fact]
+    public void PointMutationInvalidatesAndRebuildsPolygon()
+    {
+        var points = new PointCollection([new(5, 5), new(30, 5), new(5, 30)]);
+        using var shape = Filled(new Polygon { Size = new Size(100, 100), Points = points });
+        Assert.False(shape.HitTestClient(new PointF(70, 20)));
+
+        points[1] = new PointF(95, 5);
+        points[2] = new PointF(95, 40);
+
+        Assert.True(shape.HitTestClient(new PointF(70, 20)));
+    }
+
+    [Fact]
+    public void CollectionMoveRaisesOneChangeAndGeometryVersionIncrement()
+    {
+        var points = new PointCollection([new(1, 1), new(2, 2), new(3, 3)]);
+        int pointChanges = 0;
+        points.Changed += (_, _) => pointChanges++;
+        points.Move(0, 2);
+
+        var geometry = TriangleGeometry();
+        int version = geometry.Version;
+        geometry.Figures[0].Segments.Move(0, 1);
+        int movedVersion = geometry.Version;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => points.Move(-1, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => geometry.Figures.Move(-1, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => geometry.Figures[0].Segments.Move(-1, -1));
+
+        Assert.Equal([new PointF(2, 2), new PointF(3, 3), new PointF(1, 1)], points);
+        Assert.Equal(1, pointChanges);
+        Assert.Equal(unchecked(version + 1), geometry.Version);
+        Assert.Equal(movedVersion, geometry.Version);
+    }
+
+    [Fact]
+    public void ExistingSegmentPropertyMutationInvalidatesRenderingAndHitTesting()
+    {
+        var geometry = new PathGeometry();
+        var segment = new LineSegment(new PointF(25, 5));
+        var figure = new PathFigure(new PointF(5, 5), isClosed: true);
+        figure.Segments.Add(segment);
+        figure.Segments.Add(new LineSegment(new PointF(5, 25)));
+        geometry.Figures.Add(figure);
+        using var shape = Filled(new GeometryProbe { Size = new Size(100, 60), Geometry = geometry });
+        using var surface = new SkiaControlSurface(shape);
+        surface.Resize(100, 60);
+        Assert.False(shape.HitTestClient(new PointF(60, 15)));
+        int baseline = shape.InvalidationCount;
+
+        segment.Point = new PointF(90, 5);
+
+        Assert.True(shape.InvalidationCount > baseline);
+        Assert.True(shape.HitTestClient(new PointF(60, 10)));
+    }
+
+    [Fact]
+    public void SharedGeometryInvalidatesEveryConsumer()
+    {
+        var geometry = new EllipseGeometry(new RectangleF(0, 0, 20, 20));
+        using var first = Filled(new GeometryProbe { Size = new Size(100, 60), Geometry = geometry });
+        using var second = Filled(new GeometryProbe { Size = new Size(100, 60), Geometry = geometry });
+        using var firstSurface = new SkiaControlSurface(first);
+        using var secondSurface = new SkiaControlSurface(second);
+        firstSurface.Resize(100, 60);
+        secondSurface.Resize(100, 60);
+        int firstBaseline = first.InvalidationCount;
+        int secondBaseline = second.InvalidationCount;
+
+        geometry.Rect = new RectangleF(50, 10, 30, 30);
+
+        Assert.True(first.HitTestClient(new PointF(65, 25)));
+        Assert.True(second.HitTestClient(new PointF(65, 25)));
+        Assert.True(first.InvalidationCount > firstBaseline);
+        Assert.True(second.InvalidationCount > secondBaseline);
+    }
+
+    [Fact]
+    public void ReplacingSharedGeometryDetachesOnlyTheReassignedConsumer()
+    {
+        var original = new EllipseGeometry(new RectangleF(0, 0, 20, 20));
+        var replacement = new EllipseGeometry(new RectangleF(40, 0, 20, 20));
+        using var first = Filled(new GeometryProbe { Size = new Size(80, 30), Geometry = original });
+        using var second = Filled(new GeometryProbe { Size = new Size(80, 30), Geometry = original });
+        using var firstSurface = new SkiaControlSurface(first);
+        using var secondSurface = new SkiaControlSurface(second);
+        firstSurface.Resize(80, 30);
+        secondSurface.Resize(80, 30);
+
+        first.Geometry = replacement;
+        int firstBaseline = first.InvalidationCount;
+        int secondBaseline = second.InvalidationCount;
+        original.Rect = new RectangleF(5, 0, 20, 20);
+
+        Assert.Equal(firstBaseline, first.InvalidationCount);
+        Assert.True(second.InvalidationCount > secondBaseline);
+
+        replacement.Rect = new RectangleF(45, 0, 20, 20);
+        Assert.True(first.InvalidationCount > firstBaseline);
+    }
+
+    [Fact]
+    public void SharedBrushMutationInvalidatesOnceAndReplacementCleansUpSubscriptions()
+    {
+        var shared = new SolidColorBrush(Color.CornflowerBlue);
+        var replacement = new SolidColorBrush(Color.Gold);
+        using var shape = new GeometryProbe
+        {
+            Size = new Size(40, 40),
+            Geometry = new EllipseGeometry(new RectangleF(0, 0, 40, 40)),
+            Fill = shared,
+            Stroke = shared
+        };
+        using var surface = new SkiaControlSurface(shape);
+        surface.Resize(40, 40);
+        int baseline = shape.InvalidationCount;
+
+        shared.Opacity = 0.5f;
+
+        Assert.Equal(baseline + 1, shape.InvalidationCount);
+
+        shape.Fill = replacement;
+        shape.Stroke = replacement;
+        baseline = shape.InvalidationCount;
+        shared.PaintColor = Color.Red;
+        Assert.Equal(baseline, shape.InvalidationCount);
+
+        replacement.Transform = Matrix3x2.CreateTranslation(1.5f, 2.5f);
+        Assert.Equal(baseline + 1, shape.InvalidationCount);
+    }
+
+    [Fact]
+    public void AccessibilityBoundsEncloseRotatedAndMirroredPresentation()
+    {
+        using var root = new Panel { Size = new Size(300, 200) };
+        using var shape = new Ellipse
+        {
+            Bounds = new Rectangle(40, 30, 80, 40),
+            Rotation = 45,
+            ScaleX = -1
+        };
+        root.Controls.Add(shape);
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(300, 200);
+
+        Rectangle bounds = shape.AccessibilityObject.Bounds;
+
+        Assert.True(bounds.Width > shape.ScaledWidth);
+        Assert.True(bounds.Height > shape.ScaledHeight);
+        Assert.True(bounds.Width > 0);
+        Assert.True(bounds.Height > 0);
+    }
+
+    [Fact]
+    public void DisposedShapeUnsubscribesFromSharedGeometry()
+    {
+        var geometry = new EllipseGeometry(new RectangleF(0, 0, 20, 20));
+        var shape = new GeometryProbe { Size = new Size(30, 30), Geometry = geometry };
+        shape.Dispose();
+        int invalidations = shape.InvalidationCount;
+
+        geometry.Rect = new RectangleF(1, 1, 20, 20);
+
+        Assert.Equal(invalidations, shape.InvalidationCount);
+    }
+
+    [Fact]
+    public void EmptyAndOnePointCollectionsAreDeterministic()
+    {
+        using var empty = Filled(new Polygon { Size = new Size(30, 30) });
+        using var one = Stroked(new Polyline { Size = new Size(30, 30), Points = [new(10, 10)] });
+
+        Assert.False(empty.HitTestClient(new PointF(10, 10)));
+        Assert.False(one.HitTestClient(new PointF(10, 10)));
+    }
+
+    [Fact]
+    public void InvalidFiniteInputsAreRejected()
+    {
+        Assert.Throws<ArgumentException>(() => new PointCollection { new(float.NaN, 0) });
+        Assert.Throws<ArgumentException>(() => new LineGeometry(new PointF(float.PositiveInfinity, 0), PointF.Empty));
+        using var shape = new Ellipse();
+        Assert.Throws<ArgumentOutOfRangeException>(() => shape.StrokeThickness = -1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => shape.StrokeThickness = float.NaN);
+    }
+
+    [Fact]
+    public void ZeroAndVeryLargeStrokeWidthsRemainDeterministic()
+    {
+        using var zero = Stroked(new Ellipse { Size = new Size(40, 40), StrokeThickness = 0 });
+        using var large = Stroked(new Ellipse { Size = new Size(40, 40), StrokeThickness = 200 });
+
+        Assert.Equal(0, Render(zero, 20, 2).Alpha);
+        Assert.Equal(Render(large, 20, 2), Render(large, 20, 2));
+    }
+
+    [Fact]
+    public void ShapeUsesGraphicAccessibilityRole()
+    {
+        using var shape = new Ellipse();
+
+        Assert.Equal(ModernFormsNext.Accessibility.AccessibleRole.Graphic, shape.AccessibilityObject.Role);
+    }
+
+    private static T Filled<T>(T shape) where T : Shape
+    {
+        shape.Fill = new SolidColorBrush(Color.CornflowerBlue);
+        return shape;
+    }
+
+    private static T Stroked<T>(T shape) where T : Shape
+    {
+        shape.Stroke = new SolidColorBrush(Color.Navy);
+        return shape;
+    }
+
+    private static T Gradient<T>(T brush) where T : GradientBrush
+    {
+        brush.GradientStops.AddRange([
+            new GradientStop(Color.White, 0),
+            new GradientStop(Color.Navy, 1)
+        ]);
+        return brush;
+    }
+
+    private static PathGeometry TriangleGeometry()
+    {
+        var result = new PathGeometry();
+        var figure = new PathFigure(new PointF(5, 90), true);
+        figure.Segments.Add(new LineSegment(new PointF(50, 5)));
+        figure.Segments.Add(new LineSegment(new PointF(95, 90)));
+        result.Figures.Add(figure);
+        return result;
+    }
+
+    private static SKColor Render(Shape shape, int x, int y)
+    {
+        using var bitmap = new SKBitmap(Math.Max(1, shape.Width), Math.Max(1, shape.Height));
+        bitmap.Erase(SKColors.Transparent);
+        using var canvas = new SKCanvas(bitmap);
+        shape.RaisePaint(new PaintEventArgs(bitmap.Info, canvas, 1));
+        canvas.Flush();
+        return bitmap.GetPixel(x, y);
+    }
+
+    private sealed class GeometryProbe : Shape
+    {
+        public int InvalidationCount { get; private set; }
+
+        public Geometry? Geometry
+        {
+            get => DefiningGeometry;
+            set => SetDefiningGeometry(value);
+        }
+
+        protected override void OnInvalidated(EventArgs<Rectangle> e)
+        {
+            InvalidationCount++;
+            base.OnInvalidated(e);
+        }
+    }
+}

--- a/ModernFormsNext.Tests/Theming/ThemeJsonSerializerTests.cs
+++ b/ModernFormsNext.Tests/Theming/ThemeJsonSerializerTests.cs
@@ -83,7 +83,7 @@ public sealed class ThemeJsonSerializerTests
         Assert.Equal(theme.Id, fromStream.Id);
         Assert.True(stream.CanRead);
 
-        string path = Path.Combine(Path.GetTempPath(), $"mfn-theme-{Guid.NewGuid():N}.json");
+        string path = IOPath.Combine(IOPath.GetTempPath(), $"mfn-theme-{Guid.NewGuid():N}.json");
         try
         {
             serializer.SaveFile(theme, path);

--- a/ModernFormsNext.VisualStudioDesignerHost/DesignerHostIpcServer.cs
+++ b/ModernFormsNext.VisualStudioDesignerHost/DesignerHostIpcServer.cs
@@ -73,7 +73,7 @@ internal sealed class DesignerHostIpcServer : IDisposable
     {
         try
         {
-            var path = Path.Combine(Path.GetTempPath(), "ModernFormsNextDesignerHost.log");
+            var path = IOPath.Combine(IOPath.GetTempPath(), "ModernFormsNextDesignerHost.log");
             File.AppendAllText(path, $"[{DateTimeOffset.Now:O}] {message}{Environment.NewLine}");
         }
         catch

--- a/ModernFormsNext.VisualStudioDesignerHost/GlobalUsings.ShapeCompatibility.cs
+++ b/ModernFormsNext.VisualStudioDesignerHost/GlobalUsings.ShapeCompatibility.cs
@@ -1,0 +1,2 @@
+// ModernFormsNext.Path is a public vector control; keep file-system paths explicit in tooling.
+global using IOPath = System.IO.Path;

--- a/ModernFormsNext.VisualStudioDesignerHost/Program.cs
+++ b/ModernFormsNext.VisualStudioDesignerHost/Program.cs
@@ -24,7 +24,7 @@ internal static class Program
     {
         try
         {
-            var path = Path.Combine(Path.GetTempPath(), "ModernFormsNextDesignerHost.log");
+            var path = IOPath.Combine(IOPath.GetTempPath(), "ModernFormsNextDesignerHost.log");
             File.AppendAllText(path, $"[{DateTimeOffset.Now:O}] {message}{Environment.NewLine}");
         }
         catch

--- a/ModernFormsNext.VisualStudioDesignerHost/VisualStudioDesignerHostForm.cs
+++ b/ModernFormsNext.VisualStudioDesignerHost/VisualStudioDesignerHostForm.cs
@@ -98,14 +98,14 @@ public sealed class VisualStudioDesignerHostForm : Form
     private static string GetWindowTitle(string? designDocumentPath)
         => string.IsNullOrWhiteSpace(designDocumentPath)
             ? "ModernFormsNext Designer"
-            : $"{Path.GetFileName(designDocumentPath)} [Design] - ModernFormsNext Designer";
+            : $"{IOPath.GetFileName(designDocumentPath)} [Design] - ModernFormsNext Designer";
 
     private static string? FindNearestProjectPath(string? path)
     {
         var directory = string.IsNullOrWhiteSpace(path)
             ? null
             : File.Exists(path)
-                ? Path.GetDirectoryName(path)
+                ? IOPath.GetDirectoryName(path)
                 : Directory.Exists(path)
                     ? path
                     : null;

--- a/ModernFormsNext.VisualStudioExtension/Detection/ModernFormsDesignFileLocator.cs
+++ b/ModernFormsNext.VisualStudioExtension/Detection/ModernFormsDesignFileLocator.cs
@@ -14,7 +14,7 @@ public sealed class ModernFormsDesignFileLocator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(codeFilePath);
 
-        return Path.ChangeExtension(codeFilePath, ".mfdesign");
+        return IOPath.ChangeExtension(codeFilePath, ".mfdesign");
     }
 
     /// <summary>
@@ -26,9 +26,9 @@ public sealed class ModernFormsDesignFileLocator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(codeFilePath);
 
-        var directory = Path.GetDirectoryName(codeFilePath) ?? string.Empty;
-        var fileName = Path.GetFileNameWithoutExtension(codeFilePath);
-        return Path.Combine(directory, $"{fileName}.Designer.cs");
+        var directory = IOPath.GetDirectoryName(codeFilePath) ?? string.Empty;
+        var fileName = IOPath.GetFileNameWithoutExtension(codeFilePath);
+        return IOPath.Combine(directory, $"{fileName}.Designer.cs");
     }
 
     /// <summary>
@@ -40,6 +40,6 @@ public sealed class ModernFormsDesignFileLocator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(designFilePath);
 
-        return Path.ChangeExtension(designFilePath, ".cs");
+        return IOPath.ChangeExtension(designFilePath, ".cs");
     }
 }

--- a/ModernFormsNext.VisualStudioExtension/Detection/ModernFormsDesignableFileDetector.cs
+++ b/ModernFormsNext.VisualStudioExtension/Detection/ModernFormsDesignableFileDetector.cs
@@ -38,7 +38,7 @@ public sealed class ModernFormsDesignableFileDetector
     public ModernFormsDesignableFileInfo? Inspect(string codeFilePath)
     {
         if (string.IsNullOrWhiteSpace(codeFilePath)
-            || !string.Equals(Path.GetExtension(codeFilePath), ".cs", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(IOPath.GetExtension(codeFilePath), ".cs", StringComparison.OrdinalIgnoreCase)
             || codeFilePath.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase))
         {
             return null;
@@ -53,7 +53,7 @@ public sealed class ModernFormsDesignableFileDetector
 
         ClassDeclarationSyntax? classDeclaration = null;
         string? namespaceName = null;
-        string? className = Path.GetFileNameWithoutExtension(codeFilePath);
+        string? className = IOPath.GetFileNameWithoutExtension(codeFilePath);
         string? baseTypeName = null;
         var isPartial = false;
         var rootKind = DesignRootKind.Form;
@@ -264,16 +264,16 @@ public sealed class ModernFormsDesignableFileDetector
 
     private static ProjectInspectionResult ReadProjectInfo(string codeFilePath)
     {
-        var projectPath = FindNearestProjectFile(Path.GetDirectoryName(codeFilePath));
+        var projectPath = FindNearestProjectFile(IOPath.GetDirectoryName(codeFilePath));
 
         if (projectPath is null)
             return ProjectInspectionResult.Empty;
 
         try
         {
-            var projectDirectory = Path.GetDirectoryName(projectPath) ?? string.Empty;
-            var relativePath = Path.GetRelativePath(projectDirectory, codeFilePath).Replace('\\', '/');
-            var fileName = Path.GetFileName(codeFilePath);
+            var projectDirectory = IOPath.GetDirectoryName(projectPath) ?? string.Empty;
+            var relativePath = IOPath.GetRelativePath(projectDirectory, codeFilePath).Replace('\\', '/');
+            var fileName = IOPath.GetFileName(codeFilePath);
             var project = XDocument.Load(projectPath);
 
             var hasModernFormsReference = project.Descendants().Any(element =>
@@ -290,7 +290,7 @@ public sealed class ModernFormsDesignableFileDetector
                     var include = (string?)element.Attribute("Include") ?? (string?)element.Attribute("Update");
 
                     return include is not null
-                        && string.Equals(Path.GetFileName(include), "ModernFormsNext.csproj", StringComparison.OrdinalIgnoreCase);
+                        && string.Equals(IOPath.GetFileName(include), "ModernFormsNext.csproj", StringComparison.OrdinalIgnoreCase);
                 }
 
                 return false;

--- a/ModernFormsNext.VisualStudioExtension/Editors/MfDesignEditorPane.cs
+++ b/ModernFormsNext.VisualStudioExtension/Editors/MfDesignEditorPane.cs
@@ -202,7 +202,7 @@ public sealed class MfDesignEditorPane : WindowPane, IVsPersistDocData, IPersist
     private static string? FindNearestProjectPath(string path)
     {
         var directory = File.Exists(path)
-            ? Path.GetDirectoryName(path)
+            ? IOPath.GetDirectoryName(path)
             : Directory.Exists(path)
                 ? path
                 : null;

--- a/ModernFormsNext.VisualStudioExtension/Editors/MfDesignFileGenerator.cs
+++ b/ModernFormsNext.VisualStudioExtension/Editors/MfDesignFileGenerator.cs
@@ -42,7 +42,7 @@ public sealed class MfDesignFileGenerator
             document,
             new CSharpDesignerGenerationOptions
             {
-                SourceFilePath = Path.GetFileName(designDocumentPath),
+                SourceFilePath = IOPath.GetFileName(designDocumentPath),
                 DesignHash = roundTrip.ComputeDesignHash(document),
                 AnimationDefinitions = animationDefinitions ?? []
             });
@@ -57,8 +57,8 @@ public sealed class MfDesignFileGenerator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(designDocumentPath);
 
-        var directory = Path.GetDirectoryName(designDocumentPath) ?? string.Empty;
-        var name = Path.GetFileNameWithoutExtension(designDocumentPath);
-        return Path.Combine(directory, $"{name}.Designer.cs");
+        var directory = IOPath.GetDirectoryName(designDocumentPath) ?? string.Empty;
+        var name = IOPath.GetFileNameWithoutExtension(designDocumentPath);
+        return IOPath.Combine(directory, $"{name}.Designer.cs");
     }
 }

--- a/ModernFormsNext.VisualStudioExtension/GlobalUsings.ShapeCompatibility.cs
+++ b/ModernFormsNext.VisualStudioExtension/GlobalUsings.ShapeCompatibility.cs
@@ -1,0 +1,2 @@
+// ModernFormsNext.Path is a public vector control; keep file-system paths explicit in tooling.
+global using IOPath = System.IO.Path;

--- a/ModernFormsNext.VisualStudioExtension/Hosting/VisualStudioDesignerFileService.cs
+++ b/ModernFormsNext.VisualStudioExtension/Hosting/VisualStudioDesignerFileService.cs
@@ -40,7 +40,7 @@ public sealed class VisualStudioDesignerFileService
 
     private static string FindProjectPath(string designDocumentPath)
     {
-        string? directory = Path.GetDirectoryName(Path.GetFullPath(designDocumentPath));
+        string? directory = IOPath.GetDirectoryName(IOPath.GetFullPath(designDocumentPath));
         while (!string.IsNullOrWhiteSpace(directory))
         {
             string? project = Directory.GetFiles(directory, "*.csproj", SearchOption.TopDirectoryOnly).FirstOrDefault();
@@ -48,6 +48,6 @@ public sealed class VisualStudioDesignerFileService
                 return project;
             directory = Directory.GetParent(directory)?.FullName;
         }
-        return Path.GetDirectoryName(Path.GetFullPath(designDocumentPath)) ?? string.Empty;
+        return IOPath.GetDirectoryName(IOPath.GetFullPath(designDocumentPath)) ?? string.Empty;
     }
 }

--- a/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
+++ b/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
@@ -248,7 +248,7 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
 
         try
         {
-            var candidate = NormalizeExistingFilePath(Path.GetFullPath(Path.Combine(projectDirectory, canonicalName)));
+            var candidate = NormalizeExistingFilePath(IOPath.GetFullPath(IOPath.Combine(projectDirectory, canonicalName)));
 
             return candidate;
         }
@@ -282,7 +282,7 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
             return rootName;
 
         return File.Exists(rootName)
-            ? Path.GetDirectoryName(rootName)
+            ? IOPath.GetDirectoryName(rootName)
             : null;
     }
 
@@ -293,7 +293,7 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
         if (candidate.Trim().Length == 0)
             return null;
 
-        if (Path.IsPathRooted(candidate) && File.Exists(candidate))
+        if (IOPath.IsPathRooted(candidate) && File.Exists(candidate))
             return candidate;
 
         var sourceExtensionIndex = candidate.IndexOf(".cs", StringComparison.OrdinalIgnoreCase);
@@ -303,7 +303,7 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
 
         var sourcePath = candidate.Substring(0, sourceExtensionIndex + 3);
 
-        return Path.IsPathRooted(sourcePath) && File.Exists(sourcePath)
+        return IOPath.IsPathRooted(sourcePath) && File.Exists(sourcePath)
             ? sourcePath
             : null;
     }
@@ -351,8 +351,8 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
         var document = new DesignDocument
         {
             Namespace = fileInfo.Namespace ?? string.Empty,
-            ClassName = fileInfo.ClassName ?? Path.GetFileNameWithoutExtension(fileInfo.CodeFilePath),
-            FormName = fileInfo.ClassName ?? Path.GetFileNameWithoutExtension(fileInfo.CodeFilePath),
+            ClassName = fileInfo.ClassName ?? IOPath.GetFileNameWithoutExtension(fileInfo.CodeFilePath),
+            FormName = fileInfo.ClassName ?? IOPath.GetFileNameWithoutExtension(fileInfo.CodeFilePath),
             RootKind = fileInfo.RootKind,
             Size = new DesignSize(900, 600)
         };
@@ -362,7 +362,7 @@ public sealed class ModernFormsDesignerPackage : AsyncPackage
 
     private static string? FindNearestProjectPath(string path)
     {
-        string? directory = File.Exists(path) ? Path.GetDirectoryName(path) : path;
+        string? directory = File.Exists(path) ? IOPath.GetDirectoryName(path) : path;
         while (!string.IsNullOrWhiteSpace(directory))
         {
             string? project = Directory.GetFiles(directory, "*.csproj", SearchOption.TopDirectoryOnly).FirstOrDefault();

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
@@ -37,11 +37,17 @@ public partial class Control
                 if (Owner is not { } owner || !owner.Visible)
                     return Rectangle.Empty;
 
-                // Transform both corners so an animated size on any ancestor contributes the same
-                // presentation scale that composition and nested hit testing apply to the child.
-                Point location = owner.PointToScreen(Point.Empty);
+                // Transform all corners. Two diagonal corners are insufficient after rotation or
+                // a negative presentation scale and can produce inverted or undersized bounds.
+                Point topLeft = owner.PointToScreen(Point.Empty);
+                Point topRight = owner.PointToScreen(new Point(owner.ScaledWidth, 0));
+                Point bottomLeft = owner.PointToScreen(new Point(0, owner.ScaledHeight));
                 Point bottomRight = owner.PointToScreen(new Point(owner.ScaledWidth, owner.ScaledHeight));
-                return Rectangle.FromLTRB(location.X, location.Y, bottomRight.X, bottomRight.Y);
+                int left = Math.Min(Math.Min(topLeft.X, topRight.X), Math.Min(bottomLeft.X, bottomRight.X));
+                int top = Math.Min(Math.Min(topLeft.Y, topRight.Y), Math.Min(bottomLeft.Y, bottomRight.Y));
+                int right = Math.Max(Math.Max(topLeft.X, topRight.X), Math.Max(bottomLeft.X, bottomRight.X));
+                int bottom = Math.Max(Math.Max(topLeft.Y, topRight.Y), Math.Max(bottomLeft.Y, bottomRight.Y));
+                return Rectangle.FromLTRB(left, top, right, bottom);
             }
         }
 
@@ -279,6 +285,7 @@ public partial class Control
                 TableLayoutPanel => AccessibleRole.Pane,
                 Panel => AccessibleRole.Pane,
                 PictureBox => AccessibleRole.Graphic,
+                Shape => AccessibleRole.Graphic,
                 ProgressBar => AccessibleRole.ProgressBar,
                 RadioButton => AccessibleRole.RadioButton,
                 ScrollBar => AccessibleRole.ScrollBar,

--- a/ModernFormsNext/Circle.cs
+++ b/ModernFormsNext/Circle.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel;
+using System.Drawing;
+
+namespace ModernFormsNext;
+
+/// <summary>Displays a circle centered inside the control's client bounds.</summary>
+/// <remarks>
+/// The outer edge of the centered stroke fits the smaller client dimension. The contour diameter
+/// therefore equals that dimension minus <see cref="Shape.StrokeThickness"/>. This subclass reuses
+/// the complete <see cref="Ellipse"/> rendering, Brush, transform, and hit-testing implementation.
+/// </remarks>
+[DisplayName("Circle")]
+[Category("Shapes")]
+[Description("Draws a centered circle constrained by the smaller control dimension.")]
+public sealed class Circle : Ellipse
+{
+    /// <summary>Initializes a centered circle.</summary>
+    public Circle()
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override RectangleF GetEllipseBounds(Size size)
+    {
+        float diameter = Math.Max(0f, Math.Min(size.Width, size.Height) - StrokeThickness);
+        return new RectangleF(
+            (size.Width - diameter) / 2f,
+            (size.Height - diameter) / 2f,
+            diameter,
+            diameter);
+    }
+}

--- a/ModernFormsNext/ColorDialogForm.cs
+++ b/ModernFormsNext/ColorDialogForm.cs
@@ -46,7 +46,10 @@ namespace ModernFormsNext
             originalColor = initialColor;
             SelectedColor = initialColor;
             Text = TextForm;
-            Size = new Size (760, 520);
+            // Child coordinates are relative to the usable area below the managed title bar.
+            // Form.Size includes that title bar, which previously removed enough client height
+            // to clip the blue channel slider and the bottom of the dialog buttons.
+            ClientSize = new Size (760, 520);
             StartPosition = FormStartPosition.CenterParent;
             Resizeable = false;
             AllowMaximize = false;

--- a/ModernFormsNext/Control.LayoutAnimation.cs
+++ b/ModernFormsNext/Control.LayoutAnimation.cs
@@ -134,27 +134,32 @@ public partial class Control
 
     internal bool PresentationContains(Point parentPoint)
     {
-        RectangleF bounds = ScaledPresentationBounds;
-        return bounds.Width > 0f && bounds.Height > 0f &&
-            parentPoint.X >= bounds.Left && parentPoint.X < bounds.Right &&
-            parentPoint.Y >= bounds.Top && parentPoint.Y < bounds.Bottom;
+        if (!TryParentPresentationPointToClient(parentPoint, out PointF clientPoint))
+            return false;
+
+        return HitTestClient(clientPoint);
     }
+
+    /// <summary>
+    /// Determines whether a presentation-space point mapped into this control hits its content.
+    /// </summary>
+    /// <param name="clientPoint">The point in the same scaled client coordinate space used by the control's back buffer.</param>
+    /// <returns><see langword="true"/> when the point should target this control.</returns>
+    /// <remarks>
+    /// The default implementation tests the rectangular client area. Vector controls override this
+    /// hook to test their rendered geometry. The owning presentation pipeline has already inverted
+    /// layout and render transforms before this method is called.
+    /// </remarks>
+    internal virtual bool HitTestClient(PointF clientPoint)
+        => clientPoint.X >= 0f && clientPoint.Y >= 0f &&
+            clientPoint.X < ScaledWidth && clientPoint.Y < ScaledHeight;
 
     internal Point ParentPresentationPointToClient(Point parentPoint)
     {
-        RectangleF presentation = ScaledPresentationBounds;
-        float localX = parentPoint.X - presentation.X;
-        float localY = parentPoint.Y - presentation.Y;
-        int targetWidth = ScaledWidth;
-        int targetHeight = ScaledHeight;
+        if (!TryParentPresentationPointToClient(parentPoint, out PointF clientPoint))
+            return Point.Empty;
 
-        int x = presentation.Width > 0f && targetWidth > 0
-            ? (int)MathF.Floor(localX * targetWidth / presentation.Width)
-            : 0;
-        int y = presentation.Height > 0f && targetHeight > 0
-            ? (int)MathF.Floor(localY * targetHeight / presentation.Height)
-            : 0;
-        return new Point(x, y);
+        return new Point((int)MathF.Floor(clientPoint.X), (int)MathF.Floor(clientPoint.Y));
     }
 
     internal Point ClientPointToParentPresentation(Point clientPoint)
@@ -162,15 +167,68 @@ public partial class Control
         RectangleF presentation = ScaledPresentationBounds;
         int targetWidth = ScaledWidth;
         int targetHeight = ScaledHeight;
-        float x = targetWidth > 0
-            ? presentation.X + (clientPoint.X * presentation.Width / targetWidth)
-            : presentation.X;
-        float y = targetHeight > 0
-            ? presentation.Y + (clientPoint.Y * presentation.Height / targetHeight)
-            : presentation.Y;
+        float x = targetWidth > 0 ? clientPoint.X * presentation.Width / targetWidth : 0f;
+        float y = targetHeight > 0 ? clientPoint.Y * presentation.Height / targetHeight : 0f;
+
+        float centerX = presentation.Width / 2f;
+        float centerY = presentation.Height / 2f;
+        x = (x - centerX) * EffectiveScaleX;
+        y = (y - centerY) * EffectiveScaleY;
+
+        float radians = EffectiveRotation * (MathF.PI / 180f);
+        float cosine = MathF.Cos(radians);
+        float sine = MathF.Sin(radians);
+        float rotatedX = (x * cosine) - (y * sine);
+        float rotatedY = (x * sine) + (y * cosine);
+        x = presentation.X + (EffectiveTranslationX * ScaleFactor.Width) + centerX + rotatedX;
+        y = presentation.Y + (EffectiveTranslationY * ScaleFactor.Height) + centerY + rotatedY;
+
         return new Point(
             (int)MathF.Round(x, MidpointRounding.AwayFromZero),
             (int)MathF.Round(y, MidpointRounding.AwayFromZero));
+    }
+
+    private bool TryParentPresentationPointToClient(Point parentPoint, out PointF clientPoint)
+    {
+        RectangleF presentation = ScaledPresentationBounds;
+        int targetWidth = ScaledWidth;
+        int targetHeight = ScaledHeight;
+        if (presentation.Width <= 0f || presentation.Height <= 0f || targetWidth <= 0 || targetHeight <= 0)
+        {
+            clientPoint = default;
+            return false;
+        }
+
+        float scaleX = EffectiveScaleX;
+        float scaleY = EffectiveScaleY;
+        if (!float.IsFinite(scaleX) || !float.IsFinite(scaleY) ||
+            MathF.Abs(scaleX) <= 0.000001f || MathF.Abs(scaleY) <= 0.000001f)
+        {
+            clientPoint = default;
+            return false;
+        }
+
+        float drawX = presentation.X + (EffectiveTranslationX * ScaleFactor.Width);
+        float drawY = presentation.Y + (EffectiveTranslationY * ScaleFactor.Height);
+        float centerX = presentation.Width / 2f;
+        float centerY = presentation.Height / 2f;
+        float x = parentPoint.X - drawX - centerX;
+        float y = parentPoint.Y - drawY - centerY;
+
+        // DrawBackBuffer applies rotation after scale. Invert those operations in reverse order
+        // so pointer routing observes the exact same presentation geometry as composition.
+        float radians = EffectiveRotation * (MathF.PI / 180f);
+        float cosine = MathF.Cos(radians);
+        float sine = MathF.Sin(radians);
+        float unrotatedX = (x * cosine) + (y * sine);
+        float unrotatedY = (-x * sine) + (y * cosine);
+        float presentationX = (unrotatedX / scaleX) + centerX;
+        float presentationY = (unrotatedY / scaleY) + centerY;
+
+        clientPoint = new PointF(
+            presentationX * targetWidth / presentation.Width,
+            presentationY * targetHeight / presentation.Height);
+        return float.IsFinite(clientPoint.X) && float.IsFinite(clientPoint.Y);
     }
 
     internal void DrawBackBuffer(SKCanvas canvas, SKBitmap buffer, float parentOffsetX = 0f, float parentOffsetY = 0f)

--- a/ModernFormsNext/Documents/DocumentImageCache.cs
+++ b/ModernFormsNext/Documents/DocumentImageCache.cs
@@ -289,9 +289,9 @@ internal sealed class DocumentImageCache : IDisposable
                 return await ReadFileLimitedAsync(uri.LocalPath, limits, cancellationToken).ConfigureAwait(false);
         }
 
-        var path = Path.IsPathRooted(source)
+        var path = System.IO.Path.IsPathRooted(source)
             ? source
-            : Path.GetFullPath(source, AppContext.BaseDirectory);
+            : System.IO.Path.GetFullPath(source, AppContext.BaseDirectory);
 
         return await ReadFileLimitedAsync(path, limits, cancellationToken).ConfigureAwait(false);
     }

--- a/ModernFormsNext/Drawing/Geometry/BezierSegment.cs
+++ b/ModernFormsNext/Drawing/Geometry/BezierSegment.cs
@@ -1,0 +1,75 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>Represents a cubic Bézier segment with two control points.</summary>
+public sealed class BezierSegment : PathSegment
+{
+    private PointF controlPoint1;
+    private PointF controlPoint2;
+    private PointF point;
+
+    /// <summary>Initializes a degenerate cubic segment at the origin.</summary>
+    public BezierSegment()
+    {
+    }
+
+    /// <summary>Initializes a cubic Bézier segment.</summary>
+    /// <param name="controlPoint1">The first finite control point.</param>
+    /// <param name="controlPoint2">The second finite control point.</param>
+    /// <param name="point">The finite endpoint.</param>
+    public BezierSegment(PointF controlPoint1, PointF controlPoint2, PointF point)
+    {
+        ValidatePoint(controlPoint1, nameof(controlPoint1));
+        ValidatePoint(controlPoint2, nameof(controlPoint2));
+        ValidatePoint(point, nameof(point));
+        this.controlPoint1 = controlPoint1;
+        this.controlPoint2 = controlPoint2;
+        this.point = point;
+    }
+
+    /// <summary>Gets or sets the first control point in logical pixels.</summary>
+    public PointF ControlPoint1
+    {
+        get => controlPoint1;
+        set
+        {
+            ValidatePoint(value, nameof(value));
+            if (controlPoint1 == value)
+                return;
+
+            controlPoint1 = value;
+            OnChanged();
+        }
+    }
+
+    /// <summary>Gets or sets the second control point in logical pixels.</summary>
+    public PointF ControlPoint2
+    {
+        get => controlPoint2;
+        set
+        {
+            ValidatePoint(value, nameof(value));
+            if (controlPoint2 == value)
+                return;
+
+            controlPoint2 = value;
+            OnChanged();
+        }
+    }
+
+    /// <summary>Gets or sets the endpoint in logical pixels.</summary>
+    public PointF Point
+    {
+        get => point;
+        set
+        {
+            ValidatePoint(value, nameof(value));
+            if (point == value)
+                return;
+
+            point = value;
+            OnChanged();
+        }
+    }
+}

--- a/ModernFormsNext/Drawing/Geometry/EllipseGeometry.cs
+++ b/ModernFormsNext/Drawing/Geometry/EllipseGeometry.cs
@@ -1,0 +1,39 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Represents an ellipse bounded by an axis-aligned rectangle in logical coordinates.
+/// </summary>
+public sealed class EllipseGeometry : Geometry
+{
+    private RectangleF rect;
+
+    /// <summary>Initializes an empty ellipse.</summary>
+    public EllipseGeometry()
+    {
+    }
+
+    /// <summary>Initializes an ellipse inside the supplied finite rectangle.</summary>
+    /// <param name="rect">The bounding rectangle in logical pixels.</param>
+    public EllipseGeometry(RectangleF rect)
+    {
+        Geometry.ValidateRectangle(rect, nameof(rect));
+        this.rect = rect;
+    }
+
+    /// <summary>Gets or sets the ellipse bounding rectangle in logical pixels.</summary>
+    public RectangleF Rect
+    {
+        get => rect;
+        set
+        {
+            Geometry.ValidateRectangle(value, nameof(value));
+            if (rect == value)
+                return;
+
+            rect = value;
+            OnChanged();
+        }
+    }
+}

--- a/ModernFormsNext/Drawing/Geometry/Geometry.cs
+++ b/ModernFormsNext/Drawing/Geometry/Geometry.cs
@@ -1,0 +1,102 @@
+using System.Numerics;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Defines platform-neutral vector geometry that can be rendered, transformed, and shared.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Geometry instances are mutable and may be shared by multiple <see cref="ModernFormsNext.Path"/>
+/// controls. Every rendered mutation raises <see cref="Changed"/> synchronously so all consumers
+/// can invalidate their native-path caches. Mutate geometry on the UI thread while it is in use.
+/// </para>
+/// <para>
+/// This abstraction intentionally does not expose SkiaSharp types. Backends convert the geometry
+/// to their native representation and cache that representation against <see cref="Version"/>.
+/// </para>
+/// </remarks>
+public abstract class Geometry
+{
+    private Matrix3x2 transform = Matrix3x2.Identity;
+    private int version;
+
+    /// <summary>
+    /// Occurs when a property, figure, segment, or point changes the rendered geometry.
+    /// </summary>
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Gets the monotonically changing revision used by renderer caches.
+    /// </summary>
+    /// <remarks>
+    /// The value is meaningful only for equality comparisons with a previously observed revision;
+    /// it may wrap after a very large number of mutations.
+    /// </remarks>
+    public int Version => version;
+
+    /// <summary>
+    /// Gets or sets the finite platform-neutral transform applied to this geometry.
+    /// </summary>
+    /// <remarks>
+    /// Translation uses logical pixels. The transform is applied before the owning control's
+    /// presentation transform, and it affects rendering and geometry-aware hit testing equally.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when a matrix component is NaN or infinity.</exception>
+    public Matrix3x2 Transform
+    {
+        get => transform;
+        set
+        {
+            ValidateTransform(value, nameof(value));
+            if (transform.Equals(value))
+                return;
+
+            transform = value;
+            OnChanged();
+        }
+    }
+
+    /// <summary>
+    /// Raises <see cref="Changed"/> after a rendered value has changed.
+    /// </summary>
+    protected void OnChanged()
+    {
+        version = unchecked(version + 1);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    internal static void ValidatePoint(System.Drawing.PointF point, string parameterName)
+    {
+        if (!float.IsFinite(point.X) || !float.IsFinite(point.Y))
+            throw new ArgumentException("Point coordinates must be finite.", parameterName);
+    }
+
+    internal static void ValidateSize(System.Drawing.SizeF size, string parameterName)
+    {
+        if (!float.IsFinite(size.Width) || !float.IsFinite(size.Height) ||
+            size.Width < 0f || size.Height < 0f)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                size,
+                "Size components must be finite and non-negative.");
+        }
+    }
+
+    internal static void ValidateRectangle(System.Drawing.RectangleF rectangle, string parameterName)
+    {
+        ValidatePoint(rectangle.Location, parameterName);
+        ValidateSize(rectangle.Size, parameterName);
+    }
+
+    private static void ValidateTransform(Matrix3x2 value, string parameterName)
+    {
+        if (!float.IsFinite(value.M11) || !float.IsFinite(value.M12) ||
+            !float.IsFinite(value.M21) || !float.IsFinite(value.M22) ||
+            !float.IsFinite(value.M31) || !float.IsFinite(value.M32))
+        {
+            throw new ArgumentException("Transform components must be finite.", parameterName);
+        }
+    }
+}

--- a/ModernFormsNext/Drawing/Geometry/GeometryFillRule.cs
+++ b/ModernFormsNext/Drawing/Geometry/GeometryFillRule.cs
@@ -1,0 +1,14 @@
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Specifies how overlapping contours determine the filled area of a <see cref="PathGeometry"/>
+/// or <see cref="ModernFormsNext.Polygon"/>.
+/// </summary>
+public enum GeometryFillRule
+{
+    /// <summary>Uses the non-zero winding rule.</summary>
+    Winding,
+
+    /// <summary>Fills regions crossed by an odd number of contour edges.</summary>
+    EvenOdd
+}

--- a/ModernFormsNext/Drawing/Geometry/LineGeometry.cs
+++ b/ModernFormsNext/Drawing/Geometry/LineGeometry.cs
@@ -1,0 +1,58 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Represents a reusable straight line between two points in logical coordinates.
+/// </summary>
+public sealed class LineGeometry : Geometry
+{
+    private PointF startPoint;
+    private PointF endPoint;
+
+    /// <summary>Initializes an empty line whose endpoints are both at the origin.</summary>
+    public LineGeometry()
+    {
+    }
+
+    /// <summary>Initializes a line with the supplied finite endpoints.</summary>
+    /// <param name="startPoint">The starting point in logical pixels.</param>
+    /// <param name="endPoint">The ending point in logical pixels.</param>
+    public LineGeometry(PointF startPoint, PointF endPoint)
+    {
+        Geometry.ValidatePoint(startPoint, nameof(startPoint));
+        Geometry.ValidatePoint(endPoint, nameof(endPoint));
+        this.startPoint = startPoint;
+        this.endPoint = endPoint;
+    }
+
+    /// <summary>Gets or sets the starting point in logical pixels.</summary>
+    public PointF StartPoint
+    {
+        get => startPoint;
+        set
+        {
+            Geometry.ValidatePoint(value, nameof(value));
+            if (startPoint == value)
+                return;
+
+            startPoint = value;
+            OnChanged();
+        }
+    }
+
+    /// <summary>Gets or sets the ending point in logical pixels.</summary>
+    public PointF EndPoint
+    {
+        get => endPoint;
+        set
+        {
+            Geometry.ValidatePoint(value, nameof(value));
+            if (endPoint == value)
+                return;
+
+            endPoint = value;
+            OnChanged();
+        }
+    }
+}

--- a/ModernFormsNext/Drawing/Geometry/LineSegment.cs
+++ b/ModernFormsNext/Drawing/Geometry/LineSegment.cs
@@ -1,0 +1,37 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>Represents a straight segment ending at a point.</summary>
+public sealed class LineSegment : PathSegment
+{
+    private PointF point;
+
+    /// <summary>Initializes a line segment ending at the origin.</summary>
+    public LineSegment()
+    {
+    }
+
+    /// <summary>Initializes a line segment ending at the supplied point.</summary>
+    /// <param name="point">The finite endpoint in logical pixels.</param>
+    public LineSegment(PointF point)
+    {
+        ValidatePoint(point, nameof(point));
+        this.point = point;
+    }
+
+    /// <summary>Gets or sets the finite endpoint in logical pixels.</summary>
+    public PointF Point
+    {
+        get => point;
+        set
+        {
+            ValidatePoint(value, nameof(value));
+            if (point == value)
+                return;
+
+            point = value;
+            OnChanged();
+        }
+    }
+}

--- a/ModernFormsNext/Drawing/Geometry/PathFigure.cs
+++ b/ModernFormsNext/Drawing/Geometry/PathFigure.cs
@@ -1,0 +1,74 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Represents one path contour with a start point, ordered segments, and optional closure.
+/// </summary>
+public sealed class PathFigure
+{
+    private PointF startPoint;
+    private bool isClosed;
+
+    /// <summary>Initializes a figure at the origin.</summary>
+    public PathFigure()
+    {
+        Segments.Changed += HandleSegmentsChanged;
+    }
+
+    /// <summary>Initializes a figure at the supplied finite start point.</summary>
+    /// <param name="startPoint">The start point in logical pixels.</param>
+    /// <param name="isClosed">Whether rendering closes the final segment to the start point.</param>
+    public PathFigure(PointF startPoint, bool isClosed = false)
+        : this()
+    {
+        Geometry.ValidatePoint(startPoint, nameof(startPoint));
+        this.startPoint = startPoint;
+        this.isClosed = isClosed;
+    }
+
+    /// <summary>Occurs after the contour geometry changes.</summary>
+    public event EventHandler? Changed;
+
+    /// <summary>Gets or sets the finite start point in logical pixels.</summary>
+    public PointF StartPoint
+    {
+        get => startPoint;
+        set
+        {
+            Geometry.ValidatePoint(value, nameof(value));
+            if (startPoint == value)
+                return;
+
+            startPoint = value;
+            OnChanged();
+        }
+    }
+
+    /// <summary>Gets the observable ordered segment collection.</summary>
+    public PathSegmentCollection Segments { get; } = new();
+
+    /// <summary>
+    /// Gets or sets whether the contour is explicitly closed to <see cref="StartPoint"/>.
+    /// </summary>
+    /// <remarks>
+    /// Closure affects stroking as well as filling. Open contours can still contribute a filled
+    /// area because standard fill rules treat their endpoints as implicitly connected.
+    /// </remarks>
+    public bool IsClosed
+    {
+        get => isClosed;
+        set
+        {
+            if (isClosed == value)
+                return;
+
+            isClosed = value;
+            OnChanged();
+        }
+    }
+
+    private void HandleSegmentsChanged(object? sender, EventArgs e) => OnChanged();
+
+    private void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+}

--- a/ModernFormsNext/Drawing/Geometry/PathFigureCollection.cs
+++ b/ModernFormsNext/Drawing/Geometry/PathFigureCollection.cs
@@ -1,0 +1,152 @@
+using System.Collections;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>Provides an observable ordered collection of <see cref="PathFigure"/> values.</summary>
+public sealed class PathFigureCollection : IList<PathFigure>, IReadOnlyList<PathFigure>
+{
+    private readonly List<PathFigure> items = [];
+    private readonly Dictionary<PathFigure, int> subscriptions = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>Occurs after figures, ordering, or a contained figure changes.</summary>
+    public event EventHandler? Changed;
+
+    /// <inheritdoc/>
+    public int Count => items.Count;
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public PathFigure this[int index]
+    {
+        get => items[index];
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            PathFigure previous = items[index];
+            if (ReferenceEquals(previous, value))
+                return;
+
+            Release(previous);
+            items[index] = value;
+            Acquire(value);
+            OnChanged();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Add(PathFigure item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        items.Add(item);
+        Acquire(item);
+        OnChanged();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (items.Count == 0)
+            return;
+
+        foreach (PathFigure item in subscriptions.Keys.ToArray())
+            item.Changed -= HandleItemChanged;
+        subscriptions.Clear();
+        items.Clear();
+        OnChanged();
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(PathFigure item) => items.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(PathFigure[] array, int arrayIndex) => items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public IEnumerator<PathFigure> GetEnumerator() => items.GetEnumerator();
+
+    /// <inheritdoc/>
+    public int IndexOf(PathFigure item) => items.IndexOf(item);
+
+    /// <inheritdoc/>
+    public void Insert(int index, PathFigure item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        items.Insert(index, item);
+        Acquire(item);
+        OnChanged();
+    }
+
+    /// <summary>Moves a figure without changing subscriptions and raises one change notification.</summary>
+    /// <param name="oldIndex">The current zero-based position.</param>
+    /// <param name="newIndex">The destination zero-based position.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="oldIndex"/> or <paramref name="newIndex"/> is outside the collection.
+    /// </exception>
+    public void Move(int oldIndex, int newIndex)
+    {
+        if ((uint)oldIndex >= (uint)items.Count)
+            throw new ArgumentOutOfRangeException(nameof(oldIndex));
+        if ((uint)newIndex >= (uint)items.Count)
+            throw new ArgumentOutOfRangeException(nameof(newIndex));
+        if (oldIndex == newIndex)
+            return;
+
+        PathFigure item = items[oldIndex];
+        items.RemoveAt(oldIndex);
+        items.Insert(newIndex, item);
+        OnChanged();
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(PathFigure item)
+    {
+        int index = items.IndexOf(item);
+        if (index < 0)
+            return false;
+
+        RemoveAt(index);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        PathFigure item = items[index];
+        items.RemoveAt(index);
+        Release(item);
+        OnChanged();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void Acquire(PathFigure item)
+    {
+        if (subscriptions.TryGetValue(item, out int count))
+        {
+            subscriptions[item] = count + 1;
+            return;
+        }
+
+        subscriptions.Add(item, 1);
+        item.Changed += HandleItemChanged;
+    }
+
+    private void Release(PathFigure item)
+    {
+        int count = subscriptions[item];
+        if (count > 1)
+        {
+            subscriptions[item] = count - 1;
+            return;
+        }
+
+        subscriptions.Remove(item);
+        item.Changed -= HandleItemChanged;
+    }
+
+    private void HandleItemChanged(object? sender, EventArgs e) => OnChanged();
+
+    private void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+}

--- a/ModernFormsNext/Drawing/Geometry/PathGeometry.cs
+++ b/ModernFormsNext/Drawing/Geometry/PathGeometry.cs
@@ -1,0 +1,41 @@
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Represents reusable vector contours composed from figures and line or Bézier segments.
+/// </summary>
+/// <remarks>
+/// The collection hierarchy is fully observable: changing a segment, figure, or collection raises
+/// <see cref="Geometry.Changed"/> and invalidates every sharing <see cref="ModernFormsNext.Path"/>.
+/// </remarks>
+public sealed class PathGeometry : Geometry
+{
+    private GeometryFillRule fillRule;
+
+    /// <summary>Initializes an empty path using the non-zero winding fill rule.</summary>
+    public PathGeometry()
+    {
+        Figures.Changed += HandleFiguresChanged;
+    }
+
+    /// <summary>Gets the observable ordered contour collection.</summary>
+    public PathFigureCollection Figures { get; } = new();
+
+    /// <summary>Gets or sets the rule used to determine filled regions.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown for an undefined enum value.</exception>
+    public GeometryFillRule FillRule
+    {
+        get => fillRule;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The geometry fill rule is not defined.");
+            if (fillRule == value)
+                return;
+
+            fillRule = value;
+            OnChanged();
+        }
+    }
+
+    private void HandleFiguresChanged(object? sender, EventArgs e) => OnChanged();
+}

--- a/ModernFormsNext/Drawing/Geometry/PathSegment.cs
+++ b/ModernFormsNext/Drawing/Geometry/PathSegment.cs
@@ -1,0 +1,22 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Defines one mutable segment in a <see cref="PathFigure"/>.
+/// </summary>
+/// <remarks>
+/// Segments may be shared by multiple figures. A rendered mutation raises <see cref="Changed"/>
+/// so every owning figure and geometry invalidates its cache.
+/// </remarks>
+public abstract class PathSegment
+{
+    /// <summary>Occurs after a segment property changes its rendered path.</summary>
+    public event EventHandler? Changed;
+
+    /// <summary>Raises <see cref="Changed"/> after a rendered property changes.</summary>
+    protected void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+
+    internal static void ValidatePoint(PointF point, string parameterName)
+        => Geometry.ValidatePoint(point, parameterName);
+}

--- a/ModernFormsNext/Drawing/Geometry/PathSegmentCollection.cs
+++ b/ModernFormsNext/Drawing/Geometry/PathSegmentCollection.cs
@@ -1,0 +1,152 @@
+using System.Collections;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>Provides an observable ordered collection of <see cref="PathSegment"/> values.</summary>
+public sealed class PathSegmentCollection : IList<PathSegment>, IReadOnlyList<PathSegment>
+{
+    private readonly List<PathSegment> items = [];
+    private readonly Dictionary<PathSegment, int> subscriptions = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>Occurs after items, ordering, or a contained segment changes.</summary>
+    public event EventHandler? Changed;
+
+    /// <inheritdoc/>
+    public int Count => items.Count;
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public PathSegment this[int index]
+    {
+        get => items[index];
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            PathSegment previous = items[index];
+            if (ReferenceEquals(previous, value))
+                return;
+
+            Release(previous);
+            items[index] = value;
+            Acquire(value);
+            OnChanged();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Add(PathSegment item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        items.Add(item);
+        Acquire(item);
+        OnChanged();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (items.Count == 0)
+            return;
+
+        foreach (PathSegment item in subscriptions.Keys.ToArray())
+            item.Changed -= HandleItemChanged;
+        subscriptions.Clear();
+        items.Clear();
+        OnChanged();
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(PathSegment item) => items.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(PathSegment[] array, int arrayIndex) => items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public IEnumerator<PathSegment> GetEnumerator() => items.GetEnumerator();
+
+    /// <inheritdoc/>
+    public int IndexOf(PathSegment item) => items.IndexOf(item);
+
+    /// <inheritdoc/>
+    public void Insert(int index, PathSegment item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        items.Insert(index, item);
+        Acquire(item);
+        OnChanged();
+    }
+
+    /// <summary>Moves a segment without changing subscriptions and raises one change notification.</summary>
+    /// <param name="oldIndex">The current zero-based position.</param>
+    /// <param name="newIndex">The destination zero-based position.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="oldIndex"/> or <paramref name="newIndex"/> is outside the collection.
+    /// </exception>
+    public void Move(int oldIndex, int newIndex)
+    {
+        if ((uint)oldIndex >= (uint)items.Count)
+            throw new ArgumentOutOfRangeException(nameof(oldIndex));
+        if ((uint)newIndex >= (uint)items.Count)
+            throw new ArgumentOutOfRangeException(nameof(newIndex));
+        if (oldIndex == newIndex)
+            return;
+
+        PathSegment item = items[oldIndex];
+        items.RemoveAt(oldIndex);
+        items.Insert(newIndex, item);
+        OnChanged();
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(PathSegment item)
+    {
+        int index = items.IndexOf(item);
+        if (index < 0)
+            return false;
+
+        RemoveAt(index);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        PathSegment item = items[index];
+        items.RemoveAt(index);
+        Release(item);
+        OnChanged();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void Acquire(PathSegment item)
+    {
+        if (subscriptions.TryGetValue(item, out int count))
+        {
+            subscriptions[item] = count + 1;
+            return;
+        }
+
+        subscriptions.Add(item, 1);
+        item.Changed += HandleItemChanged;
+    }
+
+    private void Release(PathSegment item)
+    {
+        int count = subscriptions[item];
+        if (count > 1)
+        {
+            subscriptions[item] = count - 1;
+            return;
+        }
+
+        subscriptions.Remove(item);
+        item.Changed -= HandleItemChanged;
+    }
+
+    private void HandleItemChanged(object? sender, EventArgs e) => OnChanged();
+
+    private void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+}

--- a/ModernFormsNext/Drawing/Geometry/PointCollection.cs
+++ b/ModernFormsNext/Drawing/Geometry/PointCollection.cs
@@ -1,0 +1,151 @@
+using System.Collections;
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Provides an observable, ordered collection of finite vector points.
+/// </summary>
+/// <remarks>
+/// Every successful mutation raises <see cref="Changed"/> synchronously. A point is a value type;
+/// change an existing point by assigning through the indexer. The collection is not thread-safe
+/// and should be mutated on the UI thread while it is rendered.
+/// </remarks>
+public sealed class PointCollection : IList<PointF>, IReadOnlyList<PointF>
+{
+    private readonly List<PointF> points = [];
+
+    /// <summary>Initializes an empty point collection.</summary>
+    public PointCollection()
+    {
+    }
+
+    /// <summary>Initializes a point collection from the supplied finite points.</summary>
+    /// <param name="points">Points to copy in enumeration order.</param>
+    public PointCollection(IEnumerable<PointF> points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        foreach (PointF point in points)
+        {
+            Geometry.ValidatePoint(point, nameof(points));
+            this.points.Add(point);
+        }
+    }
+
+    /// <summary>Occurs after the collection contents or ordering changes.</summary>
+    public event EventHandler? Changed;
+
+    /// <inheritdoc/>
+    public int Count => points.Count;
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public PointF this[int index]
+    {
+        get => points[index];
+        set
+        {
+            Geometry.ValidatePoint(value, nameof(value));
+            if (points[index] == value)
+                return;
+
+            points[index] = value;
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Add(PointF item)
+    {
+        Geometry.ValidatePoint(item, nameof(item));
+        points.Add(item);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Adds validated points in enumeration order and raises one change notification.</summary>
+    /// <param name="items">Points to append.</param>
+    public void AddRange(IEnumerable<PointF> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        PointF[] validated = items.ToArray();
+        foreach (PointF point in validated)
+            Geometry.ValidatePoint(point, nameof(items));
+        if (validated.Length == 0)
+            return;
+
+        points.AddRange(validated);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (points.Count == 0)
+            return;
+
+        points.Clear();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(PointF item) => points.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(PointF[] array, int arrayIndex) => points.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public IEnumerator<PointF> GetEnumerator() => points.GetEnumerator();
+
+    /// <inheritdoc/>
+    public int IndexOf(PointF item) => points.IndexOf(item);
+
+    /// <inheritdoc/>
+    public void Insert(int index, PointF item)
+    {
+        Geometry.ValidatePoint(item, nameof(item));
+        points.Insert(index, item);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Moves one point to another collection position and raises one change notification.</summary>
+    /// <param name="oldIndex">The current zero-based position.</param>
+    /// <param name="newIndex">The destination zero-based position.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="oldIndex"/> or <paramref name="newIndex"/> is outside the collection.
+    /// </exception>
+    public void Move(int oldIndex, int newIndex)
+    {
+        if ((uint)oldIndex >= (uint)points.Count)
+            throw new ArgumentOutOfRangeException(nameof(oldIndex));
+        if ((uint)newIndex >= (uint)points.Count)
+            throw new ArgumentOutOfRangeException(nameof(newIndex));
+        if (oldIndex == newIndex)
+            return;
+
+        PointF item = points[oldIndex];
+        points.RemoveAt(oldIndex);
+        points.Insert(newIndex, item);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(PointF item)
+    {
+        if (!points.Remove(item))
+            return false;
+
+        Changed?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        points.RemoveAt(index);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/ModernFormsNext/Drawing/Geometry/QuadraticBezierSegment.cs
+++ b/ModernFormsNext/Drawing/Geometry/QuadraticBezierSegment.cs
@@ -1,0 +1,56 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>Represents a quadratic Bézier segment with one control point.</summary>
+public sealed class QuadraticBezierSegment : PathSegment
+{
+    private PointF controlPoint;
+    private PointF point;
+
+    /// <summary>Initializes a degenerate quadratic segment at the origin.</summary>
+    public QuadraticBezierSegment()
+    {
+    }
+
+    /// <summary>Initializes a quadratic segment.</summary>
+    /// <param name="controlPoint">The finite control point in logical pixels.</param>
+    /// <param name="point">The finite endpoint in logical pixels.</param>
+    public QuadraticBezierSegment(PointF controlPoint, PointF point)
+    {
+        ValidatePoint(controlPoint, nameof(controlPoint));
+        ValidatePoint(point, nameof(point));
+        this.controlPoint = controlPoint;
+        this.point = point;
+    }
+
+    /// <summary>Gets or sets the control point in logical pixels.</summary>
+    public PointF ControlPoint
+    {
+        get => controlPoint;
+        set
+        {
+            ValidatePoint(value, nameof(value));
+            if (controlPoint == value)
+                return;
+
+            controlPoint = value;
+            OnChanged();
+        }
+    }
+
+    /// <summary>Gets or sets the endpoint in logical pixels.</summary>
+    public PointF Point
+    {
+        get => point;
+        set
+        {
+            ValidatePoint(value, nameof(value));
+            if (point == value)
+                return;
+
+            point = value;
+            OnChanged();
+        }
+    }
+}

--- a/ModernFormsNext/Drawing/Geometry/RectangleGeometry.cs
+++ b/ModernFormsNext/Drawing/Geometry/RectangleGeometry.cs
@@ -1,0 +1,42 @@
+using System.Drawing;
+
+namespace ModernFormsNext.Drawing;
+
+/// <summary>
+/// Represents a reusable axis-aligned rectangle in logical coordinates.
+/// </summary>
+public sealed class RectangleGeometry : Geometry
+{
+    private RectangleF rect;
+
+    /// <summary>Initializes an empty rectangle.</summary>
+    public RectangleGeometry()
+    {
+    }
+
+    /// <summary>Initializes a rectangle geometry with finite, non-negative dimensions.</summary>
+    /// <param name="rect">The rectangle in logical pixels.</param>
+    public RectangleGeometry(RectangleF rect)
+    {
+        Geometry.ValidateRectangle(rect, nameof(rect));
+        this.rect = rect;
+    }
+
+    /// <summary>Gets or sets the rectangle in logical pixels.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when a dimension is negative, NaN, or infinity.
+    /// </exception>
+    public RectangleF Rect
+    {
+        get => rect;
+        set
+        {
+            Geometry.ValidateRectangle(value, nameof(value));
+            if (rect == value)
+                return;
+
+            rect = value;
+            OnChanged();
+        }
+    }
+}

--- a/ModernFormsNext/Drawing/StrokeLineCap.cs
+++ b/ModernFormsNext/Drawing/StrokeLineCap.cs
@@ -1,0 +1,14 @@
+namespace ModernFormsNext.Drawing;
+
+/// <summary>Specifies how the open ends of a stroked vector contour are drawn.</summary>
+public enum StrokeLineCap
+{
+    /// <summary>Ends the stroke exactly at the endpoint.</summary>
+    Flat,
+
+    /// <summary>Extends the endpoint with a semicircle whose radius is half the stroke thickness.</summary>
+    Round,
+
+    /// <summary>Extends the endpoint with a square whose length is half the stroke thickness.</summary>
+    Square
+}

--- a/ModernFormsNext/Drawing/StrokeLineJoin.cs
+++ b/ModernFormsNext/Drawing/StrokeLineJoin.cs
@@ -1,0 +1,14 @@
+namespace ModernFormsNext.Drawing;
+
+/// <summary>Specifies how consecutive stroked vector segments are joined.</summary>
+public enum StrokeLineJoin
+{
+    /// <summary>Extends segment edges until they meet, subject to the shape's miter limit.</summary>
+    Miter,
+
+    /// <summary>Rounds the outside of the join.</summary>
+    Round,
+
+    /// <summary>Bevels the outside of the join.</summary>
+    Bevel
+}

--- a/ModernFormsNext/Ellipse.cs
+++ b/ModernFormsNext/Ellipse.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel;
+using System.Drawing;
+using ModernFormsNext.Drawing;
+
+namespace ModernFormsNext;
+
+/// <summary>Displays an ellipse fitted inside the control's current client bounds.</summary>
+/// <remarks>
+/// The contour is inset by half of <see cref="Shape.StrokeThickness"/> so a centered stroke and
+/// its anti-aliased edge remain inside the control back buffer.
+/// </remarks>
+/// <example>
+/// <code>
+/// var ellipse = new Ellipse
+/// {
+///     Size = new Size(160, 90),
+///     Fill = new SolidColorBrush(Color.CornflowerBlue),
+///     Stroke = new SolidColorBrush(Color.Navy),
+///     StrokeThickness = 2
+/// };
+/// </code>
+/// </example>
+[DisplayName("Ellipse")]
+[Category("Shapes")]
+[Description("Draws a scalable ellipse using shared Brush fill and stroke values.")]
+public class Ellipse : Shape
+{
+    private readonly EllipseGeometry geometry = new();
+
+    /// <summary>Initializes an ellipse whose geometry follows its client size.</summary>
+    public Ellipse()
+    {
+        SetDefiningGeometry(geometry);
+        UpdateGeometry();
+    }
+
+    /// <summary>Returns the stroke-safe logical ellipse bounds for the current control size.</summary>
+    /// <param name="size">The current logical client size.</param>
+    /// <returns>The finite bounds used to define the ellipse.</returns>
+    protected virtual RectangleF GetEllipseBounds(Size size)
+    {
+        float inset = Math.Min(StrokeThickness / 2f, Math.Min(size.Width, size.Height) / 2f);
+        return new RectangleF(
+            inset,
+            inset,
+            Math.Max(0f, size.Width - (inset * 2f)),
+            Math.Max(0f, size.Height - (inset * 2f)));
+    }
+
+    /// <inheritdoc/>
+    protected override void OnStrokeThicknessChanged(EventArgs e)
+    {
+        UpdateGeometry();
+        base.OnStrokeThicknessChanged(e);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnSizeChanged(EventArgs e)
+    {
+        UpdateGeometry();
+        base.OnSizeChanged(e);
+    }
+
+    private void UpdateGeometry()
+        => geometry.Rect = GetEllipseBounds(ClientSize);
+}

--- a/ModernFormsNext/FileDialog.cs
+++ b/ModernFormsNext/FileDialog.cs
@@ -30,12 +30,12 @@ namespace ModernFormsNext
         /// Gets or sets the selected files. If there are multiple files selected, the first one is returned.
         /// </summary>
         public string? FileName {
-            get => FileNames.Count > 0 ? Path.GetFullPath (FileNames[0]) : null;
+            get => FileNames.Count > 0 ? System.IO.Path.GetFullPath (FileNames[0]) : null;
             set {
                 FileNames.Clear ();
 
                 if (value != null)
-                    FileNames.Add (Path.GetFullPath (value));
+                    FileNames.Add (System.IO.Path.GetFullPath (value));
             }
         }
 

--- a/ModernFormsNext/Help/Help.cs
+++ b/ModernFormsNext/Help/Help.cs
@@ -146,7 +146,7 @@ public static class Help
 
         try
         {
-            string candidate = Path.GetFullPath(partialUri, AppContext.BaseDirectory);
+            string candidate = System.IO.Path.GetFullPath(partialUri, AppContext.BaseDirectory);
             if (File.Exists(candidate) || Directory.Exists(candidate))
                 return new Uri(candidate);
         }

--- a/ModernFormsNext/Line.cs
+++ b/ModernFormsNext/Line.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel;
+using System.Drawing;
+using ModernFormsNext.Drawing;
+using MfnBrush = ModernFormsNext.Drawing.Brush;
+
+namespace ModernFormsNext;
+
+/// <summary>Displays a stroked line between two points in local logical coordinates.</summary>
+[DisplayName("Line")]
+[Category("Shapes")]
+[Description("Draws a straight vector line between two local points.")]
+public sealed class Line : Shape
+{
+    private readonly LineGeometry geometry = new();
+
+    /// <summary>Initializes a centered horizontal line from (8,20) to (112,20).</summary>
+    public Line()
+    {
+        geometry.StartPoint = new PointF(8f, 20f);
+        geometry.EndPoint = new PointF(112f, 20f);
+        SetDefiningGeometry(geometry);
+    }
+
+    /// <summary>Gets or sets the starting point in local logical pixels.</summary>
+    [Category("Geometry")]
+    [Description("The starting point in local logical pixels.")]
+    public PointF StartPoint
+    {
+        get => geometry.StartPoint;
+        set => geometry.StartPoint = value;
+    }
+
+    /// <summary>Gets or sets the ending point in local logical pixels.</summary>
+    [Category("Geometry")]
+    [Description("The ending point in local logical pixels.")]
+    public PointF EndPoint
+    {
+        get => geometry.EndPoint;
+        set => geometry.EndPoint = value;
+    }
+
+    /// <summary>Gets no fill because an open line has no fill semantics.</summary>
+    /// <remarks>Assignments are ignored; use <see cref="Shape.Stroke"/> to render a line.</remarks>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override MfnBrush? Fill
+    {
+        get => null;
+        set { }
+    }
+
+    /// <summary>Gets the default line control size.</summary>
+    protected override Size DefaultSize => new(120, 40);
+}

--- a/ModernFormsNext/MarkdownImageAssetProcessor.cs
+++ b/ModernFormsNext/MarkdownImageAssetProcessor.cs
@@ -50,13 +50,13 @@ public static class MarkdownImageAssetProcessor
                 return Failed("The destination directory must be configured by the host.");
             if (string.IsNullOrWhiteSpace(options.MarkdownBaseDirectory))
                 return Failed("The Markdown base directory must be configured by the host.");
-            if (!Path.IsPathFullyQualified(options.DestinationDirectory)
-                || !Path.IsPathFullyQualified(options.MarkdownBaseDirectory))
+            if (!System.IO.Path.IsPathFullyQualified(options.DestinationDirectory)
+                || !System.IO.Path.IsPathFullyQualified(options.MarkdownBaseDirectory))
             {
                 return Failed("Asset destination and Markdown base directories must be fully qualified.");
             }
 
-            var fullSourcePath = Path.GetFullPath(sourcePath);
+            var fullSourcePath = System.IO.Path.GetFullPath(sourcePath);
             var sourceInfo = new FileInfo(fullSourcePath);
             if (!sourceInfo.Exists)
                 return Failed("The selected image file does not exist.");
@@ -72,15 +72,15 @@ public static class MarkdownImageAssetProcessor
                 return Failed("The image content does not match its file extension.");
             }
 
-            var destinationDirectory = Path.GetFullPath(options.DestinationDirectory);
-            var markdownBaseDirectory = Path.GetFullPath(options.MarkdownBaseDirectory);
+            var destinationDirectory = System.IO.Path.GetFullPath(options.DestinationDirectory);
+            var markdownBaseDirectory = System.IO.Path.GetFullPath(options.MarkdownBaseDirectory);
             Directory.CreateDirectory(destinationDirectory);
 
             var preferredName = string.IsNullOrWhiteSpace(options.PreferredFileName)
                 ? sourceInfo.Name
                 : options.PreferredFileName;
             var sanitizedName = SanitizeFileName(preferredName!, extension);
-            var destinationPath = Path.Combine(destinationDirectory, sanitizedName);
+            var destinationPath = System.IO.Path.Combine(destinationDirectory, sanitizedName);
 
             if (File.Exists(destinationPath))
             {
@@ -105,7 +105,7 @@ public static class MarkdownImageAssetProcessor
             if (pathValidation is not null)
                 return pathValidation;
 
-            temporaryPath = Path.Combine(destinationDirectory, $".mfn-{Guid.NewGuid():N}.tmp");
+            temporaryPath = System.IO.Path.Combine(destinationDirectory, $".mfn-{Guid.NewGuid():N}.tmp");
             await CopyLimitedAsync(fullSourcePath, temporaryPath, options.MaxFileBytes, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -218,12 +218,12 @@ public static class MarkdownImageAssetProcessor
 
     private static string GetUniquePath(string path)
     {
-        var directory = Path.GetDirectoryName(path) ?? string.Empty;
-        var name = Path.GetFileNameWithoutExtension(path);
-        var extension = Path.GetExtension(path);
+        var directory = System.IO.Path.GetDirectoryName(path) ?? string.Empty;
+        var name = System.IO.Path.GetFileNameWithoutExtension(path);
+        var extension = System.IO.Path.GetExtension(path);
         for (var suffix = 2; suffix < int.MaxValue; suffix++)
         {
-            var candidate = Path.Combine(directory, $"{name}-{suffix}{extension}");
+            var candidate = System.IO.Path.Combine(directory, $"{name}-{suffix}{extension}");
             if (!File.Exists(candidate))
                 return candidate;
         }
@@ -266,11 +266,11 @@ public static class MarkdownImageAssetProcessor
 
     private static string SanitizeFileName(string preferredName, string sourceExtension)
     {
-        var baseName = Path.GetFileNameWithoutExtension(preferredName).Trim().TrimEnd('.');
+        var baseName = System.IO.Path.GetFileNameWithoutExtension(preferredName).Trim().TrimEnd('.');
         if (baseName.Length == 0)
             baseName = "image";
 
-        var invalid = Path.GetInvalidFileNameChars();
+        var invalid = System.IO.Path.GetInvalidFileNameChars();
         var portableInvalid = "<>:\"/\\|?*";
         var sanitized = new string(baseName
             .Select(character => invalid.Contains(character) || portableInvalid.Contains(character) ? '_' : character)
@@ -294,8 +294,8 @@ public static class MarkdownImageAssetProcessor
         MarkdownImageAssetOptions options,
         out string markdownSource)
     {
-        markdownSource = Path.GetRelativePath(markdownBaseDirectory, destinationPath);
-        if (Path.IsPathFullyQualified(markdownSource) && !options.AllowAbsoluteMarkdownSource)
+        markdownSource = System.IO.Path.GetRelativePath(markdownBaseDirectory, destinationPath);
+        if (System.IO.Path.IsPathFullyQualified(markdownSource) && !options.AllowAbsoluteMarkdownSource)
             return Failed("A relative Markdown path cannot be formed for the selected destination.");
 
         markdownSource = markdownSource.Replace('\\', '/');

--- a/ModernFormsNext/Path.cs
+++ b/ModernFormsNext/Path.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using ModernFormsNext.Drawing;
+
+namespace ModernFormsNext;
+
+/// <summary>Displays a reusable platform-neutral <see cref="Geometry"/>.</summary>
+/// <remarks>
+/// The same Geometry may be assigned to multiple Path controls. Every control observes changes
+/// through a weak subscription, invalidates independently, and owns its own disposable native-path
+/// cache. Assign null to render and hit-test nothing.
+/// </remarks>
+/// <example>
+/// <code>
+/// var geometry = new PathGeometry();
+/// var figure = new PathFigure(new PointF(10, 90), isClosed: true);
+/// figure.Segments.Add(new LineSegment(new PointF(50, 10)));
+/// figure.Segments.Add(new LineSegment(new PointF(90, 90)));
+/// geometry.Figures.Add(figure);
+///
+/// var path = new ModernFormsNext.Path
+/// {
+///     Data = geometry,
+///     Fill = new SolidColorBrush(Color.Gold)
+/// };
+/// </code>
+/// </example>
+[DisplayName("Path")]
+[Category("Shapes")]
+[Description("Draws reusable platform-neutral vector Geometry.")]
+public sealed class Path : Shape
+{
+    /// <summary>Initializes an empty Path.</summary>
+    public Path()
+    {
+    }
+
+    /// <summary>Gets or sets the reusable geometry rendered by this control.</summary>
+    [Category("Geometry")]
+    [Description("The reusable platform-neutral Geometry rendered by this Path.")]
+    [DefaultValue(null)]
+    public Geometry? Data
+    {
+        get => DefiningGeometry;
+        set => SetDefiningGeometry(value);
+    }
+}

--- a/ModernFormsNext/Polygon.cs
+++ b/ModernFormsNext/Polygon.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using System.Drawing;
+using ModernFormsNext.Drawing;
+
+namespace ModernFormsNext;
+
+/// <summary>Displays an automatically closed polygon from an observable point collection.</summary>
+[DisplayName("Polygon")]
+[Category("Shapes")]
+[Description("Draws a closed polygon whose point collection can change at runtime.")]
+public sealed class Polygon : Shape
+{
+    private readonly PathGeometry geometry = new();
+    private PointCollection points = new();
+
+    /// <summary>Initializes an empty polygon.</summary>
+    public Polygon()
+    {
+        points.Changed += HandlePointsChanged;
+        SetDefiningGeometry(geometry);
+    }
+
+    /// <summary>Gets or sets the observable ordered polygon points in local logical pixels.</summary>
+    /// <remarks>
+    /// Replacing or mutating the collection rebuilds and invalidates the cached path. Three or more
+    /// points normally produce a filled area; fewer points remain deterministic and do not throw.
+    /// </remarks>
+    [Category("Geometry")]
+    [Description("The ordered local points; the final point is automatically connected to the first.")]
+    public PointCollection Points
+    {
+        get => points;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            if (ReferenceEquals(points, value))
+                return;
+
+            points.Changed -= HandlePointsChanged;
+            points = value;
+            points.Changed += HandlePointsChanged;
+            RebuildGeometry();
+        }
+    }
+
+    /// <summary>Gets or sets how overlapping polygon regions contribute to the fill.</summary>
+    /// <value><see cref="GeometryFillRule.Winding"/> by default.</value>
+    /// <remarks>
+    /// The rule affects both fill rendering and geometry-aware fill hit testing. It does not
+    /// change the explicitly closed stroke contour.
+    /// </remarks>
+    [Category("Geometry")]
+    [Description("How overlapping polygon regions contribute to the fill and fill hit testing.")]
+    [DefaultValue(GeometryFillRule.Winding)]
+    public GeometryFillRule FillRule
+    {
+        get => geometry.FillRule;
+        set => geometry.FillRule = value;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        points.Changed -= HandlePointsChanged;
+        base.Dispose(disposing);
+    }
+
+    private void HandlePointsChanged(object? sender, EventArgs e) => RebuildGeometry();
+
+    private void RebuildGeometry()
+    {
+        geometry.Figures.Clear();
+        if (points.Count == 0)
+            return;
+
+        var figure = new PathFigure(points[0], isClosed: true);
+        for (int index = 1; index < points.Count; index++)
+            figure.Segments.Add(new LineSegment(points[index]));
+        geometry.Figures.Add(figure);
+    }
+}

--- a/ModernFormsNext/Polyline.cs
+++ b/ModernFormsNext/Polyline.cs
@@ -1,0 +1,78 @@
+using System.ComponentModel;
+using System.Drawing;
+using ModernFormsNext.Drawing;
+using MfnBrush = ModernFormsNext.Drawing.Brush;
+
+namespace ModernFormsNext;
+
+/// <summary>Displays an open polyline from an observable point collection.</summary>
+/// <remarks>
+/// The contour remains open and has stroke-only semantics. Assignments to
+/// <see cref="Shape.Fill"/> are ignored so an open polyline never acquires a filled hit-test area
+/// through the renderer's implicit fill closure.
+/// </remarks>
+[DisplayName("Polyline")]
+[Category("Shapes")]
+[Description("Draws an open vector polyline whose point collection can change at runtime.")]
+public sealed class Polyline : Shape
+{
+    private readonly PathGeometry geometry = new();
+    private PointCollection points = new();
+
+    /// <summary>Initializes an empty polyline.</summary>
+    public Polyline()
+    {
+        points.Changed += HandlePointsChanged;
+        SetDefiningGeometry(geometry);
+    }
+
+    /// <summary>Gets no fill because a polyline has open, stroke-only semantics.</summary>
+    /// <remarks>Assignments are ignored; use <see cref="Shape.Stroke"/> to render a polyline.</remarks>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override MfnBrush? Fill
+    {
+        get => null;
+        set { }
+    }
+
+    /// <summary>Gets or sets the observable ordered polyline points in local logical pixels.</summary>
+    [Category("Geometry")]
+    [Description("The ordered local points; the contour is not closed for stroking.")]
+    public PointCollection Points
+    {
+        get => points;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            if (ReferenceEquals(points, value))
+                return;
+
+            points.Changed -= HandlePointsChanged;
+            points = value;
+            points.Changed += HandlePointsChanged;
+            RebuildGeometry();
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        points.Changed -= HandlePointsChanged;
+        base.Dispose(disposing);
+    }
+
+    private void HandlePointsChanged(object? sender, EventArgs e) => RebuildGeometry();
+
+    private void RebuildGeometry()
+    {
+        geometry.Figures.Clear();
+        if (points.Count == 0)
+            return;
+
+        var figure = new PathFigure(points[0]);
+        for (int index = 1; index < points.Count; index++)
+            figure.Segments.Add(new LineSegment(points[index]));
+        geometry.Figures.Add(figure);
+    }
+}

--- a/ModernFormsNext/Rendering/Skia/SkiaBrushPaintFactory.cs
+++ b/ModernFormsNext/Rendering/Skia/SkiaBrushPaintFactory.cs
@@ -1,0 +1,100 @@
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Rendering.Skia;
+
+/// <summary>Creates short-lived Skia paints from shared framework brushes.</summary>
+internal static class SkiaBrushPaintFactory
+{
+    public static SkiaBrushPaint? Create(Brush? brush, SKRect bounds, SKPaintStyle style)
+    {
+        if (!CanRender(brush))
+            return null;
+
+        var paint = new SKPaint
+        {
+            IsAntialias = true,
+            Style = style
+        };
+
+        switch (brush)
+        {
+            case SolidColorBrush solid:
+                paint.Color = SkiaBrushFactory.ApplyOpacity(solid.Color, solid.Opacity);
+                return new SkiaBrushPaint(paint, null);
+
+            case GradientBrush gradient:
+                GradientStop[] stops = gradient.GetOrderedStops();
+                if (stops.Length == 1 || gradient is RadialGradientBrush { Radius: 0f })
+                {
+                    paint.Color = SkiaBrushFactory.ApplyOpacity(stops[^1].Color, gradient.Opacity);
+                    return new SkiaBrushPaint(paint, null);
+                }
+
+                SKShader? shader = SkiaBrushFactory.CreateGradientShader(gradient, EnsureUsableBounds(bounds));
+                if (shader is null)
+                {
+                    paint.Dispose();
+                    return null;
+                }
+
+                paint.Shader = shader;
+                return new SkiaBrushPaint(paint, shader);
+
+            case GlassBrush glass:
+                // A glass surface has multiple fill layers, but a stroke has only one path. Use
+                // the brush's public border color as its deterministic stroke representation.
+                paint.Color = SkiaBrushFactory.ApplyOpacity(glass.BorderColor, glass.Opacity);
+                return new SkiaBrushPaint(paint, null);
+
+            default:
+                paint.Dispose();
+                return null;
+        }
+    }
+
+    public static bool CanRender(Brush? brush)
+        => brush is not null and not NoBrush && brush.Opacity > 0f && brush switch
+        {
+            SolidColorBrush => true,
+            GradientBrush gradient => gradient.GetOrderedStops().Length > 0,
+            GlassBrush => true,
+            _ => false
+        };
+
+    private static SKRect EnsureUsableBounds(SKRect bounds)
+    {
+        const float halfMinimum = 0.5f;
+        if (bounds.Width <= 0f)
+        {
+            bounds.Left -= halfMinimum;
+            bounds.Right += halfMinimum;
+        }
+        if (bounds.Height <= 0f)
+        {
+            bounds.Top -= halfMinimum;
+            bounds.Bottom += halfMinimum;
+        }
+        return bounds;
+    }
+}
+
+/// <summary>Owns a Skia paint and its optional shader for one draw operation.</summary>
+internal sealed class SkiaBrushPaint : IDisposable
+{
+    private readonly SKShader? shader;
+
+    public SkiaBrushPaint(SKPaint paint, SKShader? shader)
+    {
+        Paint = paint;
+        this.shader = shader;
+    }
+
+    public SKPaint Paint { get; }
+
+    public void Dispose()
+    {
+        Paint.Dispose();
+        shader?.Dispose();
+    }
+}

--- a/ModernFormsNext/Rendering/Skia/SkiaGeometryConverter.cs
+++ b/ModernFormsNext/Rendering/Skia/SkiaGeometryConverter.cs
@@ -1,0 +1,103 @@
+using System.Drawing;
+using System.Numerics;
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Rendering.Skia;
+
+/// <summary>Converts platform-neutral geometry to an owned Skia path.</summary>
+internal static class SkiaGeometryConverter
+{
+    public static SKPath CreatePath(Geometry geometry, SizeF scale)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+        if (!float.IsFinite(scale.Width) || !float.IsFinite(scale.Height) ||
+            scale.Width <= 0f || scale.Height <= 0f)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scale), scale, "Geometry scale must be finite and positive.");
+        }
+
+        var path = new SKPath();
+        switch (geometry)
+        {
+            case LineGeometry line:
+                path.MoveTo(line.StartPoint.X, line.StartPoint.Y);
+                path.LineTo(line.EndPoint.X, line.EndPoint.Y);
+                break;
+
+            case RectangleGeometry rectangle when rectangle.Rect.Width > 0f && rectangle.Rect.Height > 0f:
+                path.AddRect(ToSkiaRect(rectangle.Rect));
+                break;
+
+            case EllipseGeometry ellipse when ellipse.Rect.Width > 0f && ellipse.Rect.Height > 0f:
+                path.AddOval(ToSkiaRect(ellipse.Rect));
+                break;
+
+            case PathGeometry pathGeometry:
+                AppendPathGeometry(path, pathGeometry);
+                break;
+        }
+
+        if (!geometry.Transform.IsIdentity)
+            path.Transform(ToSkiaMatrix(geometry.Transform));
+        if (scale.Width != 1f || scale.Height != 1f)
+            path.Transform(new SKMatrix(scale.Width, 0f, 0f, 0f, scale.Height, 0f, 0f, 0f, 1f));
+
+        return path;
+    }
+
+    internal static SKMatrix ToSkiaMatrix(Matrix3x2 transform)
+        => new(
+            transform.M11,
+            transform.M21,
+            transform.M31,
+            transform.M12,
+            transform.M22,
+            transform.M32,
+            0f,
+            0f,
+            1f);
+
+    private static SKRect ToSkiaRect(RectangleF rectangle)
+        => new(rectangle.Left, rectangle.Top, rectangle.Right, rectangle.Bottom);
+
+    private static void AppendPathGeometry(SKPath path, PathGeometry geometry)
+    {
+        path.FillType = geometry.FillRule == GeometryFillRule.EvenOdd
+            ? SKPathFillType.EvenOdd
+            : SKPathFillType.Winding;
+
+        foreach (PathFigure figure in geometry.Figures)
+        {
+            path.MoveTo(figure.StartPoint.X, figure.StartPoint.Y);
+            foreach (PathSegment segment in figure.Segments)
+            {
+                switch (segment)
+                {
+                    case LineSegment line:
+                        path.LineTo(line.Point.X, line.Point.Y);
+                        break;
+                    case QuadraticBezierSegment quadratic:
+                        path.QuadTo(
+                            quadratic.ControlPoint.X,
+                            quadratic.ControlPoint.Y,
+                            quadratic.Point.X,
+                            quadratic.Point.Y);
+                        break;
+                    case BezierSegment cubic:
+                        path.CubicTo(
+                            cubic.ControlPoint1.X,
+                            cubic.ControlPoint1.Y,
+                            cubic.ControlPoint2.X,
+                            cubic.ControlPoint2.Y,
+                            cubic.Point.X,
+                            cubic.Point.Y);
+                        break;
+                }
+            }
+
+            if (figure.IsClosed)
+                path.Close();
+        }
+    }
+}

--- a/ModernFormsNext/Rendering/Skia/SkiaShapeRenderer.cs
+++ b/ModernFormsNext/Rendering/Skia/SkiaShapeRenderer.cs
@@ -1,0 +1,82 @@
+using ModernFormsNext.Drawing;
+using SkiaSharp;
+
+namespace ModernFormsNext.Rendering.Skia;
+
+/// <summary>Renders every built-in Shape through one fill-and-stroke pipeline.</summary>
+internal static class SkiaShapeRenderer
+{
+    public static void Render(
+        SKCanvas canvas,
+        SKPath path,
+        SKRect paintBounds,
+        Brush? fill,
+        Brush? stroke,
+        float strokeThickness,
+        StrokeLineCap lineCap,
+        StrokeLineJoin lineJoin,
+        float miterLimit)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (SkiaBrushPaintFactory.CanRender(fill))
+        {
+            if (fill is GlassBrush)
+            {
+                canvas.Save();
+                canvas.ClipPath(path, SKClipOperation.Intersect, antialias: true);
+                SkiaExtensions.RenderBrushBackground(canvas, paintBounds, fill, SKColors.Transparent);
+                canvas.Restore();
+            }
+            else
+            {
+                using SkiaBrushPaint? fillPaint = SkiaBrushPaintFactory.Create(fill, paintBounds, SKPaintStyle.Fill);
+                if (fillPaint is not null)
+                    canvas.DrawPath(path, fillPaint.Paint);
+            }
+        }
+
+        if (strokeThickness <= 0f || !SkiaBrushPaintFactory.CanRender(stroke))
+            return;
+
+        using SkiaBrushPaint? strokePaint = SkiaBrushPaintFactory.Create(stroke, paintBounds, SKPaintStyle.Stroke);
+        if (strokePaint is null)
+            return;
+
+        ConfigureStroke(strokePaint.Paint, strokeThickness, lineCap, lineJoin, miterLimit);
+        canvas.DrawPath(path, strokePaint.Paint);
+    }
+
+    public static void ConfigureStroke(
+        SKPaint paint,
+        float strokeThickness,
+        StrokeLineCap lineCap,
+        StrokeLineJoin lineJoin,
+        float miterLimit)
+    {
+        paint.Style = SKPaintStyle.Stroke;
+        paint.StrokeWidth = strokeThickness;
+        paint.StrokeCap = MapLineCap(lineCap);
+        paint.StrokeJoin = MapLineJoin(lineJoin);
+        paint.StrokeMiter = miterLimit;
+    }
+
+    public static SKStrokeCap MapLineCap(StrokeLineCap lineCap)
+        => lineCap switch
+        {
+            StrokeLineCap.Flat => SKStrokeCap.Butt,
+            StrokeLineCap.Round => SKStrokeCap.Round,
+            StrokeLineCap.Square => SKStrokeCap.Square,
+            _ => throw new ArgumentOutOfRangeException(nameof(lineCap), lineCap, "The stroke line cap is not defined.")
+        };
+
+    public static SKStrokeJoin MapLineJoin(StrokeLineJoin lineJoin)
+        => lineJoin switch
+        {
+            StrokeLineJoin.Miter => SKStrokeJoin.Miter,
+            StrokeLineJoin.Round => SKStrokeJoin.Round,
+            StrokeLineJoin.Bevel => SKStrokeJoin.Bevel,
+            _ => throw new ArgumentOutOfRangeException(nameof(lineJoin), lineJoin, "The stroke line join is not defined.")
+        };
+}

--- a/ModernFormsNext/Shape.cs
+++ b/ModernFormsNext/Shape.cs
@@ -1,0 +1,365 @@
+using System.ComponentModel;
+using System.Drawing;
+using ModernFormsNext.Drawing;
+using ModernFormsNext.Rendering.Skia;
+using SkiaSharp;
+using MfnBrush = ModernFormsNext.Drawing.Brush;
+
+namespace ModernFormsNext;
+
+/// <summary>
+/// Provides the common control, rendering, stroke, cache, and hit-testing behavior for vector shapes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A Shape participates in normal ModernFormsNext layout, docking, anchoring, visibility,
+/// presentation transforms, parent clipping, and designer selection. Its pixels are produced by
+/// the shared Skia surface on Windows and Android; public geometry remains platform-neutral.
+/// </para>
+/// <para>
+/// <see cref="Fill"/> and <see cref="Stroke"/> use the existing shareable Brush subsystem. A null
+/// brush or <see cref="NoBrush"/> skips that paint operation. Property changes invalidate rendering
+/// but do not request layout.
+/// </para>
+/// </remarks>
+public abstract class Shape : Control
+{
+    private const float StrokeHitTolerance = 2f;
+    private MfnBrush? fill;
+    private MfnBrush? stroke;
+    private float strokeThickness = 1f;
+    private StrokeLineCap strokeLineCap;
+    private StrokeLineJoin strokeLineJoin;
+    private float miterLimit = 4f;
+    private Geometry? definingGeometry;
+    private WeakGeometryInvalidationSubscription? geometrySubscription;
+    private Geometry? cachedGeometry;
+    private int cachedGeometryVersion;
+    private float cachedScaleX;
+    private float cachedScaleY;
+    private SKPath? cachedPath;
+    private SKPath? cachedStrokeHitPath;
+    private float cachedHitStrokeWidth;
+    private StrokeLineCap cachedHitLineCap;
+    private StrokeLineJoin cachedHitLineJoin;
+    private float cachedHitMiterLimit;
+
+    /// <summary>Initializes a transparent vector control with a 100 by 100 logical-pixel default size.</summary>
+    protected Shape()
+    {
+        SetControlBehavior(ControlBehaviors.Transparent);
+    }
+
+    /// <summary>Gets or sets inherited text that is not rendered by vector shapes.</summary>
+    /// <remarks>
+    /// The member remains available for source compatibility with <see cref="Control"/>, but it is
+    /// hidden from designers because Shape rendering is defined only by geometry and brushes.
+    /// </remarks>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override string Text
+    {
+        get => base.Text;
+        set => base.Text = value;
+    }
+
+    /// <summary>Gets or sets the brush used to fill the defining geometry.</summary>
+    /// <value>A shared brush, or <see langword="null"/> to skip filling. The default is null.</value>
+    [Category("Appearance")]
+    [Description("The shared brush used to fill the vector geometry; null performs no fill.")]
+    [DefaultValue(null)]
+    public virtual MfnBrush? Fill
+    {
+        get => fill;
+        set => SetBrushField(ref fill, value);
+    }
+
+    /// <summary>Gets or sets the brush used to stroke the defining geometry.</summary>
+    /// <value>A shared brush, or <see langword="null"/> to skip stroking. The default is null.</value>
+    [Category("Appearance")]
+    [Description("The shared brush used to stroke the vector geometry; null performs no stroke.")]
+    [DefaultValue(null)]
+    public MfnBrush? Stroke
+    {
+        get => stroke;
+        set => SetBrushField(ref stroke, value);
+    }
+
+    /// <summary>Gets or sets the stroke thickness in logical pixels.</summary>
+    /// <value>A finite non-negative value. The default is 1.</value>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown for a negative, NaN, or infinite value.</exception>
+    [Category("Appearance")]
+    [Description("The stroke thickness in logical pixels.")]
+    [DefaultValue(1f)]
+    public float StrokeThickness
+    {
+        get => strokeThickness;
+        set
+        {
+            if (!float.IsFinite(value) || value < 0f)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Stroke thickness must be finite and non-negative.");
+            if (strokeThickness.Equals(value))
+                return;
+
+            strokeThickness = value;
+            OnStrokeThicknessChanged(EventArgs.Empty);
+        }
+    }
+
+    /// <summary>Gets or sets how open stroke endpoints are drawn.</summary>
+    [Category("Appearance")]
+    [Description("How open stroke endpoints are drawn.")]
+    [DefaultValue(StrokeLineCap.Flat)]
+    public StrokeLineCap StrokeLineCap
+    {
+        get => strokeLineCap;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The stroke line cap is not defined.");
+            if (strokeLineCap == value)
+                return;
+
+            strokeLineCap = value;
+            InvalidateStrokeCache();
+        }
+    }
+
+    /// <summary>Gets or sets how consecutive stroke segments are joined.</summary>
+    [Category("Appearance")]
+    [Description("How consecutive stroke segments are joined.")]
+    [DefaultValue(StrokeLineJoin.Miter)]
+    public StrokeLineJoin StrokeLineJoin
+    {
+        get => strokeLineJoin;
+        set
+        {
+            if (!Enum.IsDefined(value))
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The stroke line join is not defined.");
+            if (strokeLineJoin == value)
+                return;
+
+            strokeLineJoin = value;
+            InvalidateStrokeCache();
+        }
+    }
+
+    /// <summary>Gets or sets the maximum miter length as a multiple of stroke thickness.</summary>
+    /// <value>A finite value greater than or equal to 1. The default is 4.</value>
+    [Category("Appearance")]
+    [Description("The maximum miter length as a multiple of stroke thickness.")]
+    [DefaultValue(4f)]
+    public float MiterLimit
+    {
+        get => miterLimit;
+        set
+        {
+            if (!float.IsFinite(value) || value < 1f)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Miter limit must be finite and at least 1.");
+            if (miterLimit.Equals(value))
+                return;
+
+            miterLimit = value;
+            InvalidateStrokeCache();
+        }
+    }
+
+    /// <summary>Responds when <see cref="StrokeThickness"/> changes.</summary>
+    /// <param name="e">The event data.</param>
+    /// <remarks>
+    /// The default implementation invalidates rendering and the cached stroke hit path. Derived
+    /// controls whose defining geometry depends on stroke thickness may rebuild that geometry
+    /// before calling the base implementation.
+    /// </remarks>
+    protected virtual void OnStrokeThicknessChanged(EventArgs e)
+        => InvalidateStrokeCache();
+
+    /// <summary>Gets the geometry currently rendered by this shape.</summary>
+    protected Geometry? DefiningGeometry => definingGeometry;
+
+    /// <summary>Gets the default shape size in logical pixels.</summary>
+    protected override Size DefaultSize => new(100, 100);
+
+    /// <summary>
+    /// Replaces the defining geometry and wires shared invalidation without retaining this control.
+    /// </summary>
+    /// <param name="geometry">The new geometry, or null for an empty shape.</param>
+    protected void SetDefiningGeometry(Geometry? geometry)
+    {
+        if (ReferenceEquals(definingGeometry, geometry))
+            return;
+
+        geometrySubscription?.Dispose();
+        geometrySubscription = null;
+        definingGeometry = geometry;
+        if (geometry is not null)
+            geometrySubscription = new WeakGeometryInvalidationSubscription(this, geometry);
+        InvalidateGeometryCache();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        SKPath? path = GetCachedPath();
+        if (path is not null && !path.IsEmpty)
+        {
+            SKRect paintBounds = path.Bounds;
+            float scaledStrokeThickness = StrokeThickness * ScaleFactor.Width;
+            SkiaShapeRenderer.Render(
+                e.Canvas,
+                path,
+                paintBounds,
+                Fill,
+                Stroke,
+                scaledStrokeThickness,
+                StrokeLineCap,
+                StrokeLineJoin,
+                MiterLimit);
+        }
+
+        base.OnPaint(e);
+    }
+
+    internal override bool HitTestClient(PointF clientPoint)
+    {
+        if (!base.HitTestClient(clientPoint))
+            return false;
+
+        SKPath? path = GetCachedPath();
+        if (path is null || path.IsEmpty)
+            return false;
+
+        if (SkiaBrushPaintFactory.CanRender(Fill) && path.Contains(clientPoint.X, clientPoint.Y))
+            return true;
+
+        if (!SkiaBrushPaintFactory.CanRender(Stroke) || StrokeThickness <= 0f)
+            return false;
+
+        SKPath? strokePath = GetStrokeHitPath();
+        return strokePath is not null && strokePath.Contains(clientPoint.X, clientPoint.Y);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        geometrySubscription?.Dispose();
+        geometrySubscription = null;
+        DisposeNativeCaches();
+        base.Dispose(disposing);
+    }
+
+    private SKPath? GetCachedPath()
+    {
+        Geometry? geometry = definingGeometry;
+        if (geometry is null || ScaledWidth <= 0 || ScaledHeight <= 0)
+            return null;
+
+        SizeF scale = ScaleFactor;
+        if (cachedPath is not null && ReferenceEquals(cachedGeometry, geometry) &&
+            cachedGeometryVersion == geometry.Version && cachedScaleX == scale.Width && cachedScaleY == scale.Height)
+        {
+            return cachedPath;
+        }
+
+        cachedPath?.Dispose();
+        cachedStrokeHitPath?.Dispose();
+        cachedStrokeHitPath = null;
+        cachedGeometry = geometry;
+        cachedGeometryVersion = geometry.Version;
+        cachedScaleX = scale.Width;
+        cachedScaleY = scale.Height;
+        cachedPath = SkiaGeometryConverter.CreatePath(geometry, scale);
+        return cachedPath;
+    }
+
+    private SKPath? GetStrokeHitPath()
+    {
+        SKPath? path = GetCachedPath();
+        if (path is null)
+            return null;
+
+        float scale = ScaleFactor.Width;
+        float hitStrokeWidth = (StrokeThickness + (StrokeHitTolerance * 2f)) * scale;
+        if (cachedStrokeHitPath is not null && cachedHitStrokeWidth == hitStrokeWidth &&
+            cachedHitLineCap == StrokeLineCap && cachedHitLineJoin == StrokeLineJoin &&
+            cachedHitMiterLimit == MiterLimit)
+        {
+            return cachedStrokeHitPath;
+        }
+
+        cachedStrokeHitPath?.Dispose();
+        cachedStrokeHitPath = new SKPath();
+        using var paint = new SKPaint { IsAntialias = true };
+        SkiaShapeRenderer.ConfigureStroke(
+            paint,
+            hitStrokeWidth,
+            StrokeLineCap,
+            StrokeLineJoin,
+            MiterLimit);
+        paint.GetFillPath(path, cachedStrokeHitPath);
+        cachedHitStrokeWidth = hitStrokeWidth;
+        cachedHitLineCap = StrokeLineCap;
+        cachedHitLineJoin = StrokeLineJoin;
+        cachedHitMiterLimit = MiterLimit;
+        return cachedStrokeHitPath;
+    }
+
+    private void HandleGeometryChanged()
+        => InvalidateGeometryCache();
+
+    private void InvalidateGeometryCache()
+    {
+        DisposeNativeCaches();
+        Invalidate();
+    }
+
+    private void InvalidateStrokeCache()
+    {
+        cachedStrokeHitPath?.Dispose();
+        cachedStrokeHitPath = null;
+        Invalidate();
+    }
+
+    private void DisposeNativeCaches()
+    {
+        cachedPath?.Dispose();
+        cachedPath = null;
+        cachedStrokeHitPath?.Dispose();
+        cachedStrokeHitPath = null;
+        cachedGeometry = null;
+    }
+
+    private sealed class WeakGeometryInvalidationSubscription : IDisposable
+    {
+        private readonly WeakReference<Shape> target;
+        private Geometry? source;
+
+        public WeakGeometryInvalidationSubscription(Shape target, Geometry source)
+        {
+            this.target = new WeakReference<Shape>(target);
+            this.source = source;
+            source.Changed += HandleChanged;
+        }
+
+        public void Dispose()
+        {
+            Geometry? current = source;
+            if (current is null)
+                return;
+
+            source = null;
+            current.Changed -= HandleChanged;
+        }
+
+        private void HandleChanged(object? sender, EventArgs e)
+        {
+            if (target.TryGetTarget(out Shape? shape))
+            {
+                shape.HandleGeometryChanged();
+                return;
+            }
+
+            Dispose();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ declared as a publishable NuGet package.
 - [Dynamic resources](docs/dynamic-resources.md)
 - [Themes](docs/themes.md) and [theme JSON schema](docs/theme-json-schema.md)
 - [Paint and gradients](docs/paint-and-gradients.md)
+- [Shapes and vector geometry](docs/shapes-and-vector-geometry.md)
 - [UI animations and interaction effects](docs/animations.md)
 - [Markdown viewing](docs/markdown.md) and [Markdown editing](docs/markdown-editor.md)
 - [Data binding](docs/data-binding.md)

--- a/docs/shapes-and-vector-geometry.md
+++ b/docs/shapes-and-vector-geometry.md
@@ -1,0 +1,146 @@
+# Shapes and vector geometry
+
+ModernFormsNext provides platform-neutral vector controls built on the same control, Brush, Skia
+surface, layout, invalidation, and presentation-transform systems as the rest of the framework.
+The public model never exposes `SKPath` or `SKPaint`.
+
+## Control hierarchy
+
+`Shape` is the common abstract `Control` base. Its concrete controls are `Ellipse`, `Circle`,
+`Line`, `Polygon`, `Polyline`, and `Path`. Ellipse fits its centered stroke inside its client bounds;
+Circle does the same while centering itself in the smaller client dimension; Line uses `StartPoint`
+and `EndPoint`; Polygon automatically closes
+its observable `Points`; Polyline remains open and stroke-only; and `Path.Data` renders reusable
+`Geometry`. `Polygon.FillRule` selects winding or even-odd behavior for overlapping and
+self-intersecting polygon regions.
+
+Shapes participate in normal Bounds, Margin, Padding, Anchor, Dock, minimum/maximum size,
+visibility, enabled state, parent clipping, accessibility bounds, and Designer selection. Vector
+properties invalidate rendering rather than layout. Resizing Ellipse or Circle updates its defining
+geometry automatically.
+
+## Fill and stroke
+
+`Fill` and `Stroke` accept the existing shareable `ModernFormsNext.Drawing.Brush` hierarchy:
+`SolidColorBrush`, `LinearGradientBrush`, `RadialGradientBrush`, `SweepGradientBrush`, and
+`GlassBrush`. A null brush or `NoBrush` skips that operation. `Line.Fill` is hidden because an open
+line has no fill semantics.
+
+`StrokeThickness` is measured in logical pixels. `StrokeLineCap` supports Flat, Round, and Square;
+`StrokeLineJoin` supports Miter, Round, and Bevel; and `MiterLimit` controls maximum miter length.
+Undefined enum values, negative or non-finite thicknesses, and non-finite points are rejected.
+All built-in shapes use the same anti-aliased Skia paint factory for both fill and stroke. Geometry
+coordinates remain floating-point through native path construction and are scaled only at the
+logical-to-device rendering boundary.
+
+```csharp
+var ellipse = new Ellipse
+{
+    Bounds = new Rectangle(24, 24, 180, 96),
+    Fill = new SolidColorBrush(Color.CornflowerBlue),
+    Stroke = new SolidColorBrush(Color.MidnightBlue),
+    StrokeThickness = 4
+};
+```
+
+## Geometry model and sharing
+
+`Geometry` is mutable and shareable. The focused initial model contains `LineGeometry`,
+`RectangleGeometry`, `EllipseGeometry`, and `PathGeometry`. A path owns observable `PathFigure`
+objects containing `LineSegment`, `QuadraticBezierSegment`, or `BezierSegment` values. A figure's
+`IsClosed` flag provides explicit closure, while `GeometryFillRule` selects winding or even-odd
+fill containment.
+
+Every rendered mutation increments `Geometry.Version` and raises `Geometry.Changed` synchronously.
+Each Path uses a weak subscription, so one geometry invalidates multiple consumers without a
+long-lived geometry retaining disposed controls. Geometry and collections should be mutated on the
+UI thread while in use.
+
+```csharp
+var geometry = new PathGeometry { FillRule = GeometryFillRule.EvenOdd };
+var figure = new PathFigure(new PointF(8, 88), isClosed: true);
+figure.Segments.Add(new QuadraticBezierSegment(new PointF(36, 4), new PointF(72, 34)));
+figure.Segments.Add(new BezierSegment(
+    new PointF(96, 4), new PointF(132, 22), new PointF(152, 88)));
+geometry.Figures.Add(figure);
+
+var path = new ModernFormsNext.Path
+{
+    Data = geometry,
+    Fill = new SolidColorBrush(Color.Gold),
+    Stroke = new SolidColorBrush(Color.DarkOrange),
+    StrokeThickness = 3
+};
+```
+
+Coordinates are local logical pixels. The first version intentionally has no WPF-style Stretch,
+arc segment, geometry group, SVG-string core model, or separate shape layout engine.
+
+`ModernFormsNext.Path` intentionally follows the conventional vector-control name. Code that also
+uses `System.IO.Path` should qualify the file-system type or introduce an alias:
+
+```csharp
+using IOPath = System.IO.Path;
+
+var assetPath = IOPath.Combine("Assets", "logo.png");
+var vectorPath = new ModernFormsNext.Path { Data = geometry };
+```
+
+## Transforms, clipping, and hit testing
+
+`Geometry.Transform` is a finite `Matrix3x2` applied before the owning control's normal translation,
+scale, rotation, and opacity presentation transform. Rendering and hit testing use the same native
+path and inverse presentation mapping, so a transformed shape does not retain its old hit region.
+
+Shape pixels render into the normal per-control back buffer and compose through the existing
+ancestor pipeline. This provides hard control and parent clipping without a second clip system.
+Ellipse and Circle automatically inset their contour by half `StrokeThickness`, retaining their
+complete centered stroke and anti-aliased fringe inside the back buffer. Explicit Line, Polygon,
+Polyline, and Path coordinates are not rewritten; portions intentionally placed outside the
+control's back-buffer bounds remain clipped. Geometry is not currently exposed as a generic Control
+clip source.
+
+`Geometry.Transform` is applied while the path is still vector data, before rasterization. A
+Control presentation transform operates later on the complete control backbuffer, consistently
+with every other control. Prefer `Geometry.Transform` when the vector itself should be rasterized
+at its final transformed coordinates; use Control transforms when the whole control, including its
+children and visual effects, should move as one presentation layer.
+
+Hit testing checks filled path containment when a visible Fill exists and the stroked path when a
+visible Stroke and positive thickness exist. Lines receive an additional two-logical-pixel pointer
+tolerance. Transparent corners of an ellipse do not target it. Designer selection stays bounds-based
+so move and resize handles remain reliable.
+
+## Rendering and cache lifetime
+
+All concrete controls build platform-neutral geometry; one converter creates an owned `SKPath` and
+one renderer applies Fill and Stroke. Each control caches the native path by geometry reference,
+geometry version, and density scale. Stroke hit paths have a separate cache keyed by stroke metrics.
+Mutating points, segments, transforms, or bounds disposes stale native caches. Temporary paints and
+shaders are disposed after each draw; cached paths are disposed on invalidation or control disposal.
+
+Windows and the experimental Android backend both use this Skia control surface. Android applies
+device density before the shared renderer, retaining logical-pixel geometry and stroke semantics.
+An Android build is not evidence of emulator/device visual or touch validation.
+
+## Designer support
+
+All concrete shapes appear in the **Shapes** Toolbox category and use runtime-safe preview rendering.
+The Property Grid exposes Appearance and Geometry values. `PointCollection` has an ordered dialog
+with Add, Remove, Up, Down, and separate X/Y fields. `PathGeometry` has a structured dialog for
+figures, `StartPoint`, segment type and coordinates, `IsClosed`, `FillRule`, and transform. The
+inline editor remains available for quick entry: points use `x,y; x,y; ...`, and geometry uses a
+compact command form:
+
+```text
+path evenodd M 8,88 Q 36,4 72,34 C 96,4 132,22 152,88 Z
+```
+
+`line`, `rectangle`, `ellipse`, and an optional
+`transform(m11,m12,m21,m22,m31,m32)` prefix are supported. The Designer does not include a graphical
+Bezier canvas. `.mfdesign` stores platform-neutral values; code generation emits the public API;
+and the reverse parser understands the generator's supported output. Numeric display, parsing, JSON,
+and generated C# use invariant decimal syntax independently of the current UI culture.
+
+Open **Shapes** in ControlGallery for solid and gradient fills, gradient and solid strokes, caps,
+joins, a reusable Bezier path, a vector transform, and stroke-safe control-bound smoke tests.

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -57,6 +57,7 @@ namespace ControlGallery
             tree.Items.Add ("Ribbon", ImageLoader.Get ("button.png"));
             tree.Items.Add ("RichTextBox", ImageLoader.Get ("button.png"));
             tree.Items.Add ("ScrollableControl", ImageLoader.Get ("button.png"));
+            tree.Items.Add ("Shapes", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("ScrollBar", ImageLoader.Get ("button.png"));
             tree.Items.Add ("SplitContainer", ImageLoader.Get ("button.png"));
             tree.Items.Add ("StatusBar", ImageLoader.Get ("button.png"));
@@ -180,6 +181,8 @@ namespace ControlGallery
                     return new RichTextBoxPanel();
                 case "ScrollableControl":
                     return new ScrollableControlPanel ();
+                case "Shapes":
+                    return new ShapesPanel ();
                 case "ScrollBar":
                     return new ScrollBarPanel ();
                 case "SplitContainer":

--- a/samples/ControlGallery/Panels/MarkdownEditorPanel.cs
+++ b/samples/ControlGallery/Panels/MarkdownEditorPanel.cs
@@ -259,7 +259,7 @@ public sealed class MarkdownEditorPanel : Panel
         {
             e.AssetOptions = new MarkdownImageAssetOptions
             {
-                DestinationDirectory = Path.Combine(AppContext.BaseDirectory, "MarkdownEditorAssets"),
+                DestinationDirectory = System.IO.Path.Combine(AppContext.BaseDirectory, "MarkdownEditorAssets"),
                 MarkdownBaseDirectory = AppContext.BaseDirectory,
                 CollisionBehavior = dialog.CollisionBehavior
             };

--- a/samples/ControlGallery/Panels/ShapesPanel.cs
+++ b/samples/ControlGallery/Panels/ShapesPanel.cs
@@ -1,0 +1,220 @@
+using System.Drawing;
+using System.Numerics;
+using ModernFormsNext;
+using ModernFormsNext.Drawing;
+
+namespace ControlGallery.Panels;
+
+/// <summary>
+/// Provides manual visual smoke tests for vector controls, reusable geometry, strokes, transforms,
+/// and stroke-safe control bounds.
+/// </summary>
+public sealed class ShapesPanel : BasePanel
+{
+    /// <summary>Initializes the vector geometry gallery.</summary>
+    public ShapesPanel()
+    {
+        AutoScroll = true;
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 18,
+            Width = 760,
+            Height = 30,
+            Text = "Shapes and vector geometry",
+            Font = new ModernFormsNext.Font("Segoe UI", 16)
+        });
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 52,
+            Width = 780,
+            Height = 42,
+            Multiline = true,
+            Text = "All samples use the shared Brush and Skia control pipeline. Transparent corners and thin strokes are intended for geometry-aware pointer-routing checks."
+        });
+
+        AddEllipseCard(24, 106);
+        AddCircleCard(280, 106);
+        AddLineCard(536, 106);
+        AddPolygonCard(24, 278);
+        AddPolylineCard(280, 278);
+        AddPathCard(536, 278);
+
+        Controls.Add(new Label
+        {
+            Left = 24,
+            Top = 458,
+            Width = 756,
+            Height = 72,
+            Multiline = true,
+            Text = "Manual checks: resize and dock the gallery, verify smooth solid/linear/radial/sweep fills, round caps and joins, the rotated Path, and complete anti-aliased strokes inside every card. On Android, also verify density-correct stroke widths and touch targeting."
+        });
+    }
+
+    private void AddEllipseCard(int left, int top)
+    {
+        Panel card = AddCard(left, top, "Ellipse / linear fill");
+        card.Controls.Add(new Ellipse
+        {
+            Left = 24,
+            Top = 14,
+            Width = 184,
+            Height = 94,
+            Fill = Linear(Color.CornflowerBlue, Color.MediumPurple),
+            Stroke = new SolidColorBrush(Color.MidnightBlue),
+            StrokeThickness = 4
+        });
+    }
+
+    private void AddCircleCard(int left, int top)
+    {
+        Panel card = AddCard(left, top, "Circle / radial fill");
+        var fill = new RadialGradientBrush
+        {
+            CenterPoint = new PointF(0.35f, 0.3f),
+            GradientOrigin = new PointF(0.2f, 0.2f),
+            Radius = 0.72f
+        };
+        fill.GradientStops.AddRange([
+            new GradientStop(Color.White, 0),
+            new GradientStop(Color.DeepSkyBlue, 0.45f),
+            new GradientStop(Color.MidnightBlue, 1)
+        ]);
+        card.Controls.Add(new Circle
+        {
+            Left = 64,
+            Top = 8,
+            Width = 104,
+            Height = 104,
+            Fill = fill,
+            Stroke = new SolidColorBrush(Color.Navy),
+            StrokeThickness = 3
+        });
+    }
+
+    private void AddLineCard(int left, int top)
+    {
+        Panel card = AddCard(left, top, "Line / caps + gradient stroke");
+        var stroke = Linear(Color.Crimson, Color.Gold);
+        card.Controls.Add(new Line
+        {
+            Left = 14,
+            Top = 16,
+            Width = 204,
+            Height = 40,
+            StartPoint = new PointF(10, 20),
+            EndPoint = new PointF(194, 20),
+            Stroke = stroke,
+            StrokeThickness = 12,
+            StrokeLineCap = StrokeLineCap.Round
+        });
+        card.Controls.Add(new Line
+        {
+            Left = 14,
+            Top = 65,
+            Width = 204,
+            Height = 40,
+            StartPoint = new PointF(10, 20),
+            EndPoint = new PointF(194, 20),
+            Stroke = new SolidColorBrush(Color.RoyalBlue),
+            StrokeThickness = 8,
+            StrokeLineCap = StrokeLineCap.Square
+        });
+    }
+
+    private void AddPolygonCard(int left, int top)
+    {
+        Panel card = AddCard(left, top, "Polygon / bevel join");
+        card.Controls.Add(new Polygon
+        {
+            Left = 38,
+            Top = 8,
+            Width = 156,
+            Height = 104,
+            Points = [new(78, 4), new(148, 100), new(4, 42), new(152, 42), new(8, 100)],
+            Fill = new SolidColorBrush(Color.FromArgb(180, Color.Gold)),
+            Stroke = new SolidColorBrush(Color.DarkOrange),
+            StrokeThickness = 5,
+            StrokeLineJoin = StrokeLineJoin.Bevel
+        });
+    }
+
+    private void AddPolylineCard(int left, int top)
+    {
+        Panel card = AddCard(left, top, "Polyline / round join");
+        var stroke = new SweepGradientBrush { CenterPoint = new PointF(0.5f, 0.5f) };
+        stroke.GradientStops.AddRange([
+            new GradientStop(Color.MediumSeaGreen, 0),
+            new GradientStop(Color.RoyalBlue, 0.5f),
+            new GradientStop(Color.MediumPurple, 1)
+        ]);
+        card.Controls.Add(new Polyline
+        {
+            Left = 12,
+            Top = 8,
+            Width = 208,
+            Height = 104,
+            Points = [new(6, 84), new(42, 20), new(82, 76), new(122, 16), new(162, 72), new(202, 24)],
+            Stroke = stroke,
+            StrokeThickness = 9,
+            StrokeLineCap = StrokeLineCap.Round,
+            StrokeLineJoin = StrokeLineJoin.Round
+        });
+    }
+
+    private void AddPathCard(int left, int top)
+    {
+        Panel card = AddCard(left, top, "Path / vector transform");
+        var geometry = new PathGeometry
+        {
+            // Transform the vector before rasterization so Skia anti-aliases the final contour.
+            // A Control.Rotation would instead rotate the already-rendered control backbuffer.
+            Transform = Matrix3x2.CreateRotation(-7f * (System.MathF.PI / 180f), new Vector2(106f, 52f))
+        };
+        var figure = new PathFigure(new PointF(6, 78), isClosed: true);
+        figure.Segments.Add(new QuadraticBezierSegment(new PointF(38, 4), new PointF(86, 30)));
+        figure.Segments.Add(new BezierSegment(new PointF(126, 4), new PointF(180, 14), new PointF(204, 84)));
+        geometry.Figures.Add(figure);
+        card.Controls.Add(new ModernFormsNext.Path
+        {
+            Left = 10,
+            Top = 8,
+            Width = 212,
+            Height = 104,
+            Data = geometry,
+            Fill = Linear(Color.HotPink, Color.Orange),
+            Stroke = new SolidColorBrush(Color.DarkRed),
+            StrokeThickness = 4
+        });
+    }
+
+    private Panel AddCard(int left, int top, string caption)
+    {
+        var card = Controls.Add(new Panel
+        {
+            Left = left,
+            Top = top,
+            Width = 232,
+            Height = 152
+        });
+        card.Style.Border.Width = 1;
+        card.Style.Border.Color = Theme.BorderMidColor;
+        card.Controls.Add(new Label
+        {
+            Left = 10,
+            Top = 120,
+            Width = 210,
+            Height = 24,
+            Text = caption
+        });
+        return card;
+    }
+
+    private static LinearGradientBrush Linear(Color start, Color end)
+    {
+        var brush = new LinearGradientBrush { Start = new PointF(0, 0), End = new PointF(1, 1) };
+        brush.GradientStops.AddRange([new GradientStop(start, 0), new GradientStop(end, 1)]);
+        return brush;
+    }
+}

--- a/samples/ControlGallery/Panels/TreeViewPanel.cs
+++ b/samples/ControlGallery/Panels/TreeViewPanel.cs
@@ -66,7 +66,7 @@ namespace ControlGallery.Panels
 
         private TreeViewItem CreateDirectoryNode (string path, int level)
         {
-            var tvi = new TreeViewItem (Path.GetFileName (path)) { Image = ImageLoader.Get ("folder.png") };
+            var tvi = new TreeViewItem (System.IO.Path.GetFileName (path)) { Image = ImageLoader.Get ("folder.png") };
 
             if (level > 3)
                 return tvi;

--- a/samples/Explorer/ImageLoader.cs
+++ b/samples/Explorer/ImageLoader.cs
@@ -14,7 +14,7 @@ namespace Explore
         public static SKBitmap Get (string filename)
         {
             if (!_cache.ContainsKey (filename.ToLowerInvariant ()))
-                _cache.Add (filename.ToLowerInvariant (), SKBitmap.Decode (Path.Combine (_defaultLocation, filename)));
+                _cache.Add (filename.ToLowerInvariant (), SKBitmap.Decode (System.IO.Path.Combine (_defaultLocation, filename)));
 
             return _cache[filename.ToLowerInvariant ()];
         }

--- a/samples/Explorer/MainForm.cs
+++ b/samples/Explorer/MainForm.cs
@@ -28,7 +28,7 @@ namespace Explore
             var item = e.Value;
 
             if (item.Tag is string s && s == "Directory")
-                SetSelectedDirectory (Path.Combine (current_directory, item.Text));
+                SetSelectedDirectory (System.IO.Path.Combine (current_directory, item.Text));
         }
 
         private void Tree_ItemSelected (object sender, EventArgs<TreeViewItem> e)
@@ -51,15 +51,15 @@ namespace Explore
 
             try {
                 foreach (var d in Directory.EnumerateDirectories (directory).Take (30))
-                    view.Items.Add (new ListViewItem { Text = Path.GetFileName (d), Image = ImageLoader.Get ("folder-closed.png"), Tag = "Directory" });
+                    view.Items.Add (new ListViewItem { Text = System.IO.Path.GetFileName (d), Image = ImageLoader.Get ("folder-closed.png"), Tag = "Directory" });
 
                 directories = view.Items.Count;
 
                 if (!tree_item.HasChildren)
-                    tree_item.Items.AddRange (view.Items.Select (l => new TreeViewItem (l.Text) { Image = ImageLoader.Get ("folder.png"), Tag = Path.Combine (current_directory, l.Text) }));
+                    tree_item.Items.AddRange (view.Items.Select (l => new TreeViewItem (l.Text) { Image = ImageLoader.Get ("folder.png"), Tag = System.IO.Path.Combine (current_directory, l.Text) }));
 
                 foreach (var f in Directory.EnumerateFiles (directory).Take (50))
-                    view.Items.Add (new ListViewItem { Text = Path.GetFileName (f), Image = ImageLoader.Get ("new.png") });
+                    view.Items.Add (new ListViewItem { Text = System.IO.Path.GetFileName (f), Image = ImageLoader.Get ("new.png") });
 
                 files = view.Items.Count - directories;
 
@@ -121,7 +121,7 @@ namespace Explore
 
         private void ParentFolder_Clicked (object sender, EventArgs args)
         {
-            var parent_folder = Path.GetDirectoryName (current_directory);
+            var parent_folder = System.IO.Path.GetDirectoryName (current_directory);
 
             if (parent_folder != null)
                 SetSelectedDirectory (parent_folder);

--- a/samples/Outlaw/ImageLoader.cs
+++ b/samples/Outlaw/ImageLoader.cs
@@ -14,7 +14,7 @@ namespace Outlaw
         public static SKBitmap Get (string filename)
         {
             if (!_cache.ContainsKey (filename.ToLowerInvariant ()))
-                _cache.Add (filename.ToLowerInvariant (), SKBitmap.Decode (Path.Combine (_defaultLocation, filename)));
+                _cache.Add (filename.ToLowerInvariant (), SKBitmap.Decode (System.IO.Path.Combine (_defaultLocation, filename)));
 
             return _cache[filename.ToLowerInvariant ()];
         }


### PR DESCRIPTION
## Summary

Adds a complete, platform-neutral Shape and vector-geometry subsystem to ModernFormsNext. The implementation follows the existing Skia rendering, Brush, layout, input, accessibility, and Designer pipelines without introducing platform types into shared projects.

Closes #11.

## Implementation

- Adds the `Shape` base control and `Ellipse`, `Circle`, `Line`, `Polygon`, `Polyline`, and `Path` controls.
- Adds a platform-neutral `Geometry` model with ellipse, rectangle, line, and path geometries.
- Adds path figures and line, quadratic Bézier, and cubic Bézier segments.
- Supports fill rules, point collections, geometry transforms, and mutable collection notifications.
- Preserves Circle semantics while keeping stroke rendering safe at small sizes.

## Designer integration

- Registers Shape controls with the Toolbox and Property Grid.
- Adds structured editors for `PointCollection` and `PathGeometry`.
- Adds Designer defaults, serialization, code generation, reverse parsing, and round-trip coverage.
- Corrects ColorDialog client sizing used by the Designer brush workflow.

## Rendering and hit testing

- Reuses the shared Brush and Skia pipelines for solid, linear, radial, and sweep fills and strokes.
- Supports stroke thickness, caps, joins, clipping, presentation transforms, and antialiased vector rendering.
- Adds geometry-aware pointer hit testing for transparent fill regions and thin strokes.
- Invalidates cached Skia paths and paints when mutable Geometry or Brush content changes.
- Keeps the implementation shared by Windows and Android backends.

## Serialization and code generation

- Extends `.mfdesign` persistence for Shape controls, points, figures, segments, transforms, fill rules, and brush values.
- Generates code for structured vector geometry.
- Extends reverse parsing so generated Shape code can be reopened by the Designer.
- Adds compatibility aliases where the public `ModernFormsNext.Path` name would otherwise conflict with `System.IO.Path`.

## Testing

- `dotnet restore .\ModernFormsNext.slnx`
- Full Debug solution build, including the Android backend and VSIX validation.
- Full Release solution build, including the Android backend and VSIX validation.
- Explicit Debug and Release VSIX builds.
- Full test suite: **1062/1062 passed**, 0 failed, 0 skipped.
- `git diff --check` passed.
- Validation was run in a clean isolated copy to avoid live Designer host locks and nested worktree contamination.

## Manual validation

Manually verified on Windows:

- ControlGallery Shapes page, including resize and move behavior.
- Smooth transformed `Path` rendering after `Geometry.Transform`.
- `PointCollection` and `PathGeometry` structured editors.
- Toolbox and Property Grid integration.
- All Shape controls, including Circle sizing semantics.
- Fill, stroke, gradients, caps, joins, clipping, transforms, and geometry-aware hit testing.

## Known limitations

- Android build and automated tests are validated, but no manual Android emulator or physical-device run is claimed.
- `PathGeometry` uses a structured Designer editor; this change does not add a graphical Bézier canvas editor.
