### PR TITLE
Complete Android animation runtime integration and validation

### DIFF
--- a/ModernFormsNext.CrossPlatform.Sample.Tests/SampleApplicationTests.cs
+++ b/ModernFormsNext.CrossPlatform.Sample.Tests/SampleApplicationTests.cs
@@ -93,6 +93,7 @@ public sealed class SampleApplicationTests
         public string OperatingSystem { get; } = operatingSystem;
         public string BackendName { get; } = backendName;
         public string HostState => "Test host";
+        public string AnimationRuntimeStatus => "Test animation runtime";
         public FakeDispatcher FakeDispatcher { get; } = new();
         public PlatformPermissionStatus CheckStatus { get; set; } = PlatformPermissionStatus.Granted;
         public PlatformPermissionStatus RequestStatus { get; set; } = PlatformPermissionStatus.Granted;

--- a/ModernFormsNext.Tests/AnimatedLayoutTests.cs
+++ b/ModernFormsNext.Tests/AnimatedLayoutTests.cs
@@ -315,6 +315,41 @@ public sealed class AnimatedLayoutTests
     }
 
     [Fact]
+    public void RepeatedSurfaceResizeRetargetsWithoutLogicalOrPresentationDrift()
+    {
+        using var harness = new AnimationSchedulerTestHarness();
+        using var root = new Panel { Size = new Size(200, 100) };
+        using var child = new Control { Size = new Size(50, 30), Dock = DockStyle.Right };
+        root.Controls.Add(child);
+        using var surface = new SkiaControlSurface(root);
+        surface.Resize(200, 100);
+        child.AnimationSchedulerOverride = harness.Scheduler;
+        child.LayoutTransition = LinearTransition();
+
+        surface.Resize(300, 100);
+        harness.AdvanceAndTick(Duration / 2);
+        Assert.Equal(250, child.Left);
+        Assert.Equal(200, Rectangle.Round(child.PresentationBounds).Left);
+
+        surface.Resize(240, 100);
+        Assert.Equal(190, child.Left);
+        Assert.Equal(200, Rectangle.Round(child.PresentationBounds).Left);
+        harness.AdvanceAndTick(Duration);
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+
+        surface.Resize(360, 100);
+        harness.AdvanceAndTick(Duration / 2);
+        surface.Resize(220, 100);
+        Assert.Equal(170, child.Left);
+        harness.AdvanceAndTick(Duration);
+
+        Assert.Equal(new Rectangle(170, 0, 50, 100), child.Bounds);
+        Assert.Equal(child.Bounds, Rectangle.Round(child.PresentationBounds));
+        Assert.False(child.HasActiveLayoutTransition);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
     public void AnchorLayoutAnimatesComputedWidthWithoutChangingAnchorSemantics()
     {
         using var harness = new AnimationSchedulerTestHarness();

--- a/ModernFormsNext.Tests/AnimationPlatformPolicyTests.cs
+++ b/ModernFormsNext.Tests/AnimationPlatformPolicyTests.cs
@@ -40,6 +40,65 @@ public sealed class AnimationPlatformPolicyTests
     }
 
     [Fact]
+    public void FractionalPlatformScaleAppliesToNewAnimationsWithoutDisablingMotion()
+    {
+        var provider = new TestPlatformAnimationSettings(durationScale: 0.5d);
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+
+        AnimationHandle handle = harness.Scheduler.Start(
+            new object(),
+            "ShortenedByPlatform",
+            _ => { },
+            new AnimationOptions { Duration = TimeSpan.FromMilliseconds(200) });
+
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(99));
+        Assert.Equal(AnimationState.Running, handle.State);
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(1));
+
+        Assert.Equal(AnimationState.Completed, handle.State);
+        Assert.False(harness.Policy.ReducedMotion);
+        Assert.Equal(0.5d, harness.Scheduler.GetPlatformDiagnostics().PlatformDurationScale);
+    }
+
+    [Fact]
+    public void DynamicScaleZeroCompletesActiveAnimationAtEndpointAndStopsTicks()
+    {
+        var provider = new TestPlatformAnimationSettings();
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+        float value = 0f;
+        AnimationHandle handle = harness.Scheduler.Start(
+            new object(),
+            "DynamicScaleZero",
+            progress => value = progress,
+            new AnimationOptions { Duration = TimeSpan.FromSeconds(1) });
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        provider.Set(reducedMotion: true, animationsEnabled: false, durationScale: 0d);
+
+        Assert.Equal(AnimationState.Completed, handle.State);
+        Assert.Equal(1f, value);
+        Assert.False(harness.TickSource.IsRunning);
+        Assert.Equal(0, harness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+    }
+
+    [Fact]
+    public void ApplicationAndPlatformDurationScalesComposeForNewAnimations()
+    {
+        var provider = new TestPlatformAnimationSettings(durationScale: 0.5d);
+        using var harness = new AnimationSchedulerTestHarness(animationSettings: provider);
+        harness.Policy.DurationScale = 2d;
+
+        AnimationHandle handle = harness.Scheduler.Start(
+            new object(),
+            "ComposedScale",
+            _ => { },
+            new AnimationOptions { Duration = TimeSpan.FromMilliseconds(100) });
+        harness.AdvanceAndTick(TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(AnimationState.Completed, handle.State);
+    }
+
+    [Fact]
     public void RepeatedRefreshAndStartsDoNotDuplicateProviderSubscription()
     {
         var provider = new TestPlatformAnimationSettings();

--- a/ModernFormsNext.Tests/AnimationSchedulerTestInfrastructure.cs
+++ b/ModernFormsNext.Tests/AnimationSchedulerTestInfrastructure.cs
@@ -55,6 +55,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
     public TestPlatformAnimationSettings(
         bool reducedMotion = false,
         bool animationsEnabled = true,
+        double durationScale = 1d,
         PlatformAnimationProviderState providerState = PlatformAnimationProviderState.Ready,
         bool fallbackUsed = false,
         string? lastError = null)
@@ -62,6 +63,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
         current = CreateSnapshot(
             reducedMotion,
             animationsEnabled,
+            durationScale,
             providerState,
             fallbackUsed,
             lastError);
@@ -120,6 +122,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
     public void Set(
         bool reducedMotion,
         bool animationsEnabled = true,
+        double durationScale = 1d,
         PlatformAnimationProviderState providerState = PlatformAnimationProviderState.Ready,
         bool fallbackUsed = false,
         string? lastError = null)
@@ -127,6 +130,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
         PlatformAnimationSettingsSnapshot next = CreateSnapshot(
             reducedMotion,
             animationsEnabled,
+            durationScale,
             providerState,
             fallbackUsed,
             lastError);
@@ -136,6 +140,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
     public void SetOnNextRefresh(
         bool reducedMotion,
         bool animationsEnabled = true,
+        double durationScale = 1d,
         PlatformAnimationProviderState providerState = PlatformAnimationProviderState.Ready,
         bool fallbackUsed = false,
         string? lastError = null)
@@ -145,6 +150,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
             nextRefresh = CreateSnapshot(
                 reducedMotion,
                 animationsEnabled,
+                durationScale,
                 providerState,
                 fallbackUsed,
                 lastError);
@@ -168,6 +174,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
     private static PlatformAnimationSettingsSnapshot CreateSnapshot(
         bool reducedMotion,
         bool animationsEnabled,
+        double durationScale,
         PlatformAnimationProviderState providerState,
         bool fallbackUsed,
         string? lastError)
@@ -175,6 +182,7 @@ internal sealed class TestPlatformAnimationSettings : IPlatformAnimationSettings
             "Deterministic test provider",
             reducedMotion,
             animationsEnabled,
+            durationScale,
             DateTimeOffset.UnixEpoch,
             fallbackUsed,
             providerState,

--- a/ModernFormsNext.Tests/AnimationSchedulerTests.cs
+++ b/ModernFormsNext.Tests/AnimationSchedulerTests.cs
@@ -153,6 +153,25 @@ public sealed class AnimationSchedulerTests
     }
 
     [Fact]
+    public void ZeroDurationOnUiThreadPublishesEndpointInlineWithoutPosting()
+    {
+        var dispatcher = new ImmediateAnimationDispatcher();
+        using var harness = new AnimationSchedulerTestHarness(dispatcher);
+        float value = 0f;
+
+        AnimationHandle handle = harness.Scheduler.Start(
+            new object(),
+            "ImmediateUiThread",
+            progress => value = progress,
+            Options(0));
+
+        Assert.Equal(1f, value);
+        Assert.Equal(AnimationState.Completed, handle.State);
+        Assert.Equal(0, dispatcher.PostCount);
+        Assert.False(harness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public async Task StartFromBackgroundMarshalsAllUpdatesToUiDispatcher()
     {
         var dispatcher = new QueuedAnimationDispatcher();
@@ -308,6 +327,35 @@ public sealed class AnimationSchedulerTests
 
         harness.Dispose();
         Assert.Equal(0, lifecycle.SubscriberCount);
+    }
+
+    [Fact]
+    public async Task StaleInitialForegroundCannotOvertakeBackgroundDuringLifecycleBinding()
+    {
+        using var lifecycle = new BlockingInitialLifecycle(PlatformApplicationLifecycleState.Foreground);
+        var clock = new ManualAnimationClock();
+        var tickSource = new ManualAnimationTickSource();
+        Task<AnimationScheduler> createScheduler = Task.Run(() => new AnimationScheduler(
+            clock,
+            new ImmediateAnimationDispatcher(),
+            tickSource,
+            new AnimationPolicy(),
+            lifecycle));
+        Assert.True(lifecycle.InitialStateReadStarted.Wait(TimeSpan.FromSeconds(5)));
+
+        lifecycle.Publish(PlatformApplicationLifecycleState.Background);
+        lifecycle.ReleaseInitialStateRead();
+
+        using AnimationScheduler scheduler = await createScheduler;
+        AnimationHandle handle = scheduler.Start(
+            new object(),
+            "LifecycleBindingRace",
+            _ => { },
+            Options(100));
+
+        Assert.Equal(AnimationState.Paused, handle.State);
+        Assert.True(scheduler.GetDiagnostics().IsPaused);
+        Assert.False(tickSource.IsRunning);
     }
 
     [Fact]
@@ -652,5 +700,54 @@ public sealed class AnimationSchedulerTests
     private sealed class EasingCallbackOwner
     {
         public float Ease(float progress) => progress;
+    }
+
+    private sealed class BlockingInitialLifecycle : IPlatformApplicationLifecycle, IDisposable
+    {
+        private readonly PlatformApplicationLifecycleState initialState;
+        private readonly ManualResetEventSlim releaseInitialStateRead = new();
+        private int initialRead = 1;
+        private PlatformApplicationLifecycleState state;
+
+        public BlockingInitialLifecycle(PlatformApplicationLifecycleState initialState)
+        {
+            this.initialState = initialState;
+            state = initialState;
+        }
+
+        public ManualResetEventSlim InitialStateReadStarted { get; } = new();
+
+        public PlatformApplicationLifecycleState State
+        {
+            get
+            {
+                if (Interlocked.Exchange(ref initialRead, 0) != 0)
+                {
+                    InitialStateReadStarted.Set();
+                    if (!releaseInitialStateRead.Wait(TimeSpan.FromSeconds(10)))
+                        throw new TimeoutException("The test did not release the initial lifecycle read.");
+                    return initialState;
+                }
+
+                return state;
+            }
+        }
+
+        public event EventHandler<PlatformApplicationLifecycleChangedEventArgs>? StateChanged;
+
+        public void Publish(PlatformApplicationLifecycleState value)
+        {
+            PlatformApplicationLifecycleState previous = state;
+            state = value;
+            StateChanged?.Invoke(this, new PlatformApplicationLifecycleChangedEventArgs(previous, value));
+        }
+
+        public void ReleaseInitialStateRead() => releaseInitialStateRead.Set();
+
+        public void Dispose()
+        {
+            InitialStateReadStarted.Dispose();
+            releaseInitialStateRead.Dispose();
+        }
     }
 }

--- a/ModernFormsNext.Tests/PlatformAnimationTickSourceTests.cs
+++ b/ModernFormsNext.Tests/PlatformAnimationTickSourceTests.cs
@@ -1,0 +1,169 @@
+using ModernFormsNext.Animations;
+using ModernFormsNext.WindowKit.Backend;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class PlatformAnimationTickSourceTests
+{
+    [Fact]
+    public void ActiveFallbackDemandPromotesAfterBackendRegistration()
+    {
+        var fallback = new ManualAnimationTickSource();
+        TestPlatformFrameSource? registered = null;
+        using var tickSource = new PlatformAnimationTickSource(fallback, () => registered);
+        var clock = new ManualAnimationClock();
+        using var scheduler = new AnimationScheduler(
+            clock,
+            new ImmediateAnimationDispatcher(),
+            tickSource,
+            new AnimationPolicy());
+        float value = 0f;
+
+        AnimationHandle handle = scheduler.Start(
+            new object(),
+            "LateBackend",
+            progress => value = progress,
+            new AnimationOptions { Duration = TimeSpan.FromMilliseconds(100) });
+
+        Assert.True(fallback.IsRunning);
+        registered = new TestPlatformFrameSource();
+
+        // The next temporary fallback signal performs the handoff but is not delivered too, so
+        // backend startup cannot create a duplicate scheduler tick.
+        fallback.Fire();
+
+        Assert.False(fallback.IsRunning);
+        Assert.True(registered.IsCallbackPending);
+        Assert.Equal(1, registered.StartCount);
+        Assert.Equal(0f, value);
+
+        clock.Advance(TimeSpan.FromMilliseconds(100));
+        registered.Fire();
+
+        Assert.Equal(1f, value);
+        Assert.Equal(AnimationState.Completed, handle.State);
+        Assert.False(tickSource.IsRunning);
+        Assert.False(registered.IsCallbackPending);
+        Assert.Equal(1, registered.StopCount);
+    }
+
+    [Fact]
+    public void BackendRegisteredBeforeFirstDemandBypassesFallback()
+    {
+        var fallback = new ManualAnimationTickSource();
+        var registered = new TestPlatformFrameSource();
+        using var source = new PlatformAnimationTickSource(fallback, () => registered);
+
+        source.Start(static () => { });
+
+        Assert.True(source.IsRunning);
+        Assert.True(registered.IsCallbackPending);
+        Assert.Equal(0, fallback.StartTransitions);
+
+        source.Stop();
+
+        Assert.False(source.IsRunning);
+        Assert.False(registered.IsCallbackPending);
+    }
+
+    [Fact]
+    public void RepeatedIdleWakeKeepsOnePlatformCallbackAndReleasesDelegateOnDispose()
+    {
+        var fallback = new ManualAnimationTickSource();
+        var registered = new TestPlatformFrameSource();
+        var source = new PlatformAnimationTickSource(fallback, () => registered);
+
+        source.Start(static () => { });
+        source.Start(static () => { });
+
+        Assert.Equal(2, registered.StartCount);
+        Assert.Equal(1, registered.MaximumPendingCount);
+
+        source.Stop();
+        source.Start(static () => { });
+        source.Dispose();
+
+        Assert.False(source.IsRunning);
+        Assert.False(registered.IsCallbackPending);
+        Assert.False(registered.HasCallback);
+        Assert.Equal(0, fallback.StartTransitions);
+        Assert.Throws<ObjectDisposedException>(() => source.Start(static () => { }));
+    }
+
+    [Fact]
+    public void RejectedPlatformSourceFallsBackWithoutStrandingDemand()
+    {
+        var fallback = new ManualAnimationTickSource();
+        var rejected = new TestPlatformFrameSource
+        {
+            StartException = new InvalidOperationException("rejected"),
+            RetainCallbackBeforeStartFailure = true
+        };
+        using var source = new PlatformAnimationTickSource(fallback, () => rejected);
+        int ticks = 0;
+
+        source.Start(() => ticks++);
+        fallback.Fire();
+
+        Assert.True(source.IsRunning);
+        Assert.True(fallback.IsRunning);
+        Assert.Equal(1, rejected.StartCount);
+        Assert.Equal(1, rejected.StopCount);
+        Assert.False(rejected.HasCallback);
+        Assert.Equal(1, ticks);
+    }
+
+    private sealed class TestPlatformFrameSource : IPlatformAnimationFrameSource
+    {
+        private Action? callback;
+
+        public bool IsCallbackPending { get; private set; }
+
+        public bool HasCallback => callback is not null;
+
+        public int StartCount { get; private set; }
+
+        public int StopCount { get; private set; }
+
+        public int MaximumPendingCount { get; private set; }
+
+        public Exception? StartException { get; init; }
+
+        public bool RetainCallbackBeforeStartFailure { get; init; }
+
+        public void Start(Action frameRequested)
+        {
+            ArgumentNullException.ThrowIfNull(frameRequested);
+            StartCount++;
+            if (RetainCallbackBeforeStartFailure)
+            {
+                callback = frameRequested;
+                IsCallbackPending = true;
+            }
+            if (StartException is not null)
+                throw StartException;
+
+            callback = frameRequested;
+            IsCallbackPending = true;
+            MaximumPendingCount = Math.Max(MaximumPendingCount, 1);
+        }
+
+        public void Stop()
+        {
+            if (!IsCallbackPending && callback is null)
+                return;
+
+            StopCount++;
+            IsCallbackPending = false;
+            callback = null;
+        }
+
+        public void Fire()
+        {
+            Action? requested = callback;
+            IsCallbackPending = false;
+            requested?.Invoke();
+        }
+    }
+}

--- a/ModernFormsNext.Tests/Theming/ThemeManagerApplyAndTransitionTests.cs
+++ b/ModernFormsNext.Tests/Theming/ThemeManagerApplyAndTransitionTests.cs
@@ -439,6 +439,25 @@ public sealed class ThemeManagerApplyAndTransitionTests
     }
 
     [Fact]
+    public void ZeroDurationScaleCommitsExactThemeTargetWithoutCreatingTransitionWork()
+    {
+        using var harness = new ThemeManagerTestHarness();
+        harness.Manager.Apply(Theme("scale-zero.start", Color.Red), Immediate());
+        harness.SchedulerHarness.Policy.DurationScale = 0d;
+
+        ThemeApplyResult result = harness.Manager.Apply(
+            Theme("scale-zero.target", Color.Blue),
+            Animated());
+
+        Assert.Null(result.Transition);
+        Assert.Equal(
+            Color.Blue.ToArgb(),
+            ResourceColor(harness, ThemeTokens.Colors.Background.ResourceKey).ToArgb());
+        Assert.Equal(0, harness.SchedulerHarness.Scheduler.GetDiagnostics().ActiveAnimationCount);
+        Assert.False(harness.SchedulerHarness.TickSource.IsRunning);
+    }
+
+    [Fact]
     public async Task SchedulerAnimationPolicyCanCompleteActiveTransitionImmediately()
     {
         using var harness = new ThemeManagerTestHarness();

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAnimationScaleEvaluatorTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAnimationScaleEvaluatorTests.cs
@@ -7,70 +7,71 @@ namespace ModernFormsNext.WindowKit.Backend.Android.Tests;
 public sealed class AndroidAnimationScaleEvaluatorTests
 {
     [Theory]
-    [InlineData(0f, 1f)]
-    [InlineData(1f, 0f)]
-    [InlineData(0f, 0f)]
-    public void ZeroAnimationScaleRequestsReducedMotion(float animatorScale, float transitionScale)
+    [InlineData(0f)]
+    public void ZeroAnimationScaleRequestsReducedMotion(float animatorScale)
     {
         PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
             animatorScale,
-            transitionScale,
             DateTimeOffset.UnixEpoch);
 
         Assert.True(snapshot.ReducedMotion);
         Assert.False(snapshot.AnimationsEnabled);
         Assert.False(snapshot.FallbackUsed);
         Assert.Equal(PlatformAnimationProviderState.Ready, snapshot.ProviderState);
+        Assert.Equal(0d, snapshot.DurationScale);
     }
 
-    [Fact]
-    public void PositiveAnimationScalesKeepAnimationsEnabled()
+    [Theory]
+    [InlineData(0.5f)]
+    [InlineData(1f)]
+    [InlineData(2f)]
+    public void PositiveAnimatorScaleIsPreservedForSharedDurations(float scale)
     {
         PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
-            0.5f,
-            2f,
+            scale,
             DateTimeOffset.UnixEpoch);
 
         Assert.False(snapshot.ReducedMotion);
         Assert.True(snapshot.AnimationsEnabled);
+        Assert.Equal(scale, snapshot.DurationScale);
         Assert.Equal(PlatformAnimationProviderState.Ready, snapshot.ProviderState);
     }
 
     [Theory]
-    [InlineData(null, 1f)]
-    [InlineData(1f, null)]
-    [InlineData(-1f, 1f)]
-    [InlineData(1f, -1f)]
-    public void MissingOrInvalidScaleUsesSafeFallback(float? animatorScale, float? transitionScale)
+    [InlineData(null)]
+    [InlineData(-1f)]
+    [InlineData(101f)]
+    public void MissingOrInvalidScaleUsesSafeFallback(float? animatorScale)
     {
         PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
             animatorScale,
-            transitionScale,
             DateTimeOffset.UnixEpoch);
 
         Assert.False(snapshot.ReducedMotion);
         Assert.True(snapshot.AnimationsEnabled);
         Assert.True(snapshot.FallbackUsed);
+        Assert.Equal(1d, snapshot.DurationScale);
         Assert.Equal(PlatformAnimationProviderState.Fallback, snapshot.ProviderState);
     }
 
     [Fact]
     public void NonFiniteScaleUsesSafeFallback()
     {
-        PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
-            float.NaN,
-            float.PositiveInfinity,
-            DateTimeOffset.UnixEpoch);
+        foreach (float scale in new[] { float.NaN, float.PositiveInfinity })
+        {
+            PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
+                scale,
+                DateTimeOffset.UnixEpoch);
 
-        Assert.True(snapshot.FallbackUsed);
-        Assert.Equal(PlatformAnimationProviderState.Fallback, snapshot.ProviderState);
+            Assert.True(snapshot.FallbackUsed);
+            Assert.Equal(PlatformAnimationProviderState.Fallback, snapshot.ProviderState);
+        }
     }
 
     [Fact]
     public void ContextOrPlatformErrorIsPreservedInDiagnostics()
     {
         PlatformAnimationSettingsSnapshot snapshot = AndroidAnimationScaleEvaluator.CreateSnapshot(
-            null,
             null,
             DateTimeOffset.UnixEpoch,
             "Context unavailable");

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidFrameCallbackStateTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidFrameCallbackStateTests.cs
@@ -1,0 +1,96 @@
+using ModernFormsNext.WindowKit.Backend.Android.Animation;
+
+namespace ModernFormsNext.WindowKit.Backend.Android.Tests;
+
+public sealed class AndroidFrameCallbackStateTests
+{
+    [Fact]
+    public void SchedulerDemandRemainsIdleWithoutAnActiveSurface()
+    {
+        var state = new AndroidFrameCallbackState();
+
+        state.SetSchedulerDemand(active: true);
+
+        Assert.Equal(AndroidFrameCallbackAction.None, state.Reconcile());
+        Assert.False(state.CallbackPending);
+        Assert.Equal(0, state.PostedCallbackCount);
+    }
+
+    [Fact]
+    public void ActiveSurfaceAndSchedulerDemandPostExactlyOneCallback()
+    {
+        var state = new AndroidFrameCallbackState();
+        state.AddActiveSurface();
+        state.SetSchedulerDemand(active: true);
+
+        Assert.Equal(AndroidFrameCallbackAction.Post, state.Reconcile());
+        Assert.Equal(AndroidFrameCallbackAction.None, state.Reconcile());
+        Assert.True(state.CallbackPending);
+        Assert.Equal(1, state.PostedCallbackCount);
+    }
+
+    [Fact]
+    public void DeliveredFrameDoesNotBuildBacklogAndRepostsOnlyAfterReconcile()
+    {
+        var state = new AndroidFrameCallbackState();
+        state.AddActiveSurface();
+        state.SetSchedulerDemand(active: true);
+        state.Reconcile();
+
+        Assert.True(state.BeginFrameDelivery());
+        Assert.False(state.CallbackPending);
+        Assert.False(state.BeginFrameDelivery());
+        Assert.Equal(AndroidFrameCallbackAction.Post, state.Reconcile());
+        Assert.Equal(2, state.PostedCallbackCount);
+        Assert.Equal(1, state.DeliveredCallbackCount);
+    }
+
+    [Fact]
+    public void IdleThenWakeAndRepeatedStartStopNeverDuplicateCallbacks()
+    {
+        var state = new AndroidFrameCallbackState();
+        state.AddActiveSurface();
+
+        for (int iteration = 0; iteration < 5; iteration++)
+        {
+            state.SetSchedulerDemand(active: true);
+            Assert.Equal(AndroidFrameCallbackAction.Post, state.Reconcile());
+            Assert.Equal(AndroidFrameCallbackAction.None, state.Reconcile());
+
+            state.SetSchedulerDemand(active: false);
+            Assert.Equal(AndroidFrameCallbackAction.Remove, state.Reconcile());
+            Assert.Equal(AndroidFrameCallbackAction.None, state.Reconcile());
+        }
+
+        Assert.False(state.CallbackPending);
+        Assert.Equal(5, state.PostedCallbackCount);
+    }
+
+    [Fact]
+    public void SurfaceDetachRemovesPendingCallbackAndReattachWakesDemand()
+    {
+        var state = new AndroidFrameCallbackState();
+        state.AddActiveSurface();
+        state.SetSchedulerDemand(active: true);
+        state.Reconcile();
+
+        state.RemoveActiveSurface();
+        Assert.Equal(AndroidFrameCallbackAction.Remove, state.Reconcile());
+
+        state.AddActiveSurface();
+        Assert.Equal(AndroidFrameCallbackAction.Post, state.Reconcile());
+    }
+
+    [Fact]
+    public void DisposeRemovesPendingCallbackAndRejectsNewSurfaces()
+    {
+        var state = new AndroidFrameCallbackState();
+        state.AddActiveSurface();
+        state.SetSchedulerDemand(active: true);
+        state.Reconcile();
+
+        Assert.Equal(AndroidFrameCallbackAction.Remove, state.Dispose());
+        Assert.Equal(AndroidFrameCallbackAction.None, state.Dispose());
+        Assert.Throws<ObjectDisposedException>(state.AddActiveSurface);
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidLifecycleAndRequestPlanningTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidLifecycleAndRequestPlanningTests.cs
@@ -1,6 +1,7 @@
 using ModernFormsNext.WindowKit.Backend.Android.Lifecycle;
 using ModernFormsNext.WindowKit.Backend.Android.Permissions;
 using ModernFormsNext.WindowKit.Platform.Permissions;
+using System.Runtime.CompilerServices;
 
 namespace ModernFormsNext.WindowKit.Backend.Android.Tests;
 
@@ -21,6 +22,18 @@ public sealed class AndroidLifecycleAndRequestPlanningTests
         Assert.Null(reference.Target);
     }
 
+    [Fact]
+    public void ActivityHostReferenceDoesNotKeepAnOtherwiseUnreferencedHostAlive()
+    {
+        WeakHostReference<object> reference = CreateCollectibleHostReference();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.Null(reference.Target);
+    }
+
     [Theory]
     [InlineData(PlatformPermissionStatus.NotDeclared)]
     [InlineData(PlatformPermissionStatus.NotSupported)]
@@ -38,5 +51,13 @@ public sealed class AndroidLifecycleAndRequestPlanningTests
     public void NonTerminalPermissionStatusCanContinueToPlatformSpecificHandling(PlatformPermissionStatus status)
     {
         Assert.True(AndroidPermissionRequestPlanner.ShouldContinueRequestFlow(status));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakHostReference<object> CreateCollectibleHostReference()
+    {
+        var reference = new WeakHostReference<object>();
+        reference.Set(new object());
+        return reference;
     }
 }

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidMotionEventPlanTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidMotionEventPlanTests.cs
@@ -1,0 +1,80 @@
+using ModernFormsNext.WindowKit.Backend.Android.Rendering;
+
+namespace ModernFormsNext.WindowKit.Backend.Android.Tests;
+
+public sealed class AndroidMotionEventPlanTests
+{
+    [Fact]
+    public void ChangedPointerActionsUseAndroidActionIndex()
+    {
+        (AndroidMotionEventAction Native, AndroidPointerAction Expected)[] cases =
+        [
+            (AndroidMotionEventAction.Down, AndroidPointerAction.Down),
+            (AndroidMotionEventAction.PointerDown, AndroidPointerAction.Down),
+            (AndroidMotionEventAction.Up, AndroidPointerAction.Up),
+            (AndroidMotionEventAction.PointerUp, AndroidPointerAction.Up)
+        ];
+
+        foreach ((AndroidMotionEventAction nativeAction, AndroidPointerAction expectedAction) in cases)
+        {
+            AndroidMotionEventPlan plan = AndroidMotionEventPlan.Create(
+                nativeAction,
+                pointerCount: 3,
+                actionIndex: 1);
+
+            Assert.Equal(expectedAction, plan.PointerAction);
+            Assert.Equal(1, plan.EventCount);
+            Assert.Equal(1, plan.GetPointerIndex(0));
+        }
+    }
+
+    [Fact]
+    public void PointerReorderDoesNotChangeStableIdSelectedByActionIndex()
+    {
+        int[] beforeReorder = [7, 3];
+        int[] afterReorder = [3];
+        AndroidMotionEventPlan pointerUp = AndroidMotionEventPlan.Create(
+            AndroidMotionEventAction.PointerUp,
+            beforeReorder.Length,
+            actionIndex: 0);
+        AndroidMotionEventPlan move = AndroidMotionEventPlan.Create(
+            AndroidMotionEventAction.Move,
+            afterReorder.Length,
+            actionIndex: 0);
+
+        int releasedPointerId = beforeReorder[pointerUp.GetPointerIndex(0)];
+        int remainingPointerId = afterReorder[move.GetPointerIndex(0)];
+
+        Assert.Equal(7, releasedPointerId);
+        Assert.Equal(3, remainingPointerId);
+    }
+
+    [Fact]
+    public void MoveTranslatesEveryCurrentPointerIndexExactlyOnce()
+    {
+        int[] pointerIds = [9, 2, 14];
+        AndroidMotionEventPlan plan = AndroidMotionEventPlan.Create(
+            AndroidMotionEventAction.Move,
+            pointerIds.Length,
+            actionIndex: 0);
+
+        int[] translatedIds = Enumerable.Range(0, plan.EventCount)
+            .Select(index => pointerIds[plan.GetPointerIndex(index)])
+            .ToArray();
+
+        Assert.Equal(pointerIds, translatedIds);
+    }
+
+    [Fact]
+    public void CancelRequestsOneGlobalCancellationInsteadOfIndexRouting()
+    {
+        AndroidMotionEventPlan plan = AndroidMotionEventPlan.Create(
+            AndroidMotionEventAction.Cancel,
+            pointerCount: 2,
+            actionIndex: 0);
+
+        Assert.True(plan.CancelAll);
+        Assert.Null(plan.PointerAction);
+        Assert.Equal(0, plan.EventCount);
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/AndroidAnimationScaleEvaluator.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/AndroidAnimationScaleEvaluator.cs
@@ -4,37 +4,37 @@ namespace ModernFormsNext.WindowKit.Backend.Android;
 
 internal static class AndroidAnimationScaleEvaluator
 {
-    internal const string SourceName = "Android Settings.Global animation scales";
+    private const float MaximumSupportedScale = 100f;
+    internal const string SourceName = "Android Settings.Global animator_duration_scale";
 
     public static PlatformAnimationSettingsSnapshot CreateSnapshot(
         float? animatorDurationScale,
-        float? transitionAnimationScale,
         DateTimeOffset lastUpdate,
         string? error = null)
     {
         if (error is not null ||
             animatorDurationScale is not { } animator ||
-            transitionAnimationScale is not { } transition ||
             !float.IsFinite(animator) ||
-            !float.IsFinite(transition) ||
             animator < 0f ||
-            transition < 0f)
+            animator > MaximumSupportedScale)
         {
             return new PlatformAnimationSettingsSnapshot(
                 SourceName,
                 reducedMotion: false,
                 animationsEnabled: true,
+                durationScale: 1d,
                 lastUpdate,
                 fallbackUsed: true,
                 PlatformAnimationProviderState.Fallback,
                 error ?? "Android animation scales are unavailable or invalid.");
         }
 
-        bool enabled = animator > 0f && transition > 0f;
+        bool enabled = animator > 0f;
         return new PlatformAnimationSettingsSnapshot(
             SourceName,
             reducedMotion: !enabled,
             animationsEnabled: enabled,
+            durationScale: animator,
             lastUpdate,
             fallbackUsed: false,
             PlatformAnimationProviderState.Ready,

--- a/ModernFormsNext.WindowKit.Backend.Android/Animation/AndroidFrameCallbackState.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Animation/AndroidFrameCallbackState.cs
@@ -1,0 +1,92 @@
+namespace ModernFormsNext.WindowKit.Backend.Android.Animation;
+
+internal enum AndroidFrameCallbackAction
+{
+    None,
+    Post,
+    Remove
+}
+
+/// <summary>
+/// Stores the Android frame-source state without retaining a native surface or callback object.
+/// </summary>
+/// <remarks>
+/// The native wrapper serializes calls with its own lock. Keeping this state Android-API-free
+/// makes idle/wake, surface gating, and duplicate-callback behavior deterministic in unit tests.
+/// </remarks>
+internal sealed class AndroidFrameCallbackState
+{
+    public bool SchedulerDemand { get; private set; }
+
+    public int ActiveSurfaceCount { get; private set; }
+
+    public bool CallbackPending { get; private set; }
+
+    public long PostedCallbackCount { get; private set; }
+
+    public long DeliveredCallbackCount { get; private set; }
+
+    public bool IsDisposed { get; private set; }
+
+    public void SetSchedulerDemand(bool active)
+    {
+        if (!IsDisposed)
+            SchedulerDemand = active;
+    }
+
+    public void AddActiveSurface()
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        ActiveSurfaceCount++;
+    }
+
+    public void RemoveActiveSurface()
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        if (ActiveSurfaceCount <= 0)
+            throw new InvalidOperationException("No active Android animation surface is registered.");
+        ActiveSurfaceCount--;
+    }
+
+    public AndroidFrameCallbackAction Reconcile()
+    {
+        bool shouldRun = !IsDisposed && SchedulerDemand && ActiveSurfaceCount > 0;
+        if (shouldRun == CallbackPending)
+            return AndroidFrameCallbackAction.None;
+
+        CallbackPending = shouldRun;
+        if (shouldRun)
+        {
+            PostedCallbackCount++;
+            return AndroidFrameCallbackAction.Post;
+        }
+
+        return AndroidFrameCallbackAction.Remove;
+    }
+
+    public bool BeginFrameDelivery()
+    {
+        if (!CallbackPending)
+            return false;
+
+        CallbackPending = false;
+        if (IsDisposed || !SchedulerDemand || ActiveSurfaceCount == 0)
+            return false;
+
+        DeliveredCallbackCount++;
+        return true;
+    }
+
+    public AndroidFrameCallbackAction Dispose()
+    {
+        if (IsDisposed)
+            return AndroidFrameCallbackAction.None;
+
+        bool remove = CallbackPending;
+        IsDisposed = true;
+        SchedulerDemand = false;
+        ActiveSurfaceCount = 0;
+        CallbackPending = false;
+        return remove ? AndroidFrameCallbackAction.Remove : AndroidFrameCallbackAction.None;
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidAnimationRuntimeDiagnostics.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidAnimationRuntimeDiagnostics.cs
@@ -1,0 +1,62 @@
+using ModernFormsNext.WindowKit.Backend.Android.Lifecycle;
+
+namespace ModernFormsNext.WindowKit.Backend.Android;
+
+/// <summary>
+/// Represents a low-cost snapshot of Android animation-runtime integration state.
+/// </summary>
+/// <remarks>
+/// This diagnostic surface contains no Activity, View, or callback references. It is intended for
+/// manual smoke screens and targeted logging rather than per-frame telemetry.
+/// </remarks>
+public sealed class AndroidAnimationRuntimeDiagnostics
+{
+    internal AndroidAnimationRuntimeDiagnostics(
+        AndroidApplicationLifecycleState lifecycleState,
+        bool frameCallbackPending,
+        bool schedulerDemand,
+        int activeSurfaceCount,
+        long postedFrameCallbackCount,
+        long deliveredFrameCallbackCount,
+        double durationScale,
+        bool contentObserverRegistered,
+        string? observerError)
+    {
+        LifecycleState = lifecycleState;
+        FrameCallbackPending = frameCallbackPending;
+        SchedulerDemand = schedulerDemand;
+        ActiveSurfaceCount = activeSurfaceCount;
+        PostedFrameCallbackCount = postedFrameCallbackCount;
+        DeliveredFrameCallbackCount = deliveredFrameCallbackCount;
+        DurationScale = durationScale;
+        ContentObserverRegistered = contentObserverRegistered;
+        ObserverError = observerError;
+    }
+
+    /// <summary>Gets the latest application lifecycle state.</summary>
+    public AndroidApplicationLifecycleState LifecycleState { get; }
+
+    /// <summary>Gets whether one Choreographer callback is currently pending.</summary>
+    public bool FrameCallbackPending { get; }
+
+    /// <summary>Gets whether the shared scheduler currently requests frames.</summary>
+    public bool SchedulerDemand { get; }
+
+    /// <summary>Gets the number of attached and resumed Android Skia surfaces.</summary>
+    public int ActiveSurfaceCount { get; }
+
+    /// <summary>Gets the number of native frame callbacks posted by this backend.</summary>
+    public long PostedFrameCallbackCount { get; }
+
+    /// <summary>Gets the number of native frame callbacks delivered to the shared scheduler.</summary>
+    public long DeliveredFrameCallbackCount { get; }
+
+    /// <summary>Gets the current Android animator-duration scale.</summary>
+    public double DurationScale { get; }
+
+    /// <summary>Gets whether the lifecycle-aware animator-scale observer is registered.</summary>
+    public bool ContentObserverRegistered { get; }
+
+    /// <summary>Gets the last ContentObserver registration error, if any.</summary>
+    public string? ObserverError { get; }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidPlatformAnimationSettings.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidPlatformAnimationSettings.cs
@@ -1,21 +1,28 @@
 using Android.Content;
+using Android.Database;
+using Android.OS;
 using Android.Provider;
 using ModernFormsNext.WindowKit.Backend;
 
 namespace ModernFormsNext.WindowKit.Backend.Android;
 
-internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSettings
+internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSettings, IDisposable
 {
     private readonly object sync = new();
+    private readonly object observerLifecycleSync = new();
     private readonly Context? applicationContext;
     private EventHandler<PlatformAnimationSettingsChangedEventArgs>? changed;
     private PlatformAnimationSettingsSnapshot current;
+    private AnimationScaleContentObserver? observer;
+    private bool hostActive;
+    private bool observerRegistered;
+    private bool disposed;
+    private string? lastObserverError;
 
     public AndroidPlatformAnimationSettings(Context? applicationContext)
     {
         this.applicationContext = applicationContext;
         current = AndroidAnimationScaleEvaluator.CreateSnapshot(
-            null,
             null,
             DateTimeOffset.UtcNow,
             "Android application context is unavailable.");
@@ -35,18 +42,74 @@ internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSetti
     {
         add
         {
+            bool updateObservation;
             lock (sync)
+            {
+                ObjectDisposedException.ThrowIf(disposed, this);
+                updateObservation = changed is null;
                 changed += value;
+            }
+            if (updateObservation)
+                UpdateObserverRegistration();
         }
         remove
         {
+            bool updateObservation;
             lock (sync)
+            {
                 changed -= value;
+                updateObservation = changed is null;
+            }
+            if (updateObservation)
+                UpdateObserverRegistration();
         }
+    }
+
+    internal bool IsObserverRegistered
+    {
+        get
+        {
+            lock (sync)
+                return observerRegistered;
+        }
+    }
+
+    internal string? LastObserverError
+    {
+        get
+        {
+            lock (sync)
+                return lastObserverError;
+        }
+    }
+
+    internal void SetHostActive(bool active)
+    {
+        bool changedState;
+        lock (sync)
+        {
+            if (disposed)
+                return;
+            changedState = hostActive != active;
+            hostActive = active;
+        }
+
+        if (!changedState)
+            return;
+
+        UpdateObserverRegistration();
+        if (active)
+            Refresh();
     }
 
     public PlatformAnimationSettingsSnapshot Refresh()
     {
+        lock (sync)
+        {
+            if (disposed)
+                return current;
+        }
+
         DateTimeOffset update = DateTimeOffset.UtcNow;
         PlatformAnimationSettingsSnapshot next;
         try
@@ -55,7 +118,6 @@ internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSetti
             if (resolver is null)
             {
                 next = AndroidAnimationScaleEvaluator.CreateSnapshot(
-                    null,
                     null,
                     update,
                     "Android application context is unavailable.");
@@ -66,20 +128,14 @@ internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSetti
                     resolver,
                     Settings.Global.AnimatorDurationScale,
                     1f);
-                float transitionScale = Settings.Global.GetFloat(
-                    resolver,
-                    Settings.Global.TransitionAnimationScale,
-                    1f);
                 next = AndroidAnimationScaleEvaluator.CreateSnapshot(
                     animatorScale,
-                    transitionScale,
                     update);
             }
         }
         catch (Exception exception)
         {
             next = AndroidAnimationScaleEvaluator.CreateSnapshot(
-                null,
                 null,
                 update,
                 exception.Message);
@@ -94,6 +150,7 @@ internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSetti
             current = next;
             meaningfulChange = previous.ReducedMotion != next.ReducedMotion
                 || previous.AnimationsEnabled != next.AnimationsEnabled
+                || previous.DurationScale != next.DurationScale
                 || previous.FallbackUsed != next.FallbackUsed
                 || previous.ProviderState != next.ProviderState
                 || !string.Equals(previous.LastError, next.LastError, StringComparison.Ordinal);
@@ -102,5 +159,117 @@ internal sealed class AndroidPlatformAnimationSettings : IPlatformAnimationSetti
 
         handlers?.Invoke(this, new PlatformAnimationSettingsChangedEventArgs(previous, next));
         return next;
+    }
+
+    public void Dispose()
+    {
+        lock (observerLifecycleSync)
+        {
+            AnimationScaleContentObserver? observerToDispose;
+            bool unregister;
+            lock (sync)
+            {
+                if (disposed)
+                    return;
+
+                disposed = true;
+                hostActive = false;
+                changed = null;
+                unregister = observerRegistered;
+                observerRegistered = false;
+                observerToDispose = observer;
+                observer = null;
+            }
+
+            if (unregister && applicationContext?.ContentResolver is { } resolver && observerToDispose is not null)
+            {
+                try
+                {
+                    resolver.UnregisterContentObserver(observerToDispose);
+                }
+                catch (Exception)
+                {
+                    // Android owns no Activity reference here. A failed final unregister is safe
+                    // to ignore during process shutdown after managed callbacks were released.
+                }
+            }
+
+            observerToDispose?.Dispose();
+        }
+    }
+
+    private void UpdateObserverRegistration()
+    {
+        // Subscriber and lifecycle notifications can arrive on different threads. Serialize the
+        // native transition as well as the managed decision so an unregister cannot overtake an
+        // in-flight register and leave an untracked ContentObserver behind.
+        lock (observerLifecycleSync)
+        {
+            ContentResolver? resolver = applicationContext?.ContentResolver;
+            AnimationScaleContentObserver? currentObserver;
+            bool register;
+            lock (sync)
+            {
+                bool shouldRegister = !disposed && hostActive && changed is not null && resolver is not null;
+                if (shouldRegister == observerRegistered)
+                    return;
+
+                observer ??= shouldRegister ? new AnimationScaleContentObserver(this) : null;
+                currentObserver = observer;
+                register = shouldRegister;
+                observerRegistered = shouldRegister;
+                lastObserverError = null;
+            }
+
+            if (resolver is null || currentObserver is null)
+                return;
+
+            try
+            {
+                if (register)
+                {
+                    global::Android.Net.Uri uri = Settings.Global.GetUriFor(Settings.Global.AnimatorDurationScale)
+                        ?? throw new InvalidOperationException(
+                            "Android did not expose the animator-duration setting URI.");
+                    resolver.RegisterContentObserver(
+                        uri,
+                        false,
+                        currentObserver);
+                }
+                else
+                {
+                    resolver.UnregisterContentObserver(currentObserver);
+                }
+            }
+            catch (Exception exception)
+            {
+                lock (sync)
+                {
+                    // A failed registration did not create a live subscription. A failed
+                    // unregistration may still have one, so retain that state and retry when the
+                    // lifecycle or subscriber set changes again.
+                    observerRegistered = !register;
+                    lastObserverError = exception.Message;
+                }
+            }
+        }
+    }
+
+    private sealed class AnimationScaleContentObserver : ContentObserver
+    {
+        private readonly AndroidPlatformAnimationSettings owner;
+
+        public AnimationScaleContentObserver(AndroidPlatformAnimationSettings owner)
+            : base(new Handler(Looper.MainLooper
+                ?? throw new InvalidOperationException("Android did not provide a main Looper.")))
+        {
+            this.owner = owner;
+        }
+
+        public override void OnChange(bool selfChange)
+        {
+            base.OnChange(selfChange);
+            owner.Refresh();
+        }
     }
 }

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidWindowKitBackend.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/AndroidWindowKitBackend.cs
@@ -11,14 +11,17 @@ namespace ModernFormsNext.WindowKit.Backend.Android;
 /// Initializes the Android-specific WindowKit platform foundation.
 /// </summary>
 /// <remarks>
-/// This first backend version registers lifecycle, dispatcher, and permission infrastructure. It
-/// does not yet provide the ModernFormsNext Android window/rendering implementation, clipboard,
+/// The backend registers lifecycle, dispatcher, permission, animation-frame, and motion-policy
+/// infrastructure. The experimental shared-control host renders one control tree through Skia;
+/// Android still does not implement the complete ModernFormsNext window contract, clipboard,
 /// camera, media, WebView, notifications, file pickers, sharing, or drag-and-drop services.
 /// </remarks>
 public sealed class AndroidWindowKitBackend : IWindowKitBackend
 {
     private readonly object sync = new();
     private readonly AndroidWindowKitOptions options;
+    private AndroidPlatformAnimationSettings animationSettings = null!;
+    private AndroidChoreographerAnimationFrameSource animationFrameSource = null!;
 
     /// <summary>
     /// Creates an Android backend using explicit host options.
@@ -60,6 +63,29 @@ public sealed class AndroidWindowKitBackend : IWindowKitBackend
     /// </summary>
     public AndroidPlatformInfo PlatformInfo { get; private set; } = null!;
 
+    /// <summary>Returns a snapshot of Android frame, lifecycle, and reduced-motion integration.</summary>
+    public AndroidAnimationRuntimeDiagnostics GetAnimationRuntimeDiagnostics()
+    {
+        if (!IsInitialized)
+        {
+            throw new InvalidOperationException(
+                "The Android backend must be initialized before animation diagnostics are available.");
+        }
+
+        AndroidAnimationFrameSourceDiagnostics frame = animationFrameSource.GetDiagnostics();
+        PlatformAnimationSettingsSnapshot settings = animationSettings.Current;
+        return new AndroidAnimationRuntimeDiagnostics(
+            ActivityTracker.State,
+            frame.CallbackPending,
+            frame.SchedulerDemand,
+            frame.ActiveSurfaceCount,
+            frame.PostedCallbackCount,
+            frame.DeliveredCallbackCount,
+            settings.DurationScale,
+            animationSettings.IsObserverRegistered,
+            animationSettings.LastObserverError);
+    }
+
     /// <inheritdoc/>
     public void Initialize()
     {
@@ -82,6 +108,8 @@ public sealed class AndroidWindowKitBackend : IWindowKitBackend
             ApplicationContext = new AndroidApplicationContext(options.ApplicationContext);
             ActivityTracker = new AndroidActivityTracker(options.ActivityProvider, options.DiagnosticSink);
             Dispatcher = new AndroidMainThreadDispatcher();
+            animationSettings = new AndroidPlatformAnimationSettings(ApplicationContext.Context);
+            animationFrameSource = new AndroidChoreographerAnimationFrameSource(options.DiagnosticSink);
             Permissions = new AndroidPermissionService(
                 ApplicationContext.Context,
                 ActivityTracker,
@@ -91,13 +119,16 @@ public sealed class AndroidWindowKitBackend : IWindowKitBackend
             PlatformInfo = new AndroidPlatformInfo();
 
             ApplicationContext.Application.RegisterActivityLifecycleCallbacks(ActivityTracker);
+            IPlatformApplicationLifecycle lifecycle = ActivityTracker;
+            lifecycle.StateChanged += HandleApplicationLifecycleChanged;
+            animationSettings.SetHostActive(lifecycle.State == PlatformApplicationLifecycleState.Foreground);
 
             // Register only services that are genuinely implemented. In particular, there is no
             // IWindowingPlatform or clipboard registration until Android UI/rendering support exists.
             PlatformServiceRegistry.Register<IPlatformDispatcher>(Dispatcher);
             PlatformServiceRegistry.Register<IPlatformApplicationLifecycle>(ActivityTracker);
-            PlatformServiceRegistry.Register<IPlatformAnimationSettings>(
-                new AndroidPlatformAnimationSettings(ApplicationContext.Context));
+            PlatformServiceRegistry.Register<IPlatformAnimationSettings>(animationSettings);
+            PlatformServiceRegistry.Register<IPlatformAnimationFrameSource>(animationFrameSource);
             PlatformServiceRegistry.Register<IPermissionService>(Permissions);
 
             IsInitialized = true;
@@ -106,4 +137,9 @@ public sealed class AndroidWindowKitBackend : IWindowKitBackend
                 options.DiagnosticSink);
         }
     }
+
+    private void HandleApplicationLifecycleChanged(
+        object? sender,
+        PlatformApplicationLifecycleChangedEventArgs e)
+        => animationSettings.SetHostActive(e.CurrentState == PlatformApplicationLifecycleState.Foreground);
 }

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/Animation/AndroidChoreographerAnimationFrameSource.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/Animation/AndroidChoreographerAnimationFrameSource.cs
@@ -1,0 +1,235 @@
+using Android.OS;
+using Android.Views;
+using ModernFormsNext.WindowKit.Backend.Android.Animation;
+
+namespace ModernFormsNext.WindowKit.Backend.Android;
+
+/// <summary>
+/// Uses one coalesced Android <see cref="Choreographer"/> callback for shared scheduler work.
+/// </summary>
+internal sealed class AndroidChoreographerAnimationFrameSource : Java.Lang.Object,
+    IPlatformAnimationFrameSource,
+    Choreographer.IFrameCallback
+{
+    private readonly object sync = new();
+    private readonly AndroidFrameCallbackState state = new();
+    private readonly Handler mainHandler;
+    private readonly Action<string>? diagnosticSink;
+    private Choreographer? choreographer;
+    private Action? frameRequested;
+    private bool reconcilePosted;
+    private bool disposed;
+
+    public AndroidChoreographerAnimationFrameSource(Action<string>? diagnosticSink)
+    {
+        this.diagnosticSink = diagnosticSink;
+        Looper mainLooper = Looper.MainLooper
+            ?? throw new InvalidOperationException("Android did not provide a main Looper.");
+        mainHandler = new Handler(mainLooper);
+    }
+
+    public bool IsCallbackPending
+    {
+        get
+        {
+            lock (sync)
+                return state.CallbackPending;
+        }
+    }
+
+    internal AndroidAnimationSurfaceRegistration CreateSurfaceRegistration()
+    {
+        lock (sync)
+            ObjectDisposedException.ThrowIf(disposed, this);
+        return new AndroidAnimationSurfaceRegistration(this);
+    }
+
+    public void Start(Action frameRequested)
+    {
+        ArgumentNullException.ThrowIfNull(frameRequested);
+        lock (sync)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            this.frameRequested = frameRequested;
+            state.SetSchedulerDemand(active: true);
+            QueueReconcileLocked();
+        }
+    }
+
+    public void Stop()
+    {
+        lock (sync)
+        {
+            if (disposed)
+                return;
+            frameRequested = null;
+            state.SetSchedulerDemand(active: false);
+            QueueReconcileLocked();
+        }
+    }
+
+    public void DoFrame(long frameTimeNanos)
+    {
+        Action? callback;
+        lock (sync)
+        {
+            if (disposed)
+                return;
+            callback = state.BeginFrameDelivery() ? frameRequested : null;
+        }
+
+        try
+        {
+            callback?.Invoke();
+        }
+        catch (Exception exception)
+        {
+            // Scheduler callbacks isolate animation faults themselves. This final boundary keeps
+            // an unexpected integration failure from tearing down Android's Choreographer loop.
+            AndroidLogger.Error("Android animation frame callback failed.", exception, diagnosticSink);
+        }
+        finally
+        {
+            lock (sync)
+            {
+                if (!disposed)
+                    QueueReconcileLocked();
+            }
+        }
+    }
+
+    internal AndroidAnimationFrameSourceDiagnostics GetDiagnostics()
+    {
+        lock (sync)
+        {
+            return new AndroidAnimationFrameSourceDiagnostics(
+                state.CallbackPending,
+                state.SchedulerDemand,
+                state.ActiveSurfaceCount,
+                state.PostedCallbackCount,
+                state.DeliveredCallbackCount);
+        }
+    }
+
+    internal void SetSurfaceActive(bool active)
+    {
+        lock (sync)
+        {
+            if (disposed)
+                return;
+            if (active)
+                state.AddActiveSurface();
+            else
+                state.RemoveActiveSurface();
+            QueueReconcileLocked();
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        AndroidFrameCallbackAction action;
+        lock (sync)
+        {
+            if (disposed)
+                return;
+            disposed = true;
+            frameRequested = null;
+            action = state.Dispose();
+        }
+
+        if (action == AndroidFrameCallbackAction.Remove)
+            mainHandler.Post(RemoveFrameCallbackOnMainThread);
+        base.Dispose(disposing);
+    }
+
+    private void QueueReconcileLocked()
+    {
+        if (reconcilePosted)
+            return;
+
+        reconcilePosted = true;
+        if (!mainHandler.Post(ReconcileOnMainThread))
+        {
+            reconcilePosted = false;
+            throw new InvalidOperationException("Android rejected animation frame reconciliation.");
+        }
+    }
+
+    private void ReconcileOnMainThread()
+    {
+        AndroidFrameCallbackAction action;
+        lock (sync)
+        {
+            reconcilePosted = false;
+            action = state.Reconcile();
+        }
+
+        switch (action)
+        {
+            case AndroidFrameCallbackAction.Post:
+                GetChoreographerOnMainThread().PostFrameCallback(this);
+                break;
+            case AndroidFrameCallbackAction.Remove:
+                RemoveFrameCallbackOnMainThread();
+                break;
+        }
+    }
+
+    private Choreographer GetChoreographerOnMainThread()
+    {
+        if (!ReferenceEquals(Looper.MyLooper(), Looper.MainLooper))
+        {
+            throw new InvalidOperationException(
+                "Android animation frame reconciliation must run on the main Looper.");
+        }
+
+        return choreographer ??= Choreographer.Instance
+            ?? throw new InvalidOperationException("Android did not provide Choreographer.");
+    }
+
+    private void RemoveFrameCallbackOnMainThread()
+    {
+        // A stop/dispose can overtake the first posted reconciliation. In that case no native
+        // Choreographer instance or callback exists yet, so there is nothing to remove.
+        choreographer?.RemoveFrameCallback(this);
+    }
+}
+
+internal readonly record struct AndroidAnimationFrameSourceDiagnostics(
+    bool CallbackPending,
+    bool SchedulerDemand,
+    int ActiveSurfaceCount,
+    long PostedCallbackCount,
+    long DeliveredCallbackCount);
+
+internal sealed class AndroidAnimationSurfaceRegistration : IDisposable
+{
+    private AndroidChoreographerAnimationFrameSource? owner;
+    private bool active;
+
+    public AndroidAnimationSurfaceRegistration(AndroidChoreographerAnimationFrameSource owner)
+        => this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
+
+    public void SetActive(bool value)
+    {
+        if (owner is null || active == value)
+            return;
+
+        active = value;
+        owner.SetSurfaceActive(value);
+    }
+
+    public void Dispose()
+    {
+        AndroidChoreographerAnimationFrameSource? source = owner;
+        if (source is null)
+            return;
+
+        owner = null;
+        if (active)
+        {
+            active = false;
+            source.SetSurfaceActive(active: false);
+        }
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/Rendering/AndroidSkiaHostView.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/Rendering/AndroidSkiaHostView.cs
@@ -1,6 +1,7 @@
 using Android.Content;
 using Android.Views;
 using Android.Views.InputMethods;
+using ModernFormsNext.WindowKit.Backend;
 using SkiaSharp;
 using SkiaSharp.Views.Android;
 using System.Text.Json;
@@ -16,14 +17,16 @@ namespace ModernFormsNext.WindowKit.Backend.Android.Rendering;
 /// <remarks>
 /// Create and use the view on the Android main thread. The owning activity must forward its
 /// lifecycle and dispose the host from <c>OnDestroy</c>. Rendering occurs only after explicit
-/// invalidation or a size change; there is no continuous render timer. The view is a custom Skia
-/// surface and does not introduce an Android native-control UI tree for framework controls.
+/// invalidation or a size change. Shared animation work uses the backend's idle-aware Choreographer
+/// source; there is no continuous or per-control render timer. The view is a custom Skia surface
+/// and does not introduce an Android native-control UI tree for framework controls.
 /// </remarks>
 public sealed class AndroidSkiaHostView : SKCanvasView
 {
     private readonly AndroidSurfaceHostState state = new();
     private readonly Action<string>? diagnosticSink;
     private readonly bool detailedDiagnostics;
+    private readonly AndroidAnimationSurfaceRegistration? animationSurfaceRegistration;
     private SharedInputConnection? activeInputConnection;
     private KeyEventObservation? lastKeyEvent;
     private long inputDiagnosticSequence;
@@ -42,6 +45,9 @@ public sealed class AndroidSkiaHostView : SKCanvasView
     {
         this.diagnosticSink = diagnosticSink;
         detailedDiagnostics = enableDetailedDiagnostics;
+        animationSurfaceRegistration =
+            (PlatformServiceRegistry.GetService<IPlatformAnimationFrameSource>() as
+                AndroidChoreographerAnimationFrameSource)?.CreateSurfaceRegistration();
         Focusable = true;
         FocusableInTouchMode = true;
     }
@@ -140,6 +146,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
     {
         ThrowIfDisposed();
         state.Start();
+        UpdateAnimationSurfaceRegistration();
         AndroidLogger.Write("Skia surface activity started.", diagnosticSink);
     }
 
@@ -151,6 +158,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
             state.Start();
 
         state.Resume();
+        UpdateAnimationSurfaceRegistration();
         AndroidLogger.Write("Skia surface resumed.", diagnosticSink);
         RequestRender();
     }
@@ -161,6 +169,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         ThrowIfDisposed();
         var primaryPointerId = state.PrimaryPointerId;
         EmitCancellations(state.Pause(), primaryPointerId);
+        UpdateAnimationSurfaceRegistration();
         AndroidLogger.Write("Skia surface paused.", diagnosticSink);
     }
 
@@ -170,6 +179,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         ThrowIfDisposed();
         var primaryPointerId = state.PrimaryPointerId;
         EmitCancellations(state.Stop(), primaryPointerId);
+        UpdateAnimationSurfaceRegistration();
         AndroidLogger.Write("Skia surface stopped.", diagnosticSink);
     }
 
@@ -306,33 +316,26 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         if (motionEvent is null || disposed || state.LifecycleState != AndroidSurfaceLifecycleState.Resumed)
             return false;
 
-        var action = motionEvent.ActionMasked;
-        if (action == MotionEventActions.Cancel)
+        AndroidMotionEventPlan plan = AndroidMotionEventPlan.Create(
+            TranslateMotionEventAction(motionEvent.ActionMasked),
+            motionEvent.PointerCount,
+            motionEvent.ActionIndex);
+        if (plan.CancelAll)
         {
             var primaryPointerId = state.PrimaryPointerId;
             EmitCancellations(state.CancelActivePointers(), primaryPointerId);
             return true;
         }
 
-        if (action == MotionEventActions.Move)
-        {
-            for (var index = 0; index < motionEvent.PointerCount; index++)
-                EmitPointer(motionEvent, index, AndroidPointerAction.Move);
-            return true;
-        }
-
-        var changedIndex = motionEvent.ActionIndex;
-        var translatedAction = action switch
-        {
-            MotionEventActions.Down or MotionEventActions.PointerDown => AndroidPointerAction.Down,
-            MotionEventActions.Up or MotionEventActions.PointerUp => AndroidPointerAction.Up,
-            _ => (AndroidPointerAction?)null
-        };
-
-        if (translatedAction is null)
+        if (plan.EventCount == 0 || plan.PointerAction is not { } pointerAction)
             return base.OnTouchEvent(motionEvent);
 
-        EmitPointer(motionEvent, changedIndex, translatedAction.Value);
+        for (var translatedIndex = 0; translatedIndex < plan.EventCount; translatedIndex++)
+        {
+            int pointerIndex = plan.GetPointerIndex(translatedIndex);
+            EmitPointer(motionEvent, pointerIndex, pointerAction);
+        }
+
         return true;
     }
 
@@ -345,6 +348,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
 
         if (state.AttachSurface())
             PostInvalidateOnAnimation();
+        UpdateAnimationSurfaceRegistration();
         AndroidLogger.Write("Native Skia surface attached.", diagnosticSink);
     }
 
@@ -355,6 +359,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         {
             var primaryPointerId = state.PrimaryPointerId;
             EmitCancellations(state.DetachSurface(), primaryPointerId);
+            UpdateAnimationSurfaceRegistration();
             AndroidLogger.Write("Native Skia surface detached.", diagnosticSink);
         }
 
@@ -421,6 +426,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
             disposed = true;
             var primaryPointerId = state.PrimaryPointerId;
             EmitCancellations(state.Dispose(), primaryPointerId);
+            animationSurfaceRegistration?.Dispose();
             Render = null;
             Pointer = null;
             TextCommitted = null;
@@ -458,6 +464,9 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         return changed;
     }
 
+    private void UpdateAnimationSurfaceRegistration()
+        => animationSurfaceRegistration?.SetActive(state.CanRender);
+
     private void EmitPointer(MotionEvent motionEvent, int index, AndroidPointerAction action)
     {
         var pointerId = motionEvent.GetPointerId(index);
@@ -485,6 +494,18 @@ public sealed class AndroidSkiaHostView : SKCanvasView
             logicalY,
             isPrimary));
     }
+
+    private static AndroidMotionEventAction TranslateMotionEventAction(MotionEventActions action)
+        => action switch
+        {
+            MotionEventActions.Down => AndroidMotionEventAction.Down,
+            MotionEventActions.PointerDown => AndroidMotionEventAction.PointerDown,
+            MotionEventActions.Move => AndroidMotionEventAction.Move,
+            MotionEventActions.PointerUp => AndroidMotionEventAction.PointerUp,
+            MotionEventActions.Up => AndroidMotionEventAction.Up,
+            MotionEventActions.Cancel => AndroidMotionEventAction.Cancel,
+            _ => AndroidMotionEventAction.Other
+        };
 
     private void EmitCancellations(IReadOnlyList<int> pointerIds, int? primaryPointerId)
     {

--- a/ModernFormsNext.WindowKit.Backend.Android/Rendering/AndroidMotionEventPlan.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Rendering/AndroidMotionEventPlan.cs
@@ -1,0 +1,88 @@
+namespace ModernFormsNext.WindowKit.Backend.Android.Rendering;
+
+/// <summary>
+/// Identifies the Android MotionEvent action needed by the platform-neutral translation plan.
+/// </summary>
+internal enum AndroidMotionEventAction
+{
+    Other,
+    Down,
+    PointerDown,
+    Move,
+    PointerUp,
+    Up,
+    Cancel
+}
+
+/// <summary>
+/// Describes which MotionEvent pointer indexes must be translated for one native event.
+/// </summary>
+/// <remarks>
+/// Pointer indexes are ephemeral positions inside one MotionEvent. The native view uses the
+/// returned index only to read Android's stable pointer ID and coordinates for that event.
+/// </remarks>
+internal readonly record struct AndroidMotionEventPlan
+{
+    private AndroidMotionEventPlan(
+        AndroidPointerAction? pointerAction,
+        int pointerCount,
+        int actionIndex,
+        bool cancelAll)
+    {
+        PointerAction = pointerAction;
+        PointerCount = pointerCount;
+        ActionIndex = actionIndex;
+        CancelAll = cancelAll;
+    }
+
+    public AndroidPointerAction? PointerAction { get; }
+
+    public int PointerCount { get; }
+
+    public int ActionIndex { get; }
+
+    public bool CancelAll { get; }
+
+    public int EventCount => PointerAction == AndroidPointerAction.Move
+        ? PointerCount
+        : PointerAction is null ? 0 : 1;
+
+    public int GetPointerIndex(int translatedEventIndex)
+    {
+        if ((uint)translatedEventIndex >= (uint)EventCount)
+            throw new ArgumentOutOfRangeException(nameof(translatedEventIndex));
+        return PointerAction == AndroidPointerAction.Move ? translatedEventIndex : ActionIndex;
+    }
+
+    public static AndroidMotionEventPlan Create(
+        AndroidMotionEventAction action,
+        int pointerCount,
+        int actionIndex)
+    {
+        if (pointerCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(pointerCount));
+
+        AndroidPointerAction? translated = action switch
+        {
+            AndroidMotionEventAction.Down or AndroidMotionEventAction.PointerDown => AndroidPointerAction.Down,
+            AndroidMotionEventAction.Move => AndroidPointerAction.Move,
+            AndroidMotionEventAction.Up or AndroidMotionEventAction.PointerUp => AndroidPointerAction.Up,
+            _ => null
+        };
+
+        if (translated is not null &&
+            (pointerCount == 0 || actionIndex < 0 || actionIndex >= pointerCount))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(actionIndex),
+                actionIndex,
+                "The MotionEvent action index must identify an available pointer.");
+        }
+
+        return new AndroidMotionEventPlan(
+            translated,
+            pointerCount,
+            actionIndex,
+            cancelAll: action == AndroidMotionEventAction.Cancel);
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend/PlatformAnimationFrameSource.cs
+++ b/ModernFormsNext.WindowKit.Backend/PlatformAnimationFrameSource.cs
@@ -1,0 +1,40 @@
+namespace ModernFormsNext.WindowKit.Backend;
+
+/// <summary>
+/// Provides an idle-aware platform frame callback for the shared animation scheduler.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Platform backends implement this contract with their native display-synchronization source.
+/// The callback is a pacing signal only: elapsed animation time remains owned by the shared
+/// monotonic scheduler clock, so irregular or dropped frames never accumulate a callback backlog.
+/// </para>
+/// <para>
+/// <see cref="Start"/> and <see cref="Stop"/> must be thread-safe and idempotent. An implementation
+/// must keep at most one native callback pending for one source, stop requesting callbacks while
+/// idle, and release the callback delegate after <see cref="Stop"/>. <see cref="Start"/> schedules
+/// future delivery and must not invoke the supplied callback synchronously.
+/// </para>
+/// <para>
+/// The callback may execute on a platform UI thread. It must remain short and must not be invoked
+/// while an implementation-specific lock is held.
+/// </para>
+/// </remarks>
+public interface IPlatformAnimationFrameSource
+{
+    /// <summary>Gets whether a native frame callback is currently pending.</summary>
+    bool IsCallbackPending { get; }
+
+    /// <summary>
+    /// Starts or updates frame delivery for active scheduler work.
+    /// </summary>
+    /// <param name="frameRequested">
+    /// The short callback that asks the shared scheduler to process the current monotonic time.
+    /// </param>
+    void Start(Action frameRequested);
+
+    /// <summary>
+    /// Stops frame delivery and releases the previously supplied callback.
+    /// </summary>
+    void Stop();
+}

--- a/ModernFormsNext.WindowKit.Backend/PlatformAnimationSettings.cs
+++ b/ModernFormsNext.WindowKit.Backend/PlatformAnimationSettings.cs
@@ -41,11 +41,54 @@ public sealed class PlatformAnimationSettingsSnapshot
         bool fallbackUsed,
         PlatformAnimationProviderState providerState,
         string? lastError)
+        : this(
+            source,
+            reducedMotion,
+            animationsEnabled,
+            durationScale: 1d,
+            lastPlatformUpdate,
+            fallbackUsed,
+            providerState,
+            lastError)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a platform animation-preference snapshot with a native duration scale.
+    /// </summary>
+    /// <param name="source">A stable human-readable source identifier.</param>
+    /// <param name="reducedMotion">Whether the platform requests reduced motion.</param>
+    /// <param name="animationsEnabled">Whether the platform permits UI animations.</param>
+    /// <param name="durationScale">
+    /// The finite non-negative native multiplier applied to newly started animation durations.
+    /// </param>
+    /// <param name="lastPlatformUpdate">The last native read attempt, in UTC.</param>
+    /// <param name="fallbackUsed">Whether compatibility defaults were used.</param>
+    /// <param name="providerState">The provider health state.</param>
+    /// <param name="lastError">The last non-sensitive native error, if any.</param>
+    public PlatformAnimationSettingsSnapshot(
+        string source,
+        bool reducedMotion,
+        bool animationsEnabled,
+        double durationScale,
+        DateTimeOffset? lastPlatformUpdate,
+        bool fallbackUsed,
+        PlatformAnimationProviderState providerState,
+        string? lastError)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(source);
+        if (!double.IsFinite(durationScale) || durationScale < 0d)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(durationScale),
+                durationScale,
+                "Platform animation duration scale must be finite and non-negative.");
+        }
+
         Source = source;
         ReducedMotion = reducedMotion;
         AnimationsEnabled = animationsEnabled;
