### PR TITLE
Add versioned documentation artifacts to releases

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.78.5",
+      "commands": [
+        "docfx"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The documentation build verifies that the triggering tag resolves to github.sha.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -28,6 +31,9 @@ jobs:
 
       - name: Restore
         run: dotnet restore ModernFormsNext.slnx --force --no-cache
+
+      - name: Restore documentation tools
+        run: dotnet tool restore
 
       - name: Build
         run: dotnet build ModernFormsNext.slnx --configuration Release --no-restore --verbosity normal -m:1 /p:UseSharedCompilation=false
@@ -42,6 +48,33 @@ jobs:
         shell: pwsh
         run: .\scripts\Validate-ReleasePackages.ps1 -PackageDirectory artifacts/packages
 
+      - name: Test release documentation scripts
+        shell: pwsh
+        run: .\scripts\tests\Test-ReleaseDocumentation.ps1
+
+      - name: Build versioned documentation artifacts
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $version = $tag.TrimStart("v")
+          .\scripts\Build-ReleaseDocumentation.ps1 `
+            -Version $version `
+            -Tag $tag `
+            -Commit "${{ github.sha }}" `
+            -RequireTag `
+            -OutputDirectory artifacts/release-docs
+
+      - name: Validate versioned documentation artifacts
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $version = $tag.TrimStart("v")
+          .\scripts\Validate-ReleaseDocumentation.ps1 `
+            -ArtifactDirectory artifacts/release-docs `
+            -ExpectedVersion $version `
+            -ExpectedCommit "${{ github.sha }}" `
+            -ExpectedTag $tag
+
       - name: Create GitHub Release
         shell: pwsh
         run: |
@@ -54,6 +87,7 @@ jobs:
           gh release create "${{ github.ref_name }}" `
             artifacts/packages/*.nupkg `
             artifacts/packages/*.snupkg `
+            artifacts/release-docs/*.zip `
             --title "ModernFormsNext $version" `
             --notes-file $releaseNotesPath `
             --latest

--- a/ModernFormsNext.WindowKit/Screen.cs
+++ b/ModernFormsNext.WindowKit/Screen.cs
@@ -33,7 +33,7 @@ namespace ModernFormsNext.WindowKit.Platform
         /// Gets the actual working-area pixel-size of the screen.
         /// </summary>
         /// <remarks>
-        /// This area may be smaller than <see href="Bounds"/> to account for notches and
+        /// This area may be smaller than <see cref="Bounds"/> to account for notches and
         /// other block-out areas such as taskbars etc.
         /// </remarks>
         public PixelRect WorkingArea { get; }

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ declared as a publishable NuGet package.
 
 ## Documentation
 
+GitHub Releases provide versioned offline documentation, API reference, and selected sample
+bundles generated from the exact release tag. These assets continue to match that package version
+even after the documentation on `master` changes. See the
+[versioned documentation artifact workflow](docs/releasing/versioned-documentation-artifacts.md)
+for bundle contents and local validation.
+
 - [Getting started](docs/getting-started.md)
 - [Installation and Visual Studio Designer](docs/installation.md)
 - [Changelog](CHANGELOG.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,6 +109,32 @@ dotnet pack .\ModernFormsNext.slnx --configuration Release --no-build --output .
 
 The template package intentionally has no `.snupkg`; published library packages should have one.
 
+Versioned documentation and sample artifacts are also mandatory release inputs. Restore the pinned
+DocFX tool, run the script tests, build the four ZIP files from the Release outputs, and validate
+them before creating a tag:
+
+```powershell
+dotnet tool restore
+$commit = (git rev-parse HEAD).Trim()
+.\scripts\tests\Test-ReleaseDocumentation.ps1
+.\scripts\Build-ReleaseDocumentation.ps1 `
+    -Version 1.9.0 `
+    -Tag local `
+    -Commit $commit `
+    -OutputDirectory .\artifacts\release-docs
+.\scripts\Validate-ReleaseDocumentation.ps1 `
+    -ArtifactDirectory .\artifacts\release-docs `
+    -ExpectedVersion 1.9.0 `
+    -ExpectedCommit $commit `
+    -ExpectedTag local
+```
+
+For a prerelease dry-run before its matching release-notes file exists, use the explicit local-only
+`-ReleaseNotesPath` override documented in
+[`docs/releasing/versioned-documentation-artifacts.md`](docs/releasing/versioned-documentation-artifacts.md).
+The tag workflow never uses that override: it requires `docs/<version>-release-notes.md`, confirms
+the tag resolves to `github.sha`, and validates every archive before publication.
+
 ## Publication workflow
 
 After the release commit is reviewed and the normal `.NET` workflow is green:
@@ -119,9 +145,11 @@ After the release commit is reviewed and the normal `.NET` workflow is green:
 3. Create the annotated or lightweight `vX.Y.Z` tag on the exact reviewed commit.
 4. Push the tag only when GitHub Release and NuGet publication are intended.
 5. Monitor the `Release` workflow until GitHub Release creation and every NuGet push succeed.
-6. Attach the matching `ModernFormsNextDesigner.vsix` to the GitHub Release. The current workflow
+6. Verify the matching docs, offline HTML, samples, and SDK ZIP files are attached to the GitHub
+   Release and contain the expected tag/commit metadata.
+7. Attach the matching `ModernFormsNextDesigner.vsix` to the GitHub Release. The current workflow
    uploads NuGet packages and symbols but does not upload the VSIX automatically.
-7. Verify the public NuGet indexes, package contents, GitHub assets, and VSIX version after
+8. Verify the public NuGet indexes, package contents, GitHub assets, and VSIX version after
    publication.
 
 Example commands are intentionally explicit:

--- a/docs-site/api-index.md
+++ b/docs-site/api-index.md
@@ -1,0 +1,5 @@
+# API reference
+
+This reference is generated from the public and protected API exposed by the Release assemblies
+for the exact source commit recorded in the release metadata. Test projects, samples, templates,
+tooling executables, and internal types are excluded.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -1,0 +1,13 @@
+# ModernFormsNext documentation
+
+This offline site contains the user documentation and public API reference for one exact
+ModernFormsNext release. The release version, tag, and source commit are recorded in
+`metadata/release.json` beside this site.
+
+Start with the [project overview](content/README.md) or [getting started](content/docs/getting-started.md).
+Use the [API reference](api/index.md) for the public surface generated from the matching Release
+assemblies and XML documentation.
+
+> [!NOTE]
+> Windows is the primary and best-supported runtime target. Android support is experimental; use
+> the platform status documentation to distinguish implemented behavior from planned parity.

--- a/docs-site/toc.yml
+++ b/docs-site/toc.yml
@@ -1,0 +1,20 @@
+- name: Overview
+  href: index.md
+- name: Project README
+  href: content/README.md
+- name: Getting started
+  href: content/docs/getting-started.md
+- name: Installation
+  href: content/docs/installation.md
+- name: Samples
+  href: content/docs/samples.md
+- name: Platform status
+  href: content/docs/platform-specific-features.md
+- name: Architecture
+  href: content/docs/architecture.md
+- name: Changelog
+  href: content/CHANGELOG.md
+- name: Releasing
+  href: content/RELEASING.md
+- name: API reference
+  href: api/index.md

--- a/docs/1.9.0-release-notes.md
+++ b/docs/1.9.0-release-notes.md
@@ -112,7 +112,7 @@ VSIX identity change is included.
 - Theme JSON is intentionally strict. Unknown fields or unsupported polymorphic values that a
   custom loader previously ignored are rejected with diagnostics.
 
-See [Migration from 1.8.0 to 1.9.0](../migrations/1.8.0-to-1.9.0.md) for examples and action items.
+See [Migration from 1.8.0 to 1.9.0](migrations/1.8.0-to-1.9.0.md) for examples and action items.
 
 ## Migration from 1.8.0
 

--- a/docs/releasing/versioned-documentation-artifacts.md
+++ b/docs/releasing/versioned-documentation-artifacts.md
@@ -1,0 +1,166 @@
+# Versioned release documentation artifacts
+
+ModernFormsNext GitHub Releases include offline documentation and sample archives generated from
+the exact release tag. These assets let a user keep documentation that continues to match an
+installed NuGet version after `master` changes.
+
+The bundles supplement NuGet packages, symbols, templates, and the Visual Studio extension. They
+do not replace those distribution formats and do not contain a renamed copy of the repository.
+
+## Asset naming and contents
+
+For version `X.Y.Z`, the release workflow creates:
+
+| Asset | Purpose |
+| --- | --- |
+| `ModernFormsNext-X.Y.Z-docs.zip` | Markdown source, images, changelog, release notes, migration guides, DocFX landing/navigation source, Release XML documentation, and public API snapshots. |
+| `ModernFormsNext-X.Y.Z-docs-html.zip` | Self-contained DocFX site with user articles, local search/theme assets, and API reference generated from Release assemblies. |
+| `ModernFormsNext-X.Y.Z-samples.zip` | Selected user-facing Windows samples converted to exact-version NuGet references, plus the template application in a separate `reference` section. |
+| `ModernFormsNext-X.Y.Z-sdk.zip` | Aggregate offline/reference bundle containing documentation source, HTML, samples, XML docs, public API snapshots, release notes, license, and metadata. |
+
+Every ZIP has one versioned top-level directory. Every bundle contains `metadata/version.txt`,
+`metadata/commit.txt`, and `metadata/release.json`. `release.json` uses this schema:
+
+```json
+{
+  "schemaVersion": 1,
+  "product": "ModernFormsNext",
+  "bundle": "docs-html",
+  "version": "1.10.0",
+  "tag": "v1.10.0",
+  "commit": "full-40-character-git-sha",
+  "generatedAtUtc": "2026-08-16T12:00:00.000Z",
+  "dotnetSdk": "10.0.201"
+}
+```
+
+The timestamp intentionally records generation time. File selection and ZIP entry ordering are
+stable, so repeated builds from the same inputs are semantically equivalent even when archive
+timestamps differ.
+
+## Source identity and release failure behavior
+
+`.github/workflows/release.yml` checks out the tag event with full tag history. It derives the
+version by removing the leading `v` from `github.ref_name`, then passes the tag and `github.sha` to
+`Build-ReleaseDocumentation.ps1 -RequireTag`.
+
+The build script verifies all of the following before creating bundles:
+
+- the version is valid SemVer;
+- `HEAD` equals the expected full commit SHA;
+- the expected tag is exactly `v<version>`;
+- that tag resolves to the expected commit;
+- `docs/<version>-release-notes.md` exists;
+- the required Release assemblies and XML documentation exist.
+
+Script tests, bundle generation, archive validation, metadata validation, and offline-link checks
+all run before `gh release create` and before NuGet authentication/publication. A documentation
+failure therefore stops the release before any release asset or NuGet package is published.
+
+## Local dry-run
+
+Restore the repository and the pinned DocFX tool, build Release, then build and validate the
+archives:
+
+```powershell
+dotnet restore .\ModernFormsNext.slnx
+dotnet tool restore
+dotnet build .\ModernFormsNext.slnx --configuration Release --no-restore --verbosity normal -m:1 /p:UseSharedCompilation=false
+
+$commit = (git rev-parse HEAD).Trim()
+.\scripts\tests\Test-ReleaseDocumentation.ps1
+.\scripts\Build-ReleaseDocumentation.ps1 `
+    -Version 1.10.0-preview.docs.1 `
+    -Tag local `
+    -Commit $commit `
+    -ReleaseNotesPath docs\1.9.0-release-notes.md `
+    -OutputDirectory artifacts\release-docs
+.\scripts\Validate-ReleaseDocumentation.ps1 `
+    -ArtifactDirectory artifacts\release-docs `
+    -ExpectedVersion 1.10.0-preview.docs.1 `
+    -ExpectedCommit $commit `
+    -ExpectedTag local
+```
+
+`-ReleaseNotesPath` is an explicit local-dry-run override. The release workflow does not use it;
+real releases must provide `docs/<version>-release-notes.md`. Do not use an older release-note file
+for a published release.
+
+Generated ZIP files belong under ignored `artifacts/` and must not be committed.
+
+## Offline HTML and API reference
+
+DocFX is pinned by `.config/dotnet-tools.json`; restore it with `dotnet tool restore`. The tracked
+landing page and navigation live under `docs-site/`. The build script creates an isolated temporary
+DocFX source tree instead of writing generated `api/` or `_site/` content into the repository.
+
+API metadata is generated from the already-built Release DLLs and their XML documentation for the
+seven published library packages. Templates, tests, samples, designer hosts, backend tools, and
+the unpublished experimental Android backend are excluded. DocFX's default public/protected API
+filter remains enabled.
+
+The build also writes `reference/public-api.txt` and `reference/public-api.json` from the DocFX
+managed-reference identifiers. These stable, machine-readable snapshots are intended for future
+release-to-release compatibility comparisons; they do not yet enforce a compatibility policy.
+
+The validator checks every local HTML/CSS resource target, rejects root-relative paths and external
+CSS/JavaScript/image dependencies, and requires `index.html` plus `api/index.html`. Normal outbound
+article links may remain online links. The generated site does not assume a domain root, so the
+same site can later be deployed below a version-specific path.
+
+DocFX can emit links for empty intermediate namespace segments even though it creates no page for
+those synthetic namespaces. A narrow post-process converts only those missing links in the API
+`Namespace` fact to plain text. All other unresolved internal links remain release-blocking errors.
+
+## Sample selection
+
+The sample archive contains:
+
+- `examples/ControlGallery` for controls, layout, rendering, input, themes, shapes, and animations;
+- `examples/Explorer` and `examples/Outlaw` as broader Windows application examples;
+- `reference/ModernFormsNext.DemoApp` as the clean generated-template reference, not a playground.
+
+During staging, repository `ProjectReference` items are replaced with exact-version
+`PackageReference` items. This keeps the downloaded archive independent from the source tree and
+prevents examples from silently consuming a later framework build.
+
+`ModernFormsNext.DesignerPlayground` is an internal validation host. The Android smoke test is a
+technical backend host. The cross-platform sample depends on the unpublished Android backend and
+repository-level scripts. Those projects remain in the tagged source checkout and versioned docs,
+but are not copied into a misleading standalone samples bundle.
+
+To add a sample, update `Get-ReleaseSampleSpecs` in
+`scripts/ReleaseDocumentation.Common.psm1`, ensure all of its project references map to packages
+published at the same version, update this document, and extend the script tests and archive
+validator. Do not add a source-checkout-only technical host as a public offline sample.
+
+## Migration guides
+
+Add a guide under `docs/migrations/`, for example:
+
+```text
+docs/migrations/1.9.0-to-1.10.0.md
+```
+
+All tracked migration guides are included automatically. A release without a migration guide does
+not fail; do not create a synthetic guide when there are no known migration steps.
+
+## Security and exclusions
+
+Bundle inputs are allowlisted and selected from Git-tracked paths. Validation rejects `.git`,
+`artifacts`, `bin`, `obj`, `.vs`, test/temp directories, `.env`, user/IDE state, signing files,
+NuGet/symbol packages, VSIX/APK outputs, path traversal, absolute archive paths, and local user
+paths embedded in text files. NuGet packages, `.snupkg` files, VSIX files, and repository internals
+remain separate artifacts with separate purposes.
+
+When debugging a failure:
+
+1. run `scripts/tests/Test-ReleaseDocumentation.ps1`;
+2. confirm the Release build produced the expected DLL/XML pairs;
+3. run the build script without `-RequireTag` and with an explicit local release-note override;
+4. inspect DocFX warnings rather than suppressing them;
+5. run `Validate-ReleaseDocumentation.ps1 -Verbose` and inspect the named ZIP entry or link;
+6. confirm no stale ZIP from another version was substituted.
+
+Never weaken archive validation merely to complete a release. Fix the selected content,
+documentation link, metadata, or sample dependency at its source.

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -124,16 +124,16 @@ See [Cross-platform sample](cross-platform-sample.md).
 ## Screenshots
 
 ### Explorer (Windows)
-![Explorer Windows](docs/explorer-windows.png)
+![Explorer Windows](explorer-windows.png)
 
 ### Explorer (Linux)
-![Explorer Linux](docs/explorer-ubuntu.png)
+![Explorer Linux](explorer-ubuntu.png)
 
 ### Explorer (macOS)
-![Explorer macOS](docs/explorer-osx.png)
+![Explorer macOS](explorer-osx.png)
 
 ### Outlaw
-![Outlaw](docs/outlaw-windows.png)
+![Outlaw](outlaw-windows.png)
 
 ### ControlGallery
-![ControlGallery](docs/controlgallery-windows.png)
+![ControlGallery](controlgallery-windows.png)

--- a/scripts/Build-ReleaseDocumentation.ps1
+++ b/scripts/Build-ReleaseDocumentation.ps1
@@ -1,0 +1,586 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDirectory,
+
+    [string]$Commit,
+
+    [string]$Tag = 'local',
+
+    [string]$ReleaseNotesPath,
+
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Release',
+
+    [switch]$RequireTag
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+Import-Module (Join-Path $PSScriptRoot 'ReleaseDocumentation.Common.psm1') -Force
+
+$repositoryRoot = (Resolve-Path -LiteralPath (Split-Path -Parent $PSScriptRoot)).Path
+$normalizedVersion = ConvertTo-ReleaseVersion -Version $Version
+$assetNames = Get-ReleaseAssetNames -Version $normalizedVersion
+$releaseNotes = Resolve-ReleaseNotesFile -RepositoryRoot $repositoryRoot -Version $normalizedVersion -ReleaseNotesPath $ReleaseNotesPath
+
+function Invoke-CheckedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$ArgumentList
+    )
+
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command '$FilePath $($ArgumentList -join ' ')' failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Get-GitOutput {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$ArgumentList
+    )
+
+    $output = & git -C $repositoryRoot @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "Git command 'git $($ArgumentList -join ' ')' failed with exit code $LASTEXITCODE."
+    }
+
+    return ($output -join "`n").Trim()
+}
+
+function Copy-TrackedPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PathSpec,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationRoot,
+
+        [string]$DestinationPrefix = ''
+    )
+
+    $trackedFiles = @(& git -C $repositoryRoot ls-files -- $PathSpec)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not enumerate tracked files for '$PathSpec'."
+    }
+    if ($trackedFiles.Count -eq 0) {
+        throw "No tracked files were found for '$PathSpec'."
+    }
+
+    foreach ($relativePath in $trackedFiles) {
+        $normalized = $relativePath.Replace([char]92, '/')
+        if (Test-IsForbiddenArchivePath -Path $normalized) {
+            throw "Tracked path '$normalized' is not safe for a release bundle."
+        }
+
+        $source = Join-Path $repositoryRoot $relativePath
+        $destinationRelative = if ([string]::IsNullOrWhiteSpace($DestinationPrefix)) {
+            $relativePath
+        }
+        else {
+            Join-Path $DestinationPrefix $relativePath
+        }
+        $destination = Join-Path $DestinationRoot $destinationRelative
+        [IO.Directory]::CreateDirectory((Split-Path -Parent $destination)) | Out-Null
+        [IO.File]::Copy($source, $destination, $true)
+    }
+}
+
+function Copy-TrackedDirectoryContents {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationDirectory
+    )
+
+    $trackedFiles = @(& git -C $repositoryRoot ls-files -- $SourceDirectory)
+    if ($LASTEXITCODE -ne 0 -or $trackedFiles.Count -eq 0) {
+        throw "No tracked files were found below '$SourceDirectory'."
+    }
+
+    $sourcePrefix = $SourceDirectory.TrimEnd([char[]]@('/', [char]92)) + '/'
+    foreach ($relativePath in $trackedFiles) {
+        $normalized = $relativePath.Replace([char]92, '/')
+        if (-not $normalized.StartsWith($sourcePrefix, [StringComparison]::Ordinal)) {
+            continue
+        }
+        if (Test-IsForbiddenArchivePath -Path $normalized) {
+            throw "Tracked path '$normalized' is not safe for a release bundle."
+        }
+
+        $inside = $normalized.Substring($sourcePrefix.Length)
+        $destination = Join-Path $DestinationDirectory $inside
+        [IO.Directory]::CreateDirectory((Split-Path -Parent $destination)) | Out-Null
+        [IO.File]::Copy((Join-Path $repositoryRoot $relativePath), $destination, $true)
+    }
+}
+
+function Copy-DirectoryContents {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationDirectory,
+
+        [string[]]$ExcludedTopLevelNames = @()
+    )
+
+    $source = (Resolve-Path -LiteralPath $SourceDirectory).Path
+    foreach ($file in Get-ChildItem -LiteralPath $source -Recurse -File) {
+        $relative = [IO.Path]::GetRelativePath($source, $file.FullName)
+        $topLevel = @($relative.Replace([char]92, '/').Split('/', [StringSplitOptions]::RemoveEmptyEntries))[0]
+        if ($ExcludedTopLevelNames -contains $topLevel) {
+            continue
+        }
+
+        $destination = Join-Path $DestinationDirectory $relative
+        [IO.Directory]::CreateDirectory((Split-Path -Parent $destination)) | Out-Null
+        [IO.File]::Copy($file.FullName, $destination, $true)
+    }
+}
+
+function Convert-SampleProjectReferences {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SamplesRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PackageVersion
+    )
+
+    $allowedPackages = @(
+        'ModernFormsNext',
+        'ModernFormsNext.WindowKit.Backend.Windows'
+    )
+
+    foreach ($projectPath in Get-ChildItem -LiteralPath $SamplesRoot -Recurse -Filter '*.csproj' -File) {
+        [xml]$project = Get-Content -LiteralPath $projectPath.FullName -Raw
+        $references = @($project.SelectNodes("//*[local-name()='ProjectReference']"))
+        if ($references.Count -eq 0) {
+            throw "Sample project '$($projectPath.FullName)' has no repository ProjectReference to convert."
+        }
+
+        foreach ($reference in $references) {
+            $include = $reference.GetAttribute('Include')
+            $packageId = [IO.Path]::GetFileNameWithoutExtension($include)
+            if ($allowedPackages -cnotcontains $packageId) {
+                throw "Sample project '$($projectPath.FullName)' references unsupported project '$include'."
+            }
+
+            $packageReference = $project.CreateElement('PackageReference')
+            $packageReference.SetAttribute('Include', $packageId)
+            $packageReference.SetAttribute('Version', $PackageVersion)
+            $null = $reference.ParentNode.ReplaceChild($packageReference, $reference)
+        }
+
+        $settings = [Xml.XmlWriterSettings]::new()
+        $settings.Indent = $true
+        $settings.IndentChars = '  '
+        $settings.NewLineChars = "`r`n"
+        $settings.NewLineHandling = [Xml.NewLineHandling]::Replace
+        $settings.Encoding = [Text.UTF8Encoding]::new($false)
+        $writer = [Xml.XmlWriter]::Create($projectPath.FullName, $settings)
+        try {
+            $project.Save($writer)
+        }
+        finally {
+            $writer.Dispose()
+        }
+    }
+}
+
+function Remove-MissingDocfxNamespaceLinks {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SiteDirectory
+    )
+
+    $apiDirectory = Join-Path $SiteDirectory 'api'
+    $counter = [pscustomobject]@{ Value = 0 }
+    $namespacePattern = [regex]::new(
+        '<dt>Namespace</dt><dd>.*?</dd>',
+        [Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [Text.RegularExpressions.RegexOptions]::Singleline)
+    $linkPattern = [regex]::new(
+        '<a class="xref" href="(?<href>[^"?#]+\.html)">(?<label>.*?)</a>',
+        [Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [Text.RegularExpressions.RegexOptions]::Singleline)
+
+    foreach ($htmlFile in Get-ChildItem -LiteralPath $apiDirectory -Filter '*.html' -File) {
+        $text = [IO.File]::ReadAllText($htmlFile.FullName)
+        $updated = $namespacePattern.Replace($text, {
+            param($namespaceMatch)
+
+            return $linkPattern.Replace($namespaceMatch.Value, {
+                param($linkMatch)
+
+                $relativeTarget = $linkMatch.Groups['href'].Value.Replace('/', [IO.Path]::DirectorySeparatorChar)
+                $targetPath = [IO.Path]::GetFullPath((Join-Path $htmlFile.DirectoryName $relativeTarget))
+                if ($targetPath.StartsWith($apiDirectory, [StringComparison]::OrdinalIgnoreCase) `
+                    -and -not (Test-Path -LiteralPath $targetPath -PathType Leaf)) {
+                    $counter.Value++
+                    return ('<span class="xref">{0}</span>' -f $linkMatch.Groups['label'].Value)
+                }
+
+                return $linkMatch.Value
+            })
+        })
+
+        if ($updated -cne $text) {
+            Write-Utf8File -Path $htmlFile.FullName -Content $updated
+        }
+    }
+
+    Write-Host "Neutralized $($counter.Value) DocFX links to synthetic namespace pages that were not generated."
+}
+
+function Write-BundleMetadata {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BundleRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BundleName
+    )
+
+    $metadata = New-ReleaseMetadata `
+        -Bundle $BundleName `
+        -Version $normalizedVersion `
+        -Tag $Tag `
+        -Commit $Commit `
+        -GeneratedAtUtc $generatedAtUtc `
+        -DotNetSdk $dotnetSdk
+    Write-ReleaseMetadata -BundleRoot $BundleRoot -Metadata $metadata
+}
+
+$actualCommit = Get-GitOutput -ArgumentList @('rev-parse', 'HEAD')
+if ($actualCommit -cnotmatch '^[0-9a-f]{40}$') {
+    throw "Git returned an invalid HEAD commit '$actualCommit'."
+}
+
+if ([string]::IsNullOrWhiteSpace($Commit)) {
+    $Commit = $actualCommit
+}
+elseif ($Commit -cnotmatch '^[0-9a-fA-F]{40}$') {
+    throw "Commit '$Commit' must be a full 40-character SHA."
+}
+elseif (-not $actualCommit.Equals($Commit, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "HEAD '$actualCommit' does not match expected commit '$Commit'."
+}
+$Commit = $Commit.ToLowerInvariant()
+
+if ($RequireTag) {
+    $expectedTag = "v$normalizedVersion"
+    if ($Tag -cne $expectedTag) {
+        throw "Release tag '$Tag' does not match expected tag '$expectedTag'."
+    }
+
+    $tagCommit = Get-GitOutput -ArgumentList @('rev-list', '-n', '1', $Tag)
+    if (-not $tagCommit.Equals($Commit, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Tag '$Tag' points to '$tagCommit', not expected commit '$Commit'."
+    }
+
+}
+
+$dotnetSdk = (& dotnet --version).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($dotnetSdk)) {
+    throw 'Could not determine the active .NET SDK version.'
+}
+
+$generatedAtUtc = [DateTimeOffset]::UtcNow
+$outputRoot = if ([IO.Path]::IsPathRooted($OutputDirectory)) {
+    [IO.Path]::GetFullPath($OutputDirectory)
+}
+else {
+    [IO.Path]::GetFullPath((Join-Path (Get-Location) $OutputDirectory))
+}
+if ($outputRoot.Equals($repositoryRoot, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'OutputDirectory must not be the repository root.'
+}
+[IO.Directory]::CreateDirectory($outputRoot) | Out-Null
+
+$workingRoot = Join-Path $outputRoot ".release-documentation-work-$PID"
+if (Test-Path -LiteralPath $workingRoot) {
+    throw "Temporary working directory '$workingRoot' already exists."
+}
+[IO.Directory]::CreateDirectory($workingRoot) | Out-Null
+
+try {
+    $apiAssemblies = @(
+        [pscustomobject]@{ Id = 'ModernFormsNext'; Tfm = 'net10.0' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.CodeGeneration'; Tfm = 'net10.0' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.Designer'; Tfm = 'net10.0-windows' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.Designing'; Tfm = 'net10.0' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.WindowKit'; Tfm = 'net10.0' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.WindowKit.Backend'; Tfm = 'net10.0' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.WindowKit.Backend.Windows'; Tfm = 'net10.0' }
+    )
+
+    foreach ($assembly in $apiAssemblies) {
+        $assemblyDirectory = Join-Path $repositoryRoot "$($assembly.Id)/bin/$Configuration/$($assembly.Tfm)"
+        $assembly | Add-Member -NotePropertyName Directory -NotePropertyValue $assemblyDirectory
+        $assembly | Add-Member -NotePropertyName Dll -NotePropertyValue (Join-Path $assemblyDirectory "$($assembly.Id).dll")
+        $assembly | Add-Member -NotePropertyName Xml -NotePropertyValue (Join-Path $assemblyDirectory "$($assembly.Id).xml")
+        foreach ($requiredPath in @($assembly.Dll, $assembly.Xml)) {
+            if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+                throw "Release API input '$requiredPath' does not exist. Build the $Configuration configuration before creating documentation bundles."
+            }
+        }
+    }
+
+    $docfxSource = Join-Path $workingRoot 'docfx-source'
+    [IO.Directory]::CreateDirectory((Join-Path $docfxSource 'content')) | Out-Null
+    foreach ($rootDocument in @('README.md', 'CHANGELOG.md', 'RELEASING.md')) {
+        [IO.File]::Copy((Join-Path $repositoryRoot $rootDocument), (Join-Path $docfxSource "content/$rootDocument"), $true)
+    }
+    foreach ($supportingFile in @('license.md', 'third-party-licenses.md', 'global.json')) {
+        [IO.File]::Copy((Join-Path $repositoryRoot $supportingFile), (Join-Path $docfxSource "content/$supportingFile"), $true)
+    }
+    Copy-TrackedDirectoryContents -SourceDirectory 'docs' -DestinationDirectory (Join-Path $docfxSource 'content/docs')
+    Copy-TrackedDirectoryContents -SourceDirectory 'samples/ModernFormsNext.CrossPlatform.Sample' -DestinationDirectory (Join-Path $docfxSource 'content/samples/ModernFormsNext.CrossPlatform.Sample')
+    Copy-TrackedDirectoryContents -SourceDirectory 'samples/ModernFormsNext.Android.SmokeTest' -DestinationDirectory (Join-Path $docfxSource 'content/samples/ModernFormsNext.Android.SmokeTest')
+
+    $sampleLandingPages = [ordered]@{
+        'ControlGallery' = 'Primary Windows control, rendering, layout, input, animation, and theme gallery.'
+        'Explorer' = 'Broader file-explorer-style Windows application example.'
+        'Outlaw' = 'Broader mail-client-style Windows application example.'
+        'ModernFormsNext.DemoApp' = 'Clean reference application aligned with the generated template.'
+        'ModernFormsNext.DesignerPlayground' = 'Standalone internal host for designer development and manual validation.'
+    }
+    foreach ($sampleName in $sampleLandingPages.Keys) {
+        $landingPage = @"
+# $sampleName
+
+$($sampleLandingPages[$sampleName])
+
+See the [samples guide](../../docs/samples.md) for its role and repository run instructions.
+"@
+        Write-Utf8File -Path (Join-Path $docfxSource "content/samples/$sampleName/index.md") -Content "$landingPage`n"
+    }
+
+    $offlineReadmePath = Join-Path $docfxSource 'content/README.md'
+    $offlineReadme = [IO.File]::ReadAllText($offlineReadmePath)
+    $offlineSampleLinks = [ordered]@{
+        '(samples/ControlGallery)' = '(samples/ControlGallery/index.md)'
+        '(samples/Explorer)' = '(samples/Explorer/index.md)'
+        '(samples/Outlaw)' = '(samples/Outlaw/index.md)'
+        '(samples/ModernFormsNext.DemoApp)' = '(samples/ModernFormsNext.DemoApp/index.md)'
+        '(samples/ModernFormsNext.DesignerPlayground)' = '(samples/ModernFormsNext.DesignerPlayground/index.md)'
+        '(samples/ModernFormsNext.CrossPlatform.Sample)' = '(samples/ModernFormsNext.CrossPlatform.Sample/README.md)'
+        '(samples/ModernFormsNext.Android.SmokeTest)' = '(samples/ModernFormsNext.Android.SmokeTest/README.md)'
+    }
+    foreach ($link in $offlineSampleLinks.GetEnumerator()) {
+        $offlineReadme = $offlineReadme.Replace($link.Key, $link.Value, [StringComparison]::Ordinal)
+    }
+    $offlineReadme = [regex]::Replace(
+        $offlineReadme,
+        '(?m)^\[!\[[^\r\n]+\]\(https?://[^\r\n]+\)\]\([^\r\n]+\)\r?\n',
+        '')
+    Write-Utf8File -Path $offlineReadmePath -Content $offlineReadme
+    [IO.File]::Copy((Join-Path $repositoryRoot 'docs-site/index.md'), (Join-Path $docfxSource 'index.md'), $true)
+    [IO.File]::Copy((Join-Path $repositoryRoot 'docs-site/toc.yml'), (Join-Path $docfxSource 'toc.yml'), $true)
+
+    $metadataSources = @($apiAssemblies | ForEach-Object {
+        [ordered]@{
+            src = $_.Directory
+            files = @("$($_.Id).dll")
+        }
+    })
+    $docfxConfig = [ordered]@{
+        metadata = @(
+            [ordered]@{
+                src = $metadataSources
+                dest = 'api'
+                namespaceLayout = 'flattened'
+                memberLayout = 'samePage'
+            }
+        )
+        build = [ordered]@{
+            template = @('default', 'modern')
+            content = @(
+                [ordered]@{ files = @('index.md', 'toc.yml', 'content/**.md', 'api/**.yml', 'api/index.md', 'api/toc.yml') }
+            )
+            resource = @(
+                [ordered]@{ files = @('content/**.png', 'content/**.jpg', 'content/**.jpeg', 'content/**.gif', 'content/**.svg', 'content/**.json') }
+            )
+            globalMetadata = [ordered]@{
+                _appName = 'ModernFormsNext'
+                _appTitle = "ModernFormsNext $normalizedVersion Documentation"
+                _enableSearch = $true
+                _disableContribution = $true
+                _disableBreadcrumb = $false
+            }
+            dest = (Join-Path $workingRoot 'site')
+        }
+    }
+    $docfxConfigPath = Join-Path $docfxSource 'docfx.json'
+    Write-Utf8File -Path $docfxConfigPath -Content "$(ConvertTo-Json $docfxConfig -Depth 10)`n"
+
+    Push-Location $repositoryRoot
+    try {
+        Invoke-CheckedCommand -FilePath 'dotnet' -ArgumentList @('tool', 'run', 'docfx', 'metadata', $docfxConfigPath, '--warningsAsErrors', '--disableGitFeatures')
+        [IO.File]::Copy((Join-Path $repositoryRoot 'docs-site/api-index.md'), (Join-Path $docfxSource 'api/index.md'), $true)
+        Invoke-CheckedCommand -FilePath 'dotnet' -ArgumentList @('tool', 'run', 'docfx', 'build', $docfxConfigPath, '--warningsAsErrors', '--disableGitFeatures')
+    }
+    finally {
+        Pop-Location
+    }
+
+    # DocFX's build manifest records its temporary source_base_path. It is an implementation
+    # diagnostic rather than a site runtime asset, so exclude it from portable offline bundles.
+    $docfxManifest = Join-Path $workingRoot 'site/manifest.json'
+    if (Test-Path -LiteralPath $docfxManifest -PathType Leaf) {
+        [IO.File]::Delete($docfxManifest)
+    }
+    Remove-MissingDocfxNamespaceLinks -SiteDirectory (Join-Path $workingRoot 'site')
+
+    $apiDirectory = Join-Path $docfxSource 'api'
+    $apiIdSet = [Collections.Generic.SortedSet[string]]::new([StringComparer]::Ordinal)
+    Get-ChildItem -LiteralPath $apiDirectory -Filter '*.yml' -File |
+        Where-Object Name -CNE 'toc.yml' |
+        ForEach-Object { Select-String -LiteralPath $_.FullName -Pattern '^\s*commentId:\s*(?<id>.+?)\s*$' } |
+        ForEach-Object { $null = $apiIdSet.Add($_.Matches[0].Groups['id'].Value.Trim('"', "'")) }
+    $apiIds = @($apiIdSet)
+    if ($apiIds.Count -eq 0) {
+        throw 'DocFX did not produce any public API identifiers.'
+    }
+
+    $snapshot = [ordered]@{
+        schemaVersion = 1
+        product = 'ModernFormsNext'
+        version = $normalizedVersion
+        commit = $Commit
+        assemblies = @($apiAssemblies.Id)
+        symbols = $apiIds
+    }
+    $snapshotText = @(
+        '# ModernFormsNext public API snapshot'
+        "# Version: $normalizedVersion"
+        "# Commit: $Commit"
+        '# Generated from DocFX public/protected API metadata.'
+        ''
+        $apiIds
+    ) -join "`n"
+
+    $docsRootName = "ModernFormsNext-$normalizedVersion-docs"
+    $docsRoot = Join-Path $workingRoot $docsRootName
+    [IO.Directory]::CreateDirectory($docsRoot) | Out-Null
+    foreach ($rootFile in @('README.md', 'CHANGELOG.md', 'RELEASING.md', 'LICENSE.txt', 'license.md', 'third-party-licenses.md')) {
+        [IO.File]::Copy((Join-Path $repositoryRoot $rootFile), (Join-Path $docsRoot $rootFile), $true)
+    }
+    Copy-TrackedDirectoryContents -SourceDirectory 'docs' -DestinationDirectory (Join-Path $docsRoot 'docs')
+    Copy-TrackedDirectoryContents -SourceDirectory 'docs-site' -DestinationDirectory (Join-Path $docsRoot 'docs-site')
+    [IO.File]::Copy($releaseNotes, (Join-Path $docsRoot 'RELEASE_NOTES.md'), $true)
+    $referenceRoot = Join-Path $docsRoot 'reference'
+    [IO.Directory]::CreateDirectory((Join-Path $referenceRoot 'xml')) | Out-Null
+    foreach ($assembly in $apiAssemblies) {
+        [IO.File]::Copy($assembly.Xml, (Join-Path $referenceRoot "xml/$($assembly.Id).xml"), $true)
+    }
+    Write-Utf8File -Path (Join-Path $referenceRoot 'public-api.txt') -Content "$snapshotText`n"
+    Write-Utf8File -Path (Join-Path $referenceRoot 'public-api.json') -Content "$(ConvertTo-Json $snapshot -Depth 6)`n"
+    Write-BundleMetadata -BundleRoot $docsRoot -BundleName 'docs'
+
+    $htmlRootName = "ModernFormsNext-$normalizedVersion-docs-html"
+    $htmlRoot = Join-Path $workingRoot $htmlRootName
+    Copy-DirectoryContents -SourceDirectory (Join-Path $workingRoot 'site') -DestinationDirectory $htmlRoot
+    [IO.File]::Copy($releaseNotes, (Join-Path $htmlRoot 'RELEASE_NOTES.md'), $true)
+    [IO.File]::Copy((Join-Path $repositoryRoot 'LICENSE.txt'), (Join-Path $htmlRoot 'LICENSE.txt'), $true)
+    [IO.File]::Copy((Join-Path $repositoryRoot 'third-party-licenses.md'), (Join-Path $htmlRoot 'third-party-licenses.md'), $true)
+    Write-BundleMetadata -BundleRoot $htmlRoot -BundleName 'docs-html'
+
+    $samplesRootName = "ModernFormsNext-$normalizedVersion-samples"
+    $samplesRoot = Join-Path $workingRoot $samplesRootName
+    [IO.Directory]::CreateDirectory($samplesRoot) | Out-Null
+    foreach ($sample in Get-ReleaseSampleSpecs) {
+        Copy-TrackedDirectoryContents -SourceDirectory $sample.Source -DestinationDirectory (Join-Path $samplesRoot $sample.Destination)
+    }
+    Convert-SampleProjectReferences -SamplesRoot $samplesRoot -PackageVersion $normalizedVersion
+    [IO.File]::Copy((Join-Path $repositoryRoot 'global.json'), (Join-Path $samplesRoot 'global.json'), $true)
+    [IO.File]::Copy((Join-Path $repositoryRoot 'LICENSE.txt'), (Join-Path $samplesRoot 'LICENSE.txt'), $true)
+    [IO.File]::Copy((Join-Path $repositoryRoot 'third-party-licenses.md'), (Join-Path $samplesRoot 'third-party-licenses.md'), $true)
+    [IO.File]::Copy($releaseNotes, (Join-Path $samplesRoot 'RELEASE_NOTES.md'), $true)
+    $samplesReadme = @"
+# ModernFormsNext $normalizedVersion samples
+
+These projects are copied from commit `$Commit` and reference the exact published NuGet package
+version `$normalizedVersion`. Restore requires access to a feed containing that version.
+
+## Examples
+
+- `examples/ControlGallery`: the primary Windows control, rendering, layout, input, animation, and theme gallery.
+- `examples/Explorer`: a broader file-explorer-style Windows application.
+- `examples/Outlaw`: a broader mail-client-style Windows application.
+
+## Template reference
+
+- `reference/ModernFormsNext.DemoApp`: the clean reference application aligned with the generated template.
+
+The experimental cross-platform and Android smoke-test projects are intentionally not included.
+They depend on source-built, unpublished Android backend projects and repository-level tooling, so
+copying them into a standalone release archive would produce a misleading or incomplete sample.
+See the versioned documentation for their source-checkout workflow and current limitations.
+"@
+    Write-Utf8File -Path (Join-Path $samplesRoot 'README.md') -Content "$samplesReadme`n"
+    Write-BundleMetadata -BundleRoot $samplesRoot -BundleName 'samples'
+
+    $sdkRootName = "ModernFormsNext-$normalizedVersion-sdk"
+    $sdkRoot = Join-Path $workingRoot $sdkRootName
+    [IO.Directory]::CreateDirectory($sdkRoot) | Out-Null
+    [IO.Directory]::CreateDirectory((Join-Path $sdkRoot 'documentation')) | Out-Null
+    foreach ($document in @('README.md', 'CHANGELOG.md', 'RELEASING.md', 'license.md', 'third-party-licenses.md')) {
+        [IO.File]::Copy((Join-Path $docsRoot $document), (Join-Path $sdkRoot "documentation/$document"), $true)
+    }
+    Copy-DirectoryContents -SourceDirectory (Join-Path $docsRoot 'docs') -DestinationDirectory (Join-Path $sdkRoot 'documentation/docs')
+    Copy-DirectoryContents -SourceDirectory $htmlRoot -DestinationDirectory (Join-Path $sdkRoot 'docs-html') -ExcludedTopLevelNames @('metadata', 'RELEASE_NOTES.md', 'LICENSE.txt', 'third-party-licenses.md')
+    Copy-DirectoryContents -SourceDirectory $samplesRoot -DestinationDirectory (Join-Path $sdkRoot 'samples') -ExcludedTopLevelNames @('metadata', 'RELEASE_NOTES.md', 'LICENSE.txt', 'third-party-licenses.md')
+    Copy-DirectoryContents -SourceDirectory $referenceRoot -DestinationDirectory (Join-Path $sdkRoot 'reference')
+    [IO.Directory]::CreateDirectory((Join-Path $sdkRoot 'release-notes')) | Out-Null
+    [IO.File]::Copy($releaseNotes, (Join-Path $sdkRoot 'release-notes/RELEASE_NOTES.md'), $true)
+    [IO.File]::Copy((Join-Path $repositoryRoot 'LICENSE.txt'), (Join-Path $sdkRoot 'LICENSE.txt'), $true)
+    [IO.File]::Copy((Join-Path $repositoryRoot 'third-party-licenses.md'), (Join-Path $sdkRoot 'third-party-licenses.md'), $true)
+    $sdkReadme = @"
+# ModernFormsNext $normalizedVersion offline reference bundle
+
+This aggregate bundle is tied to tag `$Tag` and commit `$Commit`. It contains documentation source,
+the ready-to-open offline HTML site, selected NuGet-based samples, XML documentation, and a stable
+public API snapshot. It does not contain NuGet packages, symbols, a VSIX, build outputs, or a copy of
+the full repository.
+
+- Open `docs-html/index.html` to browse the offline site.
+- Read `samples/README.md` before restoring sample projects.
+- Use `reference/public-api.txt` or `reference/public-api.json` for compatibility comparisons.
+- Inspect `metadata/release.json` for release identity and generation details.
+"@
+    Write-Utf8File -Path (Join-Path $sdkRoot 'README.md') -Content "$sdkReadme`n"
+    Write-BundleMetadata -BundleRoot $sdkRoot -BundleName 'sdk'
+
+    $archives = @(
+        [pscustomobject]@{ Source = $docsRoot; Root = $docsRootName; Name = $assetNames.Docs },
+        [pscustomobject]@{ Source = $htmlRoot; Root = $htmlRootName; Name = $assetNames.Html },
+        [pscustomobject]@{ Source = $samplesRoot; Root = $samplesRootName; Name = $assetNames.Samples },
+        [pscustomobject]@{ Source = $sdkRoot; Root = $sdkRootName; Name = $assetNames.Sdk }
+    )
+    foreach ($archive in $archives) {
+        New-StableZip -SourceDirectory $archive.Source -DestinationPath (Join-Path $outputRoot $archive.Name) -RootDirectoryName $archive.Root -Timestamp $generatedAtUtc
+    }
+
+    Write-Host "Created $($archives.Count) versioned documentation archives for ModernFormsNext $normalizedVersion at commit $Commit."
+    foreach ($archive in $archives) {
+        $file = Get-Item -LiteralPath (Join-Path $outputRoot $archive.Name)
+        Write-Host ("  {0} ({1:N0} bytes)" -f $file.Name, $file.Length)
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $workingRoot) {
+        Remove-Item -LiteralPath $workingRoot -Recurse -Force
+    }
+}

--- a/scripts/ReleaseDocumentation.Common.psm1
+++ b/scripts/ReleaseDocumentation.Common.psm1
@@ -1,0 +1,330 @@
+Set-StrictMode -Version Latest
+
+function ConvertTo-ReleaseVersion {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    $normalized = $Version.Trim()
+    if ($normalized.StartsWith('v', [StringComparison]::Ordinal)) {
+        $normalized = $normalized.Substring(1)
+    }
+
+    $identifier = '(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
+    $pattern = "^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-$identifier(?:\.$identifier)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+    if ($normalized -cnotmatch $pattern) {
+        throw "Version '$Version' is not a valid SemVer 2.0 version."
+    }
+
+    return $normalized
+}
+
+function Get-ReleaseAssetNames {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    $normalized = ConvertTo-ReleaseVersion -Version $Version
+    return [pscustomobject]@{
+        Docs = "ModernFormsNext-$normalized-docs.zip"
+        Html = "ModernFormsNext-$normalized-docs-html.zip"
+        Samples = "ModernFormsNext-$normalized-samples.zip"
+        Sdk = "ModernFormsNext-$normalized-sdk.zip"
+    }
+}
+
+function Get-ReleaseSampleSpecs {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        [pscustomobject]@{ Source = 'samples/ControlGallery'; Destination = 'examples/ControlGallery'; Role = 'Windows control and rendering gallery' },
+        [pscustomobject]@{ Source = 'samples/Explorer'; Destination = 'examples/Explorer'; Role = 'Broader Windows application example' },
+        [pscustomobject]@{ Source = 'samples/Outlaw'; Destination = 'examples/Outlaw'; Role = 'Broader Windows application example' },
+        [pscustomobject]@{ Source = 'samples/ModernFormsNext.DemoApp'; Destination = 'reference/ModernFormsNext.DemoApp'; Role = 'Generated-template reference application' }
+    )
+}
+
+function Resolve-ReleaseNotesFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [string]$ReleaseNotesPath
+    )
+
+    $normalized = ConvertTo-ReleaseVersion -Version $Version
+    $candidate = if ([string]::IsNullOrWhiteSpace($ReleaseNotesPath)) {
+        Join-Path $RepositoryRoot "docs/$normalized-release-notes.md"
+    }
+    elseif ([IO.Path]::IsPathRooted($ReleaseNotesPath)) {
+        $ReleaseNotesPath
+    }
+    else {
+        Join-Path $RepositoryRoot $ReleaseNotesPath
+    }
+
+    if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+        throw "Release notes were not found at '$candidate'."
+    }
+
+    return (Resolve-Path -LiteralPath $candidate).Path
+}
+
+function Test-IsForbiddenArchivePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $normalized = $Path.Replace([char]92, '/')
+    if ([string]::IsNullOrWhiteSpace($normalized) -or $normalized.StartsWith('/') -or $normalized -match '^[A-Za-z]:/' ) {
+        return $true
+    }
+
+    $segments = @($normalized.Split('/', [StringSplitOptions]::RemoveEmptyEntries))
+    if ($segments | Where-Object { $_ -eq '..' -or $_ -match '^(?i:\.git|artifacts|bin|obj|\.vs|TestResults?|tmp|temp)$' }) {
+        return $true
+    }
+
+    $fileName = if ($segments.Count -gt 0) { $segments[-1] } else { $normalized }
+    return $fileName -match '^(?i:\.env(?:\..*)?)$' `
+        -or $fileName -match '(?i:\.(?:user|suo|pfx|snk|nupkg|snupkg|vsix|apk|aab|keystore|jks|tmp|cache))$'
+}
+
+function Write-Utf8File {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Content
+    )
+
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        [IO.Directory]::CreateDirectory($parent) | Out-Null
+    }
+
+    [IO.File]::WriteAllText($Path, $Content, [Text.UTF8Encoding]::new($false))
+}
+
+function New-ReleaseMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Bundle,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Tag,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Commit,
+
+        [Parameter(Mandatory = $true)]
+        [DateTimeOffset]$GeneratedAtUtc,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DotNetSdk
+    )
+
+    return [ordered]@{
+        schemaVersion = 1
+        product = 'ModernFormsNext'
+        bundle = $Bundle
+        version = (ConvertTo-ReleaseVersion -Version $Version)
+        tag = $Tag
+        commit = $Commit.ToLowerInvariant()
+        generatedAtUtc = $GeneratedAtUtc.UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ss.fffZ', [Globalization.CultureInfo]::InvariantCulture)
+        dotnetSdk = $DotNetSdk
+    }
+}
+
+function Write-ReleaseMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BundleRoot,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$Metadata
+    )
+
+    $metadataDirectory = Join-Path $BundleRoot 'metadata'
+    [IO.Directory]::CreateDirectory($metadataDirectory) | Out-Null
+    Write-Utf8File -Path (Join-Path $metadataDirectory 'version.txt') -Content "$($Metadata.version)`n"
+    Write-Utf8File -Path (Join-Path $metadataDirectory 'commit.txt') -Content "$($Metadata.commit)`n"
+    Write-Utf8File -Path (Join-Path $metadataDirectory 'release.json') -Content "$(ConvertTo-Json $Metadata -Depth 5)`n"
+}
+
+function New-StableZip {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RootDirectoryName,
+
+        [Parameter(Mandatory = $true)]
+        [DateTimeOffset]$Timestamp
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $source = (Resolve-Path -LiteralPath $SourceDirectory).Path
+    $fileEntries = [Collections.Generic.List[object]]::new()
+    foreach ($file in Get-ChildItem -LiteralPath $source -Recurse -File) {
+        $fileEntries.Add([pscustomobject]@{
+            File = $file
+            Relative = [IO.Path]::GetRelativePath($source, $file.FullName).Replace([char]92, '/')
+        })
+    }
+    $fileEntries.Sort([Comparison[object]]{
+        param($left, $right)
+        return [StringComparer]::Ordinal.Compare($left.Relative, $right.Relative)
+    })
+    if ($fileEntries.Count -eq 0) {
+        throw "Cannot create an empty release archive from '$source'."
+    }
+
+    [IO.Directory]::CreateDirectory((Split-Path -Parent $DestinationPath)) | Out-Null
+    if (Test-Path -LiteralPath $DestinationPath) {
+        Remove-Item -LiteralPath $DestinationPath -Force
+    }
+
+    $stream = [IO.File]::Open($DestinationPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+    try {
+        $archive = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $false)
+        try {
+            foreach ($fileEntry in $fileEntries) {
+                $entryName = "$RootDirectoryName/$($fileEntry.Relative)"
+                $entry = $archive.CreateEntry($entryName, [IO.Compression.CompressionLevel]::Optimal)
+                $entry.LastWriteTime = $Timestamp
+                $input = $fileEntry.File.OpenRead()
+                try {
+                    $output = $entry.Open()
+                    try {
+                        $input.CopyTo($output)
+                    }
+                    finally {
+                        $output.Dispose()
+                    }
+                }
+                finally {
+                    $input.Dispose()
+                }
+            }
+        }
+        finally {
+            $archive.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Get-ArchiveEntryText {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$EntryName
+    )
+
+    $entry = $Archive.GetEntry($EntryName)
+    if ($null -eq $entry) {
+        throw "Archive does not contain '$EntryName'."
+    }
+
+    $stream = $entry.Open()
+    try {
+        $reader = [IO.StreamReader]::new($stream, [Text.Encoding]::UTF8, $true)
+        try {
+            return $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Assert-SafeArchiveEntries {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath
+    )
+
+    if ($Archive.Entries.Count -eq 0) {
+        throw "Archive '$ArchivePath' is empty."
+    }
+
+    $entryNames = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($entry in $Archive.Entries) {
+        if ($entry.FullName.Contains([char]92)) {
+            throw "Archive '$ArchivePath' contains a non-portable backslash entry '$($entry.FullName)'."
+        }
+        $name = $entry.FullName.Replace([char]92, '/')
+        if (-not $entryNames.Add($name)) {
+            throw "Archive '$ArchivePath' contains duplicate entry '$name'."
+        }
+        if (Test-IsForbiddenArchivePath -Path $name) {
+            throw "Archive '$ArchivePath' contains forbidden entry '$name'."
+        }
+
+        if ($entry.Length -gt 0 -and $entry.Length -le 20MB -and $name -match '(?i:\.(?:cs|csproj|props|targets|json|xml|md|txt|html|css|js|yml|yaml|ps1|psm1))$') {
+            $text = Get-ArchiveEntryText -Archive $Archive -EntryName $entry.FullName
+            if ($text -match '(?i:[A-Za-z]:[\\/]Users[\\/][^\\/]+[\\/])' `
+                -or $text -match '(?i:/Users/[^/]+/)' `
+                -or $text -match '(?i:/home/[^/]+/)') {
+                throw "Archive '$ArchivePath' contains an absolute local user path in '$name'."
+            }
+        }
+    }
+}
+
+function Assert-HtmlArchiveLayout {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RootDirectoryName
+    )
+
+    foreach ($required in @('index.html', 'api/index.html', 'metadata/release.json')) {
+        $entryName = "$RootDirectoryName/$required"
+        if ($null -eq $Archive.GetEntry($entryName)) {
+            throw "HTML archive is missing '$entryName'."
+        }
+    }
+}
+
+Export-ModuleMember -Function *

--- a/scripts/Validate-ReleaseDocumentation.ps1
+++ b/scripts/Validate-ReleaseDocumentation.ps1
@@ -1,0 +1,320 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedCommit,
+
+    [string]$ExpectedTag = 'local'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+Import-Module (Join-Path $PSScriptRoot 'ReleaseDocumentation.Common.psm1') -Force
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$normalizedVersion = ConvertTo-ReleaseVersion -Version $ExpectedVersion
+if ($ExpectedCommit -cnotmatch '^[0-9a-fA-F]{40}$') {
+    throw "ExpectedCommit '$ExpectedCommit' must be a full 40-character SHA."
+}
+$ExpectedCommit = $ExpectedCommit.ToLowerInvariant()
+$assetNames = Get-ReleaseAssetNames -Version $normalizedVersion
+$artifactRoot = (Resolve-Path -LiteralPath $ArtifactDirectory).Path
+
+function Assert-ArchiveEntry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$EntryName
+    )
+
+    if ($null -eq $Archive.GetEntry($EntryName)) {
+        throw "Archive is missing required entry '$EntryName'."
+    }
+}
+
+function Assert-CommonBundle {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RootDirectoryName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BundleName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ReleaseNotesRelativePath
+    )
+
+    Assert-SafeArchiveEntries -Archive $Archive -ArchivePath $ArchivePath
+    $rootPrefix = "$RootDirectoryName/"
+    foreach ($entry in $Archive.Entries) {
+        $name = $entry.FullName.Replace([char]92, '/')
+        if (-not $name.StartsWith($rootPrefix, [StringComparison]::Ordinal)) {
+            throw "Archive '$ArchivePath' contains entry '$name' outside expected root '$RootDirectoryName'."
+        }
+    }
+
+    foreach ($required in @(
+        "$rootPrefix$ReleaseNotesRelativePath",
+        "${rootPrefix}LICENSE.txt",
+        "${rootPrefix}metadata/version.txt",
+        "${rootPrefix}metadata/commit.txt",
+        "${rootPrefix}metadata/release.json"
+    )) {
+        Assert-ArchiveEntry -Archive $Archive -EntryName $required
+    }
+
+    $versionText = (Get-ArchiveEntryText -Archive $Archive -EntryName "${rootPrefix}metadata/version.txt").Trim()
+    $commitText = (Get-ArchiveEntryText -Archive $Archive -EntryName "${rootPrefix}metadata/commit.txt").Trim()
+    if ($versionText -cne $normalizedVersion -or $commitText -cne $ExpectedCommit) {
+        throw "Archive '$ArchivePath' has mismatched text metadata version '$versionText' or commit '$commitText'."
+    }
+
+    $release = Get-ArchiveEntryText -Archive $Archive -EntryName "${rootPrefix}metadata/release.json" | ConvertFrom-Json
+    if ($release.schemaVersion -ne 1 `
+        -or $release.product -cne 'ModernFormsNext' `
+        -or $release.bundle -cne $BundleName `
+        -or $release.version -cne $normalizedVersion `
+        -or $release.tag -cne $ExpectedTag `
+        -or $release.commit -cne $ExpectedCommit `
+        -or [string]::IsNullOrWhiteSpace($release.generatedAtUtc) `
+        -or [string]::IsNullOrWhiteSpace($release.dotnetSdk)) {
+        throw "Archive '$ArchivePath' has invalid release.json metadata."
+    }
+
+    $parsedTimestamp = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse(
+        $release.generatedAtUtc,
+        [Globalization.CultureInfo]::InvariantCulture,
+        [Globalization.DateTimeStyles]::AssumeUniversal,
+        [ref]$parsedTimestamp)) {
+        throw "Archive '$ArchivePath' has invalid generatedAtUtc '$($release.generatedAtUtc)'."
+    }
+}
+
+function Resolve-ArchiveTarget {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Target
+    )
+
+    $candidate = [Net.WebUtility]::HtmlDecode($Target).Trim()
+    if ([string]::IsNullOrWhiteSpace($candidate) -or $candidate.StartsWith('#')) {
+        return $null
+    }
+    if ($candidate.StartsWith('//') -or $candidate -match '^[A-Za-z][A-Za-z0-9+.-]*:') {
+        return $null
+    }
+    if ($candidate.StartsWith('/') -or $candidate.StartsWith('~/')) {
+        throw "Offline documentation uses root-relative target '$candidate' in '$SourceEntry'."
+    }
+
+    $candidate = ($candidate -split '[?#]', 2)[0]
+    if ([string]::IsNullOrWhiteSpace($candidate)) {
+        return $null
+    }
+    $candidate = [Uri]::UnescapeDataString($candidate).Replace([char]92, '/')
+    if ($candidate.EndsWith('/')) {
+        $candidate += 'index.html'
+    }
+
+    $baseDirectory = $SourceEntry.Replace([char]92, '/')
+    $lastSlash = $baseDirectory.LastIndexOf('/')
+    $baseDirectory = if ($lastSlash -ge 0) { $baseDirectory.Substring(0, $lastSlash) } else { '' }
+    $segments = [Collections.Generic.List[string]]::new()
+    foreach ($segment in @($baseDirectory.Split('/', [StringSplitOptions]::RemoveEmptyEntries))) {
+        $segments.Add($segment)
+    }
+    foreach ($segment in @($candidate.Split('/', [StringSplitOptions]::RemoveEmptyEntries))) {
+        if ($segment -eq '.') {
+            continue
+        }
+        if ($segment -eq '..') {
+            if ($segments.Count -eq 0) {
+                throw "Offline documentation target '$Target' escapes the archive in '$SourceEntry'."
+            }
+            $segments.RemoveAt($segments.Count - 1)
+            continue
+        }
+        $segments.Add($segment)
+    }
+
+    return $segments -join '/'
+}
+
+function Assert-OfflineLinks {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath
+    )
+
+    $entryNames = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($entry in $Archive.Entries) {
+        $null = $entryNames.Add($entry.FullName.Replace([char]92, '/'))
+    }
+
+    foreach ($entry in $Archive.Entries | Where-Object { $_.FullName -match '(?i:\.html)$' }) {
+        $text = Get-ArchiveEntryText -Archive $Archive -EntryName $entry.FullName
+        $allLinks = [regex]::Matches($text, '(?is)\b(?:href|src)\s*=\s*["''](?<url>[^"'']+)["'']')
+        foreach ($match in $allLinks) {
+            $target = Resolve-ArchiveTarget -SourceEntry $entry.FullName -Target $match.Groups['url'].Value
+            if ($null -ne $target -and -not $entryNames.Contains($target)) {
+                throw "Offline documentation link '$($match.Groups['url'].Value)' in '$($entry.FullName)' resolves to missing '$target'."
+            }
+        }
+
+        $resourceLinks = [regex]::Matches(
+            $text,
+            '(?is)<(?:script|img)\b[^>]*?\bsrc\s*=\s*["''](?<url>[^"'']+)["'']|<link\b[^>]*?\bhref\s*=\s*["''](?<url>[^"'']+)["'']')
+        foreach ($match in $resourceLinks) {
+            $url = $match.Groups['url'].Value
+            if ($url.StartsWith('//') -or $url -match '^(?i:https?):') {
+                throw "Offline documentation loads external resource '$url' in '$($entry.FullName)'."
+            }
+        }
+    }
+
+    foreach ($entry in $Archive.Entries | Where-Object { $_.FullName -match '(?i:\.css)$' }) {
+        $text = Get-ArchiveEntryText -Archive $Archive -EntryName $entry.FullName
+        foreach ($match in [regex]::Matches($text, '(?is)url\(\s*["'']?(?<url>[^)"'']+)["'']?\s*\)')) {
+            $url = $match.Groups['url'].Value
+            if ($url.StartsWith('//') -or $url -match '^(?i:https?):') {
+                throw "Offline stylesheet loads external resource '$url' in '$($entry.FullName)'."
+            }
+            $target = Resolve-ArchiveTarget -SourceEntry $entry.FullName -Target $url
+            if ($null -ne $target -and -not $entryNames.Contains($target)) {
+                throw "Offline stylesheet resource '$url' in '$($entry.FullName)' resolves to missing '$target'."
+            }
+        }
+    }
+
+    Write-Verbose "Validated offline links in '$ArchivePath'."
+}
+
+function Assert-SampleProjects {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IO.Compression.ZipArchive]$Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RootDirectoryName
+    )
+
+    $expectedProjects = @(
+        'examples/ControlGallery/ControlGallery.csproj',
+        'examples/Explorer/Explore.csproj',
+        'examples/Outlaw/Outlaw.csproj',
+        'reference/ModernFormsNext.DemoApp/ModernFormsNext.DemoApp.csproj'
+    )
+    $actualProjects = @(
+        $Archive.Entries |
+            Where-Object { $_.FullName -match '(?i:\.csproj)$' } |
+            ForEach-Object { $_.FullName.Substring($RootDirectoryName.Length + 1) } |
+            Sort-Object
+    )
+    if ([string]::Join('|', $actualProjects) -cne [string]::Join('|', ($expectedProjects | Sort-Object))) {
+        throw "Samples archive contains an unexpected project selection: $($actualProjects -join ', ')."
+    }
+
+    foreach ($relativeProject in $expectedProjects) {
+        $entryName = "$RootDirectoryName/$relativeProject"
+        [xml]$project = Get-ArchiveEntryText -Archive $Archive -EntryName $entryName
+        if ($project.SelectNodes("//*[local-name()='ProjectReference']").Count -ne 0) {
+            throw "Sample '$entryName' still contains a repository ProjectReference."
+        }
+        $packageReferences = @($project.SelectNodes("//*[local-name()='PackageReference']"))
+        if ($packageReferences.Count -eq 0) {
+            throw "Sample '$entryName' contains no PackageReference."
+        }
+        foreach ($reference in $packageReferences) {
+            if (-not $reference.GetAttribute('Include').StartsWith('ModernFormsNext', [StringComparison]::Ordinal) `
+                -or $reference.GetAttribute('Version') -cne $normalizedVersion) {
+                throw "Sample '$entryName' contains an unexpected package reference."
+            }
+        }
+    }
+}
+
+$specs = @(
+    [pscustomobject]@{ File = $assetNames.Docs; Root = "ModernFormsNext-$normalizedVersion-docs"; Bundle = 'docs'; Notes = 'RELEASE_NOTES.md' },
+    [pscustomobject]@{ File = $assetNames.Html; Root = "ModernFormsNext-$normalizedVersion-docs-html"; Bundle = 'docs-html'; Notes = 'RELEASE_NOTES.md' },
+    [pscustomobject]@{ File = $assetNames.Samples; Root = "ModernFormsNext-$normalizedVersion-samples"; Bundle = 'samples'; Notes = 'RELEASE_NOTES.md' },
+    [pscustomobject]@{ File = $assetNames.Sdk; Root = "ModernFormsNext-$normalizedVersion-sdk"; Bundle = 'sdk'; Notes = 'release-notes/RELEASE_NOTES.md' }
+)
+
+foreach ($spec in $specs) {
+    $archivePath = Join-Path $artifactRoot $spec.File
+    if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) {
+        throw "Expected release archive '$archivePath' does not exist."
+    }
+    if ((Get-Item -LiteralPath $archivePath).Length -eq 0) {
+        throw "Release archive '$archivePath' is empty."
+    }
+
+    $archive = [IO.Compression.ZipFile]::OpenRead($archivePath)
+    try {
+        Assert-CommonBundle `
+            -Archive $archive `
+            -ArchivePath $archivePath `
+            -RootDirectoryName $spec.Root `
+            -BundleName $spec.Bundle `
+            -ReleaseNotesRelativePath $spec.Notes
+
+        switch ($spec.Bundle) {
+            'docs' {
+                foreach ($required in @('README.md', 'CHANGELOG.md', 'docs/getting-started.md', 'reference/xml/ModernFormsNext.xml', 'reference/public-api.txt', 'reference/public-api.json')) {
+                    Assert-ArchiveEntry -Archive $archive -EntryName "$($spec.Root)/$required"
+                }
+            }
+            'docs-html' {
+                Assert-HtmlArchiveLayout -Archive $archive -RootDirectoryName $spec.Root
+                if (-not ($archive.Entries | Where-Object { $_.FullName -match '(?i:\.css)$' }) `
+                    -or -not ($archive.Entries | Where-Object { $_.FullName -match '(?i:\.js)$' })) {
+                    throw "HTML archive '$archivePath' is missing local CSS or JavaScript assets."
+                }
+                Assert-OfflineLinks -Archive $archive -ArchivePath $archivePath
+            }
+            'samples' {
+                Assert-ArchiveEntry -Archive $archive -EntryName "$($spec.Root)/README.md"
+                Assert-SampleProjects -Archive $archive -RootDirectoryName $spec.Root
+            }
+            'sdk' {
+                foreach ($required in @(
+                    'README.md',
+                    'documentation/README.md',
+                    'docs-html/index.html',
+                    'samples/README.md',
+                    'samples/examples/ControlGallery/ControlGallery.csproj',
+                    'samples/reference/ModernFormsNext.DemoApp/ModernFormsNext.DemoApp.csproj',
+                    'reference/public-api.txt',
+                    'reference/public-api.json'
+                )) {
+                    Assert-ArchiveEntry -Archive $archive -EntryName "$($spec.Root)/$required"
+                }
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+Write-Host "Validated 4 versioned documentation archives for ModernFormsNext $normalizedVersion at commit $ExpectedCommit."

--- a/scripts/tests/Test-ReleaseDocumentation.ps1
+++ b/scripts/tests/Test-ReleaseDocumentation.ps1
@@ -1,0 +1,189 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$scriptsRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $scriptsRoot 'ReleaseDocumentation.Common.psm1') -Force
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$script:assertionCount = 0
+
+function Assert-Equal {
+    param(
+        [AllowNull()]
+        [object]$Expected,
+
+        [AllowNull()]
+        [object]$Actual,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $script:assertionCount++
+    if ($Expected -cne $Actual) {
+        throw "$Message Expected '$Expected', got '$Actual'."
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $script:assertionCount++
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-Throws {
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Action,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MessagePattern
+    )
+
+    $script:assertionCount++
+    try {
+        & $Action
+    }
+    catch {
+        if ($_.Exception.Message -notmatch $MessagePattern) {
+            throw "Expected error matching '$MessagePattern', got '$($_.Exception.Message)'."
+        }
+        return
+    }
+
+    throw "Expected an error matching '$MessagePattern', but no error was raised."
+}
+
+$temporaryRoot = Join-Path ([IO.Path]::GetTempPath()) "ModernFormsNext-release-doc-tests-$([Guid]::NewGuid().ToString('N'))"
+[IO.Directory]::CreateDirectory($temporaryRoot) | Out-Null
+
+try {
+    Assert-Equal '1.10.0' (ConvertTo-ReleaseVersion -Version 'v1.10.0') 'A tag version must lose exactly one v prefix.'
+    Assert-Equal '1.10.0-preview.docs.1' (ConvertTo-ReleaseVersion -Version '1.10.0-preview.docs.1') 'Prerelease versions must be preserved.'
+    Assert-Throws { ConvertTo-ReleaseVersion -Version '1.10' } 'valid SemVer'
+    Assert-Throws { ConvertTo-ReleaseVersion -Version 'vv1.10.0' } 'valid SemVer'
+    Assert-Throws { ConvertTo-ReleaseVersion -Version '1.10.0-01' } 'valid SemVer'
+
+    $names = Get-ReleaseAssetNames -Version 'v1.10.0'
+    Assert-Equal 'ModernFormsNext-1.10.0-docs.zip' $names.Docs 'Docs asset naming must be stable.'
+    Assert-Equal 'ModernFormsNext-1.10.0-docs-html.zip' $names.Html 'HTML asset naming must be stable.'
+    Assert-Equal 'ModernFormsNext-1.10.0-samples.zip' $names.Samples 'Samples asset naming must be stable.'
+    Assert-Equal 'ModernFormsNext-1.10.0-sdk.zip' $names.Sdk 'SDK asset naming must be stable.'
+
+    $sampleSpecs = @(Get-ReleaseSampleSpecs)
+    Assert-Equal 4 $sampleSpecs.Count 'The public sample selection must remain intentional.'
+    Assert-True ($sampleSpecs.Source -ccontains 'samples/ControlGallery') 'ControlGallery must be selected.'
+    Assert-True ($sampleSpecs.Destination -ccontains 'reference/ModernFormsNext.DemoApp') 'The template app must remain clearly separated as a reference.'
+    Assert-True (-not ($sampleSpecs.Source -ccontains 'samples/ModernFormsNext.DesignerPlayground')) 'DesignerPlayground must not leak into the public samples bundle.'
+    Assert-True (-not ($sampleSpecs.Source -ccontains 'samples/ModernFormsNext.Android.SmokeTest')) 'The technical Android smoke host must not leak into the public samples bundle.'
+
+    foreach ($forbidden in @(
+        'ModernFormsNext-1.10.0-docs/.git/config',
+        'ModernFormsNext-1.10.0-samples/examples/ControlGallery/bin/app.dll',
+        'ModernFormsNext-1.10.0-samples/examples/ControlGallery/obj/project.assets.json',
+        'ModernFormsNext-1.10.0-docs/artifacts/log.txt',
+        'ModernFormsNext-1.10.0-docs/secrets/.env',
+        'ModernFormsNext-1.10.0-docs/signing/key.pfx',
+        'C:/Users/Developer/file.md',
+        '../escape.txt'
+    )) {
+        Assert-True (Test-IsForbiddenArchivePath -Path $forbidden) "Path '$forbidden' must be rejected."
+    }
+    Assert-True (-not (Test-IsForbiddenArchivePath -Path 'ModernFormsNext-1.10.0-docs/docs/getting-started.md')) 'Normal documentation paths must remain allowed.'
+
+    $notesRepository = Join-Path $temporaryRoot 'notes-repository'
+    [IO.Directory]::CreateDirectory((Join-Path $notesRepository 'docs')) | Out-Null
+    Assert-Throws { Resolve-ReleaseNotesFile -RepositoryRoot $notesRepository -Version '1.10.0' } 'Release notes were not found'
+    Write-Utf8File -Path (Join-Path $notesRepository 'docs/1.10.0-release-notes.md') -Content '# Notes'
+    Assert-True ((Resolve-ReleaseNotesFile -RepositoryRoot $notesRepository -Version '1.10.0').EndsWith('1.10.0-release-notes.md', [StringComparison]::Ordinal)) 'The default release-notes convention must resolve.'
+
+    $metadataRoot = Join-Path $temporaryRoot 'metadata-bundle'
+    $metadata = New-ReleaseMetadata `
+        -Bundle 'docs' `
+        -Version '1.10.0' `
+        -Tag 'v1.10.0' `
+        -Commit '0123456789abcdef0123456789abcdef01234567' `
+        -GeneratedAtUtc ([DateTimeOffset]::Parse('2026-08-16T12:00:00Z')) `
+        -DotNetSdk '10.0.201'
+    Write-ReleaseMetadata -BundleRoot $metadataRoot -Metadata $metadata
+    $release = Get-Content -LiteralPath (Join-Path $metadataRoot 'metadata/release.json') -Raw | ConvertFrom-Json
+    Assert-Equal '1.10.0' $release.version 'release.json must contain the normalized version.'
+    Assert-Equal '0123456789abcdef0123456789abcdef01234567' $release.commit 'release.json must contain the full commit.'
+    Assert-Equal 'v1.10.0' $release.tag 'release.json must contain the tag.'
+
+    $orderedSource = Join-Path $temporaryRoot 'ordered-source'
+    [IO.Directory]::CreateDirectory((Join-Path $orderedSource 'nested')) | Out-Null
+    Write-Utf8File -Path (Join-Path $orderedSource 'z.txt') -Content 'z'
+    Write-Utf8File -Path (Join-Path $orderedSource 'a.txt') -Content 'a'
+    Write-Utf8File -Path (Join-Path $orderedSource 'nested/m.txt') -Content 'm'
+    $orderedZip = Join-Path $temporaryRoot 'ordered.zip'
+    New-StableZip -SourceDirectory $orderedSource -DestinationPath $orderedZip -RootDirectoryName 'root' -Timestamp ([DateTimeOffset]::Parse('2026-08-16T12:00:00Z'))
+    $archive = [IO.Compression.ZipFile]::OpenRead($orderedZip)
+    try {
+        $entryOrder = @($archive.Entries.FullName) -join '|'
+        Assert-Equal 'root/a.txt|root/nested/m.txt|root/z.txt' $entryOrder 'ZIP entries must use stable ordinal path ordering.'
+        Assert-SafeArchiveEntries -Archive $archive -ArchivePath $orderedZip
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    $unsafeSource = Join-Path $temporaryRoot 'unsafe-source'
+    [IO.Directory]::CreateDirectory((Join-Path $unsafeSource 'bin')) | Out-Null
+    Write-Utf8File -Path (Join-Path $unsafeSource 'bin/leak.txt') -Content 'leak'
+    $unsafeZip = Join-Path $temporaryRoot 'unsafe.zip'
+    New-StableZip -SourceDirectory $unsafeSource -DestinationPath $unsafeZip -RootDirectoryName 'root' -Timestamp ([DateTimeOffset]::Parse('2026-08-16T12:00:00Z'))
+    $archive = [IO.Compression.ZipFile]::OpenRead($unsafeZip)
+    try {
+        Assert-Throws { Assert-SafeArchiveEntries -Archive $archive -ArchivePath $unsafeZip } 'forbidden entry'
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    $localPathSource = Join-Path $temporaryRoot 'local-path-source'
+    [IO.Directory]::CreateDirectory($localPathSource) | Out-Null
+    Write-Utf8File -Path (Join-Path $localPathSource 'manifest.json') -Content '{ "source": "C:/Users/Developer/repository" }'
+    $localPathZip = Join-Path $temporaryRoot 'local-path.zip'
+    New-StableZip -SourceDirectory $localPathSource -DestinationPath $localPathZip -RootDirectoryName 'root' -Timestamp ([DateTimeOffset]::Parse('2026-08-16T12:00:00Z'))
+    $archive = [IO.Compression.ZipFile]::OpenRead($localPathZip)
+    try {
+        Assert-Throws { Assert-SafeArchiveEntries -Archive $archive -ArchivePath $localPathZip } 'absolute local user path'
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    $htmlSource = Join-Path $temporaryRoot 'html-source'
+    [IO.Directory]::CreateDirectory((Join-Path $htmlSource 'api')) | Out-Null
+    [IO.Directory]::CreateDirectory((Join-Path $htmlSource 'metadata')) | Out-Null
+    Write-Utf8File -Path (Join-Path $htmlSource 'api/index.html') -Content '<html></html>'
+    Write-Utf8File -Path (Join-Path $htmlSource 'metadata/release.json') -Content '{}'
+    $htmlZip = Join-Path $temporaryRoot 'html.zip'
+    New-StableZip -SourceDirectory $htmlSource -DestinationPath $htmlZip -RootDirectoryName 'root' -Timestamp ([DateTimeOffset]::Parse('2026-08-16T12:00:00Z'))
+    $archive = [IO.Compression.ZipFile]::OpenRead($htmlZip)
+    try {
+        Assert-Throws { Assert-HtmlArchiveLayout -Archive $archive -RootDirectoryName 'root' } 'index.html'
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+finally {
+    if ([IO.Directory]::Exists($temporaryRoot)) {
+        [IO.Directory]::Delete($temporaryRoot, $true)
+    }
+}
+
+Write-Host "Release documentation script tests passed ($script:assertionCount assertions)."


### PR DESCRIPTION
## Summary

ModernFormsNext releases will publish versioned documentation and sample bundles generated from the exact release tag and commit. Users of a specific NuGet version can therefore keep matching documentation instead of relying on the evolving content on `master`.

## Artifacts

- `ModernFormsNext-<version>-docs.zip`: README, CHANGELOG, release notes, documentation sources, Release XML docs, public API snapshots, and metadata.
- `ModernFormsNext-<version>-docs-html.zip`: self-contained offline DocFX HTML, API reference, local assets, release notes, and metadata.
- `ModernFormsNext-<version>-samples.zip`: selected NuGet-based samples: ControlGallery, Explorer, Outlaw, plus DemoApp as a template reference rather than a playground.
- `ModernFormsNext-<version>-sdk.zip`: aggregate offline/reference bundle with source docs, HTML, samples, XML docs, API snapshots, release notes, licenses, and metadata.

## Release workflow

The release workflow restores the pinned DocFX tool, builds and tests the solution, packs and validates NuGet packages, then builds and validates all documentation archives before creating the GitHub Release or publishing NuGet packages.

SemVer is derived from the release tag. Release mode requires the exact `v<version>` tag, verifies that the tag resolves to `github.sha`, and records the full commit SHA in every bundle. The release assets and NuGet packages therefore correspond to the same tagged commit.

## Validation

- Full restore: PASS
- Debug build: PASS — 0 warnings / 0 errors
- Release build: PASS — 0 warnings / 0 errors
- Tests: 1083/1083
- Release pack: PASS
- NuGet packages validated: 8
- Symbol packages validated: 7
- DocFX: PASS — 0 warnings / 0 errors
- Documentation script tests: 32/32
- `git diff --check`: PASS

## Local dry-run

A local prerelease dry-run generated all four ZIP archives and passed `Validate-ReleaseDocumentation.ps1`. Generated dry-run archives remain under ignored `artifacts/` and are not committed.

## Compatibility / safety

The change is additive and does not alter runtime APIs, package versions, rendering, layout, or platform behavior. Bundle inputs are allowlisted from tracked files; validation rejects build outputs, packages, signing material, user-specific files, machine paths, traversal, broken offline links, mismatched metadata, and incorrect sample package versions.