### PR TITLE
Prepare ModernFormsNext 1.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable ModernFormsNext changes are documented in this file.
 
 ModernFormsNext follows semantic versioning. Git tags use a `v` prefix, while NuGet package versions do not.
 
+## [1.10.0] - Unreleased
+
+ModernFormsNext 1.10.0 adds reusable vector geometry and Shape controls, animated layout and
+layout-aware visual-state metrics, first-class UserControl design, an Android Choreographer-backed
+animation runtime, and versioned offline release documentation. Windows remains the primary
+supported runtime; Android remains experimental. See the
+[full release notes](docs/1.10.0-release-notes.md) and
+[migration guide](docs/migrations/1.9.0-to-1.10.0.md).
+
+### Added
+
+- Added `Shape`, `Ellipse`, `Circle`, `Line`, `Polygon`, `Polyline`, and `Path` controls plus
+  reusable line, rectangle, ellipse, and path geometry with observable figures, segments, and point
+  collections.
+- Added scheduler-backed animated layout, layout-aware visual-state metric interpolation, and
+  compatible Brush interpolation with deterministic fallback for incompatible values.
+- Added Designer editors for layout transitions, visual-state transitions, ordered
+  `InteractionEffects`, safe project-defined animation metadata, and structured vector geometry.
+- Added first-class UserControl design roots, Visual Studio item templates, source-based custom
+  UserControl discovery, and safe data-only nested preview.
+- Added an experimental Android `Choreographer` frame source with lifecycle-aware timing, live
+  animator-scale observation, and stable multi-touch pointer ownership.
+- Added versioned release bundles for documentation sources, offline DocFX HTML, selected samples,
+  and an aggregate SDK/reference archive tied to the exact release tag and commit.
+
+### Changed
+
+- Coordinated package, template, and Visual Studio extension versions are updated to `1.10.0`
+  without changing package IDs, target frameworks, VSIX identity, publisher, or installation
+  targets.
+- Form and UserControl roots now share one Designer document/session pipeline. Project assemblies
+  and arbitrary user code are not loaded for custom UserControl preview.
+- Release publication now builds and validates NuGet and documentation artifacts before creating a
+  GitHub Release or publishing packages.
+
+### Fixed
+
+- Fixed Designer container `Padding` so preview layout, selection, hit testing, guides, generation,
+  and reload use the same padded content geometry as runtime layout.
+
+### Compatibility
+
+- The public API comparison with 1.9.0 found 40 added public types, 548 added concrete public or
+  protected members, and no removed public identifiers or changed member signatures.
+- Most applications only update references and rebuild. Code importing both `ModernFormsNext` and
+  `System.IO` may need to qualify or alias `Path` after the vector `ModernFormsNext.Path` type is
+  introduced.
+- Existing immediate layout and `.mfdesign` documents remain compatible; new transitions are
+  opt-in.
+
 ## [1.9.0] - 2026-08-02
 
 ModernFormsNext 1.9.0 adds the shared paint, animation, and theme foundations used by the framework,
@@ -449,6 +499,7 @@ Published packages:
 - GitHub `Release` workflow completed successfully for tag `v1.5.0`.
 - NuGet public indexes show version `1.5.0` for all published ModernFormsNext packages.
 