+        DurationScale = durationScale;
         LastPlatformUpdate = lastPlatformUpdate;
         FallbackUsed = fallbackUsed;
         ProviderState = providerState;
@@ -60,6 +103,14 @@ public sealed class PlatformAnimationSettingsSnapshot
 
     /// <summary>Gets whether the platform permits UI animations.</summary>
     public bool AnimationsEnabled { get; }
+
+    /// <summary>
+    /// Gets the native duration multiplier applied to newly started shared animations.
+    /// </summary>
+    /// <remarks>
+    /// A value of zero requires deterministic endpoint completion without starting a frame source.
+    /// </remarks>
+    public double DurationScale { get; }
 
     /// <summary>Gets the last native read attempt, in UTC.</summary>
     public DateTimeOffset? LastPlatformUpdate { get; }

--- a/ModernFormsNext/Animations/AnimationOptions.cs
+++ b/ModernFormsNext/Animations/AnimationOptions.cs
@@ -96,7 +96,7 @@ public sealed class AnimationOptions
     internal AnimationOptionsSnapshot CreateSnapshot(AnimationPolicy policy)
     {
         ArgumentNullException.ThrowIfNull(policy);
-        double scale = policy.DurationScale;
+        double scale = policy.EffectiveDurationScale;
         return new AnimationOptionsSnapshot(
             ScaleTime(Duration, scale),
             ScaleTime(Delay, scale),

--- a/ModernFormsNext/Animations/AnimationPlatformDiagnostics.cs
+++ b/ModernFormsNext/Animations/AnimationPlatformDiagnostics.cs
@@ -11,6 +11,7 @@ public sealed class AnimationPlatformDiagnostics
         string source,
         bool reducedMotion,
         bool animationsEnabled,
+        double platformDurationScale,
         DateTimeOffset? lastPlatformUpdate,
         bool fallbackUsed,
         PlatformAnimationProviderState providerState,
@@ -19,6 +20,7 @@ public sealed class AnimationPlatformDiagnostics
         Source = source;
         ReducedMotion = reducedMotion;
         AnimationsEnabled = animationsEnabled;
+        PlatformDurationScale = platformDurationScale;
         LastPlatformUpdate = lastPlatformUpdate;
         FallbackUsed = fallbackUsed;
         ProviderState = providerState;
@@ -33,6 +35,9 @@ public sealed class AnimationPlatformDiagnostics
 
     /// <summary>Gets whether animations are effectively enabled.</summary>
     public bool AnimationsEnabled { get; }
+
+    /// <summary>Gets the native duration multiplier applied to newly started animations.</summary>
+    public double PlatformDurationScale { get; }
 
     /// <summary>Gets the last native provider read attempt, in UTC.</summary>
     public DateTimeOffset? LastPlatformUpdate { get; }

--- a/ModernFormsNext/Animations/AnimationPolicy.cs
+++ b/ModernFormsNext/Animations/AnimationPolicy.cs
@@ -17,6 +17,7 @@ public sealed class AnimationPolicy
     private bool reducedMotion;
     private bool platformReducedMotion;
     private double durationScale = 1d;
+    private double platformDurationScale = 1d;
 
     /// <summary>
     /// Gets or sets whether animations are enabled.
@@ -104,7 +105,8 @@ public sealed class AnimationPolicy
         get
         {
             lock (sync)
-                return !animationsEnabled || reducedMotion || platformReducedMotion || durationScale == 0d;
+                return !animationsEnabled || reducedMotion || platformReducedMotion ||
+                    durationScale == 0d || platformDurationScale == 0d;
         }
     }
 
@@ -123,14 +125,37 @@ public sealed class AnimationPolicy
         }
     }
 
