### PR TITLE
Fix Designer container Padding layout parity

### DIFF
--- a/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
+++ b/ModernFormsNext.CodeGeneration/Reverse/CSharpDesignerParser.cs
@@ -1211,6 +1211,15 @@ public sealed class CSharpDesignerParser
             return true;
         }
 
+        if (IsType(typeName, "Padding") && TryReadObjectArguments(expression, 4, out var padding))
+        {
+            string[] names = ["Left", "Top", "Right", "Bottom"];
+            for (var index = 0; index < names.Length; index++)
+                propertyValues[names[index]] = DesignPropertyValue.FromInt32(padding[index]);
+            value = DesignPropertyValue.FromStructuredObject(typeName, propertyValues);
+            return true;
+        }
+
         if ((IsType(typeName, "Rectangle") || IsType(typeName, "Bounds"))
             && TryReadObjectArguments(expression, 4, out var rectangle))
         {

--- a/ModernFormsNext.Designer.Tests/CustomUserControlPreviewTests.cs
+++ b/ModernFormsNext.Designer.Tests/CustomUserControlPreviewTests.cs
@@ -115,6 +115,38 @@ public sealed class CustomUserControlPreviewTests
     }
 
     [Fact]
+    public void PreviewLayoutAppliesRootUserControlPaddingWithoutExecutingUserCode()
+    {
+        ConstructorTrapUserControl.ConstructorCalls = 0;
+        using var project = new TemporaryPreviewProject();
+        var document = CreateUserControlDocument(
+            typeof(ConstructorTrapUserControl).Namespace!,
+            nameof(ConstructorTrapUserControl),
+            300,
+            200);
+        document.Properties["Padding"] = DesignerPropertyValueEditor.ToDesignPropertyValue(
+            new Padding(10, 20, 30, 40),
+            typeof(Padding));
+        var fill = CreateNode("Panel", "fillPanel", 0, 0, 300, 200, string.Empty);
+        fill.Properties["Dock"] = DesignPropertyValue.FromEnum(typeof(DockStyle).FullName!, nameof(DockStyle.Fill));
+        document.Controls.Add(fill);
+        project.AddUserControl(document);
+        var cache = new DesignerEmbeddedPreviewCache(
+            project.ProjectFilePath,
+            DesignerProjectUserControlDiscovery.Discover(project.ProjectFilePath));
+
+        Assert.True(cache.TryGetPreview(
+            typeof(ConstructorTrapUserControl).FullName!,
+            new DesignSize(500, 300),
+            out var preview,
+            out var error), error);
+
+        var projectedFill = Assert.Single(preview!.Document.Controls);
+        Assert.Equal(new DesignBounds(10, 20, 460, 240), preview.Layout.GetEffectiveBounds(projectedFill));
+        Assert.Equal(0, ConstructorTrapUserControl.ConstructorCalls);
+    }
+
+    [Fact]
     public void CacheReloadsChangedDesignDocumentOnNextRequest()
     {
         using var project = new TemporaryPreviewProject();

--- a/ModernFormsNext.Designer.Tests/DesignerPaddingLayoutTests.cs
+++ b/ModernFormsNext.Designer.Tests/DesignerPaddingLayoutTests.cs
@@ -1,0 +1,432 @@
+using System.Drawing;
+using ModernFormsNext.CodeGeneration.CSharp;
+using ModernFormsNext.CodeGeneration.Reverse;
+using ModernFormsNext.Designer.Properties;
+using ModernFormsNext.Designer.Services;
+using ModernFormsNext.Designer.Surface;
+using ModernFormsNext.Designing;
+using Xunit;
+
+namespace ModernFormsNext.Designer.Tests;
+
+public sealed class DesignerPaddingLayoutTests
+{
+    [Fact]
+    public void FillUsesParentsAsymmetricPaddedDisplayRectangle()
+    {
+        var document = CreateDocument(new Padding(10, 20, 30, 40), DockStyle.Fill);
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(new DesignBounds(10, 20, 260, 140), PreviewBounds(document, "child1"));
+    }
+
+    [Theory]
+    [InlineData(DockStyle.Top)]
+    [InlineData(DockStyle.Bottom)]
+    [InlineData(DockStyle.Left)]
+    [InlineData(DockStyle.Right)]
+    public void RepeatedEdgeDockingStartsInsidePaddingAndMatchesRuntime(DockStyle dock)
+    {
+        var document = CreateDocument(new Padding(10, 20, 30, 40), dock, dock, dock);
+
+        AssertPreviewAndRuntimeMatch(document);
+
+        var first = PreviewBounds(document, "child1");
+        Assert.Equal(dock == DockStyle.Right ? 240 : 10, first.X);
+        Assert.Equal(dock == DockStyle.Bottom ? 130 : 20, first.Y);
+    }
+
+    [Theory]
+    [MemberData(nameof(MixedDockCases))]
+    public void MixedDockingConsumesOnlyThePaddedRectangle(DockStyle[] docks)
+    {
+        var document = CreateDocument(new Padding(10, 20, 30, 40), docks);
+
+        AssertPreviewAndRuntimeMatch(document);
+
+        foreach (var child in document.Controls[0].Children)
+        {
+            var bounds = PreviewBounds(document, child.Name);
+            Assert.True(bounds.X >= 10);
+            Assert.True(bounds.Y >= 20);
+            Assert.True(bounds.Right <= 270);
+            Assert.True(bounds.Bottom <= 160);
+        }
+    }
+
+    [Theory]
+    [InlineData("Panel")]
+    [InlineData("UserControl")]
+    public void NestedContainersUseOnlyTheirImmediateParentsPadding(string innerTypeName)
+    {
+        var document = CreateDocument(new Padding(10), DockStyle.Fill);
+        var outer = document.Controls[0];
+        var inner = outer.Children[0];
+        inner.TypeName = innerTypeName;
+        inner.Name = "innerPanel";
+        inner.Properties["Padding"] = PaddingValue(new Padding(5, 10, 15, 20));
+        inner.Children.Add(CreateDockedNode("textBox1", "TextBox", DockStyle.Fill, 40));
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(new DesignBounds(10, 10, 280, 180), PreviewBounds(document, "innerPanel"));
+        Assert.Equal(new DesignBounds(15, 20, 260, 150), PreviewBounds(document, "textBox1"));
+    }
+
+    [Fact]
+    public void AnchorKeepsRuntimeCoordinatesWhenParentHasPadding()
+    {
+        var document = CreateDocument(new Padding(10, 20, 30, 40), DockStyle.None);
+        var child = document.Controls[0].Children[0];
+        child.Bounds = new DesignBounds(25, 35, 50, 40);
+        child.Properties["Anchor"] = DesignPropertyValue.FromEnum(
+            typeof(AnchorStyles).FullName!,
+            $"{nameof(AnchorStyles.Right)}, {nameof(AnchorStyles.Bottom)}");
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(new DesignBounds(25, 35, 50, 40), PreviewBounds(document, child.Name));
+    }
+
+    [Theory]
+    [InlineData(DockStyle.Fill)]
+    [InlineData(DockStyle.Top)]
+    [InlineData(DockStyle.Left)]
+    public void DockKeepsRuntimeMarginSemantics(DockStyle dock)
+    {
+        var document = CreateDocument(new Padding(10, 20, 30, 40), dock);
+        document.Controls[0].Children[0].Properties["Margin"] = PaddingValue(new Padding(7, 11, 13, 17));
+
+        AssertPreviewAndRuntimeMatch(document);
+
+        var bounds = PreviewBounds(document, "child1");
+        Assert.Equal(10, bounds.X);
+        Assert.Equal(20, bounds.Y);
+    }
+
+    [Theory]
+    [MemberData(nameof(PaddingCases))]
+    public void ZeroUniformVerticalAndAsymmetricPaddingMatchRuntime(Padding padding, DesignBounds expected)
+    {
+        var document = CreateDocument(padding, DockStyle.Fill);
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(expected, PreviewBounds(document, "child1"));
+    }
+
+    [Fact]
+    public void NegativePaddingUsesRuntimeNormalization()
+    {
+        var document = CreateDocument(new Padding(-5, 10, -15, -20), DockStyle.Fill);
+
+        AssertPreviewAndRuntimeMatch(document);
+        Assert.Equal(new DesignBounds(0, 10, 300, 190), PreviewBounds(document, "child1"));
+    }
+
+    [Fact]
+    public void OversizedPaddingDoesNotProduceNegativeDesignerBounds()
+    {
+        var document = CreateDocument(new Padding(200, 150, 200, 150), DockStyle.Fill);
+
+        var exception = Record.Exception(() => new DesignerLayoutEngine().Layout(document));
+        var bounds = PreviewBounds(document, "child1");
+        Control? runtimeRoot = null;
+        var runtimeException = Record.Exception(() => runtimeRoot = BuildRuntimeTree(document, out _));
+
+        Assert.Null(exception);
+        Assert.Null(runtimeException);
+        Assert.Equal(new DesignBounds(200, 150, 0, 0), bounds);
+        runtimeRoot?.Dispose();
+    }
+
+    [Fact]
+    public void PropertyGridPaddingEditsRelayoutImmediatelyAndResetWithoutStaleGeometry()
+    {
+        var document = CreateDocument(Padding.Empty, DockStyle.Fill);
+        var parent = document.Controls[0];
+        var child = parent.Children[0];
+        var session = new DesignerSession();
+        session.LoadDocument(document);
+        session.SelectNode(parent);
+        var propertyGrid = new DesignerPropertyGridState(session);
+        var documentChanges = 0;
+        session.DocumentChanged += (_, _) => documentChanges++;
+
+        Assert.Equal(new DesignBounds(0, 0, 300, 200), PreviewBounds(document, child.Name));
+
+        CommitPadding(propertyGrid, "10, 10, 10, 10");
+        Assert.Equal(new DesignBounds(10, 10, 280, 180), PreviewBounds(document, child.Name));
+
+        CommitPadding(propertyGrid, "5, 10, 15, 20");
+        Assert.Equal(new DesignBounds(5, 10, 280, 170), PreviewBounds(document, child.Name));
+
+        var hitTest = new DesignerHitTestService(new DesignerCoordinateMapper());
+        Assert.Same(parent, hitTest.HitTestControl(session, new DesignPoint(2, 2)).Node);
+        Assert.Same(child, hitTest.HitTestControl(session, new DesignPoint(6, 11)).Node);
+        session.SelectAt(2, 2);
+        Assert.Same(parent, session.SelectedNode);
+        session.SelectAt(6, 11);
+        Assert.Same(child, session.SelectedNode);
+        session.SelectNode(parent);
+
+        CommitPadding(propertyGrid, "0, 0, 0, 0");
+        Assert.Equal(new DesignBounds(0, 0, 300, 200), PreviewBounds(document, child.Name));
+        Assert.Equal(3, documentChanges);
+    }
+
+    [Fact]
+    public void ResizeHandleHitTestingUsesRelayoutBoundsAfterPaddingChange()
+    {
+        var document = CreateDocument(Padding.Empty, DockStyle.Top);
+        var parent = document.Controls[0];
+        var child = parent.Children[0];
+        var session = new DesignerSession();
+        session.LoadDocument(document);
+        session.SelectNode(child);
+        const int surfaceWidth = 900;
+        const int surfaceHeight = 700;
+        var mapper = new DesignerCoordinateMapper();
+        var hitTest = new DesignerHitTestService(mapper);
+        var oldBounds = mapper.ToSurfaceBounds(
+            new DesignerLayoutEngine().Layout(document).GetEffectiveBounds(child),
+            mapper.GetView(session, surfaceWidth, surfaceHeight));
+        var oldHandle = DesignerHitTestService.GetHandleBounds(oldBounds, DesignerResizeHandle.Bottom);
+
+        parent.Properties["Padding"] = PaddingValue(new Padding(10, 20, 30, 40));
+        session.NotifyDocumentChanged();
+        var view = mapper.GetView(session, surfaceWidth, surfaceHeight);
+        var newBounds = mapper.ToSurfaceBounds(new DesignerLayoutEngine().Layout(document).GetEffectiveBounds(child), view);
+        var newHandle = DesignerHitTestService.GetHandleBounds(newBounds, DesignerResizeHandle.Bottom);
+
+        Assert.Equal(
+            DesignerResizeHandle.None,
+            hitTest.HitTestResizeHandle(session, surfaceWidth, surfaceHeight, oldHandle.Left + oldHandle.Width / 2f, oldHandle.Top + oldHandle.Height / 2f));
+        Assert.Equal(
+            DesignerResizeHandle.Bottom,
+            hitTest.HitTestResizeHandle(session, surfaceWidth, surfaceHeight, newHandle.Left + newHandle.Width / 2f, newHandle.Top + newHandle.Height / 2f));
+    }
+
+    [Fact]
+    public void ParentResizeKeepsPaddedFillBoundsWithoutDrift()
+    {
+        var document = CreateDocument(new Padding(10, 20, 30, 40), DockStyle.Fill);
+        var parent = document.Controls[0];
+
+        foreach (var size in new[] { new DesignSize(360, 240), new DesignSize(500, 320), new DesignSize(300, 200) })
+        {
+            parent.Bounds = new DesignBounds(0, 0, size.Width, size.Height);
+            document.Size = size;
+            AssertPreviewAndRuntimeMatch(document);
+            Assert.Equal(
+                new DesignBounds(10, 20, size.Width - 40, size.Height - 60),
+                PreviewBounds(document, "child1"));
+        }
+    }
+
+    [Fact]
+    public void UserControlRootAndFormRootKeepTheirRuntimePaddingSemantics()
+    {
+        var userControl = CreateRootDocument(DesignRootKind.UserControl, new Padding(10, 20, 30, 40));
+        var form = CreateRootDocument(DesignRootKind.Form, new Padding(10, 20, 30, 40));
+
+        AssertPreviewAndRuntimeMatch(userControl);
+        Assert.Equal(new DesignBounds(10, 20, 260, 140), PreviewBounds(userControl, "rootChild"));
+        Assert.Equal(new DesignBounds(0, 0, 300, 200), PreviewBounds(form, "rootChild"));
+    }
+
+    [Fact]
+    public void SerializationGenerationAndReverseParsingPreservePaddingMarginAndHierarchy()
+    {
+        var document = CreateDocument(new Padding(5, 10, 15, 20), DockStyle.Fill);
+        var child = document.Controls[0].Children[0];
+        child.Properties["Margin"] = PaddingValue(new Padding(1, 2, 3, 4));
+        var serializer = DesignDocumentSerializer.Default;
+        var reopened = serializer.Deserialize(serializer.Serialize(document));
+        var generated = new CSharpDesignerGenerator().Generate(reopened);
+
+        Assert.True(generated.Succeeded, string.Join(Environment.NewLine, generated.Validation.Errors));
+        Assert.Contains("this.panel1.Padding = new Padding(5, 10, 15, 20);", generated.Code, StringComparison.Ordinal);
+        Assert.Contains("this.child1.Margin = new Padding(1, 2, 3, 4);", generated.Code, StringComparison.Ordinal);
+
+        var parsed = new CSharpDesignerParser().Parse(generated.Code);
+        Assert.True(parsed.Success, string.Join(Environment.NewLine, parsed.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        var parsedDocument = Assert.IsType<DesignDocument>(parsed.Document);
+        var parsedParent = Assert.Single(parsedDocument.Controls);
+        var parsedChild = Assert.Single(parsedParent.Children);
+
+        Assert.Equal("panel1", parsedParent.Name);
+        Assert.Equal("child1", parsedChild.Name);
+        Assert.Equal(new Padding(5, 10, 15, 20), ReadPadding(parsedParent, "Padding"));
+        Assert.Equal(new Padding(1, 2, 3, 4), ReadPadding(parsedChild, "Margin"));
+        Assert.Equal(DockStyle.Fill, DesignerLayoutProperties.GetDock(parsedChild));
+    }
+
+    public static TheoryData<DockStyle[]> MixedDockCases => new()
+    {
+        new[] { DockStyle.Top, DockStyle.Fill },
+        new[] { DockStyle.Bottom, DockStyle.Fill },
+        new[] { DockStyle.Left, DockStyle.Fill },
+        new[] { DockStyle.Right, DockStyle.Fill },
+        new[] { DockStyle.Top, DockStyle.Bottom, DockStyle.Fill },
+        new[] { DockStyle.Left, DockStyle.Right, DockStyle.Fill }
+    };
+
+    public static TheoryData<Padding, DesignBounds> PaddingCases => new()
+    {
+        { Padding.Empty, new DesignBounds(0, 0, 300, 200) },
+        { new Padding(10), new DesignBounds(10, 10, 280, 180) },
+        { new Padding(0, 12, 0, 12), new DesignBounds(0, 12, 300, 176) },
+        { new Padding(5, 10, 15, 20), new DesignBounds(5, 10, 280, 170) }
+    };
+
+    private static DesignDocument CreateDocument(Padding padding, params DockStyle[] docks)
+    {
+        var document = new DesignDocument
+        {
+            Namespace = "PaddingLayoutReproduction",
+            ClassName = "MainForm",
+            FormName = "MainForm",
+            Size = new DesignSize(300, 200)
+        };
+        var parent = CreateDockedNode("panel1", "Panel", DockStyle.Fill, 200);
+        parent.Bounds = new DesignBounds(0, 0, 300, 200);
+        parent.Properties["Padding"] = PaddingValue(padding);
+
+        for (var index = 0; index < docks.Length; index++)
+            parent.Children.Add(CreateDockedNode($"child{index + 1}", index == 0 && docks.Length == 1 ? "TextBox" : "Panel", docks[index], 30 + (index * 5)));
+
+        document.Controls.Add(parent);
+        return document;
+    }
+
+    private static DesignDocument CreateRootDocument(DesignRootKind rootKind, Padding padding)
+    {
+        var document = new DesignDocument
+        {
+            Namespace = "PaddingLayoutReproduction",
+            ClassName = rootKind == DesignRootKind.UserControl ? "RootControl" : "MainForm",
+            FormName = rootKind == DesignRootKind.UserControl ? "RootControl" : "MainForm",
+            RootKind = rootKind,
+            Size = new DesignSize(300, 200)
+        };
+        document.Properties["Padding"] = PaddingValue(padding);
+        document.Controls.Add(CreateDockedNode("rootChild", "Panel", DockStyle.Fill, 30));
+        return document;
+    }
+
+    private static DesignControlNode CreateDockedNode(string name, string typeName, DockStyle dock, int thickness)
+        => new()
+        {
+            TypeName = typeName,
+            Name = name,
+            Bounds = new DesignBounds(0, 0, thickness, thickness),
+            Properties =
+            {
+                ["Dock"] = DesignPropertyValue.FromEnum(typeof(DockStyle).FullName!, dock.ToString())
+            }
+        };
+
+    private static DesignPropertyValue PaddingValue(Padding padding)
+        => DesignerPropertyValueEditor.ToDesignPropertyValue(padding, typeof(Padding));
+
+    private static Padding ReadPadding(DesignControlNode node, string propertyName)
+        => Assert.IsType<Padding>(DesignerPropertyValueEditor.FromDesignPropertyValue(node.Properties[propertyName], typeof(Padding)));
+
+    private static void CommitPadding(DesignerPropertyGridState propertyGrid, string value)
+    {
+        var property = Assert.Single(propertyGrid.Properties, candidate => candidate.Name == "Padding");
+        propertyGrid.SelectRow(new DesignerPropertyGridRow(property));
+        Assert.True(propertyGrid.CommitSelectedValue(value));
+    }
+
+    private static void AssertPreviewAndRuntimeMatch(DesignDocument document)
+    {
+        var preview = new DesignerLayoutEngine().Layout(document);
+        using var root = BuildRuntimeTree(document, out var runtimeControls);
+
+        foreach (var node in Enumerate(document.Controls))
+        {
+            var expected = preview.GetEffectiveBounds(node);
+            var actual = GetAbsoluteBounds(runtimeControls[node]);
+            Assert.Equal(new Rectangle(expected.X, expected.Y, expected.Width, expected.Height), actual);
+        }
+    }
+
+    private static Control BuildRuntimeTree(
+        DesignDocument document,
+        out Dictionary<DesignControlNode, Control> controls)
+    {
+        controls = new Dictionary<DesignControlNode, Control>();
+        Control root = document.RootKind == DesignRootKind.UserControl ? new UserControl() : new Panel();
+        root.Size = new Size(document.Size.Width, document.Size.Height);
+        root.SuspendLayout();
+
+        for (var index = document.Controls.Count - 1; index >= 0; index--)
+            root.Controls.Add(CreateRuntimeControl(document.Controls[index], controls));
+
+        if (document.RootKind == DesignRootKind.UserControl)
+            root.Padding = DesignerLayoutProperties.GetPadding(document.Properties);
+
+        root.ResumeLayout(true);
+        PerformLayoutRecursively(root);
+        return root;
+    }
+
+    private static Control CreateRuntimeControl(
+        DesignControlNode node,
+        IDictionary<DesignControlNode, Control> controls)
+    {
+        Control control = node.TypeName switch
+        {
+            "TextBox" => new TextBox(),
+            "Label" => new Label(),
+            "UserControl" => new UserControl(),
+            _ => new Panel()
+        };
+        control.Name = node.Name;
+        control.Bounds = new Rectangle(node.Bounds.X, node.Bounds.Y, node.Bounds.Width, node.Bounds.Height);
+
+        if (node.Properties.ContainsKey("Anchor"))
+            control.Anchor = DesignerLayoutProperties.GetAnchor(node);
+        control.Dock = DesignerLayoutProperties.GetDock(node);
+        control.Padding = DesignerLayoutProperties.GetPadding(node);
+        if (node.Properties.TryGetValue("Margin", out var margin))
+            control.Margin = Assert.IsType<Padding>(DesignerPropertyValueEditor.FromDesignPropertyValue(margin, typeof(Padding)));
+
+        controls.Add(node, control);
+        control.SuspendLayout();
+        for (var index = node.Children.Count - 1; index >= 0; index--)
+            control.Controls.Add(CreateRuntimeControl(node.Children[index], controls));
+        control.ResumeLayout(true);
+        return control;
+    }
+
+    private static void PerformLayoutRecursively(Control control)
+    {
+        control.PerformLayout();
+        foreach (var child in control.Controls)
+            PerformLayoutRecursively(child);
+    }
+
+    private static Rectangle GetAbsoluteBounds(Control control)
+    {
+        var bounds = control.Bounds;
+        for (var parent = control.Parent; parent?.Parent is not null; parent = parent.Parent)
+            bounds.Offset(parent.Left, parent.Top);
+        return bounds;
+    }
+
+    private static DesignBounds PreviewBounds(DesignDocument document, string name)
+    {
+        var node = Enumerate(document.Controls).Single(candidate => candidate.Name == name);
+        return new DesignerLayoutEngine().Layout(document).GetEffectiveBounds(node);
+    }
+
+    private static IEnumerable<DesignControlNode> Enumerate(IEnumerable<DesignControlNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            yield return node;
+            foreach (var child in Enumerate(node.Children))
+                yield return child;
+        }
+    }
+}

--- a/ModernFormsNext.Designer/Services/DesignerSession.cs
+++ b/ModernFormsNext.Designer/Services/DesignerSession.cs
@@ -19,6 +19,7 @@ public sealed class DesignerSession
 {
     private readonly List<string> outputLines = [];
     private readonly List<DesignerOpenDocument> openDocuments = [];
+    private readonly DesignerHitTestService hitTestService = new(new DesignerCoordinateMapper());
     private readonly IDesignerHostEnvironment? environment;
     private readonly IReadOnlyList<DesignerProjectUserControlInfo> projectUserControls;
     private DesignControlNode? clipboardNode;
@@ -330,7 +331,7 @@ public sealed class DesignerSession
     /// <param name="y">The document Y coordinate in logical pixels.</param>
     public void SelectAt(int x, int y)
     {
-        var result = Host.HitTest(x, y);
+        var result = hitTestService.HitTestControl(this, new DesignPoint(x, y));
         var selectedNode = GetComponentBoundary(result.Node);
         Host.Selection.Select(selectedNode);
         Log(selectedNode is null ? $"Selected {Document.FormName}." : $"Selected {selectedNode.Name}.");

--- a/ModernFormsNext.Designer/Surface/Layout/DesignerLayoutEngine.cs
+++ b/ModernFormsNext.Designer/Surface/Layout/DesignerLayoutEngine.cs
@@ -12,30 +12,38 @@ internal sealed class DesignerLayoutEngine
     public DesignerLayoutResult Layout(DesignDocument document, DesignSize rootSize)
     {
         var bounds = new Dictionary<DesignControlNode, DesignBounds>();
-        var documentClientBounds = new DesignBounds(0, 0, Math.Max(1, rootSize.Width), Math.Max(1, rootSize.Height));
+        var documentBounds = new DesignBounds(0, 0, Math.Max(1, rootSize.Width), Math.Max(1, rootSize.Height));
+        var documentContentBounds = document.RootKind == DesignRootKind.UserControl
+            ? DesignerLayoutProperties.GetPaddedContentBounds(documentBounds, DesignerLayoutProperties.GetPadding(document.Properties))
+            : documentBounds;
 
-        LayoutGenericChildren(document.Controls, documentClientBounds, document.Size, bounds);
+        LayoutGenericChildren(document.Controls, documentBounds, documentContentBounds, document.Size, bounds);
 
         return new DesignerLayoutResult(bounds);
     }
 
     private static void LayoutGenericChildren(
         DesignControlCollection children,
-        DesignBounds parentClientBounds,
+        DesignBounds parentBounds,
+        DesignBounds parentContentBounds,
         DesignSize parentDesignSize,
         IDictionary<DesignControlNode, DesignBounds> bounds)
     {
-        var remaining = new DesignBounds(0, 0, Math.Max(0, parentClientBounds.Width), Math.Max(0, parentClientBounds.Height));
+        var remaining = new DesignBounds(
+            parentContentBounds.X - parentBounds.X,
+            parentContentBounds.Y - parentBounds.Y,
+            Math.Max(0, parentContentBounds.Width),
+            Math.Max(0, parentContentBounds.Height));
 
         // The persisted collection is front-to-back. As at runtime, the front-most child consumes
         // dock space first; authored X/Y values are ignored for docked controls while thickness is
         // taken from Height (Top/Bottom) or Width (Left/Right).
         foreach (var child in children)
         {
-            var localBounds = GetLocalBounds(child, remaining, parentClientBounds, parentDesignSize);
+            var localBounds = GetLocalBounds(child, remaining, parentBounds, parentDesignSize);
             var absoluteBounds = new DesignBounds(
-                parentClientBounds.X + localBounds.X,
-                parentClientBounds.Y + localBounds.Y,
+                parentBounds.X + localBounds.X,
+                parentBounds.Y + localBounds.Y,
                 Math.Max(0, localBounds.Width),
                 Math.Max(0, localBounds.Height));
 
@@ -52,33 +60,34 @@ internal sealed class DesignerLayoutEngine
         IDictionary<DesignControlNode, DesignBounds> bounds)
     {
         DesignerSpecialContainers.EnsureSpecialChildren(container);
+        var contentBounds = DesignerLayoutProperties.GetContainerContentBounds(container, containerBounds);
 
         if (DesignerSpecialContainers.IsSplitContainer(container))
         {
-            LayoutSplitContainer(container, containerBounds, bounds);
+            LayoutSplitContainer(container, contentBounds, bounds);
             return;
         }
 
         if (DesignerSpecialContainers.IsTabControl(container))
         {
-            LayoutTabControl(container, containerBounds, bounds);
+            LayoutTabControl(container, contentBounds, bounds);
             return;
         }
 
         if (DesignerSpecialContainers.IsFlowLayoutPanel(container))
         {
-            LayoutFlowLayoutPanel(container, containerBounds, bounds);
+            LayoutFlowLayoutPanel(container, contentBounds, bounds);
             return;
         }
 
         if (DesignerSpecialContainers.IsTableLayoutPanel(container))
         {
-            LayoutTableLayoutPanel(container, containerBounds, bounds);
+            LayoutTableLayoutPanel(container, contentBounds, bounds);
             return;
         }
 
         if (container.Children.Count > 0)
-            LayoutGenericChildren(container.Children, containerBounds, GetDesignSize(container), bounds);
+            LayoutGenericChildren(container.Children, containerBounds, contentBounds, GetDesignSize(container), bounds);
     }
 
     private static void LayoutSplitContainer(
@@ -114,8 +123,18 @@ internal sealed class DesignerLayoutEngine
             effectiveBounds[panel2] = panel2Bounds;
             panel1.Bounds = new DesignBounds(0, 0, panel1Bounds.Width, panel1Bounds.Height);
             panel2.Bounds = new DesignBounds(distance + splitterWidth, 0, panel2Bounds.Width, panel2Bounds.Height);
-            LayoutGenericChildren(panel1.Children, panel1Bounds, panel1DesignSize, effectiveBounds);
-            LayoutGenericChildren(panel2.Children, panel2Bounds, panel2DesignSize, effectiveBounds);
+            LayoutGenericChildren(
+                panel1.Children,
+                panel1Bounds,
+                DesignerLayoutProperties.GetContainerContentBounds(panel1, panel1Bounds),
+                panel1DesignSize,
+                effectiveBounds);
+            LayoutGenericChildren(
+                panel2.Children,
+                panel2Bounds,
+                DesignerLayoutProperties.GetContainerContentBounds(panel2, panel2Bounds),
+                panel2DesignSize,
+                effectiveBounds);
         }
         else
         {
@@ -132,8 +151,18 @@ internal sealed class DesignerLayoutEngine
             effectiveBounds[panel2] = panel2Bounds;
             panel1.Bounds = new DesignBounds(0, 0, panel1Bounds.Width, panel1Bounds.Height);
             panel2.Bounds = new DesignBounds(0, distance + splitterWidth, panel2Bounds.Width, panel2Bounds.Height);
-            LayoutGenericChildren(panel1.Children, panel1Bounds, panel1DesignSize, effectiveBounds);
-            LayoutGenericChildren(panel2.Children, panel2Bounds, panel2DesignSize, effectiveBounds);
+            LayoutGenericChildren(
+                panel1.Children,
+                panel1Bounds,
+                DesignerLayoutProperties.GetContainerContentBounds(panel1, panel1Bounds),
+                panel1DesignSize,
+                effectiveBounds);
+            LayoutGenericChildren(
+                panel2.Children,
+                panel2Bounds,
+                DesignerLayoutProperties.GetContainerContentBounds(panel2, panel2Bounds),
+                panel2DesignSize,
+                effectiveBounds);
         }
     }
 
@@ -159,7 +188,12 @@ internal sealed class DesignerLayoutEngine
         }
 
         if (DesignerSpecialContainers.GetSelectedTabPage(tabControl) is { } selectedPage)
-            LayoutGenericChildren(selectedPage.Children, pageBounds, pageDesignSizes[selectedPage], effectiveBounds);
+            LayoutGenericChildren(
+                selectedPage.Children,
+                pageBounds,
+                DesignerLayoutProperties.GetContainerContentBounds(selectedPage, pageBounds),
+                pageDesignSizes[selectedPage],
+                effectiveBounds);
     }
 
     private static void LayoutFlowLayoutPanel(
@@ -264,7 +298,7 @@ internal sealed class DesignerLayoutEngine
     private static DesignBounds GetLocalBounds(
         DesignControlNode node,
         DesignBounds remaining,
-        DesignBounds parentClientBounds,
+        DesignBounds parentBounds,
         DesignSize parentDesignSize)
     {
         var dock = DesignerLayoutProperties.GetDock(node);
@@ -287,8 +321,11 @@ internal sealed class DesignerLayoutEngine
         var anchor = DesignerLayoutProperties.GetAnchor(node);
         var x = node.Bounds.X;
         var y = node.Bounds.Y;
-        var widthDelta = parentClientBounds.Width - Math.Max(1, parentDesignSize.Width);
-        var heightDelta = parentClientBounds.Height - Math.Max(1, parentDesignSize.Height);
+        // Runtime anchor distances are initialized from DisplayRectangle, so a constant padding
+        // value cancels from the resize delta. Authored non-docked coordinates remain relative to
+        // the outer parent bounds; only Dock consumes the padded content rectangle above.
+        var widthDelta = parentBounds.Width - Math.Max(1, parentDesignSize.Width);
+        var heightDelta = parentBounds.Height - Math.Max(1, parentDesignSize.Height);
         var anchoredLeft = (anchor & AnchorStyles.Left) != 0;
         var anchoredRight = (anchor & AnchorStyles.Right) != 0;
         var anchoredTop = (anchor & AnchorStyles.Top) != 0;

--- a/ModernFormsNext.Designer/Surface/Layout/DesignerLayoutProperties.cs
+++ b/ModernFormsNext.Designer/Surface/Layout/DesignerLayoutProperties.cs
@@ -1,5 +1,9 @@
 using ModernFormsNext;
+using ModernFormsNext.Designer.Properties;
+using ModernFormsNext.Designer.Services;
 using ModernFormsNext.Designing;
+using ModernFormsNext.Layout;
+using System.Drawing;
 
 namespace ModernFormsNext.Designer.Surface;
 
@@ -8,6 +12,8 @@ internal static class DesignerLayoutProperties
     public const string DockPropertyName = "Dock";
 
     public const string AnchorPropertyName = "Anchor";
+
+    public const string PaddingPropertyName = "Padding";
 
     public static DockStyle GetDock(DesignControlNode node)
     {
@@ -54,6 +60,60 @@ internal static class DesignerLayoutProperties
         }
 
         return AnchorStyles.Top | AnchorStyles.Left;
+    }
+
+    public static Padding GetPadding(DesignControlNode node)
+        => GetPadding(node.Properties);
+
+    public static Padding GetPadding(IReadOnlyDictionary<string, DesignPropertyValue> properties)
+    {
+        if (!properties.TryGetValue(PaddingPropertyName, out var value))
+            return Padding.Empty;
+
+        try
+        {
+            return DesignerPropertyValueEditor.FromDesignPropertyValue(value, typeof(Padding)) is Padding padding
+                ? padding
+                : Padding.Empty;
+        }
+        catch (Exception exception) when (exception is FormatException or InvalidCastException or OverflowException)
+        {
+            return Padding.Empty;
+        }
+    }
+
+    public static DesignBounds GetPaddedContentBounds(DesignBounds bounds, Padding padding)
+    {
+        // Control.Padding uses this same normalization before ScrollableControl.DisplayRectangle
+        // deflates its runtime client area. Reuse both helpers so the Designer follows the runtime
+        // geometry rules; final dimensions are then limited by DesignBounds' nonnegative contract.
+        padding = LayoutUtils.ClampNegativePaddingToZero(padding);
+        var content = LayoutUtils.DeflateRect(
+            new Rectangle(bounds.X, bounds.Y, bounds.Width, bounds.Height),
+            padding);
+
+        return new DesignBounds(
+            content.X,
+            content.Y,
+            Math.Max(0, content.Width),
+            Math.Max(0, content.Height));
+    }
+
+    public static DesignBounds GetContainerContentBounds(DesignControlNode container, DesignBounds bounds)
+        => UsesPaddedDisplayRectangle(container.TypeName)
+            ? GetPaddedContentBounds(bounds, GetPadding(container))
+            : bounds;
+
+    private static bool UsesPaddedDisplayRectangle(string typeName)
+    {
+        // Resolve only framework types from the already loaded assembly. Project UserControls are
+        // rendered from their .mfdesign data and must never be loaded or instantiated here.
+        var normalized = DesignerProjectUserControlDiscovery.NormalizeTypeName(typeName);
+        var frameworkAssembly = typeof(Control).Assembly;
+        var type = frameworkAssembly.GetType(normalized, throwOnError: false)
+            ?? frameworkAssembly.GetType($"ModernFormsNext.{normalized}", throwOnError: false);
+
+        return type is not null && typeof(ScrollableControl).IsAssignableFrom(type);
     }
 
     public static IReadOnlyList<DesignerResizeHandle> GetResizeHandles(DesignControlNode node)

--- a/ModernFormsNext/Properties/AssemblyInfo.cs
+++ b/ModernFormsNext/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ModernFormsNext.Tests")]
+[assembly: InternalsVisibleTo("ModernFormsNext.Designer")]


### PR DESCRIPTION
## Summary

- Designer lays out container children from the same padded content rectangle used by runtime layout.
- Live `Padding` changes trigger immediate relayout without stale selection geometry.
- Root handling preserves Form behavior while adding UserControl padding parity.

## Coverage

- `Dock.Fill` and `Top`/`Bottom`/`Left`/`Right`
- nested containers, asymmetric/edge-case Padding, Margin, and Anchor behavior
- UserControl roots and safe custom UserControl preview
- serialization, code generation, and reverse parsing

## Manual validation

The repository owner confirmed in Designer Playground that `Padding = 50` immediately affects nested `Dock.Fill` controls, including a `TextBox`.

Automated validation on the exact branch SHA: Debug and Release builds PASS (0 warnings / 0 errors), Designer and VSIX Debug/Release PASS, tests 1112/1112 including Designer 197/197, and `git diff --check` PASS.

Closes #31