+[1.10.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.9.0...HEAD
 [1.9.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ProGraMajster/ModernFormsNext/releases/tag/v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable ModernFormsNext changes are documented in this file.
 
 ModernFormsNext follows semantic versioning. Git tags use a `v` prefix, while NuGet package versions do not.
 
-## [1.10.0] - Unreleased
+## [1.10.0] - 2026-08-16
 
 ModernFormsNext 1.10.0 adds reusable vector geometry and Shape controls, animated layout and
 layout-aware visual-state metrics, first-class UserControl design, an Android Choreographer-backed
@@ -499,7 +499,7 @@ Published packages:
 - GitHub `Release` workflow completed successfully for tag `v1.5.0`.
 - NuGet public indexes show version `1.5.0` for all published ModernFormsNext packages.
 
-[1.10.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.9.0...HEAD
+[1.10.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/ProGraMajster/ModernFormsNext/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ProGraMajster/ModernFormsNext/releases/tag/v1.7.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
-		<ModernFormsNextPackageVersion>1.9.0</ModernFormsNextPackageVersion>
-		<ModernFormsNextVisualStudioExtensionVersion>1.9.0</ModernFormsNextVisualStudioExtensionVersion>
+		<ModernFormsNextPackageVersion>1.10.0</ModernFormsNextPackageVersion>
+		<ModernFormsNextVisualStudioExtensionVersion>1.10.0</ModernFormsNextVisualStudioExtensionVersion>
 
 		<!-- Shared assembly and publication identity. Project-specific package names,
 		     descriptions, products, and tags remain in the owning project. -->

--- a/ModernFormsNext.Templates/README.md
+++ b/ModernFormsNext.Templates/README.md
@@ -26,7 +26,7 @@ The generated project targets:
 Install the templates from NuGet.org:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.9.0
+dotnet new install ModernFormsNext.Templates::1.10.0
 ```
 
 Check that the template is available:
@@ -124,7 +124,7 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="ModernFormsNext" Version="1.9.0" />
+  <PackageReference Include="ModernFormsNext" Version="1.10.0" />
 </ItemGroup>
 ```
 
@@ -144,7 +144,7 @@ If the template is missing, reinstall it:
 
 ```powershell
 dotnet new uninstall ModernFormsNext.Templates
-dotnet new install ModernFormsNext.Templates::1.9.0
+dotnet new install ModernFormsNext.Templates::1.10.0
 ```
 
 ### The generated project cannot restore packages
@@ -154,7 +154,7 @@ Make sure the referenced ModernFormsNext package version exists on NuGet.org.
 Example:
 
 ```xml
-<PackageReference Include="ModernFormsNext" Version="1.9.0" />
+<PackageReference Include="ModernFormsNext" Version="1.10.0" />
 ```
 
 ### The generated project starts as a console application

--- a/ModernFormsNext.Templates/templates/modernformsnext-app/MyApp.csproj
+++ b/ModernFormsNext.Templates/templates/modernformsnext-app/MyApp.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ModernFormsNext" Version="1.9.0" />
+		<PackageReference Include="ModernFormsNext" Version="1.10.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
+++ b/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
@@ -5,7 +5,7 @@ namespace ModernFormsNext.Tests;
 
 public sealed class ReleaseVersionConsistencyTests
 {
-    private const string ExpectedVersion = "1.9.0";
+    private const string ExpectedVersion = "1.10.0";
 
     private static readonly string[] PackableProjects =
     [

--- a/ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsDesignerPackage.cs
+++ b/ModernFormsNext.VisualStudioExtension.Vsix/ModernFormsDesignerPackage.cs
@@ -23,7 +23,7 @@ namespace ModernFormsNext.VisualStudioExtension;
 /// only exposes Visual Studio registration and validation commands needed to deploy the extension.
 /// </remarks>
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration("ModernFormsNext Designer", "Visual Studio designer support for ModernFormsNext.", "1.9.0")]
+[InstalledProductRegistration("ModernFormsNext Designer", "Visual Studio designer support for ModernFormsNext.", "1.10.0")]
 [ProvideMenuResource("ModernFormsNext.VisualStudioExtension.CTMENU", 1)]
 [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
 [Guid(PackageGuidString)]

--- a/ModernFormsNext.VisualStudioExtension.Vsix/source.extension.vsixmanifest
+++ b/ModernFormsNext.VisualStudioExtension.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ModernFormsNext.Designer" Version="1.9.0" Language="en-US" Publisher="ProGraMajster" />
+    <Identity Id="ModernFormsNext.Designer" Version="1.10.0" Language="en-US" Publisher="ProGraMajster" />
     <DisplayName>ModernFormsNext Designer</DisplayName>
     <Description xml:space="preserve">Visual Studio designer support for ModernFormsNext.</Description>
     <MoreInfo>https://github.com/ProGraMajster/ModernFormsNext</MoreInfo>

--- a/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
+++ b/ModernFormsNext.VisualStudioExtension/ModernFormsDesignerPackage.cs
@@ -21,7 +21,7 @@ namespace ModernFormsNext.VisualStudioExtension;
 /// normal C# editor.
 /// </remarks>
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration("#110", "#112", "1.9.0")]
+[InstalledProductRegistration("#110", "#112", "1.10.0")]
 [ProvideMenuResource("ModernFormsNext.VisualStudioExtension.CTMENU", 1)]
 [ProvideEditorFactory(typeof(MfDesignEditorFactory), 101)]
 [ProvideEditorExtension(typeof(MfDesignEditorFactory), DesignFileExtension, 50, NameResourceID = 113, DefaultName = ExtensionDisplayName)]

--- a/ModernFormsNext.VisualStudioExtension/README.md
+++ b/ModernFormsNext.VisualStudioExtension/README.md
@@ -3,8 +3,8 @@
 This project builds the Visual Studio extension that registers the ModernFormsNext designer.
 
 The extension version is stored as `ModernFormsNextVisualStudioExtensionVersion` in
-`Directory.Build.props`. Coordinated framework releases use the same version; the 1.9.0 VSIX is
-therefore versioned 1.9.0. An independent extension-only patch remains possible when it is
+`Directory.Build.props`. Coordinated framework releases use the same version; the 1.10.0 VSIX is
+therefore versioned 1.10.0. An independent extension-only patch remains possible when it is
 deliberate and documented. The same version must be kept in
 `ModernFormsNext.VisualStudioExtension.Vsix\source.extension.vsixmanifest` and
 the two `InstalledProductRegistration` attributes.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The repository does not currently provide supported macOS or Linux application b
 ### Android status
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.9.0 is **Experimental**. APIs, project structure, and
+> Android support in ModernFormsNext 1.10.0 is **Experimental**. APIs, project structure, and
 > runtime behavior may still change. It is not yet recommended for production applications.
 
 The Android backend can host one real ModernFormsNext control tree in an `AndroidSkiaHostView`.
@@ -74,25 +74,25 @@ known limitations, and sample commands.
 
 ## Installation
 
-ModernFormsNext 1.9.0 requires .NET 10. The repository selects SDK `10.0.201` in `global.json` and
+ModernFormsNext 1.10.0 requires .NET 10. The repository selects SDK `10.0.201` in `global.json` and
 allows roll-forward to a later installed .NET 10 feature band.
 
 For an existing Windows application:
 
 ```powershell
-dotnet add package ModernFormsNext --version 1.9.0
+dotnet add package ModernFormsNext --version 1.10.0
 ```
 
 Install the project template and create an application:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.9.0
+dotnet new install ModernFormsNext.Templates::1.10.0
 dotnet new mfn-app -n MyApp
 cd MyApp
 dotnet run
 ```
 
-The package and template commands use the release version and become available after 1.9.0 is
+The package and template commands use the release version and become available after 1.10.0 is
 published. For source builds or pre-release validation, clone the repository and use project
 references instead. See [installation](docs/installation.md) for package, template, VSIX, and
 Experimental Instance instructions.
@@ -141,8 +141,8 @@ Android backend.
 ## Visual Studio Designer
 
 The optional `ModernFormsNextDesigner.vsix` adds **View ModernFormsNext Designer** for designable
-ModernFormsNext forms and UserControls, plus matching item templates. Version 1.9.0 of the VSIX is
-the matching extension for the 1.9.0 framework release.
+ModernFormsNext forms and UserControls, plus matching item templates. Version 1.10.0 of the VSIX is
+the matching extension for the 1.10.0 framework release.
 
 A designable form uses three related files:
 
@@ -176,7 +176,7 @@ ControlGallery rather than in the generated starter experience.
 
 ## Packages
 
-The 1.9.0 release is composed of these intentionally published NuGet packages:
+The 1.10.0 release is composed of these intentionally published NuGet packages:
 
 | Package | Purpose |
 | --- | --- |
@@ -203,8 +203,8 @@ for bundle contents and local validation.
 - [Getting started](docs/getting-started.md)
 - [Installation and Visual Studio Designer](docs/installation.md)
 - [Changelog](CHANGELOG.md)
-- [ModernFormsNext 1.9.0 release notes](docs/1.9.0-release-notes.md)
-- [Migration from 1.8.0 to 1.9.0](docs/migrations/1.8.0-to-1.9.0.md)
+- [ModernFormsNext 1.10.0 release notes](docs/1.10.0-release-notes.md)
+- [Migration from 1.9.0 to 1.10.0](docs/migrations/1.9.0-to-1.10.0.md)
 - [Android platform status](docs/platforms/android.md)
 - [Designer architecture](docs/designer-architecture.md)
 - [Dynamic resources](docs/dynamic-resources.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,20 +13,20 @@ NuGet package versions use SemVer without a `v` prefix. The shared value is stor
 `Directory.Build.props`:
 
 ```xml
-<ModernFormsNextPackageVersion>1.9.0</ModernFormsNextPackageVersion>
+<ModernFormsNextPackageVersion>1.10.0</ModernFormsNextPackageVersion>
 ```
 
 Git tags use the same version with a `v` prefix:
 
 ```text
-v1.9.0
+v1.10.0
 ```
 
 The Visual Studio extension version is stored separately so an emergency extension-only patch
 remains possible:
 
 ```xml
-<ModernFormsNextVisualStudioExtensionVersion>1.9.0</ModernFormsNextVisualStudioExtensionVersion>
+<ModernFormsNextVisualStudioExtensionVersion>1.10.0</ModernFormsNextVisualStudioExtensionVersion>
 ```
 
 For coordinated framework minor/major releases, the VSIX version must match the framework release.
@@ -72,7 +72,7 @@ the tag.
    symbol-package policy.
 5. Confirm the VSIX manifest, registration attributes, assets, prerequisites, and Visual Studio
    installation targets.
-6. Review platform claims. For 1.9.0, Android must remain explicitly **Experimental** and must not
+6. Review platform claims. For 1.10.0, Android must remain explicitly **Experimental** and must not
    be described as a complete `Application.Run(Form)` or WindowKit implementation.
 7. Review `git diff`, stage only the intended files, and create focused commits. Do not use
    `git add .` without auditing the entire worktree.
@@ -88,7 +88,7 @@ dotnet build .\ModernFormsNext.slnx --configuration Release --no-restore --verbo
 dotnet test .\ModernFormsNext.slnx --configuration Debug --no-restore
 ```
 
-For 1.9.0, additionally validate:
+For 1.10.0, additionally validate:
 
 - `net10.0-windows` framework and samples;
 - the `net10.0-android` backend, cross-platform sample, and Android backend tests when the workload
@@ -118,13 +118,13 @@ dotnet tool restore
 $commit = (git rev-parse HEAD).Trim()
 .\scripts\tests\Test-ReleaseDocumentation.ps1
 .\scripts\Build-ReleaseDocumentation.ps1 `
-    -Version 1.9.0 `
+    -Version 1.10.0 `
     -Tag local `
     -Commit $commit `
     -OutputDirectory .\artifacts\release-docs
 .\scripts\Validate-ReleaseDocumentation.ps1 `
     -ArtifactDirectory .\artifacts\release-docs `
-    -ExpectedVersion 1.9.0 `
+    -ExpectedVersion 1.10.0 `
     -ExpectedCommit $commit `
     -ExpectedTag local
 ```
@@ -139,7 +139,7 @@ the tag resolves to `github.sha`, and validates every archive before publication
 
 After the release commit is reviewed and the normal `.NET` workflow is green:
 
-1. Replace `Unreleased` with the actual release date in `CHANGELOG.md` and update the 1.9.0 link
+1. Replace `Unreleased` with the actual release date in `CHANGELOG.md` and update the 1.10.0 link
    from a comparison URL to the final tag URL.
 2. Commit that final release-note change and push it through the normal review path.
 3. Create the annotated or lightweight `vX.Y.Z` tag on the exact reviewed commit.
@@ -157,8 +157,8 @@ Example commands are intentionally explicit:
 ```powershell
 git status
 git log --oneline --decorate -n 20
-git tag v1.9.0
-git push origin v1.9.0
+git tag v1.10.0
+git push origin v1.10.0
 ```
 
 Do not run the tag or push commands until the release is approved. Never force-push or move a

--- a/docs/1.10.0-release-notes.md
+++ b/docs/1.10.0-release-notes.md
@@ -77,7 +77,7 @@ objects in the design host.
 
 `UserControl` is now a first-class Designer root alongside `Form`. The Visual Studio extension
 provides matching item templates, root selection, document loading, save/reload, code generation,
-reverse parsing, undo/redo, diagnostics, toolbox, property editing, and logical-DPI preview behavior.
+reverse parsing, diagnostics, toolbox, property editing, and logical-DPI preview behavior.
 A UserControl root is rendered without Form chrome.
 
 Project-local custom UserControls are discovered from source and represented as design metadata.

--- a/docs/1.10.0-release-notes.md
+++ b/docs/1.10.0-release-notes.md
@@ -1,0 +1,189 @@
+# ModernFormsNext 1.10.0 release notes
+
+ModernFormsNext 1.10.0 is a coordinated framework, Designer, template, Visual Studio extension,
+packaging, and documentation release. It adds a reusable vector-geometry subsystem, closes the
+remaining layout-animation gaps, makes designed UserControls a first-class workflow, and brings the
+experimental Android animation runtime onto the platform frame clock. Windows remains the primary
+and most mature runtime. Android remains experimental.
+
+The release is prepared for tag `v1.10.0`. The tag-triggered workflow builds packages and versioned
+offline documentation from the exact tagged commit, validates every artifact, and only then creates
+the GitHub Release and publishes NuGet packages.
+
+## Highlights
+
+- `Shape` and reusable `Geometry` APIs provide retained vector content through the same SkiaSharp
+  rendering path used by the rest of the framework.
+- `Ellipse`, `Circle`, `Line`, `Polygon`, `Polyline`, and `Path` controls cover common vector UI,
+  with fill, stroke, transforms, clipping, hit testing, and Designer round trips.
+- Animated layout and layout-aware visual-state metrics integrate with the existing shared
+  scheduler instead of introducing a separate layout timer.
+- Brush interpolation supports compatible solid and gradient values during themes, visual states,
+  and property animations.
+- The Designer can configure layout transitions, visual-state transitions, and ordered
+  `InteractionEffects`, including `RippleEffect` and `PressScaleEffect`, without running arbitrary
+  project code.
+- Form and UserControl roots share one design pipeline. Project-local custom UserControls receive a
+  safe, data-only preview and stay atomic when composed in another design surface.
+- Android animation frames use `Choreographer`, lifecycle-aware elapsed time, and live platform
+  animation-scale observation while Android support remains explicitly experimental.
+- GitHub releases can now attach versioned source docs, offline HTML, selected samples, and an
+  aggregate SDK/reference bundle tied to the exact release tag and commit.
+
+## Shapes and reusable vector geometry
+
+`Shape` is an abstract framework control for vector content. The built-in controls are:
+
+- `Ellipse` and `Circle` for oval and circular geometry;
+- `Line` for a single stroked segment;
+- `Polygon` and `Polyline` for reusable point collections;
+- `Path` for multi-figure vector content.
+
+Shapes use the existing observable `Brush` hierarchy for `Fill` and `Stroke`. Stroke caps, joins,
+miter limits, logical-pixel thickness, transforms, clipping, invalidation, and geometry-aware hit
+testing are supported without native WinForms controls.
+
+The reusable geometry model includes line, rectangle, ellipse, and path geometry; path figures;
+line, quadratic Bezier, and cubic Bezier segments; fill rules; and observable point/segment/figure
+collections. One geometry can be shared by multiple consumers, and mutations invalidate subscribed
+controls through the framework's existing rendering path.
+
+The Designer toolbox includes the built-in shapes. Structured editors cover point collections and
+path geometry, while deterministic serialization, generated C#, and conservative reverse parsing
+preserve the code-first workflow. The same Skia conversion is used by Windows and the experimental
+Android backend.
+
+## Animation and interaction effects
+
+The shared `AnimationScheduler` now also drives layout-affecting transitions. `LayoutTransition`
+interpolates supported layout values, retargets from the current presentation value, respects
+reduced-motion policy, and coalesces layout and repaint work with normal framework scheduling.
+Immediate layout remains the default unless a transition is explicitly enabled.
+
+Layout-aware visual-state metrics can interpolate supported values instead of switching every
+layout-related metric discretely. Compatible solid and gradient Brushes can also interpolate across
+property animations, theme transitions, and visual-state transitions. Incompatible brush kinds or
+gradient structures still switch deterministically rather than producing an invalid intermediate
+value.
+
+`InteractionEffects` remain target-local and opt-in. The built-in `RippleEffect` and
+`PressScaleEffect` continue to use normal input, capture, cancellation, and shared scheduling; they
+do not create a second input or animation pipeline. The Designer now exposes ordered editors for
+these effects plus layout and visual-state transition values. Project-defined animation
+descriptions can opt in through safe metadata and source parsing without activating arbitrary CLR
+objects in the design host.
+
+## UserControl Designer
+
+`UserControl` is now a first-class Designer root alongside `Form`. The Visual Studio extension
+provides matching item templates, root selection, document loading, save/reload, code generation,
+reverse parsing, undo/redo, diagnostics, toolbox, property editing, and logical-DPI preview behavior.
+A UserControl root is rendered without Form chrome.
+
+Project-local custom UserControls are discovered from source and represented as design metadata.
+Nested previews are assembled from `.mfdesign` data instead of loading the project assembly or
+executing constructors, static initializers, property setters, or arbitrary user code. Cycles,
+missing or stale design documents, and unsupported values fall back to a safe atomic placeholder;
+the composed UserControl remains one selectable control in its parent document.
+
+## Experimental Android animation runtime
+
+The Android backend now provides `IPlatformAnimationFrameSource` through `Choreographer` on the main
+Looper. Frame requests are demand-driven, lifecycle pause/resume excludes background time, and
+animator-duration scale changes are observed through Android settings. Pointer ownership uses stable
+Android pointer IDs so concurrent touch sequences do not corrupt animation/effect state.
+
+These changes validate the shared animation, layout, visual-state, Brush, theme, and interaction-
+effect paths on the experimental backend. They do not make Android feature-equivalent to Windows:
+complete windowing, platform services, accessibility, and broad physical-device coverage remain
+future work.
+
+## Designer layout parity fix
+
+The Designer now applies container `Padding` to child layout, preview geometry, selection,
+hit-testing, guides, and generated/reloaded documents using the same padded content rectangle
+semantics as runtime layout. Nested panels, containers, and designed UserControls therefore no
+longer preview children against the unpadded client bounds.
+
+## Versioned release documentation
+
+The release workflow produces four assets from the exact tag checkout:
+
+- `ModernFormsNext-1.10.0-docs.zip` — README, changelog, release and migration notes, documentation
+  sources, XML documentation, public API snapshot, and release metadata;
+- `ModernFormsNext-1.10.0-docs-html.zip` — offline DocFX HTML, API reference, static assets, and
+  release metadata;
+- `ModernFormsNext-1.10.0-samples.zip` — selected user-facing samples: ControlGallery, Explorer,
+  Outlaw, and the template/reference DemoApp;
+- `ModernFormsNext-1.10.0-sdk.zip` — aggregate offline/reference bundle containing documentation,
+  HTML, samples, XML docs, the API snapshot, release notes, and metadata.
+
+Metadata records the SemVer version, `v1.10.0` tag, and exact tag commit. Release mode rejects a
+missing or mismatched tag, version, or SHA. Documentation generation and validation run before the
+GitHub Release is created and before any NuGet publication, preventing a documentation failure from
+creating a partial release.
+
+## Compatibility and migration
+
+The 1.10.0 public API comparison against 1.9.0 found 40 added public types, 548 added concrete
+public/protected members, and no removed public identifiers or changed member signatures in the
+published ModernFormsNext assemblies. There are no intentional package IDs, namespaces, target
+frameworks, VSIX identity, or platform-contract removals, and no binary-breaking API change was
+identified.
+
+Under the repository's existing minor-release version policy, the weak-named library
+`AssemblyVersion` values advance from `1.9.0.0` to `1.10.0.0`. This is not a removed or changed API
+signature, but consumers should perform the normal rebuild when updating package references.
+
+Most applications can update package and VSIX references, rebuild, and continue without code
+changes. The new `ModernFormsNext.Path` type can make an unqualified `Path` reference ambiguous in a
+file that imports both `ModernFormsNext` and `System.IO`; qualify the vector type or alias
+`System.IO.Path`. Existing immediate layout remains unchanged until a layout transition is enabled,
+and existing `.mfdesign` documents require no schema migration.
+
+See [Migrating ModernFormsNext 1.9.0 applications to 1.10.0](migrations/1.9.0-to-1.10.0.md).
+
+## Known limitations
+
+- `PathGeometry` does not yet include SVG import, arc segments, geometry groups, or a general
+  `Stretch` contract.
+- Brush interpolation requires compatible brush kinds and compatible gradient-stop structures.
+- Custom animation/effect metadata is deliberately constrained in the Designer; arbitrary project
+  code is not executed for preview.
+- Android remains experimental and is not presented as a complete `Application.Run(Form)` or
+  WindowKit implementation.
+- Manual browser and Visual Studio Designer smoke tests remain separate from deterministic build,
+  package, DocFX, and script validation.
+
+## Release-candidate validation
+
+The 1.10.0 release candidate passed a no-cache solution restore; warning-free Debug and Release
+solution builds; 1,112 automated tests, including 197 Designer, 72 Android backend, 7 Windows
+backend, and 16 cross-platform sample tests; Android SmokeTest and cross-platform sample builds;
+and Debug/Release VSIX archive validation.
+
+Packaging produced and validated eight NuGet packages and seven symbol packages. A temporary
+consumer project restored `ModernFormsNext 1.10.0` from the local package source, built with no
+warnings or errors, and ran a basic control-construction smoke test. The public API snapshot contains
+13,463 identifiers from the seven published API assemblies.
+
+DocFX 2.78.5 generated 879 HTML pages with no warnings or errors. The documentation script suite
+passed all 32 assertions, and all four versioned ZIP bundles passed metadata, path-safety, content,
+offline asset, and internal-link validation. Browser rendering and interactive Visual Studio
+Designer checks remain manual gates; no physical-device Android result is inferred from builds.
+
+## Packages
+
+The coordinated release produces eight `1.10.0` NuGet packages and seven matching symbol packages.
+`ModernFormsNext.Templates` intentionally has no `.snupkg`.
+
+| Package | Framework/content | Symbols |
+| --- | --- | --- |
+| `ModernFormsNext` | `net10.0`, `net10.0-windows` | yes |
+| `ModernFormsNext.WindowKit` | `net10.0` | yes |
+| `ModernFormsNext.WindowKit.Backend` | `net10.0` | yes |
+| `ModernFormsNext.WindowKit.Backend.Windows` | `net10.0` | yes |
+| `ModernFormsNext.Designing` | `net10.0` | yes |
+| `ModernFormsNext.CodeGeneration` | `net10.0` | yes |
+| `ModernFormsNext.Designer` | `net10.0-windows` | yes |
+| `ModernFormsNext.Templates` | `dotnet new` template content | no |

--- a/docs/android-backend.md
+++ b/docs/android-backend.md
@@ -1,7 +1,7 @@
 # Android backend
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.9.0 is **Experimental** and is not recommended for
+> Android support in ModernFormsNext 1.10.0 is **Experimental** and is not recommended for
 > production applications. See the [Android platform status](platforms/android.md) for the
 > supported vertical slice and current limitations.
 

--- a/docs/android-development.md
+++ b/docs/android-development.md
@@ -1,7 +1,7 @@
 # Android development
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.9.0 is **Experimental**. APIs, project structure, and
+> Android support in ModernFormsNext 1.10.0 is **Experimental**. APIs, project structure, and
 > runtime behavior may change, and production use is not yet recommended. Start with the
 > [Android platform status](platforms/android.md).
 

--- a/docs/cross-platform-sample.md
+++ b/docs/cross-platform-sample.md
@@ -1,7 +1,7 @@
 # Cross-platform sample
 
 > [!WARNING]
-> The Android target is **Experimental** in ModernFormsNext 1.9.0. This sample validates the
+> The Android target is **Experimental** in ModernFormsNext 1.10.0. This sample validates the
 > current shared-control vertical slice; it does not represent complete Android platform parity.
 
 `samples/ModernFormsNext.CrossPlatform.Sample` is intentionally one application project, organized
@@ -125,4 +125,4 @@ This sample proves a real shared-control vertical slice, not complete Android pa
 lacks general `Application.Run(Form)`, multiple framework windows, full accessibility semantics,
 native dialogs, clipboard, file pickers, drag-and-drop, and several backend services. Windows
 remains the primary and best-supported target. See the canonical
-[Android platform status](platforms/android.md) for the complete 1.9.0 support matrix.
+[Android platform status](platforms/android.md) for the complete 1.10.0 support matrix.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ dotnet run --project .\samples\Outlaw\Outlaw.csproj
 The repository contains a template package project in `ModernFormsNext.Templates`. After packing and installing that template package, create a new app with:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.9.0
+dotnet new install ModernFormsNext.Templates::1.10.0
 dotnet new mfn-app -n MyApp
 ```
 
@@ -84,14 +84,14 @@ For packaged usage, reference the package version produced by this repository:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="ModernFormsNext" Version="1.9.0" />
+    <PackageReference Include="ModernFormsNext" Version="1.10.0" />
 </ItemGroup>
 ```
 
 ## Visual Designer
 
-ModernFormsNext 1.9.0 includes the reusable designer stack, High DPI rendering/input fixes,
-stable child Z-order, and interaction-effect serialization. The generated template includes
+ModernFormsNext 1.10.0 includes Form and UserControl design roots, safe custom UserControl preview,
+vector geometry editors, and animation/effect serialization. The generated template includes
 three related files:
 
 ```text

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ ModernFormsNext is distributed as NuGet packages, project templates, and a Visua
 designer extension. The framework remains code-first, but the designer can edit the companion
 `.mfdesign` document and regenerate the matching `.Designer.cs` file.
 
-The commands below target the coordinated 1.9.0 release. They become publicly available after the
+The commands below target the coordinated 1.10.0 release. They become publicly available after the
 NuGet packages and GitHub release assets are published.
 
 ## Requirements
@@ -18,7 +18,7 @@ NuGet packages and GitHub release assets are published.
 For an existing application, reference the framework package:
 
 ```powershell
-dotnet add package ModernFormsNext --version 1.9.0
+dotnet add package ModernFormsNext --version 1.10.0
 ```
 
 The package provides the runtime controls, forms, rendering, layout, input, dialogs, and
@@ -29,7 +29,7 @@ Windows backend integration used by ModernFormsNext applications.
 Install the template package:
 
 ```powershell
-dotnet new install ModernFormsNext.Templates::1.9.0
+dotnet new install ModernFormsNext.Templates::1.10.0
 ```
 
 Create a new app:
@@ -69,10 +69,10 @@ as a classic Windows Forms marker and may try to open the built-in WinForms desi
 
 ## Install the Visual Studio Designer
 
-Install `ModernFormsNextDesigner.vsix` version `1.9.0` from the matching 1.9.0 release assets when
-available. The extension version matches the framework because this release includes High DPI,
-code-generation, and form-size round-trip changes. Do not install an older `1.7.x` VSIX when
-validating the 1.9.0 designer workflow. During
+Install `ModernFormsNextDesigner.vsix` version `1.10.0` from the matching 1.10.0 release assets when
+available. The extension version matches the framework because this release includes UserControl
+design roots, safe custom previews, Shape editors, animation/effect editors, and the Padding parity
+fix. Do not install an older VSIX when validating the 1.10.0 designer workflow. During
 local repository development, build the VSIX project first:
 
 ```powershell
@@ -173,7 +173,7 @@ extension follows the current Visual Studio UI culture where possible.
 ## Android
 
 The packaged project template and Visual Studio designer are Windows-first. Android support in
-ModernFormsNext 1.9.0 is **Experimental**, uses an explicit activity/shared-surface host, and is not
+ModernFormsNext 1.10.0 is **Experimental**, uses an explicit activity/shared-surface host, and is not
 part of the default `mfn-app` template. See [Android platform status](platforms/android.md) before
 creating an Android evaluation project.
 

--- a/docs/migrations/1.9.0-to-1.10.0.md
+++ b/docs/migrations/1.9.0-to-1.10.0.md
@@ -1,0 +1,97 @@
+# Migrating ModernFormsNext 1.9.0 applications to 1.10.0
+
+ModernFormsNext 1.10.0 keeps the existing package IDs, namespaces, target frameworks, VSIX identity,
+and default immediate-layout behavior. The public API comparison found no removed identifiers or
+changed member signatures in the published assemblies. Most applications only need to update
+references and rebuild.
+
+## Update packages, templates, and the VSIX
+
+Update direct package references to `1.10.0` and use the matching Designer extension:
+
+```xml
+<PackageReference Include="ModernFormsNext" Version="1.10.0" />
+```
+
+```powershell
+dotnet new install ModernFormsNext.Templates::1.10.0
+```
+
+Use the 1.10.0 VSIX when validating generated code, custom UserControls, animation/effect editors,
+or `.mfdesign` round trips. The VSIX identity and Visual Studio installation targets are unchanged.
+The weak-named library `AssemblyVersion` values follow the existing minor-release policy and advance
+from `1.9.0.0` to `1.10.0.0`, so rebuild consumers after updating package references.
+
+## Resolve `Path` name ambiguity when necessary
+
+Version 1.10.0 adds the vector control `ModernFormsNext.Path`. A file that imports both
+`ModernFormsNext` and `System.IO` and refers to `Path` without qualification may become ambiguous.
+This is a source-level name-resolution issue, not a binary break.
+
+Alias the file-system type when the file uses both concepts:
+
+```csharp
+using IOPath = System.IO.Path;
+
+var assetPath = IOPath.Combine("Assets", "logo.svg");
+var vectorPath = new ModernFormsNext.Path
+{
+    Data = geometry
+};
+```
+
+Applications that do not use unqualified `System.IO.Path` in a scope importing
+`ModernFormsNext` require no change.
+
+## Layout animation is opt-in
+
+Existing layout continues to apply immediately. Assign a `LayoutTransition` only where a control
+should interpolate supported layout values. The transition uses the shared scheduler, respects
+reduced-motion policy, and retargets from the current presentation value.
+
+Review timing-sensitive code only if it opts in to animated layout. Code that must observe the final
+arrangement should use the transition completion path rather than assuming the first layout request
+has already reached its visual endpoint.
+
+## Brush and visual-state interpolation
+
+Compatible solid and gradient Brushes can now interpolate. Brush kinds or gradient-stop structures
+that are not compatible still switch deterministically. If application code supplies a custom
+interpolator, preserve the framework's ownership and invalidation rules and avoid mutating shared
+Brush values from a background thread.
+
+Layout-aware visual-state metrics may animate when a transition is configured. Without an explicit
+transition, visual-state behavior remains immediate.
+
+## Designer animation and effect metadata
+
+The Designer can edit built-in layout transitions, visual-state transitions, `RippleEffect`, and
+`PressScaleEffect`. Project-defined animations can expose constrained source metadata, but the
+Designer deliberately does not load the project assembly or instantiate arbitrary runtime types.
+
+Existing `.mfdesign` documents remain readable and require no schema migration. Saving a document
+after configuring new 1.10.0 values can add deterministic transition/effect data that an older
+Designer does not understand, so keep the extension aligned with the package version.
+
+## UserControl design documents
+
+Forms and UserControls share the same design-document pipeline. Project-local UserControls are
+previewed from source and `.mfdesign` data and stay atomic when nested in a parent design. Existing
+Form documents continue to load without conversion.
+
+For the richest safe preview, keep the custom UserControl's `.mfdesign` and generated
+`.Designer.cs` files synchronized. A missing, stale, cyclic, or unsupported nested document falls
+back to a safe placeholder rather than running user code.
+
+## Android remains experimental
+
+The Android animation runtime now uses `Choreographer`, lifecycle-aware timing, stable pointer IDs,
+and live animator-scale observation. This improves the existing shared-control vertical slice but
+does not make Android production-ready or feature-equivalent to Windows. Keep application-specific
+device and lifecycle validation separate from successful builds and deterministic backend tests.
+
+## Migration result
+
+No mandatory project-file, namespace, Designer-document, target-framework, or runtime-startup
+migration is required. Update coordinated versions, rebuild, and address the `Path` name ambiguity
+only in affected source files.

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -1,10 +1,10 @@
 # Android platform status
 
 > [!WARNING]
-> Android support in ModernFormsNext 1.9.0 is **Experimental**. APIs, project structure, and
+> Android support in ModernFormsNext 1.10.0 is **Experimental**. APIs, project structure, and
 > runtime behavior may still change. It is not yet recommended for production applications.
 
-Windows remains the primary and most mature ModernFormsNext platform. Android 1.9.0 provides a
+Windows remains the primary and most mature ModernFormsNext platform. Android 1.10.0 provides a
 real shared-control vertical slice: a .NET Android host can attach one ModernFormsNext `Control`
 tree to a SkiaSharp surface and exercise framework layout, rendering, input, and text editing.
 It is not yet a general replacement for the Windows `Form` and WindowKit windowing path.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -5,7 +5,7 @@ resource, Brush, `ControlStyle`, static `Theme`, dispatcher, and animation sched
 does not introduce XAML or a second control/property model.
 
 > [!NOTE]
-> This guide documents the ModernFormsNext 1.9.0 API. Theme transitions remain opt-in and Android
+> This guide documents the ModernFormsNext 1.10.0 API. Theme transitions remain opt-in and Android
 > integration remains experimental.
 
 ## Apply built-in themes


### PR DESCRIPTION
## Summary

- Prepares ModernFormsNext 1.10.0 from the already-audited release candidate.
- Finalizes the 2026-08-16 changelog date and the permanent v1.10.0 comparison link.
- Keeps the release notes aligned with the deferred Designer undo/redo roadmap item.

## Why

The protected master branch requires all changes to pass through a pull request and the required build check before the release tag can be created.

## Validation

- Release build: PASS, 0 warnings / 0 errors
- Release tests: PASS, 1112/1112
- NuGet packages: PASS, 8 nupkg and 7 snupkg at 1.10.0
- Documentation script tests: PASS, 32/32
- git diff --check: PASS
- Exact-SHA clean worktree validation: PASS

## Publication safety

No tag or GitHub Release is created by this PR. NuGet and VSIX are not published by this PR.