-    internal void SetPlatformReducedMotion(bool value)
+    internal double EffectiveDurationScale
     {
+        get
+        {
+            lock (sync)
+            {
+                double effective = durationScale * platformDurationScale;
+                return double.IsFinite(effective) ? effective : double.MaxValue;
+            }
+        }
+    }
+
+    internal void SetPlatformAnimationSettings(bool reducedMotionRequested, double nativeDurationScale)
+    {
+        if (!double.IsFinite(nativeDurationScale) || nativeDurationScale < 0d)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(nativeDurationScale),
+                nativeDurationScale,
+                "Platform duration scale must be finite and non-negative.");
+        }
+
         bool changed;
         lock (sync)
         {
             bool previous = reducedMotion || platformReducedMotion;
-            platformReducedMotion = value;
-            changed = previous != (reducedMotion || platformReducedMotion);
+            double previousScale = platformDurationScale;
+            platformReducedMotion = reducedMotionRequested;
+            platformDurationScale = nativeDurationScale;
+            changed = previous != (reducedMotion || platformReducedMotion) ||
+                previousScale != platformDurationScale;
         }
 
         if (changed)

--- a/ModernFormsNext/Animations/AnimationScheduler.Lifecycle.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.Lifecycle.cs
@@ -6,6 +6,7 @@ namespace ModernFormsNext.Animations;
 public sealed partial class AnimationScheduler
 {
     private IPlatformApplicationLifecycle? platformLifecycle;
+    private long platformLifecycleVersion;
 
     partial void BindPlatformLifecycleCore()
     {
@@ -25,6 +26,7 @@ public sealed partial class AnimationScheduler
 
     private void BindPlatformLifecycle(IPlatformApplicationLifecycle lifecycle)
     {
+        long version;
         lock (sync)
         {
             if (platformLifecycle is not null || isShutdown)
@@ -32,9 +34,10 @@ public sealed partial class AnimationScheduler
 
             lifecycle.StateChanged += HandlePlatformLifecycleChanged;
             platformLifecycle = lifecycle;
+            version = ++platformLifecycleVersion;
         }
 
-        ApplyPlatformLifecycleState(lifecycle.State);
+        ApplyPlatformLifecycleState(lifecycle.State, version);
     }
 
     partial void UnbindPlatformLifecycle()
@@ -44,6 +47,7 @@ public sealed partial class AnimationScheduler
         {
             lifecycle = platformLifecycle;
             platformLifecycle = null;
+            platformLifecycleVersion++;
         }
 
         if (lifecycle is not null)
@@ -53,16 +57,41 @@ public sealed partial class AnimationScheduler
     private void HandlePlatformLifecycleChanged(
         object? sender,
         PlatformApplicationLifecycleChangedEventArgs e)
-        => ApplyPlatformLifecycleState(e.CurrentState);
+    {
+        long version;
+        lock (sync)
+        {
+            if (isShutdown || !ReferenceEquals(sender, platformLifecycle))
+                return;
+            version = ++platformLifecycleVersion;
+        }
 
-    private void ApplyPlatformLifecycleState(PlatformApplicationLifecycleState state)
+        ApplyPlatformLifecycleState(e.CurrentState, version);
+    }
+
+    private void ApplyPlatformLifecycleState(
+        PlatformApplicationLifecycleState state,
+        long version)
     {
         if (state == PlatformApplicationLifecycleState.Foreground)
         {
             RefreshPlatformPolicyAfterForeground();
-            Resume();
+
+            lock (sync)
+            {
+                // A background event can arrive while the foreground settings refresh is in
+                // progress. Never let that stale foreground continuation restart frame demand.
+                if (!isShutdown && version == platformLifecycleVersion)
+                    Resume();
+            }
         }
         else if (state is PlatformApplicationLifecycleState.Background or PlatformApplicationLifecycleState.NoHost)
-            Pause();
+        {
+            lock (sync)
+            {
+                if (!isShutdown && version == platformLifecycleVersion)
+                    Pause();
+            }
+        }
     }
 }

--- a/ModernFormsNext/Animations/AnimationScheduler.PlatformPolicy.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.PlatformPolicy.cs
@@ -48,7 +48,9 @@ public sealed partial class AnimationScheduler
         return new AnimationPlatformDiagnostics(
             snapshot.Source,
             reducedMotion,
-            Policy.AnimationsEnabled && snapshot.AnimationsEnabled && !reducedMotion,
+            Policy.AnimationsEnabled && snapshot.AnimationsEnabled &&
+                snapshot.DurationScale > 0d && !reducedMotion,
+            snapshot.DurationScale,
             snapshot.LastPlatformUpdate,
             snapshot.FallbackUsed,
             snapshot.ProviderState,
@@ -123,7 +125,9 @@ public sealed partial class AnimationScheduler
                     return;
             }
 
-            Policy.SetPlatformReducedMotion(snapshot.ReducedMotion || !snapshot.AnimationsEnabled);
+            Policy.SetPlatformAnimationSettings(
+                snapshot.ReducedMotion || !snapshot.AnimationsEnabled,
+                snapshot.DurationScale);
         }
 
         try

--- a/ModernFormsNext/Animations/AnimationScheduler.cs
+++ b/ModernFormsNext/Animations/AnimationScheduler.cs
@@ -63,7 +63,7 @@ public sealed partial class AnimationScheduler : IDisposable
     private long totalTickTimestampDelta;
 
     private AnimationScheduler()
-        : this(new StopwatchAnimationClock(), new DefaultAnimationDispatcher(), new ThreadPoolAnimationTickSource(), new AnimationPolicy())
+        : this(new StopwatchAnimationClock(), new DefaultAnimationDispatcher(), CreateDefaultTickSource(), new AnimationPolicy())
     {
     }
 
@@ -512,6 +512,9 @@ public sealed partial class AnimationScheduler : IDisposable
 
     private static AnimationScheduler CreateDefault() => new();
 
+    private static IAnimationTickSource CreateDefaultTickSource()
+        => new PlatformAnimationTickSource();
+
     private void RequestTick()
     {
         if (Interlocked.Exchange(ref tickPosted, 1) != 0)
@@ -519,7 +522,13 @@ public sealed partial class AnimationScheduler : IDisposable
 
         try
         {
-            dispatcher.Post(ProcessTick);
+            // Android Choreographer invokes the source on the UI thread. Process that display
+            // signal inline so invalidation can participate in the same frame instead of always
+            // slipping to the next vsync. Timer-backed sources still marshal through Post.
+            if (dispatcher.CheckAccess())
+                ProcessTick();
+            else
+                dispatcher.Post(ProcessTick);
         }
         catch (Exception exception)
         {
@@ -658,7 +667,12 @@ public sealed partial class AnimationScheduler : IDisposable
     {
         try
         {
-            dispatcher.Post(() => CompleteImmediately(entry));
+            // Scale zero and reduced motion must publish the exact endpoint before a UI-thread
+            // caller returns. Background callers retain the normal dispatcher marshalling path.
+            if (dispatcher.CheckAccess())
+                CompleteImmediately(entry);
+            else
+                dispatcher.Post(() => CompleteImmediately(entry));
         }
         catch (Exception exception)
         {

--- a/ModernFormsNext/Animations/Internal/PlatformAnimationTickSource.cs
+++ b/ModernFormsNext/Animations/Internal/PlatformAnimationTickSource.cs
@@ -1,0 +1,198 @@
+using System.Diagnostics;
+using ModernFormsNext.WindowKit.Backend;
+
+namespace ModernFormsNext.Animations;
+
+/// <summary>
+/// Selects a registered platform frame source without making default-scheduler initialization
+/// order observable to framework applications.
+/// </summary>
+/// <remarks>
+/// The shared scheduler can be initialized by a static control or theme reference before the
+/// platform backend starts. In that case this source temporarily uses the process fallback and
+/// promotes active demand to the native frame source as soon as the backend registers it. The
+/// registry owns the platform source; this adapter only stops it when scheduler demand ends.
+/// </remarks>
+internal sealed class PlatformAnimationTickSource : IAnimationTickSource
+{
+    private readonly object sync = new();
+    private readonly IAnimationTickSource fallback;
+    private readonly Func<IPlatformAnimationFrameSource?> resolvePlatformSource;
+    private IPlatformAnimationFrameSource? platformSource;
+    private IPlatformAnimationFrameSource? rejectedPlatformSource;
+    private Action? tickRequested;
+    private bool isRunning;
+    private bool disposed;
+
+    public PlatformAnimationTickSource()
+        : this(
+            new ThreadPoolAnimationTickSource(),
+            static () => PlatformServiceRegistry.GetService<IPlatformAnimationFrameSource>())
+    {
+    }
+
+    internal PlatformAnimationTickSource(
+        IAnimationTickSource fallback,
+        Func<IPlatformAnimationFrameSource?> resolvePlatformSource)
+    {
+        this.fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+        this.resolvePlatformSource = resolvePlatformSource
+            ?? throw new ArgumentNullException(nameof(resolvePlatformSource));
+    }
+
+    public bool IsRunning
+    {
+        get
+        {
+            lock (sync)
+                return isRunning;
+        }
+    }
+
+    public void Start(Action tickRequested)
+    {
+        ArgumentNullException.ThrowIfNull(tickRequested);
+
+        lock (sync)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            this.tickRequested = tickRequested;
+            isRunning = true;
+
+            if (platformSource is { } existing)
+            {
+                // Start is also the callback-update operation defined by the public frame-source
+                // contract. Android keeps this idempotent and never adds a duplicate callback.
+                if (TryUsePlatformSourceLocked(existing, tickRequested))
+                    return;
+            }
+
+            IPlatformAnimationFrameSource? candidate = ResolvePlatformSourceLocked();
+            if (candidate is not null && TryUsePlatformSourceLocked(candidate, tickRequested))
+                return;
+
+            fallback.Start(HandleFallbackTick);
+        }
+    }
+
+    public void Stop()
+    {
+        lock (sync)
+        {
+            if (disposed)
+                return;
+
+            isRunning = false;
+            tickRequested = null;
+            fallback.Stop();
+            StopPlatformSourceLocked();
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (sync)
+        {
+            if (disposed)
+                return;
+
+            disposed = true;
+            isRunning = false;
+            tickRequested = null;
+            fallback.Dispose();
+            StopPlatformSourceLocked();
+            platformSource = null;
+            rejectedPlatformSource = null;
+        }
+    }
+
+    private void HandleFallbackTick()
+    {
+        Action? callback;
+        lock (sync)
+        {
+            if (disposed || !isRunning || platformSource is not null)
+                return;
+
+            callback = tickRequested;
+            IPlatformAnimationFrameSource? candidate = ResolvePlatformSourceLocked();
+            if (candidate is not null && callback is not null &&
+                TryUsePlatformSourceLocked(candidate, callback))
+            {
+                // The native source owns the next pacing signal. Do not deliver the fallback tick
+                // as well, otherwise backend startup could produce two scheduler requests.
+                return;
+            }
+        }
+
+        callback?.Invoke();
+    }
+
+    private IPlatformAnimationFrameSource? ResolvePlatformSourceLocked()
+    {
+        IPlatformAnimationFrameSource? candidate;
+        try
+        {
+            candidate = resolvePlatformSource();
+        }
+        catch (Exception exception)
+        {
+            Trace.TraceError($"Failed to resolve the platform animation frame source: {exception}");
+            return null;
+        }
+
+        return ReferenceEquals(candidate, rejectedPlatformSource) ? null : candidate;
+    }
+
+    private bool TryUsePlatformSourceLocked(
+        IPlatformAnimationFrameSource candidate,
+        Action callback)
+    {
+        try
+        {
+            candidate.Start(callback);
+            platformSource = candidate;
+            fallback.Stop();
+            return true;
+        }
+        catch (Exception exception)
+        {
+            // A native source that cannot accept demand must not strand an already registered
+            // shared animation. Reject that immutable registry instance and keep the safe fallback.
+            try
+            {
+                // Start is permitted to fail after recording demand (for example when Android's
+                // main Looper is already shutting down). Stop must still release that delegate.
+                candidate.Stop();
+            }
+            catch (Exception cleanupException)
+            {
+                Trace.TraceError(
+                    $"Failed to stop a rejected platform animation frame source: {cleanupException}");
+            }
+
+            platformSource = null;
+            rejectedPlatformSource = candidate;
+            fallback.Start(HandleFallbackTick);
+            Trace.TraceError($"Failed to start the platform animation frame source: {exception}");
+            return false;
+        }
+    }
+
+    private void StopPlatformSourceLocked()
+    {
+        if (platformSource is not { } source)
+            return;
+
+        try
+        {
+            source.Stop();
+        }
+        catch (Exception exception)
+        {
+            // Native Stop implementations clear their delegate before unscheduling the platform
+            // callback. A shutdown-time unschedule failure must not break scheduler cleanup.
+            Trace.TraceError($"Failed to stop the platform animation frame source: {exception}");
+        }
+    }
+}

--- a/ModernFormsNext/Theming/ThemeManager.cs
+++ b/ModernFormsNext/Theming/ThemeManager.cs
@@ -374,6 +374,7 @@ public sealed class ThemeManager
         bool transitionEnabled = options.Transition.Enabled &&
             options.Transition.Duration > TimeSpan.Zero &&
             !environment.IsDesignMode &&
+            !scheduler.Policy.ShouldCompleteImmediately &&
             (!options.Transition.RespectReducedMotion || !environment.IsReducedMotionRequested);
         ThemeTransitionPlan? plan = transitionEnabled
             ? ThemeTransitionPlan.Create(oldResources, targetResources, oldLegacy, targetLegacy)

--- a/docs/android-backend.md
+++ b/docs/android-backend.md
@@ -6,7 +6,7 @@
 > supported vertical slice and current limitations.
 
 The Android backend is an early platform foundation with an experimental shared-control Skia
-surface, not a complete ModernFormsNext window backend.
+surface and shared animation-runtime integration, not a complete ModernFormsNext window backend.
 Windows remains the primary and best-supported runtime. The Android project targets
 `net10.0-android` with API 23 as its current minimum and has no MAUI or AndroidX dependency.
 
@@ -41,27 +41,31 @@ the current host. A delayed callback from the old activity therefore cannot eras
 activity that has already been created or resumed. A permission request owned by the old activity
 completes with a diagnostic instead of hanging; the host can retry after the replacement activity
 is resumed. When initialization occurs inside the first activity's `OnCreate`, call
-`ObserveHostActivity` once so that activity is immediately available. Subsequent transitions are
-automatic.
+`ObserveHostActivity` only if a service must use that not-yet-resumed Activity immediately.
+Animation surfaces must be marked active only from their normal start/resume lifecycle. Subsequent
+Activity transitions are automatic.
 
 An optional `ActivityProvider` exists for hosts with their own lifecycle integration. It is invoked
 on demand; the delegate must not keep destroyed activities alive.
 
-### Experimental platform animation preference
+### Experimental animation runtime and platform preference
 
 The backend registers `AndroidPlatformAnimationSettings` through the shared backend service
 registry. When an application context exists, it reads
-`Settings.Global.ANIMATOR_DURATION_SCALE` and `TRANSITION_ANIMATION_SCALE`; a zero value in either
-setting requests reduced motion. The animation scheduler combines that snapshot with application
-policy on the UI dispatcher.
+`Settings.Global.ANIMATOR_DURATION_SCALE`. Its exact scalar is combined with application policy on
+the UI dispatcher; zero requests reduced motion and immediate, deterministic targets.
 
 The provider refreshes during startup, on foreground entry, and when application code calls
-`AnimationScheduler.RefreshPlatformPolicy()`. It deliberately does not register a process-lifetime
-`ContentObserver` in this experimental stage. A missing application context or failed settings
-read uses compatibility defaults, records a fallback diagnostic, and does not fail application
-startup.
-The settings evaluator and lifecycle refresh path have deterministic host-side tests, but runtime
-behavior still requires device/emulator validation.
+`AnimationScheduler.RefreshPlatformPolicy()`. A main-thread ContentObserver is registered only
+while the application is foregrounded and the scheduler is subscribed; it uses the application
+resolver and unregisters on background or disposal. A missing context, failed read, or observer
+failure uses compatibility defaults or refresh fallback, records diagnostics, and does not fail
+application startup.
+
+The scheduler uses one demand-driven Choreographer callback while an attached and resumed Skia
+surface exists. It does not assume 60 Hz or maintain a timer per control. Detailed ownership,
+frame, lifecycle, cleanup, capability, and validation guidance is in
+[Android animation runtime architecture](architecture/android-animation-runtime.md).
 
 ## Dispatcher
 
@@ -87,7 +91,8 @@ invalidation, and disposal.
 including framework layout, paint, hit testing, pointer capture, selection, and committed-text
 routing. This is the pipeline used by `ModernFormsNext.CrossPlatform.Sample`.
 
-The view renders only after invalidation or resize. It does not run a permanent frame timer.
+The view renders only after invalidation or resize. It does not run a permanent frame timer; the
+shared animation scheduler requests Choreographer callbacks only while animation work remains.
 Canvas and Android objects remain platform-owned; the adapter borrows the shared control root so
 activity recreation can detach and reattach without discarding application state.
 

--- a/docs/architecture/android-animation-runtime.md
+++ b/docs/architecture/android-animation-runtime.md
@@ -1,0 +1,254 @@
+# Android animation runtime architecture
+
+## Status and scope
+
+Android support remains experimental. This document describes the Android integration for the
+shared ModernFormsNext animation scheduler, interaction effects, animated layout, visual states,
+and theme transitions. It does not introduce an Android animation model or interpolator. Windows
+remains the primary and best-supported runtime.
+
+The runtime is designed around this path:
+
+```text
+Android lifecycle and MotionEvent
+  -> AndroidSkiaHostView logical input
+  -> SkiaControlSurface and shared Control state
+  -> AnimationScheduler
+  -> presentation state
+  -> Control invalidation
+  -> AndroidAppHost / PostInvalidateOnAnimation
+  -> Skia render
+  -> Choreographer next-frame signal while work remains
+```
+
+Shared code owns animation definitions, easing, interpolation, scheduling, effect state,
+presentation geometry, cancellation, and elapsed time. The Android backend owns only native frame
+signals, lifecycle bridging, MotionEvent translation, density conversion, system animation-scale
+observation, surface gating, and native cleanup.
+
+## Frame pacing and time
+
+`AndroidChoreographerAnimationFrameSource` implements the platform-neutral
+`IPlatformAnimationFrameSource` contract. The default shared scheduler resolves this service when
+frame demand starts, rather than permanently selecting a source when `AnimationScheduler.Default`
+is first read. An early singleton read is therefore safe. If animation work itself starts before
+backend registration, the shared idle-aware timer is temporary: the next fallback signal performs
+one atomic handoff to Choreographer and is not delivered as a duplicate scheduler tick. Other
+environments retain the shared fallback.
+
+There is one Choreographer source for the process-wide scheduler. It keeps no per-control timer and
+never uses `Thread.Sleep` or a busy loop. A native callback is pending only when both conditions are
+true:
+
+- the shared scheduler has active animation work; and
+- at least one Android Skia surface is attached and resumed.
+
+The state machine coalesces repeated starts and allows at most one Choreographer callback to be
+pending. Delivery clears the pending state before scheduler work runs. If work remains, the source
+posts one callback for a subsequent display frame; otherwise it becomes idle. Starting work after
+an idle period wakes the source without retaining the previous callback delegate.
+
+All native post/remove operations are marshaled through a `Handler` created for
+`Looper.MainLooper`. The Choreographer instance is acquired lazily inside that main-Looper
+reconciliation, so even backend initialization invoked from another thread cannot bind frame
+callbacks to that thread's Looper. `DoFrame`, shared presentation updates, and resulting
+invalidations consequently execute on the Android UI thread.
+
+Choreographer supplies pacing only. The scheduler continues to calculate progress from its
+monotonic clock and clamps progress to the animation interval. It therefore follows the display's
+actual refresh rate rather than assuming 60 Hz. Dropped or late frames advance directly to the
+appropriate elapsed-time presentation, without accumulating a callback backlog. A long frame may
+visibly skip intermediate states but cannot extend a completed animation indefinitely.
+
+`PostInvalidateOnAnimation` remains the coalesced render endpoint. An animation property or
+presentation-state update requests invalidation through the established Control-to-host path; the
+frame source does not repaint the entire tree by itself.
+
+## Background, foreground, and surface lifecycle
+
+`AndroidActivityTracker` publishes the platform-neutral application lifecycle already consumed by
+`AnimationScheduler`. Background or no-host state globally pauses the scheduler and stops native
+frame demand. Resume rebases the scheduler's effective monotonic time by subtracting the paused
+interval. For example, a 500 ms animation paused after 100 ms resumes near 100 ms even if the app
+spent 20 seconds in the background.
+
+Native surface availability is a separate gate. `AndroidSkiaHostView` activates its lightweight
+frame-source registration only while the view is attached and the host is resumed. Pause, stop,
+detach, disposal, and surface recreation remove that registration and any pending callback when no
+other active surface exists. Resume or reattach can wake a still-active scheduler entry. This
+separation covers activity switching, screen off/on, view detach, and activity recreation without
+putting Android lifecycle types into shared APIs.
+
+## Touch, pointer ownership, and interaction effects
+
+`AndroidMotionEventPlan` maps Android action codes and action indices into platform-neutral pointer
+events. Pointer indices are used only to read the current `MotionEvent`; the resulting stable
+Android pointer ID is passed to shared input. The mapping is:
+
+| Android action | Framework input |
+| --- | --- |
+| `ACTION_DOWN` | one `Down` for the action pointer ID |
+| `ACTION_POINTER_DOWN` | one `Down` for the action pointer ID |
+| `ACTION_MOVE` | one `Move` for every current pointer ID |
+| `ACTION_POINTER_UP` | one `Up` for the action pointer ID |
+| `ACTION_UP` | one `Up` for the action pointer ID |
+| `ACTION_CANCEL` | cancel all active pointer IDs |
+
+Coordinates are converted from device pixels to logical pixels before shared hit testing. Shared
+`SkiaControlSurface` capture then keeps each pointer associated with its original target. Reordering
+native pointer indices does not transfer ownership.
+
+`RippleEffect` stores one ripple per shared pointer ID. Its existing `MaxConcurrentRipples` and
+overflow policy remain authoritative. `StartFromPointer` uses the logical, target-local coordinate
+from the shared routed event. `PressScaleEffect` tracks a set of active pointer IDs, so releasing or
+canceling one finger does not clear another finger's press. Move-out, disable, detach, subtree
+removal, reparent, disposal, and lifecycle cancellation continue through shared interaction-scope
+cleanup. Presentation geometry remains part of shared hit testing; Android does not maintain a
+second geometry model.
+
+## Reduced motion and animator duration scale
+
+Android reads only `Settings.Global.ANIMATOR_DURATION_SCALE`, the system setting that controls
+animator duration. Window transition scale is not combined with framework animation duration:
+doing so could disable or multiply application animations because of an unrelated system-window
+preference.
+
+The backend preserves the finite positive scalar, so values such as `0.5`, `1`, and `2` shorten,
+preserve, or lengthen newly started shared animations. The application duration scale and platform
+scale multiply in the platform-neutral `AnimationPolicy`. A scale of zero marks animations
+disabled and reduced, completes active and newly started animations immediately at their exact
+targets, and leaves the scheduler idle. Invalid, inaccessible, or implausibly large values use the
+compatibility scale `1` and expose fallback diagnostics rather than failing startup.
+
+A main-Looper `ContentObserver` watches the animator-duration setting while the application is in
+the foreground and the scheduler is subscribed. It refreshes the immutable platform snapshot when
+the setting changes, without requiring an application restart. The observer uses the application
+`ContentResolver`, not an Activity, and unregisters on background, final unsubscribe, or provider
+disposal. Startup, foreground entry, and explicit policy refresh remain safe fallback refresh
+points if observation cannot be registered.
+
+## Themes, layout, orientation, and resizing
+
+Theme transitions continue to use the shared ThemeManager and Brush interpolators. Android adds no
+Brush implementation. Solid-to-solid, solid-to-gradient, gradient-to-solid, compatible-gradient,
+retarget, and documented discrete-fallback behavior therefore match other backends. Platform scale
+zero and disabled animation policy make ThemeManager commit the exact target snapshot without
+creating transition scheduler work.
+
+Logical bounds remain the source of truth for Dock, Anchor, orientation, density, and surface-size
+layout. `LayoutTransition` and visual-state metric transitions only animate shared presentation
+geometry between the latest logical results. A resize during active work retargets from the current
+presentation state to the new logical target; completion clears presentation overrides. Repeated
+portrait/landscape or size changes must therefore converge on the latest logical bounds without
+accumulating transform drift.
+
+## Cleanup and ownership
+
+- Shared `Control.Dispose`, detach, subtree removal, and reparent paths cancel scheduler ownership,
+  pointer capture, ripples, press state, layout presentation, and visual-state transitions.
+- `AndroidSkiaHostView` cancels active native pointers and removes its active-surface registration
+  on pause, stop, detach, and disposal.
+- The frame source releases the scheduler callback on idle and removes a pending native callback
+  when its surface/demand gate closes.
+- The animation-settings provider stores only the application context and unregisters its observer;
+  neither the observer nor frame-source registration retains an Activity or Control.
+- Scheduler callback faults terminate only the failing entry, release it, and remain visible in
+  shared diagnostics.
+- A single-surface host must cancel process-owned work such as an active ThemeManager transition
+  when that host is shutting down. The cross-platform sample does this before detaching its tree;
+  multi-window hosts should instead cancel at their application-level ownership boundary.
+
+The shared scheduler intentionally retains active owners and update delegates until termination;
+explicit cancellation/disposal is therefore the deterministic lifetime boundary. There is no
+finalizer-based animation cleanup and no arbitrary sleep in lifecycle or GC tests.
+
+## Diagnostics
+
+`AnimationScheduler.GetDiagnostics()` reports active count, active/idle state, tick and completion
+counters, and scheduler faults. `AnimationScheduler.GetPlatformDiagnostics()` reports provider
+state, effective reduced-motion flags, and the exact platform duration scale.
+
+`AndroidWindowKit.Current.GetAnimationRuntimeDiagnostics()` adds Android lifecycle state, active
+surface count, scheduler frame demand, whether one Choreographer callback is pending, posted and
+delivered callback counters, observer registration state, and the latest observer error. The
+cross-platform sample displays these snapshots on demand. They are intentionally snapshots rather
+than per-frame log output, so normal rendering does not spam diagnostics.
+
+## Capability and fallback matrix
+
+The validation column is evidence-specific. "Automated" means deterministic tests or builds in
+the repository; it does not mean emulator or physical-device observation.
+
+| Feature | Android support | Implementation | Fallback | Validation |
+| --- | --- | --- | --- | --- |
+| Animation scheduler | Experimental shared runtime | Shared `AnimationScheduler`, monotonic clock, and late-bound platform source | Temporary shared timer until a backend source is registered or when native source startup fails | Automated early-access/handoff, scheduler, and Android builds; manual smoothness required |
+| Frame pacing | Integrated | One demand-driven Choreographer source gated by active surfaces | No frames while no surface is active | Automated state-machine tests; emulator/device refresh-rate check required |
+| RippleEffect | Integrated shared effect | Stable pointer IDs and shared presentation rendering | Existing overflow policy | Automated shared effect and MotionEvent-plan tests; visual touch check required |
+| Multi-touch | Integrated | One shared capture/effect owner per Android pointer ID | `ACTION_CANCEL` clears all pointers | Automated reorder/cancel tests; real multi-touch required |
+| PressScaleEffect | Integrated shared effect | Shared active-pointer set and scheduler | Exact neutral scale after cancellation/cleanup | Automated shared interaction tests; visual check required |
+| Layout transitions | Integrated shared presentation | Latest logical layout retargets presentation bounds | Immediate layout under reduced motion | Automated layout tests; rotate/resize check required |
+| Visual-state transitions | Integrated shared presentation | Shared state plans and scheduler | Exact target state | Automated core tests; sample check required |
+| Brush/theme transitions | Integrated shared interpolation | ThemeManager and shared Brush plans | Documented discrete fallback for incompatible brushes | Automated compatibility/retarget tests; Skia visual check required |
+| Reduced motion | Dynamic | Animator-duration scale plus lifecycle-aware ContentObserver | Foreground/explicit refresh and scale `1` on read failure | Automated evaluator/policy tests; settings UI check required |
+| Orientation and resize | Integrated | Density-aware surface resize and logical relayout | Immediate presentation when transitions are disabled | Automated surface/layout tests; repeated rotate check required |
+| Background/foreground | Integrated | Shared pause/resume time rebasing plus surface gate | No native frames while inactive | Automated elapsed-time/lifecycle tests; app-switch and screen-off check required |
+| Detach/reparent/dispose | Integrated | Shared ownership cleanup plus Android surface registration disposal | Explicit owner cancellation | Automated subtree/effect/surface tests; activity-recreate check required |
+| Diagnostics | Integrated | Shared and Android snapshot APIs | Observer failures are recorded | Automated build/sample checks; inspect during smoke test |
+| GPU/CPU rendering | Experimental Skia surface | `SKCanvasView`, existing invalidation and Skia renderer | Platform-selected canvas path; no Android-only animation fallback | Build verified; emulator/device profiling and visual validation required |
+
+## IME boundary
+
+Animation integration does not create a second input loop, replace the selected control, request
+focus per frame, or recreate the input connection during invalidation. Existing TextBox selection,
+composition, committed-text, keyboard, and UTF-16/code-point routing remain unchanged. The sample
+keeps single-line and multiline TextBox cases beside the animation smoke controls. Actual soft
+keyboard behavior across orientation and background/foreground remains a manual emulator/device
+regression check.
+
+## Manual validation checklist
+
+### Recorded issue #29 evidence
+
+Automated validation and manual runtime evidence are intentionally separate:
+
+- Automated validation covers scheduler timing and policy, lifecycle interleavings, source
+  idle/wake and late binding, pointer-plan translation, shared multi-pointer ownership, cleanup,
+  layout/visual-state/theme retargeting, project builds, and packaging validation.
+- A user-reported emulator smoke test on 2026-08-15 verified application startup, the basic Android
+  host, AnimationScheduler/Choreographer operation, animation start and retarget, theme transition,
+  and TextBox with the Android soft keyboard/IME. No crash was observed. Emulator API level,
+  refresh rate, and image were not recorded, so this is not evidence for a particular device class
+  or display cadence.
+- No physical-device validation has been recorded for issue #29.
+
+The remaining cases below still require explicit manual observation unless a later validation
+record says otherwise.
+
+Run the Android target of `ModernFormsNext.CrossPlatform.Sample` on every available environment.
+Record emulator image/API/refresh rate or physical-device model/API separately.
+
+1. Start and rapidly retarget simultaneous layout, opacity, scale, and rotation animations. Confirm
+   the diagnostic callback counters advance only while work is active and restart after idle.
+2. Touch the interaction button with one and then two fingers. Confirm each ripple stays under its
+   finger, press scale remains active until the last pointer releases, and cancel/move-out recovers.
+3. Trigger the visual-state-capable control and animated light/dark theme changes, including theme
+   retargeting during layout and interaction work.
+4. Set Android animator duration scale to `0`, a fractional value, `1`, and a value above `1` while
+   the app is running. Confirm the displayed scale changes without restart; scale `0` lands exactly
+   at targets and becomes idle.
+5. Rotate portrait to landscape and back repeatedly during layout and visual-state transitions.
+   Resize if the emulator supports it and confirm controls converge to logical layout without drift.
+6. Background for at least 20 seconds during a 500 ms animation, then return. Confirm it resumes
+   near its pre-background progress instead of jumping by background elapsed time. Repeat with
+   screen off/on.
+7. Recreate or close the Activity during active ripple, press, layout, and theme work. Confirm no
+   crash, stale callback, duplicate frame loop, retained old Activity, or continuing old input.
+8. Focus both TextBox controls, show the soft keyboard, edit composed/emoji text, animate nearby
+   controls, rotate, and background/foreground. Confirm focus and IME state are not reset merely by
+   animation invalidation.
+9. Inspect diagnostics after the final animation: active count `0`, scheduler idle, frame demand
+   false, and no callback pending. Review log output only for scheduler/observer faults.
+
+Automated validation must be reported separately from emulator and physical-device results. Never
+infer device smoothness, GPU behavior, multi-touch ergonomics, IME behavior, or leak freedom solely
+from a successful APK build.

--- a/docs/architecture/ui-animation-scheduler.md
+++ b/docs/architecture/ui-animation-scheduler.md
@@ -67,7 +67,9 @@ The existing public helpers remain adapters. The new implementation consists of:
 
 - one `AnimationScheduler.Default` instance for the current UI process;
 - an internal monotonic clock based on `Stopwatch.GetTimestamp`;
-- one shared periodic tick source, created on first use and stopped when idle;
+- one shared idle-aware tick source, created on first use, late-bound to a backend source, and
+  stopped when idle;
+- an optional platform-neutral frame-source service, implemented by Android with Choreographer;
 - a dispatcher adapter that prefers the registered Android `IPlatformDispatcher` and otherwise
   uses WindowKit `Dispatcher.UIThread`;
 - an owner-and-key identity for replacement;
@@ -91,12 +93,19 @@ finite active animation still completes according to monotonic time when the dis
 
 ## Android requirements
 
-Android already registers `IPlatformDispatcher` backed by its main `Looper`. The scheduler uses
-that service when present, so shared controls and brushes are mutated on the Android main thread.
-The Android activity tracker will expose the platform-neutral lifecycle contract: backgrounding
-pauses the scheduler and stops ticks, while foregrounding resumes from the same effective time.
-The background duration is excluded, preventing a visual jump after resume. Android support
-remains experimental and physical-device frame pacing still requires manual validation.
+Android registers `IPlatformDispatcher` backed by its main `Looper` and an
+`IPlatformAnimationFrameSource` backed by Choreographer. The scheduler uses these services when
+present, even if `AnimationScheduler.Default` was read before backend startup, so shared controls
+and brushes are mutated on the Android main thread and frames follow the display cadence without
+assuming 60 Hz. Active fallback demand hands off once without delivering a duplicate tick. The
+Choreographer instance is acquired only from a main-Looper reconciliation. The source keeps at
+most one callback pending and is
+gated by scheduler demand plus an attached, resumed Skia surface. The activity tracker exposes the
+platform-neutral lifecycle contract: backgrounding pauses the scheduler and stops callbacks, while
+foregrounding resumes from the same effective time. The background duration is excluded,
+preventing a visual jump after resume. See
+[Android animation runtime architecture](android-animation-runtime.md). Physical-device frame
+pacing still requires manual validation.
 
 ## UI thread model
 
@@ -215,14 +224,15 @@ scheduler subscribes once, marshals provider changes through its UI dispatcher, 
 then releases provider and scheduler locks before user-visible completion callbacks can run.
 Startup and foreground entry explicitly refresh the snapshot. Windows additionally refreshes from
 the existing message-only WindowKit window on `WM_SETTINGCHANGE`; no poller, timer, or native handle
-is introduced. Experimental Android reads its global animator/transition scales when a usable
-Activity context exists and refreshes on foreground entry rather than using a live observer.
+is introduced. Experimental Android reads the exact global animator duration scale from the
+application context and uses a lifecycle-aware ContentObserver for changes while foregrounded.
 
 When animations are disabled, reduced motion is requested, or duration scale is zero, newly started
 animations apply their final value once on the UI thread and complete without a timer. Disabling
 motion while animations are active completes them through the same final-value path. A positive
-duration scale is captured when an entry starts; for example, 0.5 halves its duration and 2 doubles
-it. Native read failures retain compatibility defaults and are visible through
+application duration scale is multiplied by the platform scale and captured when an entry starts;
+for example, 0.5 halves its duration and 2 doubles it. Native read failures retain compatibility
+defaults and are visible through
 `GetPlatformDiagnostics()` instead of failing application startup.
 
 ## Performance and memory risks

--- a/samples/ModernFormsNext.CrossPlatform.Sample/MainPage.cs
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/MainPage.cs
@@ -1,5 +1,7 @@
+using ModernFormsNext.Animations;
 using ModernFormsNext.WindowKit.Platform.Permissions;
 using SkiaSharp;
+using System.Drawing;
 
 namespace ModernFormsNext.CrossPlatform.Sample;
 
@@ -10,7 +12,8 @@ namespace ModernFormsNext.CrossPlatform.Sample;
 /// Every visible widget is a framework control. Android renders this exact tree through
 /// <see cref="SkiaControlSurface"/>; it does not replace the controls with native Android views.
 /// The page intentionally exercises text input, Unicode, layout, scrolling, focus, lifecycle
-/// diagnostics, dispatching, and an explicitly initiated permission flow.
+/// diagnostics, dispatching, shared animations and effects, theme transitions, reduced motion,
+/// and an explicitly initiated permission flow.
 /// </remarks>
 public sealed class MainPage : Control
 {
@@ -32,6 +35,8 @@ public sealed class MainPage : Control
     private readonly Label serviceResultLabel;
     private readonly Label focusLabel;
     private readonly Label clickLabel;
+    private readonly Label animationRuntimeLabel;
+    private readonly Label animationStatusLabel;
     private readonly Label unicodeLabel;
     private readonly Label longContentLabel;
     private readonly TextBox nameTextBox;
@@ -43,11 +48,22 @@ public sealed class MainPage : Control
     private readonly Button dispatcherButton;
     private readonly Button lifecycleButton;
     private readonly FlowLayoutPanel permissionButtons;
+    private readonly FlowLayoutPanel animationButtons;
+    private readonly Panel animationStage;
+    private readonly Panel animationCard;
+    private readonly Button effectButton;
+    private readonly Button startAnimationsButton;
+    private readonly Button stopAnimationsButton;
+    private readonly Button themeButton;
+    private readonly Button reducedMotionButton;
     private readonly Button permissionCheckButton;
     private readonly Button permissionRequestButton;
     private readonly Button settingsButton;
     private readonly Label[] diagnosticLabels;
     private int displayedRenderBucket = -1;
+    private AnimationRun? activeDemoRun;
+    private bool alternateAnimationTarget;
+    private bool darkTheme;
 
     /// <summary>Creates the shared page for an application.</summary>
     /// <param name="app">The owning shared application.</param>
@@ -78,10 +94,13 @@ public sealed class MainPage : Control
         serviceResultLabel = CreateLabel(string.Empty);
         focusLabel = CreateLabel(string.Empty);
         clickLabel = CreateLabel(string.Empty);
+        animationRuntimeLabel = CreateLabel(string.Empty);
+        animationStatusLabel = CreateLabel("Animation smoke controls are ready.");
         unicodeLabel = CreateLabel("Unicode: Zażółć gęślą jaźń · 你好 · مرحبًا · 👋🏽 🚀");
         longContentLabel = CreateLabel(
-            "Scrollable content: resize the Windows window or rotate the Android device. " +
-            "The same shared layout remains active while the native host updates its logical surface.");
+            "Manual smoke: use two fingers on the effect button; start and rapidly retarget; " +
+            "rotate/resize; background and resume; change Android animator scale; then verify " +
+            "active work and the frame callback return to idle without losing TextBox focus.");
 
         nameTextBox = new TextBox { Text = "ModernFormsNext" };
         multiLineTextBox = new TextBox
@@ -104,6 +123,74 @@ public sealed class MainPage : Control
             WrapContents = true
         };
         permissionButtons.Controls.AddRange([permissionCheckButton, permissionRequestButton, settingsButton]);
+
+        effectButton = new Button
+        {
+            Text = "Ripple + press scale + visual state",
+            Ripple = new RippleEffect
+            {
+                Color = Color.FromArgb(105, 255, 255, 255),
+                Duration = TimeSpan.FromMilliseconds(500),
+                StartFromPointer = true,
+                MaxConcurrentRipples = 4
+            },
+            PressEffect = new PressScaleEffect
+            {
+                PressedScale = 0.94f,
+                PressDuration = TimeSpan.FromMilliseconds(90),
+                ReleaseDuration = TimeSpan.FromMilliseconds(140)
+            }
+        };
+        effectButton.Style.BackgroundColor = SKColors.SlateBlue;
+        effectButton.Style.ForegroundColor = SKColors.White;
+        effectButton.StyleHover.BackgroundColor = SKColors.MediumPurple;
+        effectButton.StyleHover.ScaleX = 1.03f;
+        effectButton.StyleHover.ScaleY = 1.03f;
+        effectButton.StylePressed.BackgroundColor = SKColors.DarkSlateBlue;
+        AddStateTransition(effectButton, VisualState.Normal, VisualState.Hover);
+        AddStateTransition(effectButton, VisualState.Normal, VisualState.Pressed);
+        AddStateTransition(effectButton, VisualState.Hover, VisualState.Normal);
+        AddStateTransition(effectButton, VisualState.Hover, VisualState.Pressed);
+        AddStateTransition(effectButton, VisualState.Pressed, VisualState.Normal);
+        AddStateTransition(effectButton, VisualState.Pressed, VisualState.Hover);
+
+        animationStage = new Panel { BackColor = new SKColor(236, 240, 247) };
+        animationCard = new Panel
+        {
+            Bounds = new Rectangle(12, 18, 118, 72),
+            BackColor = SKColors.CornflowerBlue,
+            LayoutTransition = new LayoutTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(520),
+                Easing = Easings.EaseOut
+            }
+        };
+        animationStage.SetResourceReference(nameof(Control.BackgroundBrush), "SurfaceGlow");
+        animationCard.SetResourceReference(nameof(Control.BackgroundBrush), "PrimaryGradient");
+        animationCard.Controls.Add(new Label
+        {
+            Dock = DockStyle.Fill,
+            Text = "Layout + visual animation",
+            TextAlign = ModernFormsNext.ContentAlignment.MiddleCenter,
+            ForeColor = SKColors.White
+        });
+        animationStage.Controls.Add(animationCard);
+
+        startAnimationsButton = new Button { Text = "Start / retarget" };
+        stopAnimationsButton = new Button { Text = "Stop / reset" };
+        themeButton = new Button { Text = "Theme transition" };
+        reducedMotionButton = new Button { Text = "Reduced motion" };
+        animationButtons = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.LeftToRight,
+            WrapContents = true
+        };
+        animationButtons.Controls.AddRange([
+            startAnimationsButton,
+            stopAnimationsButton,
+            themeButton,
+            reducedMotionButton
+        ]);
 
         diagnosticLabels =
         [
@@ -175,6 +262,15 @@ public sealed class MainPage : Control
         permissionCheckButton.Click += async (_, _) => await RunPermissionActionAsync(requestPermission: false);
         permissionRequestButton.Click += async (_, _) => await RunPermissionActionAsync(requestPermission: true);
         settingsButton.Click += async (_, _) => await OpenSettingsAsync();
+        effectButton.Click += (_, _) =>
+        {
+            app.State.LastInput = "Ripple/press/state button clicked";
+            RefreshStatus();
+        };
+        startAnimationsButton.Click += (_, _) => StartAnimationSmoke();
+        stopAnimationsButton.Click += (_, _) => StopAnimationSmoke();
+        themeButton.Click += (_, _) => ToggleAnimatedTheme();
+        reducedMotionButton.Click += (_, _) => ToggleReducedMotion();
 
         TrackFocus(nameTextBox, "Single-line TextBox");
         TrackFocus(multiLineTextBox, "Multiline TextBox");
@@ -193,6 +289,11 @@ public sealed class MainPage : Control
             dispatcherButton,
             lifecycleButton,
             permissionButtons,
+            animationRuntimeLabel,
+            effectButton,
+            animationButtons,
+            animationStage,
+            animationStatusLabel,
             longContentLabel
         ]);
         Controls.Add(scrollArea);
@@ -221,11 +322,21 @@ public sealed class MainPage : Control
         serviceResultLabel.Text = $"Service result: {app.State.LastServiceResult}";
         focusLabel.Text = $"Shared focus: {app.State.FocusedControl}";
         clickLabel.Text = $"Shared clicks: {app.State.ClickCount}";
+        AnimationSchedulerDiagnostics animationDiagnostics = AnimationScheduler.Default.GetDiagnostics();
+        AnimationPlatformDiagnostics platformAnimation = AnimationScheduler.Default.GetPlatformDiagnostics();
+        animationRuntimeLabel.Text =
+            $"Scheduler active: {animationDiagnostics.ActiveAnimationCount}; " +
+            $"state: {(animationDiagnostics.IsPaused ? "paused" : animationDiagnostics.IsTickSourceRunning ? "active" : "idle")}; " +
+            $"platform scale: {platformAnimation.PlatformDurationScale:0.##}. " +
+            app.PlatformServices.AnimationRuntimeStatus;
         greetingLabel.Text = $"Label bound to TextBox: Hello, {nameTextBox.Text}!";
         clickButton.Enabled = enabledCheckBox.Checked;
         permissionCheckButton.Enabled = platform.SupportsPermissionAction;
         permissionRequestButton.Enabled = platform.SupportsPermissionAction;
         settingsButton.Enabled = platform.SupportsPermissionAction;
+        reducedMotionButton.Text = AnimationScheduler.Default.Policy.ReducedMotion
+            ? "Reduced motion: on"
+            : "Reduced motion: off";
         Invalidate();
     }
 
@@ -359,6 +470,14 @@ public sealed class MainPage : Control
         foreach (var button in permissionButtons.Controls.OfType<Button>())
             button.SetBounds(0, 0, permissionButtonWidth, 42);
         SetRow(permissionButtons, margin, ref y, contentWidth, contentWidth < 620 ? 146 : 50, gap);
+        SetRow(animationRuntimeLabel, margin, ref y, contentWidth, 54, gap);
+        SetRow(effectButton, margin, ref y, contentWidth, 48, gap);
+        var animationButtonWidth = Math.Max(150, Math.Min(220, (contentWidth - 12) / 2));
+        foreach (var button in animationButtons.Controls.OfType<Button>())
+            button.SetBounds(0, 0, animationButtonWidth, 38);
+        SetRow(animationButtons, margin, ref y, contentWidth, contentWidth < 650 ? 92 : 46, gap);
+        SetRow(animationStage, margin, ref y, contentWidth, 132, gap);
+        SetRow(animationStatusLabel, margin, ref y, contentWidth, 54, gap);
         SetRow(longContentLabel, margin, ref y, contentWidth, 76, margin);
 
         scrollArea.PerformLayout();
@@ -374,6 +493,90 @@ public sealed class MainPage : Control
         PlatformPermissionStatus.NotSupported => "Not supported",
         _ => status.ToString()
     };
+
+    private void StartAnimationSmoke()
+    {
+        activeDemoRun?.Cancel();
+        alternateAnimationTarget = !alternateAnimationTarget;
+        animationCard.Bounds = alternateAnimationTarget
+            ? new Rectangle(Math.Max(12, animationStage.Width - 190), 34, 166, 82)
+            : new Rectangle(12, 18, 118, 72);
+        activeDemoRun = Animation.Parallel(
+                animationCard.RotateTo(alternateAnimationTarget ? 8f : -8f, SmokeAnimationOptions(620)),
+                animationCard.ScaleTo(alternateAnimationTarget ? 1.08f : 0.96f, SmokeAnimationOptions(620)),
+                animationCard.FadeTo(alternateAnimationTarget ? 0.72f : 1f, SmokeAnimationOptions(620)))
+            .Start(AnimationScheduler.Default);
+        animationStatusLabel.Text =
+            "Started simultaneous LayoutTransition, transform, opacity, and state-capable effects. " +
+            "Rotate or resize while it runs, then retarget rapidly.";
+        RefreshStatus();
+    }
+
+    private void StopAnimationSmoke()
+    {
+        activeDemoRun?.Cancel();
+        activeDemoRun = null;
+        if (animationCard.LayoutTransition is { } transition)
+        {
+            transition.Enabled = false;
+            transition.Enabled = true;
+        }
+        animationCard.Rotation = 0f;
+        animationCard.ScaleX = 1f;
+        animationCard.ScaleY = 1f;
+        animationCard.Opacity = 1f;
+        animationCard.Bounds = new Rectangle(12, 18, 118, 72);
+        animationStatusLabel.Text = "Animations canceled and presentation state reset.";
+        RefreshStatus();
+    }
+
+    private void ToggleAnimatedTheme()
+    {
+        darkTheme = !darkTheme;
+        ThemeApplyResult result = ThemeManager.Current.Apply(
+            darkTheme ? BuiltInThemes.Dark : BuiltInThemes.Light,
+            new ThemeApplyOptions
+            {
+                Transition = new ThemeTransitionOptions
+                {
+                    Enabled = true,
+                    Duration = TimeSpan.FromMilliseconds(650),
+                    Easing = ThemeEasing.EaseInOut,
+                    RespectReducedMotion = true
+                }
+            });
+        animationStatusLabel.Text = result.Success
+            ? $"Theme '{result.Snapshot!.Name}' committed; transition: {result.Transition?.State.ToString() ?? "immediate"}."
+            : "Theme transition was rejected; inspect diagnostics.";
+        RefreshStatus();
+    }
+
+    private void ToggleReducedMotion()
+    {
+        AnimationPolicy policy = AnimationScheduler.Default.Policy;
+        policy.ReducedMotion = !policy.ApplicationReducedMotion;
+        animationStatusLabel.Text = policy.ReducedMotion
+            ? "Reduced motion enabled: active work must snap to exact targets and return idle."
+            : "Application reduced motion disabled; Android system scale remains authoritative.";
+        RefreshStatus();
+    }
+
+    private static void AddStateTransition(Button button, VisualState from, VisualState to)
+        => button.StyleTransitions.Add(
+            from,
+            to,
+            new VisualStateTransition
+            {
+                Duration = TimeSpan.FromMilliseconds(150),
+                Easing = Easings.CubicOut
+            });
+
+    private static AnimationOptions SmokeAnimationOptions(int milliseconds)
+        => new()
+        {
+            Duration = TimeSpan.FromMilliseconds(milliseconds),
+            Easing = Easings.CubicOut
+        };
 
     private static Label CreateLabel(string text) => new() { Text = text };
 

--- a/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/AndroidAppHost.cs
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/AndroidAppHost.cs
@@ -123,6 +123,10 @@ public sealed class AndroidAppHost : IDisposable
         nativeSurface.KeyInput -= OnKeyInput;
         nativeSurface.TextSelectionRequested -= OnTextSelectionRequested;
         nativeSurface.TextInputStateProvider = null;
+        // This sample owns one process-wide surface. Snap its global theme transition before
+        // detaching so Activity recreation cannot leave non-control scheduler work waiting for a
+        // surface that no longer exists.
+        ThemeManager.Current.CancelTransition();
         controlSurface.Dispose();
         nativeSurface.Dispose();
     }

--- a/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/AndroidPlatformServices.cs
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/AndroidPlatformServices.cs
@@ -24,6 +24,22 @@ internal sealed class AndroidPlatformServices(AndroidWindowKitBackend backend) :
         _ => "Activity unknown"
     };
 
+    public string AnimationRuntimeStatus
+    {
+        get
+        {
+            AndroidAnimationRuntimeDiagnostics diagnostics = backend.GetAnimationRuntimeDiagnostics();
+            return $"Choreographer pending: {diagnostics.FrameCallbackPending}; " +
+                $"demand: {diagnostics.SchedulerDemand}; active surfaces: {diagnostics.ActiveSurfaceCount}; " +
+                $"frames delivered/posted: {diagnostics.DeliveredFrameCallbackCount}/{diagnostics.PostedFrameCallbackCount}; " +
+                $"animator scale: {diagnostics.DurationScale:0.##}; " +
+                $"observer: {(diagnostics.ContentObserverRegistered ? "registered" : "idle")}" +
+                (string.IsNullOrWhiteSpace(diagnostics.ObserverError)
+                    ? string.Empty
+                    : $"; observer error: {diagnostics.ObserverError}");
+        }
+    }
+
     public IPlatformDispatcher Dispatcher => backend.Dispatcher;
 
     public bool SupportsPermissionAction => true;

--- a/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/MainActivity.cs
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/MainActivity.cs
@@ -28,7 +28,6 @@ public sealed class MainActivity : Activity
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
-        AndroidWindowKit.ObserveHostActivity(this);
         var application = (SampleApplication)Application!;
         var enableInputDiagnostics = Intent?.GetBooleanExtra(
             AndroidAppHost.EnableInputDiagnosticsIntentExtra,

--- a/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Windows/WindowsPlatformServices.cs
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Windows/WindowsPlatformServices.cs
@@ -16,6 +16,16 @@ internal sealed class WindowsPlatformServices : ISamplePlatformServices
 
     public string HostState => "Desktop window active";
 
+    public string AnimationRuntimeStatus
+    {
+        get
+        {
+            var diagnostics = ModernFormsNext.Animations.AnimationScheduler.Default.GetDiagnostics();
+            return $"Shared timer active: {diagnostics.IsTickSourceRunning}; " +
+                $"scheduler active: {diagnostics.ActiveAnimationCount}; ticks: {diagnostics.TickCount}";
+        }
+    }
+
     public IPlatformDispatcher Dispatcher => dispatcher;
 
     public bool SupportsPermissionAction => false;

--- a/samples/ModernFormsNext.CrossPlatform.Sample/README.md
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/README.md
@@ -7,7 +7,10 @@ both targets. Platform startup and native adaptation are isolated under `Platfor
 
 The shared page uses real ModernFormsNext controls and exercises scrolling, resizing, single-line
 and multiline IME input, Polish/Asian/RTL text, emoji, focus, buttons, checkboxes, flow layout,
-dispatcher callbacks, lifecycle/density diagnostics, and an explicit camera permission flow.
+dispatcher callbacks, lifecycle/density diagnostics, an explicit camera permission flow, and the
+shared animation runtime. The animation smoke section covers ripple, press scale, visual states,
+layout/presentation transitions, simultaneous animations, theme transitions, reduced motion, and
+idle-to-wake diagnostics.
 
 Windows attaches `App.Root` to a normal ModernFormsNext `Form`. Android creates one Skia view and
 adapts touch, hardware keys, IME, density, invalidation, and lifecycle into the same framework
@@ -26,4 +29,7 @@ From the repository root:
 ```
 
 See [`docs/cross-platform-sample.md`](../../docs/cross-platform-sample.md) for Visual Studio steps,
-ADB/emulator commands, limitations, and the complete manual validation checklist.
+ADB/emulator commands, limitations, and the general manual validation checklist. The animation-
+specific architecture, support matrix, and rotate/background/multi-touch/reduced-motion checklist
+are in
+[`docs/architecture/android-animation-runtime.md`](../../docs/architecture/android-animation-runtime.md).

--- a/samples/ModernFormsNext.CrossPlatform.Sample/Shared/ISamplePlatformServices.cs
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/Shared/ISamplePlatformServices.cs
@@ -24,6 +24,9 @@ public interface ISamplePlatformServices
     /// <summary>Gets the current native host lifecycle description.</summary>
     string HostState { get; }
 
+    /// <summary>Gets a compact platform animation-runtime diagnostic description.</summary>
+    string AnimationRuntimeStatus { get; }
+
     /// <summary>Gets the platform UI dispatcher.</summary>
     IPlatformDispatcher Dispatcher { get; }
 


### PR DESCRIPTION
## Summary

Completes Android runtime integration for the shared ModernFormsNext animation system without introducing Android-only schedulers, easing, or interpolation.

This integrates the shared `AnimationScheduler` with Choreographer-based frame pacing and covers lifecycle pause/resume/rebase, Android animator-duration scaling, stable multi-touch ownership, interaction effects, theme transitions, layout and visual-state transitions, cleanup, diagnostics, and the Android diagnostic sample.

## Architecture

The platform-neutral runtime remains responsible for:

- animation models and easing
- interpolation
- `AnimationScheduler`
- `ThemeManager`
- `InteractionEffect`, `RippleEffect`, and `PressScaleEffect`
- `LayoutTransition` and `VisualStateTransition`
- logical and presentation state

The Android backend is limited to:

- the Choreographer frame source
- the lifecycle bridge
- MotionEvent translation
- density conversion
- animator-duration-scale observation
- native callback and subscription cleanup
- Android runtime diagnostics

No second Android-only animation system was created.

## Frame pacing

- Uses one process-wide Choreographer source for the shared scheduler.
- Keeps at most one native frame callback pending.
- Requests callbacks only while shared animation demand and an attached/resumed surface are both present.
- Returns to idle after the final animation and wakes for later work.
- Uses the scheduler's monotonic clock and does not assume 60 Hz.
- Dropped and long frames advance to the current presentation value without accumulating a frame backlog.
- Late-binds the platform frame source, so early `AnimationScheduler.Default` access cannot permanently select the fallback ticker.
- Active fallback demand hands off once to Choreographer without delivering a duplicate scheduler tick.

## Lifecycle

- Backgrounding stops frame demand and pauses the shared scheduler.
- Resume rebases scheduler time so background elapsed time is excluded and cannot produce catch-up animation.
- Attach/resume activates the Android surface; pause/stop/detach/dispose deactivates it.
- A monotonic lifecycle version prevents stale foreground work from overtaking a newer background event.
- Choreographer is acquired and reconciled on Android's main Looper.

## Reduced motion

Android `ANIMATOR_DURATION_SCALE` is read through a lifecycle-aware `ContentObserver` using the application context and a main-thread Handler.

- `scale == 0`: active animations publish their exact target immediately and the scheduler remains idle.
- `scale < 1`: newly started animations use shortened durations.
- `scale == 1`: normal duration.
- `scale > 1`: newly started animations use extended durations.
- Invalid or unavailable reads use a diagnostic fallback of `1.0`.
- Observation is enabled only while needed in the foreground and is unregistered during background/shutdown/disposal cleanup.

## Multi-touch

- Uses stable Android pointer IDs for shared pointer capture and effect ownership.
- Uses `ActionIndex` only to find the changed pointer for DOWN/POINTER_DOWN and POINTER_UP/UP.
- MOVE translates every currently present pointer.
- CANCEL clears every tracked pointer.
- Pointer-index reordering does not transfer ownership.
- Ripple instances retain independent pointer ownership.
- Press-scale ownership and cancellation remain in the shared effect implementation.

## Cleanup and leak prevention

Cleanup covers scheduler entries, native frame callbacks, pointer captures, lifecycle and invalidation subscriptions, ContentObserver registration, detach/reparent/dispose, and surface recreation.

The Android activity tracker uses a `WeakReference` for the current Activity. The frame source does not retain a View or Activity, and reduced-motion observation uses application context. Automated weak-reference and lifecycle tests cover managed cleanup paths; no device-profiler leak claim is made.

## Automated validation

- Full restore: PASS
- Debug solution build: PASS, 0 warnings / 0 errors
- Release solution build: PASS, 0 warnings / 0 errors
- All tests: **1083/1083**
  - Core: 820/820
  - Android backend: 72/72
  - Designer: 168/168
  - Windows backend: 7/7
  - Cross-platform sample: 16/16
- Android SmokeTest Debug/Release: PASS
- CrossPlatform.Sample Android Debug/Release: PASS
- VSIX Debug/Release validation: PASS
- `git diff --check`: PASS

The complete test count was confirmed from a clean worktree at the exact feature SHA because nested worktrees under `artifacts` can otherwise contaminate `ReleaseVersionConsistencyTests`.

## Manual emulator validation

A manual emulator smoke test confirmed only:

- Android host startup
- basic AnimationScheduler/Choreographer operation
- animation start and retargeting
- theme transition
- TextBox
- Android soft keyboard / IME
- no visible crash in that scenario

## Remaining device-specific validation

The following still require deeper manual/device validation and are not claimed as completed here:

- real two-finger multi-touch
- system-generated ACTION_CANCEL
- dynamic animator-scale changes while the app is running
- long background intervals, screen off/on, and app switching
- rapid repeated rotation and resize
- Activity/surface recreation during active effects
- 90/120 Hz displays
- visual behavior under dropped or unusually long frames
- device-profiler leak checks
- physical-device validation
- more complex IME/composition scenarios

Closes #29
