### PR TITLE
Add shared accessibility semantic foundation

### DIFF
--- a/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
+++ b/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
@@ -1,0 +1,578 @@
+using System.Drawing;
+using System.Reflection;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.WindowKit.Platform;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class AccessibilitySemanticTests
+{
+    [Fact]
+    public void ButtonExposesNameTypeAndNormalInvokeAction()
+    {
+        using var root = new VisibleRootControl();
+        using var button = root.Controls.Add(new Button { Text = "Save" });
+        int clicks = 0;
+        button.Click += (_, _) => clicks++;
+
+        AccessibleObject accessible = button.AccessibilityObject;
+
+        Assert.Equal("Save", accessible.Name);
+        Assert.Equal(AccessibleRole.PushButton, accessible.Role);
+        Assert.Equal(AccessibleControlType.Button, accessible.ControlType);
+        AssertHasFlag(accessible.SupportedActions, AccessibleActions.Invoke);
+        Assert.True(accessible.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(1, clicks);
+
+        accessible.DoDefaultAction();
+        Assert.Equal(2, clicks);
+    }
+
+    [Fact]
+    public void ControlMetadataKeepsAutomationAndRuntimeIdentitySeparate()
+    {
+        using var root = new VisibleRootControl();
+        using var button = root.Controls.Add(new Button
+        {
+            Name = "saveButton",
+            Text = "Save",
+            AccessibleAutomationId = "document.save"
+        });
+
+        AccessibleObject first = button.AccessibilityObject;
+        long runtimeId = first.RuntimeId;
+
+        Assert.Same(first, button.AccessibilityObject);
+        Assert.Equal(runtimeId, button.AccessibilityObject.RuntimeId);
+        Assert.Equal("document.save", first.AutomationId);
+        Assert.Equal("Save", first.Name);
+
+        button.AccessibleAutomationId = null;
+        Assert.Equal("saveButton", first.AutomationId);
+        Assert.Equal(runtimeId, first.RuntimeId);
+    }
+
+    [Fact]
+    public void CheckBoxToggleUpdatesCheckedAndMixedStates()
+    {
+        using var root = new VisibleRootControl();
+        using var checkBox = root.Controls.Add(new CheckBox { Text = "Remember" });
+        AccessibleObject accessible = checkBox.AccessibilityObject;
+
+        Assert.Equal(AccessibleControlType.CheckBox, accessible.ControlType);
+        AssertDoesNotHaveFlag(accessible.State, AccessibleStates.Checked);
+        Assert.True(accessible.PerformAction(AccessibleActions.Toggle));
+        Assert.True(checkBox.Checked);
+        AssertHasFlag(accessible.State, AccessibleStates.Checked);
+
+        checkBox.ThreeState = true;
+        checkBox.CheckState = CheckState.Indeterminate;
+        AssertHasFlag(accessible.State, AccessibleStates.Mixed);
+    }
+
+    [Fact]
+    public void RadioButtonSelectUsesNormalMutuallyExclusiveBehavior()
+    {
+        using var root = new VisibleRootControl();
+        using var first = root.Controls.Add(new RadioButton { Text = "First", Checked = true });
+        using var second = root.Controls.Add(new RadioButton { Text = "Second" });
+
+        Assert.True(second.AccessibilityObject.PerformAction(AccessibleActions.Select));
+        Assert.False(first.Checked);
+        Assert.True(second.Checked);
+        AssertHasFlag(second.AccessibilityObject.State, AccessibleStates.Selected);
+    }
+
+    [Fact]
+    public void SwitchToggleUsesTheControlStateMachine()
+    {
+        using var root = new VisibleRootControl();
+        using var toggle = root.Controls.Add(new Switch { Text = "Wi-Fi" });
+
+        Assert.Equal(AccessibleControlType.Switch, toggle.AccessibilityObject.ControlType);
+        Assert.True(toggle.AccessibilityObject.PerformAction(AccessibleActions.Toggle));
+        Assert.True(toggle.IsToggled);
+        AssertHasFlag(toggle.AccessibilityObject.State, AccessibleStates.Checked);
+    }
+
+    [Fact]
+    public void TextBoxSeparatesNameValueReadOnlyAndSensitiveData()
+    {
+        const string sampleSensitiveValue = "semantic-test-sensitive-value";
+        using var root = new VisibleRootControl();
+        using var textBox = root.Controls.Add(new TextBox
+        {
+            Name = "passwordField",
+            Text = sampleSensitiveValue
+        });
+
+        AccessibleObject accessible = textBox.AccessibilityObject;
+
+        Assert.Equal(AccessibleControlType.Edit, accessible.ControlType);
+        Assert.Equal("passwordField", accessible.Name);
+        Assert.Equal(sampleSensitiveValue, accessible.Value);
+        Assert.False(accessible.IsSensitive);
+        AssertHasFlag(accessible.SupportedActions, AccessibleActions.SetValue);
+
+        textBox.ReadOnly = true;
+        AssertHasFlag(accessible.State, AccessibleStates.ReadOnly);
+        AssertDoesNotHaveFlag(accessible.SupportedActions, AccessibleActions.SetValue);
+
+        textBox.ReadOnly = false;
+        textBox.PasswordCharacter = '*';
+        Assert.True(accessible.IsSensitive);
+        Assert.Equal(string.Empty, accessible.Value);
+        Assert.Equal("passwordField", accessible.Name);
+        AssertHasFlag(accessible.State, AccessibleStates.Protected);
+        Assert.True(accessible.PerformAction(AccessibleActions.SetValue, "replacement"));
+        Assert.Equal("replacement", textBox.Text);
+        Assert.Equal(string.Empty, accessible.Value);
+
+        string diagnosticProjection = $"{accessible.Name}|{(accessible.IsSensitive ? "<redacted>" : accessible.Value)}";
+        Assert.DoesNotContain(sampleSensitiveValue, diagnosticProjection);
+    }
+
+    [Fact]
+    public void ComboBoxExposesCollapsedStateAndSelectableLogicalItems()
+    {
+        using var root = new VisibleRootControl();
+        using var comboBox = root.Controls.Add(new ComboBox { Name = "choice" });
+        comboBox.Items.Add("Alpha");
+        comboBox.Items.Add("Beta");
+
+        AccessibleObject accessible = comboBox.AccessibilityObject;
+        AccessibleObject beta = Assert.IsAssignableFrom<AccessibleObject>(accessible.GetChild(1));
+
+        Assert.Equal(AccessibleControlType.ComboBox, accessible.ControlType);
+        AssertHasFlag(accessible.State, AccessibleStates.Collapsed);
+        AssertHasFlag(accessible.SupportedActions, AccessibleActions.Expand);
+        AssertHasFlag(accessible.SupportedActions, AccessibleActions.Collapse);
+        Assert.Equal(2, accessible.GetChildCount());
+        Assert.Equal(AccessibleControlType.ListItem, beta.ControlType);
+        Assert.True(beta.PerformAction(AccessibleActions.Select));
+        Assert.Equal(1, comboBox.SelectedIndex);
+        Assert.Same(beta, accessible.GetSelected());
+    }
+
+    [Fact]
+    public void ListBoxItemsKeepIdentityAcrossMoveAndDetachAfterRemoval()
+    {
+        using var root = new VisibleRootControl();
+        using var listBox = root.Controls.Add(new ListBox());
+        var alpha = new NamedItem("Alpha");
+        var beta = new NamedItem("Beta");
+        listBox.Items.Add(alpha);
+        listBox.Items.Add(beta);
+
+        AccessibleObject list = listBox.AccessibilityObject;
+        AccessibleObject betaNode = Assert.IsAssignableFrom<AccessibleObject>(list.GetChild(1));
+        long runtimeId = betaNode.RuntimeId;
+
+        Assert.True(betaNode.PerformAction(AccessibleActions.Select));
+        Assert.Same(betaNode, list.GetSelected());
+
+        listBox.Items.Move(1, 0);
+        Assert.Same(betaNode, list.GetChild(0));
+        Assert.Equal(runtimeId, betaNode.RuntimeId);
+        Assert.Equal(0, listBox.SelectedIndex);
+        Assert.Same(betaNode, list.GetSelected());
+
+        listBox.Items.Remove(beta);
+        Assert.Null(betaNode.Parent);
+        Assert.Equal(AccessibilityView.Hidden, betaNode.View);
+        Assert.Null(list.GetSelected());
+    }
+
+    [Fact]
+    public void ListViewItemsExposeSelectionAndDetachOnRemoval()
+    {
+        using var root = new VisibleRootControl();
+        using var listView = root.Controls.Add(new ListView());
+        ListViewItem first = listView.Items.Add("First");
+        ListViewItem second = listView.Items.Add("Second");
+
+        AccessibleObject list = listView.AccessibilityObject;
+        AccessibleObject secondNode = Assert.IsAssignableFrom<AccessibleObject>(list.GetChild(1));
+
+        Assert.True(secondNode.PerformAction(AccessibleActions.Select));
+        Assert.Same(second, listView.SelectedItem);
+        AssertHasFlag(secondNode.State, AccessibleStates.Selected);
+        Assert.Same(secondNode, list.GetSelected());
+
+        listView.Items.Remove(second);
+        Assert.Null(secondNode.Parent);
+        Assert.Equal(AccessibilityView.Hidden, secondNode.View);
+        Assert.Null(list.GetSelected());
+        Assert.Same(first, listView.Items[0]);
+    }
+
+    [Fact]
+    public void TreeItemsExposeHierarchyExpansionSelectionAndRemoval()
+    {
+        using var root = new VisibleRootControl();
+        using var treeView = root.Controls.Add(new TreeView());
+        var child = new TreeViewItem("Child");
+        var branch = treeView.Items.Add(new TreeViewItem("Branch", child));
+
+        AccessibleObject tree = treeView.AccessibilityObject;
+        AccessibleObject branchNode = Assert.IsAssignableFrom<AccessibleObject>(tree.GetChild(0));
+        AccessibleObject childNode = Assert.IsAssignableFrom<AccessibleObject>(branchNode.GetChild(0));
+
+        Assert.Equal(AccessibleControlType.TreeItem, branchNode.ControlType);
+        AssertHasFlag(branchNode.State, AccessibleStates.Collapsed);
+        Assert.Same(branchNode, childNode.Parent);
+        Assert.True(branchNode.PerformAction(AccessibleActions.Expand));
+        Assert.True(branch.Expanded);
+        AssertHasFlag(branchNode.State, AccessibleStates.Expanded);
+        Assert.True(childNode.PerformAction(AccessibleActions.Select));
+        Assert.Same(child, treeView.SelectedItem);
+        Assert.Same(childNode, tree.GetSelected());
+
+        treeView.Items.Remove(branch);
+        Assert.Null(branchNode.Parent);
+        Assert.Null(childNode.Parent);
+        Assert.Equal(AccessibilityView.Hidden, branchNode.View);
+        Assert.Null(tree.GetSelected());
+    }
+
+    [Fact]
+    public void TabItemsExposeStableSelectionAndDetachOnRemoval()
+    {
+        using var root = new VisibleRootControl();
+        using var tabs = root.Controls.Add(new TabControl());
+        TabPage first = tabs.TabPages.Add("First");
+        TabPage second = tabs.TabPages.Add("Second");
+        tabs.SelectedTabPage = first;
+
+        AccessibleObject tabRoot = tabs.AccessibilityObject;
+        AccessibleObject firstNode = Assert.IsAssignableFrom<AccessibleObject>(tabRoot.GetChild(0));
+        AccessibleObject secondNode = Assert.IsAssignableFrom<AccessibleObject>(tabRoot.GetChild(1));
+
+        Assert.Equal(AccessibleControlType.TabItem, firstNode.ControlType);
+        AssertHasFlag(firstNode.State, AccessibleStates.Selected);
+        Assert.True(secondNode.PerformAction(AccessibleActions.Select));
+        Assert.Same(second, tabs.SelectedTabPage);
+        Assert.Same(secondNode, tabRoot.GetSelected());
+
+        tabs.TabPages.Remove(second);
+        Assert.Null(secondNode.Parent);
+        Assert.Equal(AccessibilityView.Hidden, secondNode.View);
+    }
+
+    [Fact]
+    public void TrackBarExposesWritableRangeAndUsesSmallChangeActions()
+    {
+        using var root = new VisibleRootControl();
+        using var trackBar = root.Controls.Add(new TrackBar
+        {
+            Minimum = 0,
+            Maximum = 100,
+            SmallChange = 5,
+            LargeChange = 20,
+            Value = 20
+        });
+        AccessibleObject accessible = trackBar.AccessibilityObject;
+        AccessibleRangeValue range = Assert.IsType<AccessibleRangeValue>(accessible.RangeValue);
+
+        Assert.Equal(20, range.Value);
+        Assert.Equal(0, range.Minimum);
+        Assert.Equal(100, range.Maximum);
+        Assert.Equal(5, range.SmallChange);
+        Assert.Equal(20, range.LargeChange);
+        Assert.False(range.IsReadOnly);
+        Assert.True(accessible.PerformAction(AccessibleActions.SetValue, 30d));
+        Assert.Equal(30, trackBar.Value);
+        Assert.True(accessible.PerformAction(AccessibleActions.Increment));
+        Assert.Equal(35, trackBar.Value);
+        Assert.True(accessible.PerformAction(AccessibleActions.Decrement));
+        Assert.Equal(30, trackBar.Value);
+        Assert.False(accessible.PerformAction(AccessibleActions.SetValue, 101d));
+    }
+
+    [Fact]
+    public void ProgressBarExposesReadOnlyRangeWithoutSetValue()
+    {
+        using var root = new VisibleRootControl();
+        using var progressBar = root.Controls.Add(new ProgressBar
+        {
+            Minimum = 0,
+            Maximum = 200,
+            Step = 10,
+            Value = 80
+        });
+        AccessibleObject accessible = progressBar.AccessibilityObject;
+        AccessibleRangeValue range = Assert.IsType<AccessibleRangeValue>(accessible.RangeValue);
+
+        Assert.Equal(AccessibleControlType.ProgressBar, accessible.ControlType);
+        Assert.Equal(80, range.Value);
+        Assert.True(range.IsReadOnly);
+        AssertHasFlag(accessible.State, AccessibleStates.ReadOnly);
+        AssertDoesNotHaveFlag(accessible.SupportedActions, AccessibleActions.SetValue);
+        Assert.False(accessible.PerformAction(AccessibleActions.SetValue, 100d));
+    }
+
+    [Fact]
+    public void MenuItemsExposeCommandsSubmenusAndHierarchy()
+    {
+        using var root = new VisibleRootControl();
+        using var menu = root.Controls.Add(new Menu());
+        int invocations = 0;
+        MenuItem file = menu.Items.Add("File");
+        file.Items.Add("Open", onClick: (_, _) => invocations++);
+        menu.Items.Add("Exit", onClick: (_, _) => invocations++);
+
+        AccessibleObject menuRoot = menu.AccessibilityObject;
+        AccessibleObject fileNode = Assert.IsAssignableFrom<AccessibleObject>(menuRoot.GetChild(0));
+        AccessibleObject openNode = Assert.IsAssignableFrom<AccessibleObject>(fileNode.GetChild(0));
+        AccessibleObject exitNode = Assert.IsAssignableFrom<AccessibleObject>(menuRoot.GetChild(1));
+
+        Assert.Equal(AccessibleControlType.MenuItem, fileNode.ControlType);
+        AssertHasFlag(fileNode.SupportedActions, AccessibleActions.Expand);
+        Assert.Same(fileNode, openNode.Parent);
+        AssertHasFlag(openNode.SupportedActions, AccessibleActions.Invoke);
+        Assert.True(exitNode.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public void FormExposesWindowSemanticsAndUserControlHierarchy()
+    {
+        IWindowImpl implementation = DispatchProxy.Create<IWindowImpl, WindowImplProxy>();
+        using var form = new Form(implementation) { Text = "Settings" };
+        using var button = form.Controls.Add(new Button { Text = "Apply" });
+
+        AccessibleObject window = form.AccessibilityObject;
+
+        Assert.Equal("Settings", window.Name);
+        Assert.Equal(AccessibleRole.Window, window.Role);
+        Assert.Equal(AccessibleControlType.Window, window.ControlType);
+        Assert.Equal(1, window.GetChildCount());
+        Assert.Same(button.AccessibilityObject, window.GetChild(0));
+
+        form.Text = "Preferences";
+        Assert.Equal("Preferences", window.Name);
+    }
+
+    [Fact]
+    public void VisibilityViewParentAndDisposalFilterTheActiveTree()
+    {
+        using var firstRoot = new VisibleRootControl();
+        using var secondRoot = new VisibleRootControl();
+        var child = firstRoot.Controls.Add(new Button { Text = "Action" });
+        AccessibleObject childObject = child.AccessibilityObject;
+
+        Assert.Same(childObject, firstRoot.AccessibilityObject.GetChild(0));
+
+        child.AccessibilityView = AccessibilityView.Hidden;
+        Assert.Equal(0, firstRoot.AccessibilityObject.GetChildCount());
+        child.AccessibilityView = AccessibilityView.Control;
+
+        child.Visible = false;
+        Assert.Equal(0, firstRoot.AccessibilityObject.GetChildCount());
+        child.Visible = true;
+
+        secondRoot.Controls.Add(child);
+        Assert.Same(secondRoot.AccessibilityObject, childObject.Parent);
+        Assert.Equal(0, firstRoot.AccessibilityObject.GetChildCount());
+        Assert.Equal(1, secondRoot.AccessibilityObject.GetChildCount());
+
+        child.Dispose();
+        Assert.Null(childObject.Parent);
+        Assert.Equal(AccessibilityView.Hidden, childObject.View);
+        Assert.Equal(0, secondRoot.AccessibilityObject.GetChildCount());
+    }
+
+    [Fact]
+    public void DynamicControlChangesRaiseExistingSemanticNotifications()
+    {
+        using var root = new VisibleRootControl();
+        AccessibleObject rootObject = root.AccessibilityObject;
+        var rootEvents = new List<AccessibleEvents>();
+        rootObject.ClientNotification += (_, e) => rootEvents.Add(e.EventId);
+
+        using var first = root.Controls.Add(new Button { Text = "First" });
+        using var second = root.Controls.Add(new Button { Text = "Second" });
+        root.Controls.SetChildIndex(second, 0);
+        root.Controls.Remove(first);
+
+        Assert.True(rootEvents.Count(value => value == AccessibleEvents.Reorder) >= 4);
+
+        var childEvents = new List<AccessibleEvents>();
+        second.AccessibilityObject.ClientNotification += (_, e) => childEvents.Add(e.EventId);
+        second.AccessibleName = "Renamed";
+        second.Enabled = false;
+        second.Enabled = true;
+        second.Bounds = new Rectangle(10, 20, 80, 30);
+        second.Select();
+
+        Assert.Contains(AccessibleEvents.NameChange, childEvents);
+        Assert.Contains(AccessibleEvents.StateChange, childEvents);
+        Assert.Contains(AccessibleEvents.LocationChange, childEvents);
+        Assert.Contains(AccessibleEvents.Focus, childEvents);
+    }
+
+    [Fact]
+    public void CustomRenderedControlCanExposeLogicalChildStateBoundsAndAction()
+    {
+        using var root = new VisibleRootControl();
+        using var custom = root.Controls.Add(new CustomSemanticControl());
+        var customObject = Assert.IsType<CustomSemanticAccessibleObject>(custom.AccessibilityObject);
+        AccessibleObject child = Assert.IsAssignableFrom<AccessibleObject>(customObject.GetChild(0));
+
+        Assert.Equal(AccessibleControlType.Group, customObject.ControlType);
+        Assert.Equal(AccessibleRole.Grouping, customObject.Role);
+        Assert.Equal("Painted action", child.Name);
+        Assert.Equal(new Rectangle(4, 5, 60, 20), child.Bounds);
+        AssertHasFlag(child.State, AccessibleStates.Focusable);
+        Assert.Same(customObject, child.Parent);
+        Assert.True(child.PerformAction(AccessibleActions.Invoke));
+        Assert.True(customObject.ActionInvoked);
+    }
+
+    [Fact]
+    public void FocusActionUsesFrameworkKeyboardFocus()
+    {
+        using var root = new VisibleRootControl();
+        using var button = root.Controls.Add(new Button { Text = "Focus me" });
+
+        AssertHasFlag(button.AccessibilityObject.SupportedActions, AccessibleActions.Focus);
+        Assert.True(button.AccessibilityObject.PerformAction(AccessibleActions.Focus));
+        Assert.True(button.Focused);
+        AssertHasFlag(button.AccessibilityObject.State, AccessibleStates.Focused);
+    }
+
+    [Fact]
+    public void UnsupportedOrMalformedActionsAreRejectedDeterministically()
+    {
+        using var root = new VisibleRootControl();
+        using var button = root.Controls.Add(new Button { Text = "Action" });
+
+        Assert.False(button.AccessibilityObject.PerformAction(AccessibleActions.Toggle));
+        Assert.False(button.AccessibilityObject.PerformAction(AccessibleActions.Invoke | AccessibleActions.Focus));
+        Assert.False(button.AccessibilityObject.PerformAction(AccessibleActions.Invoke, "unexpected"));
+
+        button.Enabled = false;
+        Assert.False(button.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+    }
+
+    [Fact]
+    public void RangeValueRejectsInvalidMetadata()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AccessibleRangeValue(0, 10, 5, 1, 1, false));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AccessibleRangeValue(11, 0, 10, 1, 1, false));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AccessibleRangeValue(1, 0, 10, -1, 1, false));
+    }
+
+    private sealed class VisibleRootControl : Control
+    {
+        public override bool Visible
+        {
+            get => true;
+            set { }
+        }
+    }
+
+    private static void AssertHasFlag(AccessibleActions value, AccessibleActions flag)
+        => Assert.Equal(flag, value & flag);
+
+    private static void AssertHasFlag(AccessibleStates value, AccessibleStates flag)
+        => Assert.Equal(flag, value & flag);
+
+    private static void AssertDoesNotHaveFlag(AccessibleActions value, AccessibleActions flag)
+        => Assert.Equal(AccessibleActions.None, value & flag);
+
+    private static void AssertDoesNotHaveFlag(AccessibleStates value, AccessibleStates flag)
+        => Assert.Equal(AccessibleStates.None, value & flag);
+
+    private sealed class NamedItem
+    {
+        private readonly string text;
+
+        public NamedItem(string text)
+        {
+            this.text = text;
+        }
+
+        public override string ToString() => text;
+    }
+
+    private sealed class CustomSemanticControl : Control
+    {
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new CustomSemanticAccessibleObject(this);
+    }
+
+    private sealed class CustomSemanticAccessibleObject : Control.ControlAccessibleObject
+    {
+        private readonly CustomSemanticChild child;
+
+        public CustomSemanticAccessibleObject(CustomSemanticControl owner)
+            : base(owner)
+        {
+            child = new CustomSemanticChild(this, () => ActionInvoked = true);
+        }
+
+        public bool ActionInvoked { get; private set; }
+
+        public override AccessibleControlType ControlType => AccessibleControlType.Group;
+
+        public override AccessibleRole Role => AccessibleRole.Grouping;
+
+        protected override IEnumerable<AccessibleObject> GetAccessibilityChildren()
+        {
+            yield return child;
+        }
+    }
+
+    private sealed class CustomSemanticChild : AccessibleObject
+    {
+        private readonly WeakReference<AccessibleObject> parent;
+        private readonly Action invoke;
+
+        public CustomSemanticChild(AccessibleObject parent, Action invoke)
+        {
+            this.parent = new WeakReference<AccessibleObject>(parent);
+            this.invoke = invoke;
+        }
+
+        public override Rectangle Bounds => new(4, 5, 60, 20);
+
+        public override AccessibleControlType ControlType => AccessibleControlType.Button;
+
+        public override string? Name
+        {
+            get => "Painted action";
+            set { }
+        }
+
+        public override AccessibleObject? Parent
+            => parent.TryGetTarget(out AccessibleObject? value) ? value : null;
+
+        public override AccessibleRole Role => AccessibleRole.PushButton;
+
+        public override AccessibleStates State => AccessibleStates.Focusable;
+
+        public override AccessibleActions SupportedActions => AccessibleActions.Invoke;
+
+        public override bool PerformAction(AccessibleActions action, object? parameter = null)
+        {
+            if (action != AccessibleActions.Invoke || parameter is not null)
+                return false;
+
+            invoke();
+            return true;
+        }
+    }
+
+    private class WindowImplProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            Type? returnType = targetMethod?.ReturnType;
+            return returnType is not null && returnType != typeof(void) && returnType.IsValueType
+                ? Activator.CreateInstance(returnType)
+                : null;
+        }
+    }
+}

--- a/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
+++ b/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
@@ -7,6 +7,13 @@ using Xunit;
 
 namespace ModernFormsNext.Tests;
 
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class AccessibilitySemanticCollection
+{
+    public const string Name = "Accessibility semantics";
+}
+
+[Collection(AccessibilitySemanticCollection.Name)]
 public sealed class AccessibilitySemanticTests
 {
     [Fact]

--- a/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
+++ b/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using ModernFormsNext.Accessibility;
 using ModernFormsNext.WindowKit.Platform;
 using Xunit;
@@ -48,8 +49,14 @@ public sealed class AccessibilitySemanticTests
         Assert.Equal("document.save", first.AutomationId);
         Assert.Equal("Save", first.Name);
 
+        button.Name = "renamedButton";
+        Assert.Equal("document.save", first.AutomationId);
+        Assert.Equal(runtimeId, first.RuntimeId);
+
         button.AccessibleAutomationId = null;
-        Assert.Equal("saveButton", first.AutomationId);
+        Assert.Equal("renamedButton", first.AutomationId);
+        button.Name = string.Empty;
+        Assert.Equal(string.Empty, first.AutomationId);
         Assert.Equal(runtimeId, first.RuntimeId);
     }
 
@@ -122,22 +129,35 @@ public sealed class AccessibilitySemanticTests
         textBox.ReadOnly = false;
         textBox.PasswordCharacter = '*';
         Assert.True(accessible.IsSensitive);
-        Assert.Equal(string.Empty, accessible.Value);
+        Assert.True(string.IsNullOrEmpty(accessible.Value));
         Assert.Equal("passwordField", accessible.Name);
         AssertHasFlag(accessible.State, AccessibleStates.Protected);
+        Assert.False((accessible.ToString() ?? string.Empty).Contains(sampleSensitiveValue, StringComparison.Ordinal));
         Assert.True(accessible.PerformAction(AccessibleActions.SetValue, "replacement"));
         Assert.Equal("replacement", textBox.Text);
+        Assert.True(string.IsNullOrEmpty(accessible.Value));
+        Assert.False((accessible.ToString() ?? string.Empty).Contains("replacement", StringComparison.Ordinal));
+
+        textBox.ReadOnly = true;
+        AssertDoesNotHaveFlag(accessible.SupportedActions, AccessibleActions.SetValue);
+        Assert.False(accessible.PerformAction(AccessibleActions.SetValue, "rejected"));
+        textBox.Text = string.Empty;
+        Assert.True(string.IsNullOrEmpty(accessible.Value));
+
+        textBox.ReadOnly = false;
+        textBox.PasswordCharacter = null;
+        Assert.False(accessible.IsSensitive);
         Assert.Equal(string.Empty, accessible.Value);
 
         string diagnosticProjection = $"{accessible.Name}|{(accessible.IsSensitive ? "<redacted>" : accessible.Value)}";
-        Assert.DoesNotContain(sampleSensitiveValue, diagnosticProjection);
+        Assert.False(diagnosticProjection.Contains(sampleSensitiveValue, StringComparison.Ordinal));
     }
 
     [Fact]
     public void ComboBoxExposesCollapsedStateAndSelectableLogicalItems()
     {
-        using var root = new VisibleRootControl();
-        using var comboBox = root.Controls.Add(new ComboBox { Name = "choice" });
+        using var form = new Form(CreateWindowImplementation());
+        using var comboBox = form.Controls.Add(new ComboBox { Name = "choice" });
         comboBox.Items.Add("Alpha");
         comboBox.Items.Add("Beta");
 
@@ -147,7 +167,12 @@ public sealed class AccessibilitySemanticTests
         Assert.Equal(AccessibleControlType.ComboBox, accessible.ControlType);
         AssertHasFlag(accessible.State, AccessibleStates.Collapsed);
         AssertHasFlag(accessible.SupportedActions, AccessibleActions.Expand);
+        AssertDoesNotHaveFlag(accessible.SupportedActions, AccessibleActions.Collapse);
+        Assert.True(accessible.PerformAction(AccessibleActions.Expand));
+        AssertHasFlag(accessible.State, AccessibleStates.Expanded);
         AssertHasFlag(accessible.SupportedActions, AccessibleActions.Collapse);
+        AssertDoesNotHaveFlag(accessible.SupportedActions, AccessibleActions.Expand);
+        Assert.True(accessible.PerformAction(AccessibleActions.Collapse));
         Assert.Equal(2, accessible.GetChildCount());
         Assert.Equal(AccessibleControlType.ListItem, beta.ControlType);
         Assert.True(beta.PerformAction(AccessibleActions.Select));
@@ -182,6 +207,52 @@ public sealed class AccessibilitySemanticTests
         Assert.Null(betaNode.Parent);
         Assert.Equal(AccessibilityView.Hidden, betaNode.View);
         Assert.Null(list.GetSelected());
+    }
+
+    [Fact]
+    public void EqualListAndComboOccurrencesKeepDistinctIdentityAcrossReorder()
+    {
+        using var root = new VisibleRootControl();
+        using var listBox = root.Controls.Add(new ListBox());
+        using var comboBox = root.Controls.Add(new ComboBox());
+        var repeatedItem = new NamedItem("Repeated");
+
+        listBox.Items.Add(repeatedItem);
+        listBox.Items.Add(repeatedItem);
+        comboBox.Items.Add(repeatedItem);
+        comboBox.Items.Add(repeatedItem);
+
+        AssertOccurrenceIdentityAcrossMove(listBox.AccessibilityObject, listBox.Items);
+        AssertOccurrenceIdentityAcrossMove(comboBox.AccessibilityObject, comboBox.Items);
+    }
+
+    [Fact]
+    public void EqualTreeItemTextDoesNotCollideAndReinsertionIsDeterministic()
+    {
+        using var root = new VisibleRootControl();
+        using var treeView = root.Controls.Add(new TreeView());
+        var first = new TreeViewItem("Repeated");
+        var second = new TreeViewItem("Repeated");
+        treeView.Items.Add(first);
+        treeView.Items.Add(second);
+
+        AccessibleObject tree = treeView.AccessibilityObject;
+        AccessibleObject firstNode = Assert.IsAssignableFrom<AccessibleObject>(tree.GetChild(0));
+        AccessibleObject secondNode = Assert.IsAssignableFrom<AccessibleObject>(tree.GetChild(1));
+        long firstId = firstNode.RuntimeId;
+        long secondId = secondNode.RuntimeId;
+
+        Assert.NotSame(firstNode, secondNode);
+        Assert.NotEqual(firstId, secondId);
+
+        treeView.Items.Remove(first);
+        Assert.Null(firstNode.Parent);
+        treeView.Items.Insert(1, first);
+
+        Assert.Same(firstNode, tree.GetChild(1));
+        Assert.Same(secondNode, tree.GetChild(0));
+        Assert.Equal(firstId, firstNode.RuntimeId);
+        Assert.Equal(secondId, secondNode.RuntimeId);
     }
 
     [Fact]
@@ -315,8 +386,8 @@ public sealed class AccessibilitySemanticTests
     [Fact]
     public void MenuItemsExposeCommandsSubmenusAndHierarchy()
     {
-        using var root = new VisibleRootControl();
-        using var menu = root.Controls.Add(new Menu());
+        using var form = new Form(CreateWindowImplementation());
+        using var menu = form.Controls.Add(new Menu());
         int invocations = 0;
         MenuItem file = menu.Items.Add("File");
         file.Items.Add("Open", onClick: (_, _) => invocations++);
@@ -329,6 +400,9 @@ public sealed class AccessibilitySemanticTests
 
         Assert.Equal(AccessibleControlType.MenuItem, fileNode.ControlType);
         AssertHasFlag(fileNode.SupportedActions, AccessibleActions.Expand);
+        Assert.True(fileNode.PerformAction(AccessibleActions.Expand));
+        AssertHasFlag(fileNode.SupportedActions, AccessibleActions.Collapse);
+        Assert.True(fileNode.PerformAction(AccessibleActions.Collapse));
         Assert.Same(fileNode, openNode.Parent);
         AssertHasFlag(openNode.SupportedActions, AccessibleActions.Invoke);
         Assert.True(exitNode.PerformAction(AccessibleActions.Invoke));
@@ -338,8 +412,7 @@ public sealed class AccessibilitySemanticTests
     [Fact]
     public void FormExposesWindowSemanticsAndUserControlHierarchy()
     {
-        IWindowImpl implementation = DispatchProxy.Create<IWindowImpl, WindowImplProxy>();
-        using var form = new Form(implementation) { Text = "Settings" };
+        using var form = new Form(CreateWindowImplementation()) { Text = "Settings" };
         using var button = form.Controls.Add(new Button { Text = "Apply" });
 
         AccessibleObject window = form.AccessibilityObject;
@@ -352,6 +425,25 @@ public sealed class AccessibilitySemanticTests
 
         form.Text = "Preferences";
         Assert.Equal("Preferences", window.Name);
+    }
+
+    [Fact]
+    public async Task ModalFormExposesDialogSemanticsWhileShown()
+    {
+        using var parent = new Form(CreateWindowImplementation());
+        using var dialog = new Form(CreateWindowImplementation())
+        {
+            Text = "Confirm",
+            StartPosition = FormStartPosition.Manual
+        };
+
+        Task<DialogResult> completion = dialog.ShowDialog(parent);
+
+        Assert.Equal(AccessibleRole.Dialog, dialog.AccessibilityObject.Role);
+        Assert.Equal(AccessibleControlType.Dialog, dialog.AccessibilityObject.ControlType);
+
+        dialog.DialogResult = DialogResult.OK;
+        Assert.Equal(DialogResult.OK, await completion);
     }
 
     [Fact]
@@ -413,6 +505,75 @@ public sealed class AccessibilitySemanticTests
     }
 
     [Fact]
+    public void CollectionSelectionAndPopupNotificationsAreSpecificAndNotDuplicated()
+    {
+        using var root = new VisibleRootControl();
+        using var listBox = root.Controls.Add(new ListBox());
+        AccessibleObject listBoxObject = listBox.AccessibilityObject;
+        var listBoxEvents = new List<AccessibleEvents>();
+        listBoxObject.ClientNotification += (_, e) => listBoxEvents.Add(e.EventId);
+
+        listBox.Items.Add("Item");
+
+        Assert.Single(listBoxEvents, value => value == AccessibleEvents.Reorder);
+        Assert.DoesNotContain(AccessibleEvents.Selection, listBoxEvents);
+
+        using var listView = root.Controls.Add(new ListView());
+        ListViewItem first = listView.Items.Add("First");
+        ListViewItem second = listView.Items.Add("Second");
+        var listViewEvents = new List<AccessibleEvents>();
+        listView.AccessibilityObject.ClientNotification += (_, e) => listViewEvents.Add(e.EventId);
+
+        listView.SelectedItem = first;
+        Assert.Equal([AccessibleEvents.Selection, AccessibleEvents.ValueChange], listViewEvents);
+
+        listViewEvents.Clear();
+        listView.SelectedItem = second;
+        Assert.Equal(
+            [AccessibleEvents.SelectionRemove, AccessibleEvents.Selection, AccessibleEvents.ValueChange],
+            listViewEvents);
+
+        listViewEvents.Clear();
+        listView.Items[1] = new ListViewItem { Text = "Replacement", Selected = true };
+        Assert.Equal(
+            [AccessibleEvents.Reorder, AccessibleEvents.SelectionRemove, AccessibleEvents.Selection],
+            listViewEvents);
+
+        using var form = new Form(CreateWindowImplementation());
+        using var comboBox = form.Controls.Add(new ComboBox());
+        using var menu = form.Controls.Add(new Menu());
+        MenuItem submenu = menu.Items.Add("Submenu");
+        submenu.Items.Add("Child");
+        AccessibleObject submenuObject = Assert.IsAssignableFrom<AccessibleObject>(
+            menu.AccessibilityObject.GetChild(0));
+        var comboEvents = new List<AccessibleEvents>();
+        var menuRootEvents = new List<AccessibleEvents>();
+        var menuItemEvents = new List<AccessibleEvents>();
+        comboBox.AccessibilityObject.ClientNotification += (_, e) => comboEvents.Add(e.EventId);
+        menu.AccessibilityObject.ClientNotification += (_, e) => menuRootEvents.Add(e.EventId);
+        submenuObject.ClientNotification += (_, e) => menuItemEvents.Add(e.EventId);
+
+        comboBox.Items.Add("Selected");
+        comboBox.SelectedIndex = 0;
+        comboEvents.Clear();
+        comboBox.Items.RemoveAt(0);
+
+        Assert.Equal(
+            [AccessibleEvents.Reorder, AccessibleEvents.Selection, AccessibleEvents.ValueChange],
+            comboEvents);
+
+        comboEvents.Clear();
+        Assert.True(comboBox.AccessibilityObject.PerformAction(AccessibleActions.Expand));
+        Assert.True(comboBox.AccessibilityObject.PerformAction(AccessibleActions.Collapse));
+        Assert.True(submenuObject.PerformAction(AccessibleActions.Expand));
+        Assert.True(submenuObject.PerformAction(AccessibleActions.Collapse));
+
+        Assert.Equal(2, comboEvents.Count(value => value == AccessibleEvents.StateChange));
+        Assert.Equal(2, menuRootEvents.Count(value => value == AccessibleEvents.StateChange));
+        Assert.Equal(2, menuItemEvents.Count(value => value == AccessibleEvents.StateChange));
+    }
+
+    [Fact]
     public void CustomRenderedControlCanExposeLogicalChildStateBoundsAndAction()
     {
         using var root = new VisibleRootControl();
@@ -423,6 +584,7 @@ public sealed class AccessibilitySemanticTests
         Assert.Equal(AccessibleControlType.Group, customObject.ControlType);
         Assert.Equal(AccessibleRole.Grouping, customObject.Role);
         Assert.Equal("Painted action", child.Name);
+        Assert.Equal("painted.action", child.AutomationId);
         Assert.Equal(new Rectangle(4, 5, 60, 20), child.Bounds);
         AssertHasFlag(child.State, AccessibleStates.Focusable);
         Assert.Same(customObject, child.Parent);
@@ -457,6 +619,133 @@ public sealed class AccessibilitySemanticTests
     }
 
     [Fact]
+    public void SupportedActionsAreExecutableForRepresentativeControlsAndLogicalItems()
+    {
+        using var form = new Form(CreateWindowImplementation());
+        using var button = form.Controls.Add(new Button { Text = "Action" });
+        using var checkBox = form.Controls.Add(new CheckBox { Text = "Check" });
+        using var radioButton = form.Controls.Add(new RadioButton { Text = "Choice" });
+        using var toggle = form.Controls.Add(new Switch { Text = "Toggle" });
+        using var textBox = form.Controls.Add(new TextBox { Name = "editor" });
+        using var comboBox = form.Controls.Add(new ComboBox());
+        using var trackBar = form.Controls.Add(new TrackBar { Minimum = 0, Maximum = 10, Value = 5 });
+        using var listBox = form.Controls.Add(new ListBox());
+        using var listView = form.Controls.Add(new ListView());
+        using var treeView = form.Controls.Add(new TreeView());
+        using var tabs = form.Controls.Add(new TabControl());
+        using var menu = form.Controls.Add(new Menu());
+        using var progressBar = form.Controls.Add(new ProgressBar());
+
+        comboBox.Items.Add("Combo item");
+        listBox.Items.Add("List item");
+        listView.Items.Add("List view item");
+        treeView.Items.Add(new TreeViewItem("Branch", new TreeViewItem("Child")));
+        tabs.TabPages.Add("Tab");
+        MenuItem submenu = menu.Items.Add("Submenu");
+        submenu.Items.Add("Child command");
+        menu.Items.Add("Command");
+
+        AccessibleObject comboItem = Assert.IsAssignableFrom<AccessibleObject>(comboBox.AccessibilityObject.GetChild(0));
+        AccessibleObject listItem = Assert.IsAssignableFrom<AccessibleObject>(listBox.AccessibilityObject.GetChild(0));
+        AccessibleObject listViewItem = Assert.IsAssignableFrom<AccessibleObject>(listView.AccessibilityObject.GetChild(0));
+        AccessibleObject treeItem = Assert.IsAssignableFrom<AccessibleObject>(treeView.AccessibilityObject.GetChild(0));
+        AccessibleObject tabItem = Assert.IsAssignableFrom<AccessibleObject>(tabs.AccessibilityObject.GetChild(0));
+        AccessibleObject submenuItem = Assert.IsAssignableFrom<AccessibleObject>(menu.AccessibilityObject.GetChild(0));
+        AccessibleObject commandItem = Assert.IsAssignableFrom<AccessibleObject>(menu.AccessibilityObject.GetChild(1));
+
+        AccessibleObject[] representatives =
+        [
+            button.AccessibilityObject,
+            checkBox.AccessibilityObject,
+            radioButton.AccessibilityObject,
+            toggle.AccessibilityObject,
+            textBox.AccessibilityObject,
+            comboBox.AccessibilityObject,
+            trackBar.AccessibilityObject,
+            listBox.AccessibilityObject,
+            listView.AccessibilityObject,
+            treeView.AccessibilityObject,
+            tabs.AccessibilityObject,
+            menu.AccessibilityObject,
+            progressBar.AccessibilityObject,
+            comboItem,
+            listItem,
+            listViewItem,
+            treeItem,
+            tabItem,
+            submenuItem,
+            commandItem
+        ];
+
+        foreach (AccessibleObject accessible in representatives)
+            AssertEveryAdvertisedActionCanExecute(accessible);
+
+        // Expanding changes the advertised action from Expand to Collapse. Exercise the second
+        // state as a separate contract snapshot.
+        AssertEveryAdvertisedActionCanExecute(submenuItem);
+        AssertEveryAdvertisedActionCanExecute(comboBox.AccessibilityObject);
+        AssertEveryAdvertisedActionCanExecute(comboBox.AccessibilityObject);
+    }
+
+    [Fact]
+    public void UnavailableOrInapplicableActionsAreNotAdvertised()
+    {
+        using var root = new VisibleRootControl();
+        using var button = root.Controls.Add(new Button());
+        using var toggle = root.Controls.Add(new Switch { AutoToggle = false });
+        using var comboBox = root.Controls.Add(new ComboBox());
+        using var listBox = root.Controls.Add(new ListBox { SelectionMode = SelectionMode.None });
+        using var menu = root.Controls.Add(new Menu());
+        listBox.Items.Add("Item");
+        MenuItem submenu = menu.Items.Add("Submenu");
+        submenu.Items.Add("Child");
+
+        button.Enabled = false;
+        Assert.Equal(AccessibleActions.None, button.AccessibilityObject.SupportedActions);
+        AssertDoesNotHaveFlag(toggle.AccessibilityObject.SupportedActions, AccessibleActions.Toggle);
+        AssertDoesNotHaveFlag(comboBox.AccessibilityObject.SupportedActions, AccessibleActions.Expand);
+        AssertDoesNotHaveFlag(
+            Assert.IsAssignableFrom<AccessibleObject>(listBox.AccessibilityObject.GetChild(0)).SupportedActions,
+            AccessibleActions.Select);
+        AssertDoesNotHaveFlag(
+            Assert.IsAssignableFrom<AccessibleObject>(menu.AccessibilityObject.GetChild(0)).SupportedActions,
+            AccessibleActions.Expand);
+    }
+
+    [Fact]
+    public void RuntimeIdsArePositiveAndUniqueUnderConcurrentConstruction()
+    {
+        const int count = 512;
+        var runtimeIds = new long[count];
+
+        Parallel.For(0, count, index => runtimeIds[index] = new AccessibleObject().RuntimeId);
+
+        Assert.All(runtimeIds, runtimeId => Assert.True(runtimeId > 0));
+        Assert.Equal(count, runtimeIds.Distinct().Count());
+    }
+
+    [Fact]
+    public void RetainedPeerDoesNotKeepItsControlOrLogicalOwnerAlive()
+    {
+        (AccessibleObject controlPeer, WeakReference controlReference) = CreateCollectibleControlPeer();
+        (AccessibleObject itemPeer, WeakReference ownerReference, WeakReference itemReference) =
+            CreateCollectibleLogicalItemPeer();
+
+        CollectGarbage();
+
+        Assert.False(controlReference.IsAlive);
+        Assert.Null(Assert.IsType<Control.ControlAccessibleObject>(controlPeer).Owner);
+        Assert.Equal(AccessibleActions.None, controlPeer.SupportedActions);
+        Assert.False(ownerReference.IsAlive);
+        Assert.False(itemReference.IsAlive);
+        Assert.Null(itemPeer.Parent);
+        Assert.Equal(AccessibilityView.Hidden, itemPeer.View);
+        Assert.Equal(AccessibleActions.None, itemPeer.SupportedActions);
+        GC.KeepAlive(controlPeer);
+        GC.KeepAlive(itemPeer);
+    }
+
+    [Fact]
     public void RangeValueRejectsInvalidMetadata()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new AccessibleRangeValue(0, 10, 5, 1, 1, false));
@@ -484,6 +773,77 @@ public sealed class AccessibilitySemanticTests
 
     private static void AssertDoesNotHaveFlag(AccessibleStates value, AccessibleStates flag)
         => Assert.Equal(AccessibleStates.None, value & flag);
+
+    private static void AssertOccurrenceIdentityAcrossMove(
+        AccessibleObject root,
+        ListBoxItemCollection items)
+    {
+        AccessibleObject firstNode = Assert.IsAssignableFrom<AccessibleObject>(root.GetChild(0));
+        AccessibleObject secondNode = Assert.IsAssignableFrom<AccessibleObject>(root.GetChild(1));
+        long firstId = firstNode.RuntimeId;
+        long secondId = secondNode.RuntimeId;
+
+        Assert.NotSame(firstNode, secondNode);
+        Assert.NotEqual(firstId, secondId);
+
+        items.Move(0, 1);
+
+        Assert.Same(firstNode, root.GetChild(1));
+        Assert.Same(secondNode, root.GetChild(0));
+        Assert.Equal(firstId, firstNode.RuntimeId);
+        Assert.Equal(secondId, secondNode.RuntimeId);
+    }
+
+    private static void AssertEveryAdvertisedActionCanExecute(AccessibleObject accessible)
+    {
+        AccessibleActions advertised = accessible.SupportedActions;
+
+        foreach (AccessibleActions action in Enum.GetValues<AccessibleActions>())
+        {
+            if (action == AccessibleActions.None || (advertised & action) == 0)
+                continue;
+
+            object? parameter = action == AccessibleActions.SetValue
+                ? accessible.ControlType == AccessibleControlType.Edit
+                    ? "updated"
+                    : accessible.RangeValue?.Value
+                : null;
+
+            Assert.True(
+                accessible.PerformAction(action, parameter),
+                $"{accessible.ControlType} advertised {action} but rejected it.");
+        }
+    }
+
+    private static IWindowImpl CreateWindowImplementation()
+        => DispatchProxy.Create<IWindowImpl, WindowImplProxy>();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (AccessibleObject Peer, WeakReference ControlReference) CreateCollectibleControlPeer()
+    {
+        var control = new Button();
+        return (control.AccessibilityObject, new WeakReference(control));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (AccessibleObject Peer, WeakReference OwnerReference, WeakReference ItemReference)
+        CreateCollectibleLogicalItemPeer()
+    {
+        var root = new VisibleRootControl();
+        var owner = root.Controls.Add(new ListBox());
+        var item = new NamedItem("Collectible");
+        owner.Items.Add(item);
+        AccessibleObject peer = Assert.IsAssignableFrom<AccessibleObject>(owner.AccessibilityObject.GetChild(0));
+        return (peer, new WeakReference(owner), new WeakReference(item));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CollectGarbage()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
 
     private sealed class NamedItem
     {
@@ -534,6 +894,7 @@ public sealed class AccessibilitySemanticTests
         {
             this.parent = new WeakReference<AccessibleObject>(parent);
             this.invoke = invoke;
+            AutomationId = "painted.action";
         }
 
         public override Rectangle Bounds => new(4, 5, 60, 20);
@@ -569,6 +930,12 @@ public sealed class AccessibilitySemanticTests
     {
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
         {
+            if (targetMethod?.Name == nameof(ITopLevelImpl.CreatePopup))
+                return DispatchProxy.Create<IPopupImpl, WindowImplProxy>();
+
+            if (targetMethod?.Name is "get_RenderScaling" or "get_DesktopScaling")
+                return 1d;
+
             Type? returnType = targetMethod?.ReturnType;
             return returnType is not null && returnType != typeof(void) && returnType.IsValueType
                 ? Activator.CreateInstance(returnType)

--- a/ModernFormsNext/Accessibility/AccessibilityView.cs
+++ b/ModernFormsNext/Accessibility/AccessibilityView.cs
@@ -38,4 +38,3 @@ public enum AccessibilityView
     /// </summary>
     Hidden
 }
-

--- a/ModernFormsNext/Accessibility/AccessibilityView.cs
+++ b/ModernFormsNext/Accessibility/AccessibilityView.cs
@@ -9,12 +9,16 @@ namespace ModernFormsNext.Accessibility;
 /// available only in the complete semantic tree, <see cref="Control"/> objects also appear in the
 /// interactive control projection, and <see cref="Content"/> objects also appear in the content
 /// projection. <see cref="Hidden"/> objects are excluded from active accessibility trees. This enum
-/// is independent from platform-specific view enumerations.
+/// is independent from platform-specific view enumerations. Phase 1 records this classification but
+/// does not expose separate projection-query endpoints; active child enumeration filters
+/// <see cref="Hidden"/> objects.
 /// </remarks>
 public enum AccessibilityView
 {
     /// <summary>
-    /// The framework should infer the view from the represented object.
+    /// The framework should infer the view from the represented object. Standard static content and
+    /// progress indicators resolve to <see cref="Content"/>; other standard controls resolve to
+    /// <see cref="Control"/> unless their accessible object overrides the classification.
     /// </summary>
     Default,
 

--- a/ModernFormsNext/Accessibility/AccessibilityView.cs
+++ b/ModernFormsNext/Accessibility/AccessibilityView.cs
@@ -1,0 +1,41 @@
+namespace ModernFormsNext.Accessibility;
+
+/// <summary>
+/// Specifies which platform-neutral accessibility projection should contain an
+/// <see cref="AccessibleObject"/>.
+/// </summary>
+/// <remarks>
+/// The values describe progressively more user-relevant projections. <see cref="Raw"/> objects are
+/// available only in the complete semantic tree, <see cref="Control"/> objects also appear in the
+/// interactive control projection, and <see cref="Content"/> objects also appear in the content
+/// projection. <see cref="Hidden"/> objects are excluded from active accessibility trees. This enum
+/// is independent from platform-specific view enumerations.
+/// </remarks>
+public enum AccessibilityView
+{
+    /// <summary>
+    /// The framework should infer the view from the represented object.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// The object appears only in the complete raw semantic tree.
+    /// </summary>
+    Raw,
+
+    /// <summary>
+    /// The object appears in raw and interactive-control projections.
+    /// </summary>
+    Control,
+
+    /// <summary>
+    /// The object appears in raw, control, and user-content projections.
+    /// </summary>
+    Content,
+
+    /// <summary>
+    /// The object is decorative, removed, disposed, or otherwise excluded from active trees.
+    /// </summary>
+    Hidden
+}
+

--- a/ModernFormsNext/Accessibility/AccessibleActions.cs
+++ b/ModernFormsNext/Accessibility/AccessibleActions.cs
@@ -1,0 +1,79 @@
+namespace ModernFormsNext.Accessibility;
+
+/// <summary>
+/// Specifies platform-neutral operations that an <see cref="AccessibleObject"/> can perform.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These values describe framework behavior rather than Windows UI Automation patterns or Android
+/// accessibility actions. Platform adapters translate supported values to their native equivalents.
+/// </para>
+/// <para>
+/// Pass exactly one flag to <see cref="AccessibleObject.PerformAction(AccessibleActions, object?)"/>.
+/// The flags form is used so callers can efficiently inspect <see cref="AccessibleObject.SupportedActions"/>.
+/// </para>
+/// </remarks>
+[Flags]
+public enum AccessibleActions
+{
+    /// <summary>
+    /// The object exposes no semantic action.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Activates the object's primary command.
+    /// </summary>
+    Invoke = 1 << 0,
+
+    /// <summary>
+    /// Changes a two-state or three-state object to its next state.
+    /// </summary>
+    Toggle = 1 << 1,
+
+    /// <summary>
+    /// Selects the object in its owning container.
+    /// </summary>
+    Select = 1 << 2,
+
+    /// <summary>
+    /// Reveals the object's logical children or popup content.
+    /// </summary>
+    Expand = 1 << 3,
+
+    /// <summary>
+    /// Hides the object's logical children or popup content.
+    /// </summary>
+    Collapse = 1 << 4,
+
+    /// <summary>
+    /// Replaces the object's editable value using the action parameter.
+    /// </summary>
+    SetValue = 1 << 5,
+
+    /// <summary>
+    /// Increases a numeric value by its small-change amount.
+    /// </summary>
+    Increment = 1 << 6,
+
+    /// <summary>
+    /// Decreases a numeric value by its small-change amount.
+    /// </summary>
+    Decrement = 1 << 7,
+
+    /// <summary>
+    /// Scrolls the object or viewport according to the action parameter.
+    /// </summary>
+    Scroll = 1 << 8,
+
+    /// <summary>
+    /// Scrolls the containing viewport until the object is visible.
+    /// </summary>
+    ScrollIntoView = 1 << 9,
+
+    /// <summary>
+    /// Gives the object normal framework keyboard focus.
+    /// </summary>
+    Focus = 1 << 10
+}
+

--- a/ModernFormsNext/Accessibility/AccessibleActions.cs
+++ b/ModernFormsNext/Accessibility/AccessibleActions.cs
@@ -76,4 +76,3 @@ public enum AccessibleActions
     /// </summary>
     Focus = 1 << 10
 }
-

--- a/ModernFormsNext/Accessibility/AccessibleControlType.cs
+++ b/ModernFormsNext/Accessibility/AccessibleControlType.cs
@@ -146,4 +146,3 @@ public enum AccessibleControlType
     /// </summary>
     Separator
 }
-

--- a/ModernFormsNext/Accessibility/AccessibleControlType.cs
+++ b/ModernFormsNext/Accessibility/AccessibleControlType.cs
@@ -1,0 +1,149 @@
+namespace ModernFormsNext.Accessibility;
+
+/// <summary>
+/// Identifies the normalized, platform-neutral kind of user-interface element represented by an
+/// <see cref="AccessibleObject"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="AccessibleRole"/> preserves WinForms and MSAA-compatible role values. This type is the
+/// canonical ModernFormsNext control classification used by future platform adapters and automation
+/// consumers; it is intentionally not a copy of a Windows UI Automation enumeration.
+/// </remarks>
+public enum AccessibleControlType
+{
+    /// <summary>
+    /// The framework should infer the control type from the represented object.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// A custom element without a more specific normalized type.
+    /// </summary>
+    Custom,
+
+    /// <summary>
+    /// A top-level application window.
+    /// </summary>
+    Window,
+
+    /// <summary>
+    /// A structural pane within a window.
+    /// </summary>
+    Pane,
+
+    /// <summary>
+    /// A logical group of related elements.
+    /// </summary>
+    Group,
+
+    /// <summary>
+    /// Read-only textual content.
+    /// </summary>
+    Text,
+
+    /// <summary>
+    /// A command button.
+    /// </summary>
+    Button,
+
+    /// <summary>
+    /// A check box.
+    /// </summary>
+    CheckBox,
+
+    /// <summary>
+    /// A mutually exclusive radio button.
+    /// </summary>
+    RadioButton,
+
+    /// <summary>
+    /// A switch that changes between discrete states.
+    /// </summary>
+    Switch,
+
+    /// <summary>
+    /// An editable or read-only text field.
+    /// </summary>
+    Edit,
+
+    /// <summary>
+    /// A combo box with a popup list.
+    /// </summary>
+    ComboBox,
+
+    /// <summary>
+    /// A list container.
+    /// </summary>
+    List,
+
+    /// <summary>
+    /// An item in a list container.
+    /// </summary>
+    ListItem,
+
+    /// <summary>
+    /// A hierarchical tree container.
+    /// </summary>
+    Tree,
+
+    /// <summary>
+    /// An item in a hierarchical tree.
+    /// </summary>
+    TreeItem,
+
+    /// <summary>
+    /// A tab container.
+    /// </summary>
+    Tab,
+
+    /// <summary>
+    /// A selectable tab header.
+    /// </summary>
+    TabItem,
+
+    /// <summary>
+    /// A menu container.
+    /// </summary>
+    Menu,
+
+    /// <summary>
+    /// A command or submenu entry in a menu.
+    /// </summary>
+    MenuItem,
+
+    /// <summary>
+    /// A slider with a user-adjustable numeric value.
+    /// </summary>
+    Slider,
+
+    /// <summary>
+    /// A read-only progress indicator.
+    /// </summary>
+    ProgressBar,
+
+    /// <summary>
+    /// A horizontal or vertical scroll bar.
+    /// </summary>
+    ScrollBar,
+
+    /// <summary>
+    /// A dialog window.
+    /// </summary>
+    Dialog,
+
+    /// <summary>
+    /// An image or other non-text graphic.
+    /// </summary>
+    Image,
+
+    /// <summary>
+    /// A toolbar containing commands.
+    /// </summary>
+    ToolBar,
+
+    /// <summary>
+    /// A visual or semantic separator.
+    /// </summary>
+    Separator
+}
+

--- a/ModernFormsNext/Accessibility/AccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/AccessibleObject.cs
@@ -22,7 +22,7 @@ namespace ModernFormsNext.Accessibility;
 public class AccessibleObject
 {
     private static long s_nextRuntimeId;
-    private readonly long runtime_id = Interlocked.Increment(ref s_nextRuntimeId);
+    private readonly long runtime_id = CreateRuntimeId();
 
     /// <summary>
     /// Occurs when <see cref="NotifyClients(AccessibleEvents, int, int)"/> is called for this object.
@@ -247,6 +247,23 @@ public class AccessibleObject
     /// <param name="flags">Selection behavior flags.</param>
     public virtual void Select(AccessibleSelection flags)
     {
+    }
+
+    private static long CreateRuntimeId()
+    {
+        while (true)
+        {
+            long current = Volatile.Read(ref s_nextRuntimeId);
+            if (current == long.MaxValue)
+            {
+                throw new InvalidOperationException(
+                    "The process-local accessibility runtime identifier space has been exhausted.");
+            }
+
+            long next = current + 1;
+            if (Interlocked.CompareExchange(ref s_nextRuntimeId, next, current) == current)
+                return next;
+        }
     }
 }
 

--- a/ModernFormsNext/Accessibility/AccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/AccessibleObject.cs
@@ -93,7 +93,7 @@ public class AccessibleObject
     /// Gets a stable identifier for this accessible object within the current process session.
     /// </summary>
     /// <remarks>
-    /// Runtime identifiers are assigned lazily with object construction and are not persistent
+    /// Runtime identifiers are assigned atomically during object construction and are not persistent
     /// across application runs. Logical-item implementations should cache their accessible object
     /// for the lifetime of the represented item so this value remains stable across reorderings.
     /// </remarks>

--- a/ModernFormsNext/Accessibility/AccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/AccessibleObject.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Threading;
 
 namespace ModernFormsNext.Accessibility;
 
@@ -20,6 +21,9 @@ namespace ModernFormsNext.Accessibility;
 /// </remarks>
 public class AccessibleObject
 {
+    private static long s_nextRuntimeId;
+    private readonly long runtime_id = Interlocked.Increment(ref s_nextRuntimeId);
+
     /// <summary>
     /// Occurs when <see cref="NotifyClients(AccessibleEvents, int, int)"/> is called for this object.
     /// </summary>
@@ -33,6 +37,22 @@ public class AccessibleObject
     /// Gets the object bounds in screen coordinates.
     /// </summary>
     public virtual Rectangle Bounds => Rectangle.Empty;
+
+    /// <summary>
+    /// Gets or sets the stable developer-defined identifier used by semantic automation consumers.
+    /// </summary>
+    /// <remarks>
+    /// The value identifies the same logical element across repeated queries while that element
+    /// exists. It is distinct from <see cref="RuntimeId"/> and need not be globally unique. Control
+    /// implementations normally fall back to <see cref="Control.Name"/> when no explicit value is
+    /// supplied.
+    /// </remarks>
+    public virtual string? AutomationId { get; set; }
+
+    /// <summary>
+    /// Gets the normalized platform-neutral control type.
+    /// </summary>
+    public virtual AccessibleControlType ControlType => AccessibleControlType.Custom;
 
     /// <summary>
     /// Gets a localized description of the object's default action.
@@ -70,14 +90,49 @@ public class AccessibleObject
     public virtual AccessibleRole Role => AccessibleRole.Default;
 
     /// <summary>
+    /// Gets a stable identifier for this accessible object within the current process session.
+    /// </summary>
+    /// <remarks>
+    /// Runtime identifiers are assigned lazily with object construction and are not persistent
+    /// across application runs. Logical-item implementations should cache their accessible object
+    /// for the lifetime of the represented item so this value remains stable across reorderings.
+    /// </remarks>
+    public long RuntimeId => runtime_id;
+
+    /// <summary>
+    /// Gets whether the object contains sensitive data that must be redacted from semantic output,
+    /// snapshots, diagnostics, and logs.
+    /// </summary>
+    public virtual bool IsSensitive => false;
+
+    /// <summary>
+    /// Gets optional numeric range metadata for sliders, progress indicators, and similar objects.
+    /// </summary>
+    public virtual AccessibleRangeValue? RangeValue => null;
+
+    /// <summary>
     /// Gets the current accessibility state flags for the object.
     /// </summary>
     public virtual AccessibleStates State => AccessibleStates.None;
 
     /// <summary>
+    /// Gets the semantic actions supported by this object.
+    /// </summary>
+    public virtual AccessibleActions SupportedActions => AccessibleActions.None;
+
+    /// <summary>
     /// Gets or sets the current value exposed by the object.
     /// </summary>
+    /// <remarks>
+    /// Objects for which <see cref="IsSensitive"/> is <see langword="true"/> must return a redacted
+    /// value, normally <see cref="string.Empty"/>, rather than exposing the underlying content.
+    /// </remarks>
     public virtual string? Value { get; set; }
+
+    /// <summary>
+    /// Gets the projection in which this object participates.
+    /// </summary>
+    public virtual AccessibilityView View => AccessibilityView.Control;
 
     /// <summary>
     /// Performs the default action for the object, when one is available.
@@ -87,16 +142,41 @@ public class AccessibleObject
     }
 
     /// <summary>
+    /// Performs one supported platform-neutral semantic action.
+    /// </summary>
+    /// <param name="action">Exactly one action flag declared by <see cref="SupportedActions"/>.</param>
+    /// <param name="parameter">
+    /// Optional action data. <see cref="AccessibleActions.SetValue"/> accepts the natural semantic
+    /// value type of the represented object. Actions without parameters require <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the supported request was accepted; otherwise
+    /// <see langword="false"/> for unsupported actions, invalid parameters, unavailable objects, or
+    /// rejected state changes.
+    /// </returns>
+    /// <remarks>
+    /// Mutable framework state is UI-thread-affine. Callers on a platform callback thread must
+    /// dispatch to the owning UI thread before invoking this method. Implementations must use normal
+    /// control APIs and must not invoke private event handlers or discover actions through reflection.
+    /// </remarks>
+    public virtual bool PerformAction(AccessibleActions action, object? parameter = null) => false;
+
+    /// <summary>
     /// Gets a child accessible object by zero-based index.
     /// </summary>
     /// <param name="index">The zero-based child index.</param>
     /// <returns>The child accessible object, or <see langword="null"/> when the index is invalid.</returns>
+    /// <remarks>
+    /// Implementations may return logical children that are not <see cref="Control"/> instances.
+    /// Removed, disposed, and <see cref="AccessibilityView.Hidden"/> children must not remain in the
+    /// active child sequence.
+    /// </remarks>
     public virtual AccessibleObject? GetChild(int index) => null;
 
     /// <summary>
     /// Gets the number of child accessible objects.
     /// </summary>
-    /// <returns>The number of child objects.</returns>
+    /// <returns>The number of active child objects.</returns>
     public virtual int GetChildCount() => 0;
 
     /// <summary>

--- a/ModernFormsNext/Accessibility/AccessibleRangeValue.cs
+++ b/ModernFormsNext/Accessibility/AccessibleRangeValue.cs
@@ -79,4 +79,3 @@ public readonly struct AccessibleRangeValue
     /// </summary>
     public bool IsReadOnly { get; }
 }
-

--- a/ModernFormsNext/Accessibility/AccessibleRangeValue.cs
+++ b/ModernFormsNext/Accessibility/AccessibleRangeValue.cs
@@ -1,0 +1,82 @@
+namespace ModernFormsNext.Accessibility;
+
+/// <summary>
+/// Describes a platform-neutral numeric range exposed by an <see cref="AccessibleObject"/>.
+/// </summary>
+/// <remarks>
+/// Values use logical control units rather than pixels. A read-only range can report progress but
+/// must not advertise <see cref="AccessibleActions.SetValue"/>.
+/// </remarks>
+public readonly struct AccessibleRangeValue
+{
+    /// <summary>
+    /// Initializes range metadata.
+    /// </summary>
+    /// <param name="value">The current value, between <paramref name="minimum"/> and <paramref name="maximum"/>.</param>
+    /// <param name="minimum">The inclusive minimum value.</param>
+    /// <param name="maximum">The inclusive maximum value.</param>
+    /// <param name="smallChange">The amount used for a small increment or decrement.</param>
+    /// <param name="largeChange">The amount used for a page-sized increment or decrement.</param>
+    /// <param name="isReadOnly">Whether callers may change the value through semantic actions.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A value is not finite, the range is inverted, the current value is outside the range, or a
+    /// change amount is negative.
+    /// </exception>
+    public AccessibleRangeValue(
+        double value,
+        double minimum,
+        double maximum,
+        double smallChange,
+        double largeChange,
+        bool isReadOnly)
+    {
+        if (!double.IsFinite(minimum))
+            throw new ArgumentOutOfRangeException(nameof(minimum));
+        if (!double.IsFinite(maximum) || maximum < minimum)
+            throw new ArgumentOutOfRangeException(nameof(maximum));
+        if (!double.IsFinite(value) || value < minimum || value > maximum)
+            throw new ArgumentOutOfRangeException(nameof(value));
+        if (!double.IsFinite(smallChange) || smallChange < 0)
+            throw new ArgumentOutOfRangeException(nameof(smallChange));
+        if (!double.IsFinite(largeChange) || largeChange < 0)
+            throw new ArgumentOutOfRangeException(nameof(largeChange));
+
+        Value = value;
+        Minimum = minimum;
+        Maximum = maximum;
+        SmallChange = smallChange;
+        LargeChange = largeChange;
+        IsReadOnly = isReadOnly;
+    }
+
+    /// <summary>
+    /// Gets the current numeric value.
+    /// </summary>
+    public double Value { get; }
+
+    /// <summary>
+    /// Gets the inclusive minimum value.
+    /// </summary>
+    public double Minimum { get; }
+
+    /// <summary>
+    /// Gets the inclusive maximum value.
+    /// </summary>
+    public double Maximum { get; }
+
+    /// <summary>
+    /// Gets the amount used for a small increment or decrement.
+    /// </summary>
+    public double SmallChange { get; }
+
+    /// <summary>
+    /// Gets the amount used for a page-sized increment or decrement.
+    /// </summary>
+    public double LargeChange { get; }
+
+    /// <summary>
+    /// Gets whether semantic consumers must treat the range as read-only.
+    /// </summary>
+    public bool IsReadOnly { get; }
+}
+

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
@@ -1,0 +1,815 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using ModernFormsNext.Accessibility;
+
+namespace ModernFormsNext;
+
+public partial class Control
+{
+    public partial class ControlAccessibleObject
+    {
+        private List<ListBoxItemAccessibleObject>? list_box_item_objects;
+        private List<ComboBoxItemAccessibleObject>? combo_box_item_objects;
+        private readonly ConditionalWeakTable<ListViewItem, ListViewItemAccessibleObject> list_view_item_objects = new();
+        private readonly ConditionalWeakTable<TreeViewItem, TreeViewItemAccessibleObject> tree_view_item_objects = new();
+        private readonly ConditionalWeakTable<TabPage, TabItemAccessibleObject> tab_item_objects = new();
+        private readonly ConditionalWeakTable<MenuItem, MenuItemAccessibleObject> menu_item_objects = new();
+
+        /// <inheritdoc/>
+        public override AccessibleObject? GetSelected()
+        {
+            if (Owner is not { IsDisposed: false } owner)
+                return null;
+
+            return owner switch
+            {
+                ListBox listBox when listBox.SelectedIndex >= 0
+                    => GetListBoxItemObjects(listBox).ElementAtOrDefault(listBox.SelectedIndex),
+                ComboBox comboBox when comboBox.SelectedIndex >= 0
+                    => GetComboBoxItemObjects(comboBox).ElementAtOrDefault(comboBox.SelectedIndex),
+                ListView { SelectedItem: { } item } listView
+                    => GetListViewItemObject(listView, item),
+                TreeView treeView when treeView.SelectedItem.Parent is not null
+                    && treeView.SelectedItem.TreeView == treeView
+                    => GetTreeViewItemObject(treeView, treeView.SelectedItem),
+                TabControl { SelectedTabPage: { } page } tabControl
+                    => GetTabItemObject(tabControl, page),
+                MenuBase { SelectedItem: { } item } menu
+                    => GetMenuItemObject(menu, item),
+                _ => base.GetSelected()
+            };
+        }
+
+        private IEnumerable<AccessibleObject> GetLogicalAccessibilityChildren(Control owner)
+        {
+            return owner switch
+            {
+                ListBox listBox => GetListBoxItemObjects(listBox),
+                ComboBox comboBox => GetComboBoxItemObjects(comboBox),
+                ListView listView => listView.Items.Select(item => GetListViewItemObject(listView, item)),
+                TreeView treeView => treeView.Items.Select(item => GetTreeViewItemObject(treeView, item)),
+                TabControl tabControl => tabControl.TabPages.Select(page => GetTabItemObject(tabControl, page)),
+                MenuBase menu => menu.Items.Select(item => GetMenuItemObject(menu, item)),
+                _ => []
+            };
+        }
+
+        private IReadOnlyList<ListBoxItemAccessibleObject> GetListBoxItemObjects(ListBox owner)
+        {
+            list_box_item_objects = SynchronizeOccurrenceItems(
+                list_box_item_objects,
+                owner.Items,
+                item => new ListBoxItemAccessibleObject(this, owner, item));
+
+            return list_box_item_objects;
+        }
+
+        private IReadOnlyList<ComboBoxItemAccessibleObject> GetComboBoxItemObjects(ComboBox owner)
+        {
+            combo_box_item_objects = SynchronizeOccurrenceItems(
+                combo_box_item_objects,
+                owner.Items,
+                item => new ComboBoxItemAccessibleObject(this, owner, item));
+
+            return combo_box_item_objects;
+        }
+
+        private static List<TNode> SynchronizeOccurrenceItems<TNode>(
+            List<TNode>? existing,
+            IReadOnlyList<object> items,
+            Func<object, TNode> create)
+            where TNode : OccurrenceItemAccessibleObject
+        {
+            existing ??= [];
+            var used = new bool[existing.Count];
+            var synchronized = new List<TNode>(items.Count);
+
+            foreach (object item in items)
+            {
+                TNode? matched = null;
+
+                for (int i = 0; i < existing.Count; i++)
+                {
+                    if (!used[i] && existing[i].Represents(item))
+                    {
+                        used[i] = true;
+                        matched = existing[i];
+                        break;
+                    }
+                }
+
+                matched ??= create(item);
+                matched.Attach();
+                synchronized.Add(matched);
+            }
+
+            for (int i = 0; i < existing.Count; i++)
+            {
+                if (!used[i])
+                    existing[i].Detach();
+            }
+
+            return synchronized;
+        }
+
+        private ListViewItemAccessibleObject GetListViewItemObject(ListView owner, ListViewItem item)
+            => list_view_item_objects.GetValue(item, value => new ListViewItemAccessibleObject(this, owner, value));
+
+        private TreeViewItemAccessibleObject GetTreeViewItemObject(TreeView owner, TreeViewItem item)
+            => tree_view_item_objects.GetValue(item, value => new TreeViewItemAccessibleObject(this, owner, value));
+
+        private TabItemAccessibleObject GetTabItemObject(TabControl owner, TabPage page)
+            => tab_item_objects.GetValue(page, value => new TabItemAccessibleObject(this, owner, value));
+
+        private MenuItemAccessibleObject GetMenuItemObject(MenuBase owner, MenuItem item)
+            => menu_item_objects.GetValue(item, value => new MenuItemAccessibleObject(this, owner, value));
+
+        private int IndexOfListBoxItem(ListBoxItemAccessibleObject item, ListBox owner)
+            => GetListBoxItemObjects(owner).IndexOfReference(item);
+
+        private int IndexOfComboBoxItem(ComboBoxItemAccessibleObject item, ComboBox owner)
+            => GetComboBoxItemObjects(owner).IndexOfReference(item);
+
+        private static AccessibleObject? NavigateLogicalObject(AccessibleObject current, AccessibleNavigation direction)
+        {
+            if (direction == AccessibleNavigation.FirstChild)
+                return current.GetChildCount() > 0 ? current.GetChild(0) : null;
+
+            if (direction == AccessibleNavigation.LastChild)
+                return current.GetChildCount() > 0 ? current.GetChild(current.GetChildCount() - 1) : null;
+
+            if (direction is not (AccessibleNavigation.Next or AccessibleNavigation.Previous)
+                || current.Parent is not { } parent)
+            {
+                return null;
+            }
+
+            int offset = direction == AccessibleNavigation.Next ? 1 : -1;
+            for (int i = 0; i < parent.GetChildCount(); i++)
+            {
+                if (!ReferenceEquals(parent.GetChild(i), current))
+                    continue;
+
+                int siblingIndex = i + offset;
+                return siblingIndex >= 0 && siblingIndex < parent.GetChildCount()
+                    ? parent.GetChild(siblingIndex)
+                    : null;
+            }
+
+            return null;
+        }
+
+        private static Rectangle ToScreenBounds(Control owner, Rectangle localBounds)
+        {
+            if (localBounds.Width <= 0 || localBounds.Height <= 0)
+                return Rectangle.Empty;
+
+            Point topLeft = owner.PointToScreen(localBounds.Location);
+            return new Rectangle(topLeft, localBounds.Size);
+        }
+
+        private abstract class LogicalItemAccessibleObject : AccessibleObject
+        {
+            private readonly WeakReference<Control> owner_reference;
+
+            protected LogicalItemAccessibleObject(ControlAccessibleObject root, Control owner)
+            {
+                Root = root;
+                owner_reference = new WeakReference<Control>(owner);
+            }
+
+            protected ControlAccessibleObject Root { get; }
+
+            protected Control? OwnerControl
+                => owner_reference.TryGetTarget(out Control? owner) && !owner.IsDisposed ? owner : null;
+
+            protected bool IsOwnerAvailable
+                => OwnerControl is { Enabled: true, Visible: true };
+
+            public override AccessibilityView View
+                => OwnerControl is { Visible: true } ? AccessibilityView.Control : AccessibilityView.Hidden;
+
+            public override AccessibleObject? Navigate(AccessibleNavigation navdir)
+                => NavigateLogicalObject(this, navdir);
+
+            protected AccessibleStates GetCommonState(bool isAttached, bool isOffscreen)
+            {
+                if (!isAttached || OwnerControl is not { } owner)
+                    return AccessibleStates.Unavailable | AccessibleStates.Invisible | AccessibleStates.Offscreen;
+
+                var state = AccessibleStates.Selectable;
+
+                if (!owner.Enabled)
+                    state |= AccessibleStates.Unavailable;
+
+                if (!owner.Visible)
+                    state |= AccessibleStates.Invisible;
+
+                if (isOffscreen)
+                    state |= AccessibleStates.Offscreen;
+
+                return state;
+            }
+        }
+
+        private abstract class OccurrenceItemAccessibleObject : LogicalItemAccessibleObject
+        {
+            private readonly WeakReference<object> item_reference;
+            private bool attached = true;
+
+            protected OccurrenceItemAccessibleObject(ControlAccessibleObject root, Control owner, object item)
+                : base(root, owner)
+            {
+                item_reference = new WeakReference<object>(item);
+            }
+
+            protected object? Item
+                => item_reference.TryGetTarget(out object? item) ? item : null;
+
+            protected bool IsAttached => attached && Item is not null;
+
+            public bool Represents(object item)
+                => item_reference.TryGetTarget(out object? current) && ReferenceEquals(current, item);
+
+            public void Attach() => attached = true;
+
+            public void Detach() => attached = false;
+
+            public override string? Name
+            {
+                get => Item?.ToString();
+                set { }
+            }
+
+            public override string? Value
+            {
+                get => Item?.ToString();
+                set { }
+            }
+
+            public override AccessibilityView View
+                => IsAttached ? base.View : AccessibilityView.Hidden;
+        }
+
+        private sealed class ListBoxItemAccessibleObject : OccurrenceItemAccessibleObject
+        {
+            private readonly WeakReference<ListBox> owner_reference;
+
+            public ListBoxItemAccessibleObject(ControlAccessibleObject root, ListBox owner, object item)
+                : base(root, owner, item)
+            {
+                owner_reference = new WeakReference<ListBox>(owner);
+            }
+
+            private ListBox? Owner
+                => owner_reference.TryGetTarget(out ListBox? owner) && !owner.IsDisposed ? owner : null;
+
+            private int Index => Owner is { } owner ? Root.IndexOfListBoxItem(this, owner) : -1;
+
+            public override AccessibleObject? Parent => Index >= 0 ? Root : null;
+
+            public override AccessibilityView View
+                => Index >= 0 ? base.View : AccessibilityView.Hidden;
+
+            public override AccessibleRole Role => AccessibleRole.ListItem;
+
+            public override AccessibleControlType ControlType => AccessibleControlType.ListItem;
+
+            public override Rectangle Bounds
+            {
+                get
+                {
+                    if (Owner is not { } owner || Index < 0 || !owner.Visible)
+                        return Rectangle.Empty;
+
+                    return ToScreenBounds(owner, owner.GetItemRectangle(Index));
+                }
+            }
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    if (Owner is not { } owner || Index < 0)
+                        return GetCommonState(isAttached: false, isOffscreen: true);
+
+                    bool offscreen = Bounds.IsEmpty || Index < owner.FirstVisibleIndex;
+                    var state = GetCommonState(IsAttached, offscreen);
+
+                    if (owner.Items.SelectedIndexes.Contains(Index))
+                        state |= AccessibleStates.Selected;
+
+                    if (owner.Focused && owner.Items.FocusedIndex == Index)
+                        state |= AccessibleStates.Focused;
+
+                    return state;
+                }
+            }
+
+            public override AccessibleActions SupportedActions
+                => Index >= 0 ? AccessibleActions.Select | AccessibleActions.ScrollIntoView : AccessibleActions.None;
+
+            public override bool PerformAction(AccessibleActions action, object? parameter = null)
+            {
+                if (parameter is not null || Owner is not { } owner || Index < 0 || !IsOwnerAvailable)
+                    return false;
+
+                if (action == AccessibleActions.Select)
+                {
+                    owner.SelectedIndex = Index;
+                    return true;
+                }
+
+                if (action == AccessibleActions.ScrollIntoView)
+                {
+                    owner.FirstVisibleIndex = Index;
+                    return true;
+                }
+
+                return false;
+            }
+
+            public override void Select(AccessibleSelection flags)
+            {
+                if ((flags & AccessibleSelection.TakeSelection) != 0)
+                    PerformAction(AccessibleActions.Select);
+
+                if ((flags & AccessibleSelection.TakeFocus) != 0)
+                    Owner?.Select();
+            }
+        }
+
+        private sealed class ComboBoxItemAccessibleObject : OccurrenceItemAccessibleObject
+        {
+            private readonly WeakReference<ComboBox> owner_reference;
+
+            public ComboBoxItemAccessibleObject(ControlAccessibleObject root, ComboBox owner, object item)
+                : base(root, owner, item)
+            {
+                owner_reference = new WeakReference<ComboBox>(owner);
+            }
+
+            private ComboBox? Owner
+                => owner_reference.TryGetTarget(out ComboBox? owner) && !owner.IsDisposed ? owner : null;
+
+            private int Index => Owner is { } owner ? Root.IndexOfComboBoxItem(this, owner) : -1;
+
+            public override AccessibleObject? Parent => Index >= 0 ? Root : null;
+
+            public override AccessibilityView View
+                => Index >= 0 ? base.View : AccessibilityView.Hidden;
+
+            public override AccessibleRole Role => AccessibleRole.ListItem;
+
+            public override AccessibleControlType ControlType => AccessibleControlType.ListItem;
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    if (Owner is not { } owner || Index < 0)
+                        return GetCommonState(isAttached: false, isOffscreen: true);
+
+                    var state = GetCommonState(IsAttached, isOffscreen: !owner.DroppedDown);
+                    if (owner.SelectedIndex == Index)
+                        state |= AccessibleStates.Selected;
+
+                    return state;
+                }
+            }
+
+            public override AccessibleActions SupportedActions
+                => Index >= 0 ? AccessibleActions.Select : AccessibleActions.None;
+
+            public override bool PerformAction(AccessibleActions action, object? parameter = null)
+            {
+                if (action != AccessibleActions.Select
+                    || parameter is not null
+                    || Owner is not { } owner
+                    || Index < 0
+                    || !IsOwnerAvailable)
+                {
+                    return false;
+                }
+
+                owner.SelectedIndex = Index;
+                return true;
+            }
+        }
+
+        private sealed class ListViewItemAccessibleObject : LogicalItemAccessibleObject
+        {
+            private readonly WeakReference<ListView> owner_reference;
+            private readonly WeakReference<ListViewItem> item_reference;
+
+            public ListViewItemAccessibleObject(ControlAccessibleObject root, ListView owner, ListViewItem item)
+                : base(root, owner)
+            {
+                owner_reference = new WeakReference<ListView>(owner);
+                item_reference = new WeakReference<ListViewItem>(item);
+            }
+
+            private ListView? Owner
+                => owner_reference.TryGetTarget(out ListView? owner) && !owner.IsDisposed ? owner : null;
+
+            private ListViewItem? Item
+                => item_reference.TryGetTarget(out ListViewItem? item) ? item : null;
+
+            private bool IsAttached => Owner is { } owner && Item is { Parent: { } parent } && ReferenceEquals(owner, parent);
+
+            public override AccessibilityView View
+                => IsAttached ? base.View : AccessibilityView.Hidden;
+
+            public override AccessibleObject? Parent => IsAttached ? Root : null;
+
+            public override string? Name
+            {
+                get => Item?.Text;
+                set { }
+            }
+
+            public override AccessibleRole Role => AccessibleRole.ListItem;
+
+            public override AccessibleControlType ControlType => AccessibleControlType.ListItem;
+
+            public override Rectangle Bounds
+                => IsAttached && Owner is { } owner && Item is { } item
+                    ? ToScreenBounds(owner, item.Bounds)
+                    : Rectangle.Empty;
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    var state = GetCommonState(IsAttached, Bounds.IsEmpty);
+                    if (Item?.Selected == true)
+                        state |= AccessibleStates.Selected;
+
+                    return state;
+                }
+            }
+
+            public override AccessibleActions SupportedActions
+                => IsAttached ? AccessibleActions.Select : AccessibleActions.None;
+
+            public override bool PerformAction(AccessibleActions action, object? parameter = null)
+            {
+                if (action != AccessibleActions.Select
+                    || parameter is not null
+                    || !IsOwnerAvailable
+                    || !IsAttached
+                    || Owner is not { } owner
+                    || Item is not { } item)
+                {
+                    return false;
+                }
+
+                owner.SelectedItem = item;
+                return true;
+            }
+        }
+
+        private sealed class TreeViewItemAccessibleObject : LogicalItemAccessibleObject
+        {
+            private readonly WeakReference<TreeView> owner_reference;
+            private readonly WeakReference<TreeViewItem> item_reference;
+
+            public TreeViewItemAccessibleObject(ControlAccessibleObject root, TreeView owner, TreeViewItem item)
+                : base(root, owner)
+            {
+                owner_reference = new WeakReference<TreeView>(owner);
+                item_reference = new WeakReference<TreeViewItem>(item);
+            }
+
+            private TreeView? Owner
+                => owner_reference.TryGetTarget(out TreeView? owner) && !owner.IsDisposed ? owner : null;
+
+            private TreeViewItem? Item
+                => item_reference.TryGetTarget(out TreeViewItem? item) ? item : null;
+
+            private bool IsAttached => Owner is { } owner && Item?.TreeView == owner;
+
+            public override AccessibilityView View
+                => IsAttached ? base.View : AccessibilityView.Hidden;
+
+            public override AccessibleObject? Parent
+            {
+                get
+                {
+                    if (!IsAttached || Owner is not { } owner || Item is not { } item)
+                        return null;
+
+                    return owner.Items.Contains(item) || item.Parent is null
+                        ? Root
+                        : Root.GetTreeViewItemObject(owner, item.Parent);
+                }
+            }
+
+            public override string? Name
+            {
+                get => Item?.Text;
+                set { }
+            }
+
+            public override AccessibleRole Role => AccessibleRole.OutlineItem;
+
+            public override AccessibleControlType ControlType => AccessibleControlType.TreeItem;
+
+            public override Rectangle Bounds
+                => IsAttached && Owner is { } owner && Item is { } item && owner.GetVisibleItems().Contains(item)
+                    ? ToScreenBounds(owner, item.Bounds)
+                    : Rectangle.Empty;
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    var state = GetCommonState(IsAttached, Bounds.IsEmpty);
+
+                    if (Owner is { } owner && Item is { } item && ReferenceEquals(owner.SelectedItem, item))
+                        state |= AccessibleStates.Selected;
+
+                    if (Item is { HasChildren: true } branch)
+                        state |= branch.Expanded ? AccessibleStates.Expanded : AccessibleStates.Collapsed;
+
+                    return state;
+                }
+            }
+
+            public override AccessibleActions SupportedActions
+            {
+                get
+                {
+                    if (!IsAttached)
+                        return AccessibleActions.None;
+
+                    var actions = AccessibleActions.Select | AccessibleActions.ScrollIntoView;
+                    if (Item is { HasChildren: true })
+                        actions |= AccessibleActions.Expand | AccessibleActions.Collapse;
+
+                    return actions;
+                }
+            }
+
+            public override int GetChildCount()
+                => IsAttached && Item is { } item ? item.Items.Count : 0;
+
+            public override AccessibleObject? GetChild(int index)
+            {
+                if (!IsAttached || Owner is not { } owner || Item is not { } item || index < 0 || index >= item.Items.Count)
+                    return null;
+
+                return Root.GetTreeViewItemObject(owner, item.Items[index]);
+            }
+
+            public override bool PerformAction(AccessibleActions action, object? parameter = null)
+            {
+                if (parameter is not null
+                    || !IsOwnerAvailable
+                    || !IsAttached
+                    || Owner is not { } owner
+                    || Item is not { } item)
+                {
+                    return false;
+                }
+
+                switch (action)
+                {
+                    case AccessibleActions.Select:
+                        owner.SelectedItem = item;
+                        return true;
+                    case AccessibleActions.Expand when item.HasChildren:
+                        item.Expand();
+                        NotifyClients(AccessibleEvents.StateChange);
+                        return true;
+                    case AccessibleActions.Collapse when item.HasChildren:
+                        item.Collapse();
+                        NotifyClients(AccessibleEvents.StateChange);
+                        return true;
+                    case AccessibleActions.ScrollIntoView:
+                        item.EnsureVisible();
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        private sealed class TabItemAccessibleObject : LogicalItemAccessibleObject
+        {
+            private readonly WeakReference<TabControl> owner_reference;
+            private readonly WeakReference<TabPage> page_reference;
+
+            public TabItemAccessibleObject(ControlAccessibleObject root, TabControl owner, TabPage page)
+                : base(root, owner)
+            {
+                owner_reference = new WeakReference<TabControl>(owner);
+                page_reference = new WeakReference<TabPage>(page);
+            }
+
+            private TabControl? Owner
+                => owner_reference.TryGetTarget(out TabControl? owner) && !owner.IsDisposed ? owner : null;
+
+            private TabPage? Page
+                => page_reference.TryGetTarget(out TabPage? page) ? page : null;
+
+            private bool IsAttached => Owner is { } owner && Page is { } page && owner.TabPages.Contains(page);
+
+            public override AccessibilityView View
+                => IsAttached ? base.View : AccessibilityView.Hidden;
+
+            public override AccessibleObject? Parent => IsAttached ? Root : null;
+
+            public override string? Name
+            {
+                get => Page?.Text;
+                set { }
+            }
+
+            public override AccessibleRole Role => AccessibleRole.PageTab;
+
+            public override AccessibleControlType ControlType => AccessibleControlType.TabItem;
+
+            public override Rectangle Bounds
+                => IsAttached && Owner is { } owner && Page is { } page
+                    ? ToScreenBounds(owner, page.TabStripItem.Bounds)
+                    : Rectangle.Empty;
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    var state = GetCommonState(IsAttached, Bounds.IsEmpty);
+                    if (Owner is { } owner && Page is { } page && ReferenceEquals(owner.SelectedTabPage, page))
+                        state |= AccessibleStates.Selected;
+
+                    return state;
+                }
+            }
+
+            public override AccessibleActions SupportedActions
+                => IsAttached ? AccessibleActions.Select : AccessibleActions.None;
+
+            public override bool PerformAction(AccessibleActions action, object? parameter = null)
+            {
+                if (action != AccessibleActions.Select
+                    || parameter is not null
+                    || !IsOwnerAvailable
+                    || !IsAttached
+                    || Owner is not { } owner
+                    || Page is not { } page)
+                {
+                    return false;
+                }
+
+                owner.SelectedTabPage = page;
+                return true;
+            }
+        }
+
+        private sealed class MenuItemAccessibleObject : LogicalItemAccessibleObject
+        {
+            private readonly WeakReference<MenuBase> owner_reference;
+            private readonly WeakReference<MenuItem> item_reference;
+
+            public MenuItemAccessibleObject(ControlAccessibleObject root, MenuBase owner, MenuItem item)
+                : base(root, owner)
+            {
+                owner_reference = new WeakReference<MenuBase>(owner);
+                item_reference = new WeakReference<MenuItem>(item);
+            }
+
+            private MenuBase? Owner
+                => owner_reference.TryGetTarget(out MenuBase? owner) && !owner.IsDisposed ? owner : null;
+
+            private MenuItem? Item
+                => item_reference.TryGetTarget(out MenuItem? item) ? item : null;
+
+            private bool IsAttached => Owner is { } owner && Item?.GetTopMenu() == owner;
+
+            public override AccessibilityView View
+                => IsAttached ? base.View : AccessibilityView.Hidden;
+
+            public override AccessibleObject? Parent
+            {
+                get
+                {
+                    if (!IsAttached || Owner is not { } owner || Item is not { } item)
+                        return null;
+
+                    return owner.Items.Contains(item) || item.Parent is null
+                        ? Root
+                        : Root.GetMenuItemObject(owner, item.Parent);
+                }
+            }
+
+            public override string? Name
+            {
+                get => Item?.Text;
+                set { }
+            }
+
+            public override AccessibleRole Role
+                => Item is MenuSeparatorItem ? AccessibleRole.Separator : AccessibleRole.MenuItem;
+
+            public override AccessibleControlType ControlType
+                => Item is MenuSeparatorItem ? AccessibleControlType.Separator : AccessibleControlType.MenuItem;
+
+            public override Rectangle Bounds
+                => IsAttached && Item is { AccessibilityOwnerControl: { } owner } item
+                    ? ToScreenBounds(owner, item.Bounds)
+                    : Rectangle.Empty;
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    var state = GetCommonState(IsAttached, Bounds.IsEmpty);
+                    if (Item is not { } item)
+                        return state;
+
+                    if (!item.Enabled)
+                        state |= AccessibleStates.Unavailable;
+                    if (item.Checked)
+                        state |= AccessibleStates.Checked;
+                    if (item.Selected)
+                        state |= AccessibleStates.Selected;
+                    if (item.HasItems)
+                        state |= item.IsDropDownOpened ? AccessibleStates.Expanded : AccessibleStates.Collapsed;
+
+                    return state;
+                }
+            }
+
+            public override AccessibleActions SupportedActions
+                => Item switch
+                {
+                    _ when !IsAttached => AccessibleActions.None,
+                    MenuSeparatorItem => AccessibleActions.None,
+                    { HasItems: true } => AccessibleActions.Expand | AccessibleActions.Collapse,
+                    not null => AccessibleActions.Invoke,
+                    _ => AccessibleActions.None
+                };
+
+            public override int GetChildCount()
+                => IsAttached && Item is { } item ? item.Items.Count : 0;
+
+            public override AccessibleObject? GetChild(int index)
+            {
+                if (!IsAttached || Owner is not { } owner || Item is not { } item || index < 0 || index >= item.Items.Count)
+                    return null;
+
+                return Root.GetMenuItemObject(owner, item.Items[index]);
+            }
+
+            public override bool PerformAction(AccessibleActions action, object? parameter = null)
+            {
+                if (parameter is not null
+                    || !IsOwnerAvailable
+                    || !IsAttached
+                    || Item is not { Enabled: true } item)
+                {
+                    return false;
+                }
+
+                switch (action)
+                {
+                    case AccessibleActions.Invoke when !item.HasItems:
+                        item.OnClick(CreateAccessibilityClick());
+                        return true;
+                    case AccessibleActions.Expand when item.HasItems:
+                        if (item.AccessibilityOwnerControl?.FindForm() is null)
+                            return false;
+
+                        item.ShowDropDown();
+                        NotifyClients(AccessibleEvents.StateChange);
+                        return true;
+                    case AccessibleActions.Collapse when item.HasItems:
+                        item.HideDropDown();
+                        NotifyClients(AccessibleEvents.StateChange);
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+    }
+}
+
+internal static class AccessibleObjectListExtensions
+{
+    public static int IndexOfReference<T>(this IReadOnlyList<T> items, T item)
+        where T : class
+    {
+        for (int i = 0; i < items.Count; i++)
+        {
+            if (ReferenceEquals(items[i], item))
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
@@ -62,7 +62,8 @@ public partial class Control
             list_box_item_objects = SynchronizeOccurrenceItems(
                 list_box_item_objects,
                 owner.Items,
-                item => new ListBoxItemAccessibleObject(this, owner, item));
+                owner.Items.GetAccessibilityIdentity,
+                (item, identity) => new ListBoxItemAccessibleObject(this, owner, item, identity));
 
             return list_box_item_objects;
         }
@@ -72,7 +73,8 @@ public partial class Control
             combo_box_item_objects = SynchronizeOccurrenceItems(
                 combo_box_item_objects,
                 owner.Items,
-                item => new ComboBoxItemAccessibleObject(this, owner, item));
+                owner.Items.GetAccessibilityIdentity,
+                (item, identity) => new ComboBoxItemAccessibleObject(this, owner, item, identity));
 
             return combo_box_item_objects;
         }
@@ -80,7 +82,8 @@ public partial class Control
         private static List<TNode> SynchronizeOccurrenceItems<TNode>(
             List<TNode>? existing,
             IReadOnlyList<object> items,
-            Func<object, TNode> create)
+            Func<int, object> getIdentity,
+            Func<object, object, TNode> create)
             where TNode : OccurrenceItemAccessibleObject
         {
             existing ??= [];
@@ -90,11 +93,12 @@ public partial class Control
             for (int itemIndex = 0; itemIndex < items.Count; itemIndex++)
             {
                 object item = items[itemIndex];
+                object identity = getIdentity(itemIndex);
                 TNode? matched = null;
 
                 for (int i = 0; i < existing.Count; i++)
                 {
-                    if (!used[i] && existing[i].Represents(item))
+                    if (!used[i] && existing[i].Represents(identity))
                     {
                         used[i] = true;
                         matched = existing[i];
@@ -102,7 +106,7 @@ public partial class Control
                     }
                 }
 
-                matched ??= create(item);
+                matched ??= create(item, identity);
                 matched.Attach(itemIndex);
                 synchronized.Add(matched);
             }
@@ -163,7 +167,14 @@ public partial class Control
                 return Rectangle.Empty;
 
             Point topLeft = owner.PointToScreen(localBounds.Location);
-            return new Rectangle(topLeft, localBounds.Size);
+            Point topRight = owner.PointToScreen(new Point(localBounds.Right, localBounds.Top));
+            Point bottomLeft = owner.PointToScreen(new Point(localBounds.Left, localBounds.Bottom));
+            Point bottomRight = owner.PointToScreen(new Point(localBounds.Right, localBounds.Bottom));
+            int left = Math.Min(Math.Min(topLeft.X, topRight.X), Math.Min(bottomLeft.X, bottomRight.X));
+            int top = Math.Min(Math.Min(topLeft.Y, topRight.Y), Math.Min(bottomLeft.Y, bottomRight.Y));
+            int right = Math.Max(Math.Max(topLeft.X, topRight.X), Math.Max(bottomLeft.X, bottomRight.X));
+            int bottom = Math.Max(Math.Max(topLeft.Y, topRight.Y), Math.Max(bottomLeft.Y, bottomRight.Y));
+            return Rectangle.FromLTRB(left, top, right, bottom);
         }
 
         private abstract class LogicalItemAccessibleObject : AccessibleObject
@@ -182,10 +193,13 @@ public partial class Control
                 => owner_reference.TryGetTarget(out Control? owner) && !owner.IsDisposed ? owner : null;
 
             protected bool IsOwnerAvailable
-                => OwnerControl is { Enabled: true, Visible: true };
+                => Root.View != AccessibilityView.Hidden
+                    && OwnerControl is { Enabled: true, Visible: true };
 
             public override AccessibilityView View
-                => OwnerControl is { Visible: true } ? AccessibilityView.Control : AccessibilityView.Hidden;
+                => Root.View != AccessibilityView.Hidden && OwnerControl is { Visible: true }
+                    ? AccessibilityView.Control
+                    : AccessibilityView.Hidden;
 
             public override AccessibleObject? Navigate(AccessibleNavigation navdir)
                 => NavigateLogicalObject(this, navdir);
@@ -213,13 +227,19 @@ public partial class Control
         private abstract class OccurrenceItemAccessibleObject : LogicalItemAccessibleObject
         {
             private readonly WeakReference<object> item_reference;
+            private readonly object occurrence_identity;
             private bool attached = true;
             private int current_index;
 
-            protected OccurrenceItemAccessibleObject(ControlAccessibleObject root, Control owner, object item)
+            protected OccurrenceItemAccessibleObject(
+                ControlAccessibleObject root,
+                Control owner,
+                object item,
+                object occurrenceIdentity)
                 : base(root, owner)
             {
                 item_reference = new WeakReference<object>(item);
+                occurrence_identity = occurrenceIdentity;
             }
 
             protected object? Item
@@ -229,8 +249,8 @@ public partial class Control
 
             protected int CurrentIndex => IsAttached ? current_index : -1;
 
-            public bool Represents(object item)
-                => item_reference.TryGetTarget(out object? current) && ReferenceEquals(current, item);
+            public bool Represents(object identity)
+                => ReferenceEquals(occurrence_identity, identity);
 
             public void Attach(int index)
             {
@@ -264,8 +284,12 @@ public partial class Control
         {
             private readonly WeakReference<ListBox> owner_reference;
 
-            public ListBoxItemAccessibleObject(ControlAccessibleObject root, ListBox owner, object item)
-                : base(root, owner, item)
+            public ListBoxItemAccessibleObject(
+                ControlAccessibleObject root,
+                ListBox owner,
+                object item,
+                object occurrenceIdentity)
+                : base(root, owner, item, occurrenceIdentity)
             {
                 owner_reference = new WeakReference<ListBox>(owner);
             }
@@ -305,6 +329,9 @@ public partial class Control
                     bool offscreen = Bounds.IsEmpty || Index < owner.FirstVisibleIndex;
                     var state = GetCommonState(IsAttached, offscreen);
 
+                    if (owner.SelectionMode == SelectionMode.None)
+                        state &= ~AccessibleStates.Selectable;
+
                     if (owner.Items.SelectedIndexes.Contains(Index))
                         state |= AccessibleStates.Selected;
 
@@ -316,12 +343,30 @@ public partial class Control
             }
 
             public override AccessibleActions SupportedActions
-                => Index >= 0 ? AccessibleActions.Select | AccessibleActions.ScrollIntoView : AccessibleActions.None;
+            {
+                get
+                {
+                    if (Index < 0 || !IsOwnerAvailable || Owner is not { } owner)
+                        return AccessibleActions.None;
+
+                    var actions = AccessibleActions.ScrollIntoView;
+                    if (owner.SelectionMode != SelectionMode.None)
+                        actions |= AccessibleActions.Select;
+
+                    return actions;
+                }
+            }
 
             public override bool PerformAction(AccessibleActions action, object? parameter = null)
             {
-                if (parameter is not null || Owner is not { } owner || Index < 0 || !IsOwnerAvailable)
+                if (!IsSingleAction(action)
+                    || (SupportedActions & action) == 0
+                    || parameter is not null
+                    || Owner is not { } owner
+                    || Index < 0)
+                {
                     return false;
+                }
 
                 if (action == AccessibleActions.Select)
                 {
@@ -352,8 +397,12 @@ public partial class Control
         {
             private readonly WeakReference<ComboBox> owner_reference;
 
-            public ComboBoxItemAccessibleObject(ControlAccessibleObject root, ComboBox owner, object item)
-                : base(root, owner, item)
+            public ComboBoxItemAccessibleObject(
+                ControlAccessibleObject root,
+                ComboBox owner,
+                object item,
+                object occurrenceIdentity)
+                : base(root, owner, item, occurrenceIdentity)
             {
                 owner_reference = new WeakReference<ComboBox>(owner);
             }
@@ -388,15 +437,16 @@ public partial class Control
             }
 
             public override AccessibleActions SupportedActions
-                => Index >= 0 ? AccessibleActions.Select : AccessibleActions.None;
+                => Index >= 0 && IsOwnerAvailable ? AccessibleActions.Select : AccessibleActions.None;
 
             public override bool PerformAction(AccessibleActions action, object? parameter = null)
             {
-                if (action != AccessibleActions.Select
+                if (!IsSingleAction(action)
+                    || (SupportedActions & action) == 0
+                    || action != AccessibleActions.Select
                     || parameter is not null
                     || Owner is not { } owner
-                    || Index < 0
-                    || !IsOwnerAvailable)
+                    || Index < 0)
                 {
                     return false;
                 }
@@ -459,13 +509,14 @@ public partial class Control
             }
 
             public override AccessibleActions SupportedActions
-                => IsAttached ? AccessibleActions.Select : AccessibleActions.None;
+                => IsAttached && IsOwnerAvailable ? AccessibleActions.Select : AccessibleActions.None;
 
             public override bool PerformAction(AccessibleActions action, object? parameter = null)
             {
-                if (action != AccessibleActions.Select
+                if (!IsSingleAction(action)
+                    || (SupportedActions & action) == 0
+                    || action != AccessibleActions.Select
                     || parameter is not null
-                    || !IsOwnerAvailable
                     || !IsAttached
                     || Owner is not { } owner
                     || Item is not { } item)
@@ -549,7 +600,7 @@ public partial class Control
             {
                 get
                 {
-                    if (!IsAttached)
+                    if (!IsAttached || !IsOwnerAvailable)
                         return AccessibleActions.None;
 
                     var actions = AccessibleActions.Select | AccessibleActions.ScrollIntoView;
@@ -573,8 +624,9 @@ public partial class Control
 
             public override bool PerformAction(AccessibleActions action, object? parameter = null)
             {
-                if (parameter is not null
-                    || !IsOwnerAvailable
+                if (!IsSingleAction(action)
+                    || (SupportedActions & action) == 0
+                    || parameter is not null
                     || !IsAttached
                     || Owner is not { } owner
                     || Item is not { } item)
@@ -657,13 +709,14 @@ public partial class Control
             }
 
             public override AccessibleActions SupportedActions
-                => IsAttached ? AccessibleActions.Select : AccessibleActions.None;
+                => IsAttached && IsOwnerAvailable ? AccessibleActions.Select : AccessibleActions.None;
 
             public override bool PerformAction(AccessibleActions action, object? parameter = null)
             {
-                if (action != AccessibleActions.Select
+                if (!IsSingleAction(action)
+                    || (SupportedActions & action) == 0
+                    || action != AccessibleActions.Select
                     || parameter is not null
-                    || !IsOwnerAvailable
                     || !IsAttached
                     || Owner is not { } owner
                     || Page is not { } page)
@@ -751,14 +804,26 @@ public partial class Control
             }
 
             public override AccessibleActions SupportedActions
-                => Item switch
+            {
+                get
                 {
-                    _ when !IsAttached => AccessibleActions.None,
-                    MenuSeparatorItem => AccessibleActions.None,
-                    { HasItems: true } => AccessibleActions.Expand | AccessibleActions.Collapse,
-                    not null => AccessibleActions.Invoke,
-                    _ => AccessibleActions.None
-                };
+                    if (!IsAttached || !IsOwnerAvailable || Item is not { Enabled: true } item)
+                        return AccessibleActions.None;
+
+                    if (item is MenuSeparatorItem)
+                        return AccessibleActions.None;
+
+                    if (!item.HasItems)
+                        return AccessibleActions.Invoke;
+
+                    if (item.IsDropDownOpened)
+                        return AccessibleActions.Collapse;
+
+                    return item.AccessibilityOwnerControl?.FindForm() is not null
+                        ? AccessibleActions.Expand
+                        : AccessibleActions.None;
+                }
+            }
 
             public override int GetChildCount()
                 => IsAttached && Item is { } item ? item.Items.Count : 0;
@@ -773,8 +838,9 @@ public partial class Control
 
             public override bool PerformAction(AccessibleActions action, object? parameter = null)
             {
-                if (parameter is not null
-                    || !IsOwnerAvailable
+                if (!IsSingleAction(action)
+                    || (SupportedActions & action) == 0
+                    || parameter is not null
                     || !IsAttached
                     || Item is not { Enabled: true } item)
                 {
@@ -792,10 +858,12 @@ public partial class Control
 
                         item.ShowDropDown();
                         NotifyClients(AccessibleEvents.StateChange);
+                        item.AccessibilityOwnerControl?.NotifyAccessibilityClients(AccessibleEvents.StateChange);
                         return true;
                     case AccessibleActions.Collapse when item.HasItems:
                         item.HideDropDown();
                         NotifyClients(AccessibleEvents.StateChange);
+                        item.AccessibilityOwnerControl?.NotifyAccessibilityClients(AccessibleEvents.StateChange);
                         return true;
                     default:
                         return false;

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
@@ -87,8 +87,9 @@ public partial class Control
             var used = new bool[existing.Count];
             var synchronized = new List<TNode>(items.Count);
 
-            foreach (object item in items)
+            for (int itemIndex = 0; itemIndex < items.Count; itemIndex++)
             {
+                object item = items[itemIndex];
                 TNode? matched = null;
 
                 for (int i = 0; i < existing.Count; i++)
@@ -102,7 +103,7 @@ public partial class Control
                 }
 
                 matched ??= create(item);
-                matched.Attach();
+                matched.Attach(itemIndex);
                 synchronized.Add(matched);
             }
 
@@ -126,12 +127,6 @@ public partial class Control
 
         private MenuItemAccessibleObject GetMenuItemObject(MenuBase owner, MenuItem item)
             => menu_item_objects.GetValue(item, value => new MenuItemAccessibleObject(this, owner, value));
-
-        private int IndexOfListBoxItem(ListBoxItemAccessibleObject item, ListBox owner)
-            => GetListBoxItemObjects(owner).IndexOfReference(item);
-
-        private int IndexOfComboBoxItem(ComboBoxItemAccessibleObject item, ComboBox owner)
-            => GetComboBoxItemObjects(owner).IndexOfReference(item);
 
         private static AccessibleObject? NavigateLogicalObject(AccessibleObject current, AccessibleNavigation direction)
         {
@@ -219,6 +214,7 @@ public partial class Control
         {
             private readonly WeakReference<object> item_reference;
             private bool attached = true;
+            private int current_index;
 
             protected OccurrenceItemAccessibleObject(ControlAccessibleObject root, Control owner, object item)
                 : base(root, owner)
@@ -231,12 +227,22 @@ public partial class Control
 
             protected bool IsAttached => attached && Item is not null;
 
+            protected int CurrentIndex => IsAttached ? current_index : -1;
+
             public bool Represents(object item)
                 => item_reference.TryGetTarget(out object? current) && ReferenceEquals(current, item);
 
-            public void Attach() => attached = true;
+            public void Attach(int index)
+            {
+                attached = true;
+                current_index = index;
+            }
 
-            public void Detach() => attached = false;
+            public void Detach()
+            {
+                attached = false;
+                current_index = -1;
+            }
 
             public override string? Name
             {
@@ -267,7 +273,7 @@ public partial class Control
             private ListBox? Owner
                 => owner_reference.TryGetTarget(out ListBox? owner) && !owner.IsDisposed ? owner : null;
 
-            private int Index => Owner is { } owner ? Root.IndexOfListBoxItem(this, owner) : -1;
+            private int Index => Owner is not null ? CurrentIndex : -1;
 
             public override AccessibleObject? Parent => Index >= 0 ? Root : null;
 
@@ -355,7 +361,7 @@ public partial class Control
             private ComboBox? Owner
                 => owner_reference.TryGetTarget(out ComboBox? owner) && !owner.IsDisposed ? owner : null;
 
-            private int Index => Owner is { } owner ? Root.IndexOfComboBoxItem(this, owner) : -1;
+            private int Index => Owner is not null ? CurrentIndex : -1;
 
             public override AccessibleObject? Parent => Index >= 0 ? Root : null;
 
@@ -796,20 +802,5 @@ public partial class Control
                 }
             }
         }
-    }
-}
-
-internal static class AccessibleObjectListExtensions
-{
-    public static int IndexOfReference<T>(this IReadOnlyList<T> items, T item)
-        where T : class
-    {
-        for (int i = 0; i < items.Count; i++)
-        {
-            if (ReferenceEquals(items[i], item))
-                return i;
-        }
-
-        return -1;
     }
 }

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
@@ -218,8 +218,13 @@ public partial class Control
         {
             get
             {
-                if (Owner is not { IsDisposed: false } owner)
+                if (Owner is not { IsDisposed: false } owner
+                    || !owner.Enabled
+                    || !owner.Visible
+                    || owner.AccessibilityView == AccessibilityView.Hidden)
+                {
                     return AccessibleActions.None;
+                }
 
                 var actions = owner.CanSelect ? AccessibleActions.Focus : AccessibleActions.None;
 
@@ -228,9 +233,10 @@ public partial class Control
                     Button => AccessibleActions.Invoke,
                     CheckBox { AutoCheck: true } => AccessibleActions.Toggle,
                     RadioButton { AutoCheck: true } => AccessibleActions.Select,
-                    Switch => AccessibleActions.Toggle,
+                    Switch { AutoToggle: true } => AccessibleActions.Toggle,
                     TextBox { ReadOnly: false } => AccessibleActions.SetValue,
-                    ComboBox => AccessibleActions.Expand | AccessibleActions.Collapse,
+                    ComboBox { DroppedDown: true } => AccessibleActions.Collapse,
+                    ComboBox comboBox when comboBox.FindForm() is not null => AccessibleActions.Expand,
                     TrackBar => AccessibleActions.SetValue | AccessibleActions.Increment | AccessibleActions.Decrement,
                     _ => AccessibleActions.None
                 };
@@ -457,11 +463,15 @@ public partial class Control
                     return true;
 
                 case AccessibleActions.Increment when owner is TrackBar trackBar:
-                    trackBar.Value = Math.Min(trackBar.Maximum, trackBar.Value + trackBar.SmallChange);
+                    trackBar.Value = (int)Math.Min(
+                        trackBar.Maximum,
+                        (long)trackBar.Value + trackBar.SmallChange);
                     return true;
 
                 case AccessibleActions.Decrement when owner is TrackBar trackBar:
-                    trackBar.Value = Math.Max(trackBar.Minimum, trackBar.Value - trackBar.SmallChange);
+                    trackBar.Value = (int)Math.Max(
+                        trackBar.Minimum,
+                        (long)trackBar.Value - trackBar.SmallChange);
                     return true;
 
                 case AccessibleActions.Focus:
@@ -521,6 +531,7 @@ public partial class Control
         private static AccessibleRole GetDefaultRole(Control? owner)
             => owner switch
             {
+                ControlAdapter { ParentForm: Form { IsAccessibilityDialog: true } } => AccessibleRole.Dialog,
                 ControlAdapter => AccessibleRole.Window,
                 Button => AccessibleRole.PushButton,
                 CheckBox => AccessibleRole.CheckButton,
@@ -554,6 +565,7 @@ public partial class Control
         private static AccessibleControlType GetDefaultControlType(Control? owner)
             => owner switch
             {
+                ControlAdapter { ParentForm: Form { IsAccessibilityDialog: true } } => AccessibleControlType.Dialog,
                 ControlAdapter => AccessibleControlType.Window,
                 Button => AccessibleControlType.Button,
                 CheckBox => AccessibleControlType.CheckBox,

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
@@ -17,7 +17,7 @@ public partial class Control
     /// not create native handles or COM providers; platform backends can adapt this object to
     /// their native accessibility systems.
     /// </remarks>
-    public class ControlAccessibleObject : AccessibleObject
+    public partial class ControlAccessibleObject : AccessibleObject
     {
         private readonly WeakReference<Control> _owner;
 
@@ -302,6 +302,9 @@ public partial class Control
             if (Owner is not { IsDisposed: false } owner)
                 yield break;
 
+            foreach (AccessibleObject logicalChild in GetLogicalAccessibilityChildren(owner))
+                yield return logicalChild;
+
             foreach (Control child in owner.Controls)
                 yield return child.AccessibilityObject;
         }
@@ -425,6 +428,9 @@ public partial class Control
                     return true;
 
                 case AccessibleActions.Expand when owner is ComboBox comboBox:
+                    if (comboBox.FindForm() is null)
+                        return false;
+
                     comboBox.DroppedDown = true;
                     return true;
 

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
+using System.Linq;
 using ModernFormsNext.Accessibility;
 
 namespace ModernFormsNext;
@@ -34,7 +36,7 @@ public partial class Control
         {
             get
             {
-                if (Owner is not { } owner || !owner.Visible)
+                if (Owner is not { } owner || owner.IsDisposed || !owner.Visible)
                     return Rectangle.Empty;
 
                 // Transform all corners. Two diagonal corners are insufficient after rotation or
@@ -60,6 +62,35 @@ public partial class Control
                     return base.DefaultAction;
 
                 return owner.AccessibleDefaultActionDescription ?? GetDefaultAction(owner) ?? base.DefaultAction;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string? AutomationId
+        {
+            get
+            {
+                if (Owner is not { } owner)
+                    return base.AutomationId;
+
+                return owner.AccessibleAutomationId ?? owner.Name;
+            }
+            set
+            {
+                if (Owner is { } owner)
+                    owner.AccessibleAutomationId = value;
+                else
+                    base.AutomationId = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override AccessibleControlType ControlType
+        {
+            get
+            {
+                var controlType = Owner?.AccessibleControlType ?? AccessibleControlType.Default;
+                return controlType == AccessibleControlType.Default ? GetDefaultControlType(Owner) : controlType;
             }
         }
 
@@ -108,7 +139,16 @@ public partial class Control
         public Control? Owner => _owner.TryGetTarget(out Control? owner) ? owner : null;
 
         /// <inheritdoc/>
-        public override AccessibleObject? Parent => Owner?.Parent?.AccessibilityObject;
+        public override AccessibleObject? Parent
+        {
+            get
+            {
+                if (Owner is not { IsDisposed: false } owner)
+                    return null;
+
+                return owner.Parent?.AccessibilityObject;
+            }
+        }
 
         /// <inheritdoc/>
         public override AccessibleRole Role
@@ -125,8 +165,8 @@ public partial class Control
         {
             get
             {
-                if (Owner is not { } owner)
-                    return AccessibleStates.Unavailable;
+                if (Owner is not { } owner || owner.IsDisposed)
+                    return AccessibleStates.Unavailable | AccessibleStates.Invisible | AccessibleStates.Offscreen;
 
                 var state = AccessibleStates.None;
 
@@ -134,7 +174,7 @@ public partial class Control
                     state |= AccessibleStates.Unavailable;
 
                 if (!owner.Visible)
-                    state |= AccessibleStates.Invisible;
+                    state |= AccessibleStates.Invisible | AccessibleStates.Offscreen;
 
                 if (owner.Focused)
                     state |= AccessibleStates.Focused;
@@ -145,6 +185,70 @@ public partial class Control
                 state |= GetDefaultState(owner);
 
                 return state;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override bool IsSensitive
+            => Owner is TextBox { PasswordCharacter: not null };
+
+        /// <inheritdoc/>
+        public override AccessibleRangeValue? RangeValue
+            => Owner switch
+            {
+                TrackBar trackBar => new AccessibleRangeValue(
+                    trackBar.Value,
+                    trackBar.Minimum,
+                    trackBar.Maximum,
+                    trackBar.SmallChange,
+                    trackBar.LargeChange,
+                    isReadOnly: false),
+                ProgressBar progressBar => new AccessibleRangeValue(
+                    progressBar.Value,
+                    progressBar.Minimum,
+                    progressBar.Maximum,
+                    progressBar.Step,
+                    progressBar.Step,
+                    isReadOnly: true),
+                _ => null
+            };
+
+        /// <inheritdoc/>
+        public override AccessibleActions SupportedActions
+        {
+            get
+            {
+                if (Owner is not { IsDisposed: false } owner)
+                    return AccessibleActions.None;
+
+                var actions = owner.CanSelect ? AccessibleActions.Focus : AccessibleActions.None;
+
+                actions |= owner switch
+                {
+                    Button => AccessibleActions.Invoke,
+                    CheckBox { AutoCheck: true } => AccessibleActions.Toggle,
+                    RadioButton { AutoCheck: true } => AccessibleActions.Select,
+                    Switch => AccessibleActions.Toggle,
+                    TextBox { ReadOnly: false } => AccessibleActions.SetValue,
+                    ComboBox => AccessibleActions.Expand | AccessibleActions.Collapse,
+                    TrackBar => AccessibleActions.SetValue | AccessibleActions.Increment | AccessibleActions.Decrement,
+                    _ => AccessibleActions.None
+                };
+
+                return actions;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override AccessibilityView View
+        {
+            get
+            {
+                if (Owner is not { IsDisposed: false } owner || !owner.Visible)
+                    return AccessibilityView.Hidden;
+
+                var view = owner.AccessibilityView;
+                return view == AccessibilityView.Default ? GetDefaultAccessibilityView(owner) : view;
             }
         }
 
@@ -170,14 +274,37 @@ public partial class Control
         /// <inheritdoc/>
         public override AccessibleObject? GetChild(int index)
         {
-            if (Owner is not { } owner || index < 0 || index >= owner.Controls.Count)
+            if (index < 0)
                 return null;
 
-            return owner.Controls[index].AccessibilityObject;
+            return EnumerateActiveChildren().ElementAtOrDefault(index);
         }
 
         /// <inheritdoc/>
-        public override int GetChildCount() => Owner?.Controls.Count ?? 0;
+        public override int GetChildCount() => EnumerateActiveChildren().Count();
+
+        /// <summary>
+        /// Enumerates the control and logical objects that are candidates for this object's child
+        /// sequence before visibility and view filtering is applied.
+        /// </summary>
+        /// <returns>
+        /// An on-demand sequence of accessible children. The default implementation returns the
+        /// represented control's explicit visual children.
+        /// </returns>
+        /// <remarks>
+        /// Override this method to insert logical children for custom-rendered or composite
+        /// controls. Logical children do not need to derive from <see cref="Control"/>. Return the
+        /// same child object while its logical item remains alive so <see cref="AccessibleObject.RuntimeId"/>
+        /// is stable. Do not cache a strong owner reference when a weak reference is sufficient.
+        /// </remarks>
+        protected virtual IEnumerable<AccessibleObject> GetAccessibilityChildren()
+        {
+            if (Owner is not { IsDisposed: false } owner)
+                yield break;
+
+            foreach (Control child in owner.Controls)
+                yield return child.AccessibilityObject;
+        }
 
         /// <inheritdoc/>
         public override AccessibleObject? GetFocused()
@@ -185,10 +312,13 @@ public partial class Control
             if (Owner is not { } owner)
                 return null;
 
-            foreach (var child in owner.Controls.GetAllControls(true))
+            foreach (AccessibleObject child in EnumerateActiveChildren())
             {
-                if (child.Focused)
-                    return child.AccessibilityObject;
+                if ((child.State & AccessibleStates.Focused) != 0)
+                    return child;
+
+                if (child.GetFocused() is { } focused)
+                    return focused;
             }
 
             return owner.Focused ? this : null;
@@ -216,11 +346,11 @@ public partial class Control
                 return null;
 
             // Accessibility hit testing follows the same front-to-back contract as pointer
-            // dispatch: the last collection index is the first eligible overlapping child.
-            for (int i = owner.Controls.Count - 1; i >= 0; i--)
+            // dispatch: the last child is the first eligible overlapping object.
+            AccessibleObject[] children = EnumerateActiveChildren().ToArray();
+            for (int i = children.Length - 1; i >= 0; i--)
             {
-                var child = owner.Controls[i];
-                var hit = child.AccessibilityObject.HitTest(x, y);
+                var hit = children[i].HitTest(x, y);
                 if (hit is not null)
                     return hit;
             }
@@ -245,6 +375,108 @@ public partial class Control
         }
 
         /// <inheritdoc/>
+        public override void DoDefaultAction()
+        {
+            AccessibleActions action = Owner switch
+            {
+                Button => AccessibleActions.Invoke,
+                CheckBox => AccessibleActions.Toggle,
+                RadioButton => AccessibleActions.Select,
+                Switch => AccessibleActions.Toggle,
+                ComboBox comboBox => comboBox.DroppedDown ? AccessibleActions.Collapse : AccessibleActions.Expand,
+                _ => AccessibleActions.None
+            };
+
+            if (action != AccessibleActions.None)
+                PerformAction(action);
+        }
+
+        /// <inheritdoc/>
+        public override bool PerformAction(AccessibleActions action, object? parameter = null)
+        {
+            if (!IsSingleAction(action)
+                || (SupportedActions & action) == 0
+                || Owner is not { IsDisposed: false } owner
+                || !owner.Enabled
+                || !owner.Visible)
+            {
+                return false;
+            }
+
+            if (action != AccessibleActions.SetValue && parameter is not null)
+                return false;
+
+            switch (action)
+            {
+                case AccessibleActions.Invoke when owner is Button button:
+                    button.PerformClick();
+                    return true;
+
+                case AccessibleActions.Toggle when owner is CheckBox checkBox:
+                    checkBox.OnClick(CreateAccessibilityClick());
+                    return true;
+
+                case AccessibleActions.Select when owner is RadioButton radioButton:
+                    radioButton.OnClick(CreateAccessibilityClick());
+                    return true;
+
+                case AccessibleActions.Toggle when owner is Switch @switch:
+                    @switch.Toggle();
+                    return true;
+
+                case AccessibleActions.Expand when owner is ComboBox comboBox:
+                    comboBox.DroppedDown = true;
+                    return true;
+
+                case AccessibleActions.Collapse when owner is ComboBox comboBox:
+                    comboBox.DroppedDown = false;
+                    return true;
+
+                case AccessibleActions.SetValue when owner is TextBox textBox:
+                    if (parameter is not null and not string)
+                        return false;
+
+                    textBox.Text = (string?)parameter ?? string.Empty;
+                    return true;
+
+                case AccessibleActions.SetValue when owner is TrackBar trackBar:
+                    if (!TryGetRangeActionValue(parameter, trackBar.Minimum, trackBar.Maximum, out int requestedValue))
+                        return false;
+
+                    trackBar.Value = requestedValue;
+                    return true;
+
+                case AccessibleActions.Increment when owner is TrackBar trackBar:
+                    trackBar.Value = Math.Min(trackBar.Maximum, trackBar.Value + trackBar.SmallChange);
+                    return true;
+
+                case AccessibleActions.Decrement when owner is TrackBar trackBar:
+                    trackBar.Value = Math.Max(trackBar.Minimum, trackBar.Value - trackBar.SmallChange);
+                    return true;
+
+                case AccessibleActions.Focus:
+                    owner.Select();
+                    return owner.Focused;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Select(AccessibleSelection flags)
+        {
+            if ((flags & AccessibleSelection.TakeFocus) != 0)
+                PerformAction(AccessibleActions.Focus);
+
+            if ((flags & AccessibleSelection.TakeSelection) != 0
+                && (SupportedActions & AccessibleActions.Select) != 0)
+            {
+                PerformAction(AccessibleActions.Select);
+            }
+        }
+
+        /// <inheritdoc/>
         public override string ToString() => $"{nameof(ControlAccessibleObject)}: Owner = {Owner}";
 
         private static string? GetDefaultAction(Control owner)
@@ -262,6 +494,14 @@ public partial class Control
 
         private static string? GetDefaultAccessibleName(Control owner)
         {
+            if (owner is ControlAdapter { ParentForm: Form form })
+                return form.Text;
+
+            // Editable text is a value, not a label. Falling back to Text here would leak user
+            // content into the accessible name and would conflate two distinct semantic fields.
+            if (owner is TextBox)
+                return owner.Name;
+
             if (!string.IsNullOrEmpty(owner.Text))
                 return owner.Text;
 
@@ -271,6 +511,7 @@ public partial class Control
         private static AccessibleRole GetDefaultRole(Control? owner)
             => owner switch
             {
+                ControlAdapter => AccessibleRole.Window,
                 Button => AccessibleRole.PushButton,
                 CheckBox => AccessibleRole.CheckButton,
                 ComboBox => AccessibleRole.ComboBox,
@@ -294,7 +535,42 @@ public partial class Control
                 TabControl => AccessibleRole.PageTabList,
                 TextBox => AccessibleRole.Text,
                 TrackBar => AccessibleRole.Slider,
+                TreeView => AccessibleRole.Outline,
+                Menu => AccessibleRole.MenuBar,
+                MenuDropDown => AccessibleRole.MenuPopup,
                 _ => AccessibleRole.Client
+            };
+
+        private static AccessibleControlType GetDefaultControlType(Control? owner)
+            => owner switch
+            {
+                ControlAdapter => AccessibleControlType.Window,
+                Button => AccessibleControlType.Button,
+                CheckBox => AccessibleControlType.CheckBox,
+                RadioButton => AccessibleControlType.RadioButton,
+                Switch => AccessibleControlType.Switch,
+                TextBox => AccessibleControlType.Edit,
+                ComboBox => AccessibleControlType.ComboBox,
+                ListBox or ListView => AccessibleControlType.List,
+                TreeView => AccessibleControlType.Tree,
+                TabControl => AccessibleControlType.Tab,
+                TrackBar => AccessibleControlType.Slider,
+                ProgressBar => AccessibleControlType.ProgressBar,
+                ScrollBar => AccessibleControlType.ScrollBar,
+                Menu or MenuDropDown => AccessibleControlType.Menu,
+                ToolBar => AccessibleControlType.ToolBar,
+                Label => AccessibleControlType.Text,
+                PictureBox or Shape => AccessibleControlType.Image,
+                GroupBox => AccessibleControlType.Group,
+                Panel or FlowLayoutPanel or TableLayoutPanel => AccessibleControlType.Pane,
+                _ => AccessibleControlType.Custom
+            };
+
+        private static AccessibilityView GetDefaultAccessibilityView(Control owner)
+            => owner switch
+            {
+                Label or PictureBox or Shape or ProgressBar => AccessibilityView.Content,
+                _ => AccessibilityView.Control
             };
 
         private static AccessibleStates GetDefaultState(Control owner)
@@ -317,7 +593,7 @@ public partial class Control
                 state |= AccessibleStates.Selectable;
 
                 if (radioButton.Checked)
-                    state |= AccessibleStates.Checked;
+                    state |= AccessibleStates.Checked | AccessibleStates.Selected;
             }
             else if (owner is Switch @switch)
             {
@@ -389,6 +665,10 @@ public partial class Control
                 if (trackBar.ThumbPressed)
                     state |= AccessibleStates.Pressed;
             }
+            else if (owner is ProgressBar)
+            {
+                state |= AccessibleStates.ReadOnly;
+            }
 
             return state;
         }
@@ -408,18 +688,93 @@ public partial class Control
                 _ => null
             };
 
+        private IEnumerable<AccessibleObject> EnumerateActiveChildren()
+        {
+            foreach (AccessibleObject child in GetAccessibilityChildren())
+            {
+                if (child is null
+                    || child.View == AccessibilityView.Hidden
+                    || (child.State & AccessibleStates.Invisible) != 0)
+                {
+                    continue;
+                }
+
+                yield return child;
+            }
+        }
+
         private static AccessibleObject? GetSibling(Control owner, int offset)
         {
             if (owner.Parent is not { } parent)
                 return null;
 
-            int index = parent.Controls.IndexOf(owner);
+            AccessibleObject parentObject = parent.AccessibilityObject;
+            AccessibleObject ownerObject = owner.AccessibilityObject;
+            int index = -1;
+
+            for (int i = 0; i < parentObject.GetChildCount(); i++)
+            {
+                if (ReferenceEquals(parentObject.GetChild(i), ownerObject))
+                {
+                    index = i;
+                    break;
+                }
+            }
+
             int siblingIndex = index + offset;
 
-            if (index < 0 || siblingIndex < 0 || siblingIndex >= parent.Controls.Count)
+            if (index < 0 || siblingIndex < 0 || siblingIndex >= parentObject.GetChildCount())
                 return null;
 
-            return parent.Controls[siblingIndex].AccessibilityObject;
+            return parentObject.GetChild(siblingIndex);
+        }
+
+        private static MouseEventArgs CreateAccessibilityClick()
+            => new(MouseButtons.Left, 1, 0, 0, Point.Empty);
+
+        private static bool IsSingleAction(AccessibleActions action)
+        {
+            int value = (int)action;
+            return value > 0 && (value & (value - 1)) == 0;
+        }
+
+        private static bool TryGetRangeActionValue(object? parameter, int minimum, int maximum, out int value)
+        {
+            value = default;
+
+            try
+            {
+                double number = parameter switch
+                {
+                    byte typed => typed,
+                    sbyte typed => typed,
+                    short typed => typed,
+                    ushort typed => typed,
+                    int typed => typed,
+                    uint typed => typed,
+                    long typed => typed,
+                    ulong typed => typed,
+                    float typed => typed,
+                    double typed => typed,
+                    decimal typed => (double)typed,
+                    _ => double.NaN
+                };
+
+                if (!double.IsFinite(number)
+                    || number < minimum
+                    || number > maximum
+                    || number != Math.Truncate(number))
+                {
+                    return false;
+                }
+
+                value = checked((int)number);
+                return true;
+            }
+            catch (OverflowException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.cs
@@ -305,7 +305,11 @@ public partial class Control
             foreach (AccessibleObject logicalChild in GetLogicalAccessibilityChildren(owner))
                 yield return logicalChild;
 
-            foreach (Control child in owner.Controls)
+            IEnumerable<Control> visualChildren = owner is ControlAdapter adapter
+                ? adapter.ParentForm.Controls
+                : owner.Controls;
+
+            foreach (Control child in visualChildren)
                 yield return child.AccessibilityObject;
         }
 

--- a/ModernFormsNext/ComboBox.cs
+++ b/ModernFormsNext/ComboBox.cs
@@ -21,7 +21,12 @@ namespace ModernFormsNext
         {
             popup_listbox = new ListBox { Dock = DockStyle.Fill, SelectItemOnMouseUp = true, ShowHover = true };
             popup_listbox.SelectedIndexChanged += ListBox_SelectedIndexChanged;
-            popup_listbox.Items.CollectionChanged += (_, _) => NotifyAccessibilityClients(AccessibleEvents.Reorder);
+            popup_listbox.Items.CollectionChanged += (_, _) => {
+                if (IsAccessibilityObjectCreated)
+                    _ = AccessibilityObject.GetChildCount();
+
+                NotifyAccessibilityClients(AccessibleEvents.Reorder);
+            };
         }
 
         /// <inheritdoc/>

--- a/ModernFormsNext/ComboBox.cs
+++ b/ModernFormsNext/ComboBox.cs
@@ -21,6 +21,7 @@ namespace ModernFormsNext
         {
             popup_listbox = new ListBox { Dock = DockStyle.Fill, SelectItemOnMouseUp = true, ShowHover = true };
             popup_listbox.SelectedIndexChanged += ListBox_SelectedIndexChanged;
+            popup_listbox.Items.CollectionChanged += (_, _) => NotifyAccessibilityClients(AccessibleEvents.Reorder);
         }
 
         /// <inheritdoc/>
@@ -71,6 +72,7 @@ namespace ModernFormsNext
                 if (DroppedDown && !value) {
                     popup?.Hide ();
                     OnDropDownClosed (EventArgs.Empty);
+                    NotifyAccessibilityClients(AccessibleEvents.StateChange);
                 } else if (!DroppedDown && value) {
                     if (FindForm () is not Form form)
                         throw new InvalidOperationException ("Cannot drop down a ComboBox that is not parented to a Form");
@@ -84,6 +86,7 @@ namespace ModernFormsNext
                     popup.Show (this, 1, Height);
 
                     OnDropDownOpened (EventArgs.Empty);
+                    NotifyAccessibilityClients(AccessibleEvents.StateChange);
                 }
             }
         }

--- a/ModernFormsNext/ComboBox.cs
+++ b/ModernFormsNext/ComboBox.cs
@@ -21,11 +21,16 @@ namespace ModernFormsNext
         {
             popup_listbox = new ListBox { Dock = DockStyle.Fill, SelectItemOnMouseUp = true, ShowHover = true };
             popup_listbox.SelectedIndexChanged += ListBox_SelectedIndexChanged;
-            popup_listbox.Items.CollectionChanged += (_, _) => {
+            popup_listbox.Items.AccessibilityCollectionChanged += selectionChanged => {
                 if (IsAccessibilityObjectCreated)
                     _ = AccessibilityObject.GetChildCount();
 
                 NotifyAccessibilityClients(AccessibleEvents.Reorder);
+
+                if (selectionChanged) {
+                    NotifyAccessibilityClients(AccessibleEvents.Selection);
+                    NotifyAccessibilityClients(AccessibleEvents.ValueChange);
+                }
             };
         }
 
@@ -77,7 +82,6 @@ namespace ModernFormsNext
                 if (DroppedDown && !value) {
                     popup?.Hide ();
                     OnDropDownClosed (EventArgs.Empty);
-                    NotifyAccessibilityClients(AccessibleEvents.StateChange);
                 } else if (!DroppedDown && value) {
                     if (FindForm () is not Form form)
                         throw new InvalidOperationException ("Cannot drop down a ComboBox that is not parented to a Form");
@@ -91,7 +95,6 @@ namespace ModernFormsNext
                     popup.Show (this, 1, Height);
 
                     OnDropDownOpened (EventArgs.Empty);
-                    NotifyAccessibilityClients(AccessibleEvents.StateChange);
                 }
             }
         }

--- a/ModernFormsNext/Control.Accessibility.cs
+++ b/ModernFormsNext/Control.Accessibility.cs
@@ -212,7 +212,11 @@ public partial class Control
                 accessibleObject = CreateAccessibilityInstance()
                     ?? throw new InvalidOperationException($"{nameof(CreateAccessibilityInstance)} must not return null.");
 
-                accessibleObject.ClientNotification += AccessibilityObject_ClientNotification;
+                // An accessible object can outlive its control when a platform adapter or test
+                // retains the peer. Keep the notification route weak so the event subscription
+                // does not defeat ControlAccessibleObject's weak owner contract.
+                var notificationForwarder = new AccessibilityNotificationForwarder(this);
+                accessibleObject.ClientNotification += notificationForwarder.OnClientNotification;
                 Properties.SetObject(s_accessibilityObjectProperty, accessibleObject);
             }
 
@@ -293,6 +297,22 @@ public partial class Control
     {
         if (!raising_accessibility_notification)
             NotifyPlatformAccessibilityClients(e.EventId, e.ObjectId, e.ChildId);
+    }
+
+    private sealed class AccessibilityNotificationForwarder
+    {
+        private readonly WeakReference<Control> owner_reference;
+
+        public AccessibilityNotificationForwarder(Control owner)
+        {
+            owner_reference = new WeakReference<Control>(owner);
+        }
+
+        public void OnClientNotification(object? sender, AccessibleObjectNotificationEventArgs e)
+        {
+            if (owner_reference.TryGetTarget(out Control? owner))
+                owner.AccessibilityObject_ClientNotification(sender, e);
+        }
     }
 
     private void NotifyPlatformAccessibilityClients(AccessibleEvents accEvent, int objectID, int childID)

--- a/ModernFormsNext/Control.Accessibility.cs
+++ b/ModernFormsNext/Control.Accessibility.cs
@@ -10,9 +10,12 @@ public partial class Control
 {
     private static readonly int s_accessibilityObjectProperty = PropertyStore.CreateKey();
     private static readonly int s_accessibleDefaultActionDescriptionProperty = PropertyStore.CreateKey();
+    private static readonly int s_accessibleAutomationIdProperty = PropertyStore.CreateKey();
+    private static readonly int s_accessibleControlTypeProperty = PropertyStore.CreateKey();
     private static readonly int s_accessibleDescriptionProperty = PropertyStore.CreateKey();
     private static readonly int s_accessibleNameProperty = PropertyStore.CreateKey();
     private static readonly int s_accessibleRoleProperty = PropertyStore.CreateKey();
+    private static readonly int s_accessibilityViewProperty = PropertyStore.CreateKey();
     private bool raising_accessibility_notification;
 
     /// <summary>
@@ -33,6 +36,53 @@ public partial class Control
 
             SetNullableAccessibilityString(s_accessibleDefaultActionDescriptionProperty, value);
             NotifyAccessibilityClients(AccessibleEvents.DefaultActionChange);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the stable developer-defined semantic automation identifier for this control.
+    /// </summary>
+    /// <remarks>
+    /// A <see langword="null"/> value lets <see cref="AccessibleObject.AutomationId"/> fall
+    /// back to <see cref="Name"/>. This identifier is distinct from the process-local
+    /// <see cref="AccessibleObject.RuntimeId"/> and does not change the accessible name.
+    /// </remarks>
+    public string? AccessibleAutomationId
+    {
+        get => Properties.GetObject<string>(s_accessibleAutomationIdProperty);
+        set
+        {
+            if (AccessibleAutomationId == value)
+                return;
+
+            SetNullableAccessibilityString(s_accessibleAutomationIdProperty, value);
+            NotifyAccessibilityClients(AccessibleEvents.StateChange);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the normalized platform-neutral semantic type for this control.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AccessibleControlType.Default"/> lets <see cref="ControlAccessibleObject"/> infer a
+    /// type while <see cref="AccessibleRole"/> continues to provide WinForms/MSAA compatibility.
+    /// </remarks>
+    public AccessibleControlType AccessibleControlType
+    {
+        get => Properties.GetEnum(s_accessibleControlTypeProperty, AccessibleControlType.Default);
+        set
+        {
+            SourceGenerated.EnumValidator.Validate(value);
+
+            if (AccessibleControlType == value)
+                return;
+
+            if (value == AccessibleControlType.Default)
+                Properties.RemoveInteger(s_accessibleControlTypeProperty);
+            else
+                Properties.SetEnum(s_accessibleControlTypeProperty, value);
+
+            NotifyAccessibilityClients(AccessibleEvents.StateChange);
         }
     }
 
@@ -113,6 +163,35 @@ public partial class Control
                 Properties.SetEnum(s_accessibleRoleProperty, value);
 
             NotifyAccessibilityClients(AccessibleEvents.StateChange);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the accessibility-tree projection for this control.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ModernFormsNext.Accessibility.AccessibilityView.Default"/> lets the framework infer
+    /// a suitable projection. Setting <see cref="ModernFormsNext.Accessibility.AccessibilityView.Hidden"/>
+    /// excludes the control from its parent's active accessibility children without changing the
+    /// visual tree or <see cref="Visible"/> property.
+    /// </remarks>
+    public AccessibilityView AccessibilityView
+    {
+        get => Properties.GetEnum(s_accessibilityViewProperty, AccessibilityView.Default);
+        set
+        {
+            SourceGenerated.EnumValidator.Validate(value);
+
+            if (AccessibilityView == value)
+                return;
+
+            if (value == AccessibilityView.Default)
+                Properties.RemoveInteger(s_accessibilityViewProperty);
+            else
+                Properties.SetEnum(s_accessibilityViewProperty, value);
+
+            NotifyAccessibilityClients(AccessibleEvents.StateChange);
+            Parent?.NotifyAccessibilityClients(AccessibleEvents.Reorder);
         }
     }
 

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -720,6 +720,11 @@ namespace ModernFormsNext
         public bool Disposing => GetState (States.Disposing);
 
         /// <summary>
+        /// Gets whether this control has completed its disposal path.
+        /// </summary>
+        internal bool IsDisposed => disposedValue;
+
+        /// <summary>
         /// Gets or sets whether the control can be interacted with.
         /// </summary>
         public bool Enabled {
@@ -1296,12 +1301,20 @@ namespace ModernFormsNext
         /// <summary>
         ///  Raises the <see cref='ControlAdded'/> event.
         /// </summary>
-        protected virtual void OnControlAdded (EventArgs<Control> e) => (Events[s_controlAddedEvent] as EventHandler<EventArgs<Control>>)?.Invoke (this, e);
+        protected virtual void OnControlAdded (EventArgs<Control> e)
+        {
+            (Events[s_controlAddedEvent] as EventHandler<EventArgs<Control>>)?.Invoke(this, e);
+            NotifyAccessibilityClients(AccessibleEvents.Reorder);
+        }
 
         /// <summary>
         ///  Raises the <see cref='ControlRemoved'/> event.
         /// </summary>
-        protected virtual void OnControlRemoved (EventArgs<Control> e) => (Events[s_controlRemovedEvent] as EventHandler<EventArgs<Control>>)?.Invoke (this, e);
+        protected virtual void OnControlRemoved (EventArgs<Control> e)
+        {
+            (Events[s_controlRemovedEvent] as EventHandler<EventArgs<Control>>)?.Invoke(this, e);
+            NotifyAccessibilityClients(AccessibleEvents.Reorder);
+        }
 
         /// <summary>
         ///  Called when the control is first created.
@@ -2576,6 +2589,7 @@ namespace ModernFormsNext
                     c.Dispose (disposing);
 
                 disposedValue = true;
+                Parent?.NotifyAccessibilityClients(AccessibleEvents.Reorder);
             }
 
             base.Dispose (disposing);

--- a/ModernFormsNext/ControlCollection.cs
+++ b/ModernFormsNext/ControlCollection.cs
@@ -453,6 +453,7 @@ public partial class Control
             MoveElement (child, currentIndex, newIndex);
 
             LayoutTransaction.DoLayout (Owner, child, PropertyNames.ChildIndex);
+            Owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
 
         /// <summary>

--- a/ModernFormsNext/Form.cs
+++ b/ModernFormsNext/Form.cs
@@ -509,6 +509,7 @@ namespace ModernFormsNext
                     text = value;
                     Window.SetTitle (text);
                     TitleBar.Text = text;
+                    adapter.NotifyAccessibilityClients(Accessibility.AccessibleEvents.NameChange);
                 }
             }
         }

--- a/ModernFormsNext/Form.cs
+++ b/ModernFormsNext/Form.cs
@@ -59,6 +59,8 @@ namespace ModernFormsNext
             ClientSize = DefaultSize;
         }
 
+        internal bool IsAccessibilityDialog => dialog_parent is not null;
+
         private static IWindowBaseImpl CreateWindowImpl()
         {
             if (TestWindowFactoryScope.TryCreateWindow() is { } testWindow)
@@ -468,6 +470,7 @@ namespace ModernFormsNext
 
             dialog_parent = parent.Window;
             Window.SetParent (parent.Window);
+            adapter.NotifyAccessibilityClients(Accessibility.AccessibleEvents.StateChange);
 
             ShowDialog (parent.Window);
 

--- a/ModernFormsNext/Form.cs
+++ b/ModernFormsNext/Form.cs
@@ -32,7 +32,11 @@ namespace ModernFormsNext
         /// <summary>
         /// Initializes a new instance of the Form class.
         /// </summary>
-        public Form () : base (CreateWindowImpl())
+        public Form () : this(CreateWindowImpl())
+        {
+        }
+
+        internal Form(IWindowBaseImpl window) : base(window)
         {
             // The client area must be an internal root child, not the public
             // Controls collection. Dock layout processes children from the back,

--- a/ModernFormsNext/ListBoxItemCollection.cs
+++ b/ModernFormsNext/ListBoxItemCollection.cs
@@ -6,7 +6,6 @@ using System.Linq;
 
 namespace ModernFormsNext
 {
-    // TODO: Update selected indexes when adding/removing items
     /// <summary>
     /// Represents a collection of items for ListBox.
     /// </summary>
@@ -88,7 +87,73 @@ namespace ModernFormsNext
         {
             base.OnCollectionChanged (e);
 
+            UpdateSelectionAfterCollectionChange(e);
             owner.Invalidate ();
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+        }
+
+        private void UpdateSelectionAfterCollectionChange(NotifyCollectionChangedEventArgs e)
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add when e.NewStartingIndex >= 0:
+                    int addedCount = e.NewItems?.Count ?? 1;
+                    for (int i = 0; i < SelectedIndexes.Count; i++)
+                    {
+                        if (SelectedIndexes[i] >= e.NewStartingIndex)
+                            SelectedIndexes[i] += addedCount;
+                    }
+
+                    if (focused_index >= e.NewStartingIndex)
+                        focused_index += addedCount;
+                    break;
+
+                case NotifyCollectionChangedAction.Remove when e.OldStartingIndex >= 0:
+                    int removedCount = e.OldItems?.Count ?? 1;
+                    int removedEnd = e.OldStartingIndex + removedCount;
+                    SelectedIndexes.RemoveAll(index => index >= e.OldStartingIndex && index < removedEnd);
+                    for (int i = 0; i < SelectedIndexes.Count; i++)
+                    {
+                        if (SelectedIndexes[i] >= removedEnd)
+                            SelectedIndexes[i] -= removedCount;
+                    }
+
+                    if (focused_index >= removedEnd)
+                        focused_index -= removedCount;
+                    else if (focused_index >= e.OldStartingIndex)
+                        focused_index = e.OldStartingIndex;
+                    break;
+
+                case NotifyCollectionChangedAction.Move when e.OldStartingIndex >= 0 && e.NewStartingIndex >= 0:
+                    for (int i = 0; i < SelectedIndexes.Count; i++)
+                        SelectedIndexes[i] = RemapMovedIndex(SelectedIndexes[i], e.OldStartingIndex, e.NewStartingIndex);
+
+                    focused_index = RemapMovedIndex(focused_index, e.OldStartingIndex, e.NewStartingIndex);
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    SelectedIndexes.Clear();
+                    focused_index = 0;
+                    break;
+            }
+
+            SelectedIndexes.Sort();
+            focused_index = Count == 0 ? 0 : Math.Clamp(focused_index, 0, Count - 1);
+        }
+
+        private static int RemapMovedIndex(int index, int oldIndex, int newIndex)
+        {
+            if (index == oldIndex)
+                return newIndex;
+
+            if (oldIndex < newIndex && index > oldIndex && index <= newIndex)
+                return index - 1;
+
+            if (newIndex < oldIndex && index >= newIndex && index < oldIndex)
+                return index + 1;
+
+            return index;
         }
 
         internal void RemoveSelectedIndex (int index)

--- a/ModernFormsNext/ListBoxItemCollection.cs
+++ b/ModernFormsNext/ListBoxItemCollection.cs
@@ -11,6 +11,7 @@ namespace ModernFormsNext
     /// </summary>
     public class ListBoxItemCollection : ObservableCollection<object>
     {
+        private readonly List<object> accessibility_identities = new();
         private readonly ListBox owner;
         private int focused_index = 0;
         private int hovered_index = -1;
@@ -19,6 +20,8 @@ namespace ModernFormsNext
         {
             this.owner = owner;
         }
+
+        internal event Action<bool>? AccessibilityCollectionChanged;
 
         /// <summary>
         /// Adds a collection of items to the collection.
@@ -85,9 +88,13 @@ namespace ModernFormsNext
         /// <inheritdoc/>
         protected override void OnCollectionChanged (NotifyCollectionChangedEventArgs e)
         {
+            // Each collection occurrence has its own identity. The item value cannot serve as the
+            // identity because the same object (most commonly an interned string) may be inserted
+            // more than once and each occurrence is a distinct semantic element.
+            UpdateAccessibilityIdentities(e);
             base.OnCollectionChanged (e);
 
-            UpdateSelectionAfterCollectionChange(e);
+            bool selectionChanged = UpdateSelectionAfterCollectionChange(e);
             owner.Invalidate ();
 
             // Once semantics have been requested, synchronize the occurrence cache at the
@@ -96,11 +103,60 @@ namespace ModernFormsNext
                 _ = owner.AccessibilityObject.GetChildCount();
 
             owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
-            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+            if (selectionChanged)
+                owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+
+            AccessibilityCollectionChanged?.Invoke(selectionChanged);
         }
 
-        private void UpdateSelectionAfterCollectionChange(NotifyCollectionChangedEventArgs e)
+        internal object GetAccessibilityIdentity(int index) => accessibility_identities[index];
+
+        private void UpdateAccessibilityIdentities(NotifyCollectionChangedEventArgs e)
         {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add when e.NewStartingIndex >= 0:
+                    for (int i = 0; i < (e.NewItems?.Count ?? 1); i++)
+                        accessibility_identities.Insert(e.NewStartingIndex + i, new object());
+                    break;
+
+                case NotifyCollectionChangedAction.Remove when e.OldStartingIndex >= 0:
+                    for (int i = 0; i < (e.OldItems?.Count ?? 1); i++)
+                        accessibility_identities.RemoveAt(e.OldStartingIndex);
+                    break;
+
+                case NotifyCollectionChangedAction.Move when e.OldStartingIndex >= 0 && e.NewStartingIndex >= 0:
+                    object identity = accessibility_identities[e.OldStartingIndex];
+                    accessibility_identities.RemoveAt(e.OldStartingIndex);
+                    accessibility_identities.Insert(e.NewStartingIndex, identity);
+                    break;
+
+                case NotifyCollectionChangedAction.Replace when e.NewStartingIndex >= 0:
+                    for (int i = 0; i < (e.NewItems?.Count ?? 1); i++)
+                    {
+                        bool representsSameItem = e.OldItems is not null
+                            && e.NewItems is not null
+                            && i < e.OldItems.Count
+                            && i < e.NewItems.Count
+                            && ReferenceEquals(e.OldItems[i], e.NewItems[i]);
+
+                        if (!representsSameItem)
+                            accessibility_identities[e.NewStartingIndex + i] = new object();
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    accessibility_identities.Clear();
+                    for (int i = 0; i < Count; i++)
+                        accessibility_identities.Add(new object());
+                    break;
+            }
+        }
+
+        private bool UpdateSelectionAfterCollectionChange(NotifyCollectionChangedEventArgs e)
+        {
+            bool selectionChanged = false;
+
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add when e.NewStartingIndex >= 0:
@@ -118,7 +174,8 @@ namespace ModernFormsNext
                 case NotifyCollectionChangedAction.Remove when e.OldStartingIndex >= 0:
                     int removedCount = e.OldItems?.Count ?? 1;
                     int removedEnd = e.OldStartingIndex + removedCount;
-                    SelectedIndexes.RemoveAll(index => index >= e.OldStartingIndex && index < removedEnd);
+                    selectionChanged = SelectedIndexes.RemoveAll(
+                        index => index >= e.OldStartingIndex && index < removedEnd) > 0;
                     for (int i = 0; i < SelectedIndexes.Count; i++)
                     {
                         if (SelectedIndexes[i] >= removedEnd)
@@ -138,7 +195,14 @@ namespace ModernFormsNext
                     focused_index = RemapMovedIndex(focused_index, e.OldStartingIndex, e.NewStartingIndex);
                     break;
 
+                case NotifyCollectionChangedAction.Replace when e.NewStartingIndex >= 0:
+                    int replacedCount = e.NewItems?.Count ?? 1;
+                    selectionChanged = SelectedIndexes.Any(
+                        index => index >= e.NewStartingIndex && index < e.NewStartingIndex + replacedCount);
+                    break;
+
                 case NotifyCollectionChangedAction.Reset:
+                    selectionChanged = SelectedIndexes.Count > 0;
                     SelectedIndexes.Clear();
                     focused_index = 0;
                     break;
@@ -146,6 +210,7 @@ namespace ModernFormsNext
 
             SelectedIndexes.Sort();
             focused_index = Count == 0 ? 0 : Math.Clamp(focused_index, 0, Count - 1);
+            return selectionChanged;
         }
 
         private static int RemapMovedIndex(int index, int oldIndex, int newIndex)

--- a/ModernFormsNext/ListBoxItemCollection.cs
+++ b/ModernFormsNext/ListBoxItemCollection.cs
@@ -89,6 +89,12 @@ namespace ModernFormsNext
 
             UpdateSelectionAfterCollectionChange(e);
             owner.Invalidate ();
+
+            // Once semantics have been requested, synchronize the occurrence cache at the
+            // mutation boundary so an externally held peer detaches immediately after removal.
+            if (owner.IsAccessibilityObjectCreated)
+                _ = owner.AccessibilityObject.GetChildCount();
+
             owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
             owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
         }

--- a/ModernFormsNext/ListView.cs
+++ b/ModernFormsNext/ListView.cs
@@ -109,7 +109,6 @@ namespace ModernFormsNext
                     value.Selected = true;
 
                 Invalidate ();
-                NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
                 NotifyAccessibilityClients(Accessibility.AccessibleEvents.ValueChange);
             }
         }

--- a/ModernFormsNext/ListView.cs
+++ b/ModernFormsNext/ListView.cs
@@ -109,6 +109,8 @@ namespace ModernFormsNext
                     value.Selected = true;
 
                 Invalidate ();
+                NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+                NotifyAccessibilityClients(Accessibility.AccessibleEvents.ValueChange);
             }
         }
 

--- a/ModernFormsNext/ListViewItem.cs
+++ b/ModernFormsNext/ListViewItem.cs
@@ -9,6 +9,9 @@ namespace ModernFormsNext
     /// </summary>
     public class ListViewItem
     {
+        private bool selected;
+        private string text = string.Empty;
+
         /// <summary>
         /// Gets the current bounding box of the item.
         /// </summary>
@@ -27,7 +30,19 @@ namespace ModernFormsNext
         /// <summary>
         /// Gets or sets a value indicating if the item is currently selected.
         /// </summary>
-        public bool Selected { get; set; }
+        public bool Selected
+        {
+            get => selected;
+            set
+            {
+                if (selected == value)
+                    return;
+
+                selected = value;
+                Parent?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+                Parent?.Invalidate();
+            }
+        }
 
         /// <summary>
         /// Sets the bounding box of the item. This is internal API and should not be called.
@@ -45,6 +60,19 @@ namespace ModernFormsNext
         /// <summary>
         /// Gets or sets the text displayed on the item.
         /// </summary>
-        public string Text { get; set; } = string.Empty;
+        public string Text
+        {
+            get => text;
+            set
+            {
+                value ??= string.Empty;
+                if (text == value)
+                    return;
+
+                text = value;
+                Parent?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.NameChange);
+                Parent?.Invalidate();
+            }
+        }
     }
 }

--- a/ModernFormsNext/ListViewItem.cs
+++ b/ModernFormsNext/ListViewItem.cs
@@ -39,7 +39,10 @@ namespace ModernFormsNext
                     return;
 
                 selected = value;
-                Parent?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+                Parent?.NotifyAccessibilityClients(
+                    value
+                        ? Accessibility.AccessibleEvents.Selection
+                        : Accessibility.AccessibleEvents.SelectionRemove);
                 Parent?.Invalidate();
             }
         }

--- a/ModernFormsNext/ListViewItemCollection.cs
+++ b/ModernFormsNext/ListViewItemCollection.cs
@@ -55,6 +55,8 @@ namespace ModernFormsNext
             base.ClearItems ();
 
             owner.Invalidate ();
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
         }
 
         /// <inheritdoc/>
@@ -64,6 +66,7 @@ namespace ModernFormsNext
 
             item.Parent = owner;
             owner.Invalidate ();
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
 
         /// <inheritdoc/>
@@ -75,6 +78,8 @@ namespace ModernFormsNext
 
             item.Parent = null;
             owner.Invalidate ();
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
         }
 
         /// <inheritdoc/>
@@ -89,6 +94,8 @@ namespace ModernFormsNext
 
             item.Parent = owner;
             owner.Invalidate ();
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
+            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
         }
     }
 }

--- a/ModernFormsNext/ListViewItemCollection.cs
+++ b/ModernFormsNext/ListViewItemCollection.cs
@@ -49,6 +49,8 @@ namespace ModernFormsNext
         /// <inheritdoc/>
         protected override void ClearItems ()
         {
+            bool selectionChanged = Items.Any(item => item.Selected);
+
             foreach (var item in Items)
                 item.Parent = null;
 
@@ -56,7 +58,8 @@ namespace ModernFormsNext
 
             owner.Invalidate ();
             owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
-            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+            if (selectionChanged)
+                owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.SelectionRemove);
         }
 
         /// <inheritdoc/>
@@ -67,25 +70,30 @@ namespace ModernFormsNext
             item.Parent = owner;
             owner.Invalidate ();
             owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
+            if (item.Selected)
+                owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
         }
 
         /// <inheritdoc/>
         protected override void RemoveItem (int index)
         {
             var item = this[index];
+            bool selectionChanged = item.Selected;
 
             base.RemoveItem (index);
 
             item.Parent = null;
             owner.Invalidate ();
             owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
-            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+            if (selectionChanged)
+                owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.SelectionRemove);
         }
 
         /// <inheritdoc/>
         protected override void SetItem (int index, ListViewItem item)
         {
             var old_item = this.ElementAtOrDefault (index);
+            bool oldSelected = old_item?.Selected == true;
 
             if (old_item != null)
                 old_item.Parent = null;
@@ -95,7 +103,10 @@ namespace ModernFormsNext
             item.Parent = owner;
             owner.Invalidate ();
             owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
-            owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+            if (oldSelected)
+                owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.SelectionRemove);
+            if (item.Selected)
+                owner.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
         }
     }
 }

--- a/ModernFormsNext/MenuItem.cs
+++ b/ModernFormsNext/MenuItem.cs
@@ -16,6 +16,7 @@ namespace ModernFormsNext
         private bool checkedState;
         private bool enabled = true;
         private bool selected;
+        private string text = string.Empty;
 
         /// <summary>
         /// Initializes a new instance of the MenuItem class.
@@ -59,6 +60,7 @@ namespace ModernFormsNext
 
                 checkedState = value;
                 OwnerControl?.Invalidate (Bounds);
+                OwnerControl?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.StateChange);
             }
         }
 
@@ -71,6 +73,7 @@ namespace ModernFormsNext
                 if (enabled != value) {
                     enabled = value;
                     OwnerControl?.Invalidate ();
+                    OwnerControl?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.StateChange);
                 }
             }
         }
@@ -178,6 +181,10 @@ namespace ModernFormsNext
             }
         }
 
+        // Accessibility peers use the same owning control to transform item-local bounds without
+        // exposing MenuItem internals or introducing a platform-specific node type.
+        internal Control? AccessibilityOwnerControl => OwnerControl;
+
         /// <summary>
         /// Gets or sets the amount of padding to apply to the menu item.
         /// </summary>
@@ -239,7 +246,20 @@ namespace ModernFormsNext
         /// <summary>
         /// Gets or sets the text of the menu item.
         /// </summary>
-        public string Text { get; set; } = string.Empty;
+        public string Text
+        {
+            get => text;
+            set
+            {
+                value ??= string.Empty;
+                if (text == value)
+                    return;
+
+                text = value;
+                OwnerControl?.Invalidate();
+                OwnerControl?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.NameChange);
+            }
+        }
 
         /// <summary>
         /// Gets or sets the explanatory text displayed when the pointer rests over this item in a

--- a/ModernFormsNext/MenuItemCollection.cs
+++ b/ModernFormsNext/MenuItemCollection.cs
@@ -35,11 +35,22 @@ namespace ModernFormsNext
         }
 
         /// <inheritdoc/>
+        protected override void ClearItems()
+        {
+            foreach (MenuItem item in Items)
+                item.Parent = null;
+
+            base.ClearItems();
+            owner.AccessibilityOwnerControl?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
+        }
+
+        /// <inheritdoc/>
         protected override void InsertItem (int index, MenuItem item)
         {
             base.InsertItem (index, item);
 
             item.Parent = owner;
+            owner.AccessibilityOwnerControl?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
 
         /// <inheritdoc/>
@@ -50,6 +61,7 @@ namespace ModernFormsNext
             base.RemoveItem (index);
 
             item.Parent = null;
+            owner.AccessibilityOwnerControl?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
 
         /// <inheritdoc/>
@@ -63,6 +75,7 @@ namespace ModernFormsNext
             base.SetItem (index, item);
 
             item.Parent = owner;
+            owner.AccessibilityOwnerControl?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
     }
 }

--- a/ModernFormsNext/TabPage.cs
+++ b/ModernFormsNext/TabPage.cs
@@ -74,7 +74,14 @@ namespace ModernFormsNext
         public override string Text
         {
             get => TabStripItem.Text;
-            set => TabStripItem.Text = value;
+            set
+            {
+                if (TabStripItem.Text == value)
+                    return;
+
+                TabStripItem.Text = value;
+                Parent?.NotifyAccessibilityClients(ModernFormsNext.Accessibility.AccessibleEvents.NameChange);
+            }
         }
 
         /// <summary>

--- a/ModernFormsNext/TextBox.cs
+++ b/ModernFormsNext/TextBox.cs
@@ -449,7 +449,14 @@ namespace ModernFormsNext
         /// </summary>
         public char? PasswordCharacter {
             get => document.PasswordCharacter;
-            set => document.PasswordCharacter = value;
+            set {
+                if (document.PasswordCharacter == value)
+                    return;
+
+                document.PasswordCharacter = value;
+                NotifyAccessibilityClients (Accessibility.AccessibleEvents.StateChange);
+                NotifyAccessibilityClients (Accessibility.AccessibleEvents.ValueChange);
+            }
         }
 
         /// <summary>
@@ -479,7 +486,13 @@ namespace ModernFormsNext
         /// </summary>
         public bool ReadOnly {
             get => document.ReadOnly;
-            set => document.ReadOnly = value;
+            set {
+                if (document.ReadOnly == value)
+                    return;
+
+                document.ReadOnly = value;
+                NotifyAccessibilityClients (Accessibility.AccessibleEvents.StateChange);
+            }
         }
 
         /// <summary>

--- a/ModernFormsNext/TreeView.cs
+++ b/ModernFormsNext/TreeView.cs
@@ -246,7 +246,24 @@ namespace ModernFormsNext
         /// <summary>
         /// Raises the ItemSelected event.
         /// </summary>
-        protected virtual void OnItemSelected (EventArgs<TreeViewItem> e) => ItemSelected?.Invoke (this, e);
+        protected virtual void OnItemSelected (EventArgs<TreeViewItem> e)
+        {
+            ItemSelected?.Invoke(this, e);
+            NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+            NotifyAccessibilityClients(Accessibility.AccessibleEvents.ValueChange);
+        }
+
+        // A logical accessible item can outlive its collection membership. Clear a selection that
+        // points into a removed subtree so GetSelected never returns a detached semantic object.
+        internal void OnAccessibilityItemsRemoved(IEnumerable<TreeViewItem> removedItems)
+        {
+            if (!removedItems.Any(item => item.GetAllItems().Contains(selected_item)))
+                return;
+
+            selected_item = root_item;
+            NotifyAccessibilityClients(Accessibility.AccessibleEvents.Selection);
+            NotifyAccessibilityClients(Accessibility.AccessibleEvents.ValueChange);
+        }
 
         /// <inheritdoc/>
         protected override void OnKeyDown (KeyEventArgs e)

--- a/ModernFormsNext/TreeViewItem.cs
+++ b/ModernFormsNext/TreeViewItem.cs
@@ -15,6 +15,7 @@ namespace ModernFormsNext
         private readonly TreeView? tree_view;
 
         private bool expanded;
+        private string text = string.Empty;
         internal TreeViewItemCollection? items;
 
         /// <summary>
@@ -55,6 +56,7 @@ namespace ModernFormsNext
             if (expanded && tree_view is null) {
                 expanded = false;
                 Invalidate ();
+                TreeView?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.StateChange);
             }
         }
 
@@ -88,6 +90,7 @@ namespace ModernFormsNext
 
             expanded = true;
             Invalidate ();
+            TreeView?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.StateChange);
         }
 
         /// <summary>
@@ -259,7 +262,20 @@ namespace ModernFormsNext
         /// <summary>
         /// Gets or sets the text of the item.
         /// </summary>
-        public string Text { get; set; } = string.Empty;
+        public string Text
+        {
+            get => text;
+            set
+            {
+                value ??= string.Empty;
+                if (text == value)
+                    return;
+
+                text = value;
+                Invalidate();
+                TreeView?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.NameChange);
+            }
+        }
 
         /// <summary>
         /// Gets the TreeView that contains this item.

--- a/ModernFormsNext/TreeViewItemCollection.cs
+++ b/ModernFormsNext/TreeViewItemCollection.cs
@@ -54,29 +54,49 @@ namespace ModernFormsNext
         }
 
         /// <inheritdoc/>
+        protected override void ClearItems()
+        {
+            TreeView? treeView = owner.TreeView;
+            TreeViewItem[] removedItems = Items.ToArray();
+
+            foreach (TreeViewItem item in removedItems)
+                item.Parent = null;
+
+            base.ClearItems();
+            owner.Invalidate();
+            treeView?.OnAccessibilityItemsRemoved(removedItems);
+            treeView?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
+        }
+
+        /// <inheritdoc/>
         protected override void InsertItem (int index, TreeViewItem item)
         {
             base.InsertItem (index, item);
 
             item.Parent = owner;
             owner.Invalidate ();
+            owner.TreeView?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
 
         /// <inheritdoc/>
         protected override void RemoveItem (int index)
         {
             var item = this[index];
+            TreeView? treeView = owner.TreeView;
 
             base.RemoveItem (index);
 
             item.Parent = null;
             owner.Invalidate ();
+            treeView?.OnAccessibilityItemsRemoved([item]);
+            treeView?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
 
         /// <inheritdoc/>
         protected override void SetItem (int index, TreeViewItem item)
         {
             var old_item = this.ElementAtOrDefault (index);
+            TreeView? treeView = owner.TreeView;
 
             if (old_item != null)
                 old_item.Parent = null;
@@ -85,6 +105,9 @@ namespace ModernFormsNext
 
             item.Parent = owner;
             owner.Invalidate ();
+            if (old_item is not null)
+                treeView?.OnAccessibilityItemsRemoved([old_item]);
+            treeView?.NotifyAccessibilityClients(Accessibility.AccessibleEvents.Reorder);
         }
     }
 }

--- a/ModernFormsNext/WindowBase.cs
+++ b/ModernFormsNext/WindowBase.cs
@@ -60,6 +60,16 @@ namespace ModernFormsNext
             get => new System.Drawing.Rectangle (Location, Size);
         }
 
+        /// <summary>
+        /// Gets the canonical platform-neutral accessibility object for this window.
+        /// </summary>
+        /// <remarks>
+        /// The object is backed by the window's internal root adapter and exposes the window title,
+        /// normalized window type, state, and user-control hierarchy without creating a native UI
+        /// Automation provider. Mutable state must be read and acted upon on the UI thread.
+        /// </remarks>
+        public Accessibility.AccessibleObject AccessibilityObject => adapter.AccessibilityObject;
+
         private MouseEventArgs BuildMouseClickArgs (MouseButtons buttons, Point point, Keys keyData)
         {
             var click_count = 1;

--- a/docs-site/toc.yml
+++ b/docs-site/toc.yml
@@ -18,6 +18,8 @@
   href: content/docs/samples.md
 - name: Headless testing
   href: content/docs/testing/testhost.md
+- name: Accessibility semantic model
+  href: content/docs/accessibility/semantic-model.md
 - name: Platform status
   href: content/docs/platform-specific-features.md
 - name: Known limitations

--- a/docs/accessibility/semantic-model.md
+++ b/docs/accessibility/semantic-model.md
@@ -1,0 +1,216 @@
+# Shared accessibility semantic model
+
+ModernFormsNext exposes one canonical, platform-neutral semantic model in
+`ModernFormsNext.Accessibility`. The existing `AccessibleObject` remains its root abstraction. A
+control normally maps through this chain:
+
+```text
+Control
+  -> ControlAccessibleObject
+  -> AccessibleObject
+  -> thin platform adapter
+  -> native accessibility backend
+```
+
+The model does not depend on Windows UI Automation, MSAA, Android accessibility, native handles,
+IPC, or an automation transport. A backend may use an internal data-transfer type, but applications
+and future diagnostics or automation features should consume the canonical `AccessibleObject`
+surface instead of defining another public semantic domain.
+
+## Compatibility role and normalized control type
+
+`AccessibleRole` retains WinForms/MSAA-compatible role values. It remains useful to the existing
+Windows MSAA bridge and to applications migrating custom accessible objects from WinForms.
+
+`AccessibleControlType` is the normalized ModernFormsNext classification. It describes concepts such
+as button, edit, list item, tree item, tab item, slider, progress bar, and window without copying a
+native platform enum. `Control.AccessibleControlType` defaults to `Default`, allowing
+`ControlAccessibleObject` to infer the type. A custom control can explicitly set that property or
+override `AccessibleObject.ControlType`.
+
+Both properties are intentional:
+
+- `AccessibleRole` is the compatibility/legacy role.
+- `AccessibleControlType` is the canonical normalized semantic type.
+
+## Tree views and visibility
+
+`AccessibilityView` classifies an object into progressively more user-relevant projections:
+
+- `Raw` appears only in a complete raw tree.
+- `Control` also appears in an interactive-control projection.
+- `Content` also appears in a content projection.
+- `Hidden` is excluded from active trees.
+- `Default` lets a control infer the appropriate value.
+
+Setting `Control.AccessibilityView` to `Hidden` changes only the accessibility tree; it does not
+change the visual tree or `Control.Visible`. Standard invisible and disposed controls report a
+hidden view and are omitted from their parent's active child sequence. `AccessibleStates.Invisible`
+and `AccessibleStates.Offscreen` remain available when an object is queried directly.
+
+## Names, values, and sensitive data
+
+`Name` labels an object. `Value` represents editable text, a current selection, or a numeric value.
+They are separate semantic fields.
+
+Standard name fallbacks are deliberately conservative:
+
+- buttons, check boxes, radio buttons, switches, labels, and similar labelled controls use
+  `AccessibleName`, then visible `Text`, then `Control.Name`;
+- text boxes use `AccessibleName`, then `Control.Name`, and never use entered text as their name;
+- a form root uses its window title;
+- logical list, tree, tab, and menu items use the corresponding item text.
+
+`AccessibleObject.IsSensitive` marks values that must be redacted from accessibility snapshots,
+diagnostics, and logs. A password `TextBox` reports `IsSensitive == true`, retains its label/name and
+edit control type, and returns an empty semantic `Value`. Setting the text through a supported action
+does not make the underlying password readable through `Value`.
+
+## Actions
+
+`AccessibleActions` is the only public action vocabulary. `SupportedActions` is a flags value used
+for capability inspection; `PerformAction` accepts exactly one action and an optional parameter.
+It returns `false` for an unsupported action, an invalid parameter, an unavailable object, or a
+rejected state change.
+
+Standard actions call normal framework behavior:
+
+- `Button`: `Invoke` through `PerformClick`;
+- `CheckBox` and `Switch`: `Toggle`;
+- `RadioButton`: `Select` with the normal mutually-exclusive update;
+- editable `TextBox`: `SetValue`;
+- `ComboBox`: `Expand` and `Collapse`, with `Select` on logical items;
+- list/list-view items: `Select`, and list-box items also support `ScrollIntoView`;
+- tree items: `Select`, `Expand`, `Collapse`, and `ScrollIntoView`;
+- tab items: `Select`;
+- `TrackBar`: `SetValue`, `Increment`, and `Decrement`;
+- command menu items: `Invoke`; submenu items advertise expand/collapse;
+- focusable controls: `Focus` through the normal framework focus path.
+
+Unsupported behavior is not advertised. For example, a read-only text box omits `SetValue`, a
+`ProgressBar` exposes range information without a write action, and a separator exposes no action.
+Actions do not use reflection or call private event-handler delegates.
+
+## Values and ranges
+
+`AccessibleRangeValue` reports `Value`, `Minimum`, `Maximum`, `SmallChange`, `LargeChange`, and
+`IsReadOnly`. It validates finite, ordered range metadata. `TrackBar` exposes a writable range;
+`ProgressBar` exposes a read-only range. The representation uses the control's logical value units,
+not pixels.
+
+## Identity
+
+Every `AccessibleObject` receives a positive process-session `RuntimeId`. It remains stable for that
+object but is not persistent across application runs. Logical-item peers are cached for the life of
+their represented item, so moving an item does not change its runtime identity.
+
+`AutomationId` is a separate developer-facing semantic identifier. `Control.AccessibleAutomationId`
+can set it explicitly and otherwise falls back to `Control.Name`. Reordering a control does not alter
+either identifier.
+
+## Logical and custom children
+
+`GetChildCount` and `GetChild` can return objects that are not `Control` instances. The protected
+`ControlAccessibleObject.GetAccessibilityChildren()` method lets a custom control combine or replace
+visual control children with logical children while retaining the standard filtering behavior.
+
+The built-in Phase 1 mapping creates logical peers on demand for:
+
+- `ComboBox` and `ListBox` items;
+- `ListViewItem` instances;
+- hierarchical `TreeViewItem` instances;
+- `TabPage` tab headers;
+- `MenuItem` instances and nested menu items.
+
+These peers use weak owner/item references where retaining an object would extend UI lifetime. Item
+move operations preserve runtime identity. Removal or owner disposal detaches the peer from its
+parent and makes it hidden. Tree selection is cleared when a selected subtree is removed. The
+implementation does not materialize controls for logical items and does not implement the separate
+virtualization roadmap work.
+
+Example custom semantic child:
+
+```csharp
+sealed class PaintedGroupAccessibleObject : Control.ControlAccessibleObject
+{
+    private readonly AccessibleObject action;
+
+    public PaintedGroupAccessibleObject(Control owner, AccessibleObject action)
+        : base(owner)
+    {
+        this.action = action;
+    }
+
+    public override AccessibleControlType ControlType => AccessibleControlType.Group;
+
+    protected override IEnumerable<AccessibleObject> GetAccessibilityChildren()
+    {
+        yield return action;
+    }
+}
+```
+
+The logical child's `Parent` should return the group object, and the same child instance should be
+returned while the painted item remains alive.
+
+## State and focus
+
+The existing `AccessibleStates` enum remains canonical. Enabled and unchecked states are represented
+by the absence of `Unavailable` and `Checked`/`Mixed`; disabled, invisible, focusable, focused,
+checked, mixed, selected, expanded, collapsed, read-only, protected, and offscreen states use the
+existing flags.
+
+Phase 1 reuses normal framework keyboard focus. It does not introduce an accessibility focus manager.
+`Focus` calls the regular control selection/focus path, and `Focused` reports that framework state.
+Native accessibility-focus distinctions belong in platform phases.
+
+## Notifications
+
+The existing `NotifyClients`/`AccessibleEvents` path remains the only notification mechanism.
+Semantic changes map as follows:
+
+| Semantic change | Existing event |
+| --- | --- |
+| name | `NameChange` |
+| value | `ValueChange` |
+| enabled, checked, expanded, read-only, or other state | `StateChange` |
+| keyboard focus | `Focus` plus `StateChange` |
+| selection | `Selection` or `SelectionWithin` |
+| child add, remove, reorder, or dispose | `Reorder` |
+| bounds | `LocationChange` |
+
+Control and logical-item collection mutations update the queried tree without recreating the whole
+control hierarchy. Notifications remain platform-neutral; Phase 1 does not raise Windows UIA or
+Android native events.
+
+## Threading and lifetime
+
+Control state is UI-thread-affine. Read mutable semantic properties and call `PerformAction` on the
+owning UI thread. A future native backend receiving callbacks on another thread must dispatch before
+querying or mutating a control; Phase 1 deliberately does not add backend callback marshalling.
+
+`Control.AccessibilityObject` is lazy and cached. Merely constructing controls does not build a
+semantic snapshot or native provider. Standard accessible objects keep a weak reference to their
+control owner. Consumers may retain an accessible object after removal, but it then reports no active
+parent and cannot perform control actions.
+
+## Platform boundary and later phases
+
+`PlatformAccessibleObjectAdapter` remains a thin internal bridge to the existing public WindowKit
+transport. Phase 1 does not add another set of public semantic enums to WindowKit and does not change
+the existing `IPlatformAccessibleObject` contract. The Windows `WM_GETOBJECT`/MSAA path continues to
+consume names, roles, states, values, bounds, hierarchy, navigation, selection, and default actions.
+
+The remaining issue phases are intentionally separate:
+
+- **Phase 2 — Windows:** native UI Automation provider, patterns, UIA event translation, and observed
+  validation with accessibility inspection tools.
+- **Phase 3 — Android:** `AccessibilityNodeProvider` mapping, native events/focus, and TalkBack
+  validation.
+- **Phase 4 — broader coverage:** deeper control and virtualized-item coverage, diagnostics,
+  Developer Tools integration, samples, and platform validation matrices.
+
+The Phase 1 implementation does not include TestHost input simulation, waits, live automation,
+Developer Tools, MCP, IPC, commands, IME, lifecycle infrastructure, native view hosting, or a
+read-only TestHost snapshot. A future `AccessibilityTreeSnapshot` can be a redacting projection of
+this model without becoming another semantic source of truth.

--- a/docs/accessibility/semantic-model.md
+++ b/docs/accessibility/semantic-model.md
@@ -28,6 +28,9 @@ native platform enum. `Control.AccessibleControlType` defaults to `Default`, all
 `ControlAccessibleObject` to infer the type. A custom control can explicitly set that property or
 override `AccessibleObject.ControlType`.
 
+A top-level `Form` is a window by default. While it is shown through `ShowDialog`, its root maps to
+the compatibility `Dialog` role and normalized `Dialog` control type.
+
 Both properties are intentional:
 
 - `AccessibleRole` is the compatibility/legacy role.
@@ -42,6 +45,12 @@ Both properties are intentional:
 - `Content` also appears in a content projection.
 - `Hidden` is excluded from active trees.
 - `Default` lets a control infer the appropriate value.
+
+These values classify semantic nodes; they are not Windows UIA `TreeScope` or native view values.
+Phase 1 does not expose separate projection-query endpoints. Its active child enumeration filters
+`Hidden`; future platform adapters and diagnostics can use `Raw`, `Control`, and `Content` to build
+the projection they require. For the standard mapping, `Default` resolves labels, images, shapes,
+and progress indicators to `Content`, and other controls to `Control`.
 
 Setting `Control.AccessibilityView` to `Hidden` changes only the accessibility tree; it does not
 change the visual tree or `Control.Visible`. Standard invisible and disposed controls report a
@@ -71,7 +80,9 @@ does not make the underlying password readable through `Value`.
 `AccessibleActions` is the only public action vocabulary. `SupportedActions` is a flags value used
 for capability inspection; `PerformAction` accepts exactly one action and an optional parameter.
 It returns `false` for an unsupported action, an invalid parameter, an unavailable object, or a
-rejected state change.
+rejected state change. Capability flags describe the current state: disabled, invisible, hidden,
+detached, or otherwise unavailable elements do not advertise actions, and expandable controls
+advertise `Expand` or `Collapse` according to their current state rather than both at once.
 
 Standard actions call normal framework behavior:
 
@@ -100,9 +111,15 @@ not pixels.
 
 ## Identity
 
-Every `AccessibleObject` receives a positive process-session `RuntimeId`. It remains stable for that
-object but is not persistent across application runs. Logical-item peers are cached for the life of
-their represented item, so moving an item does not change its runtime identity.
+Every `AccessibleObject` receives a positive process-session `RuntimeId`. Allocation is atomic,
+thread-safe, and fails explicitly if the signed 64-bit identifier space is ever exhausted rather
+than wrapping into duplicate or negative identifiers. The identifier remains stable for that object
+but is not persistent across application runs.
+
+Logical-item peers are cached for the life of their represented element, so moving an item does not
+change its runtime identity. `ListBox` and `ComboBox` assign identity per collection occurrence:
+inserting the same object instance more than once produces distinct semantic elements, and moving
+either occurrence preserves the corresponding peer and runtime identifier.
 
 `AutomationId` is a separate developer-facing semantic identifier. `Control.AccessibleAutomationId`
 can set it explicitly and otherwise falls back to `Control.Name`. Reordering a control does not alter
@@ -122,11 +139,12 @@ The built-in Phase 1 mapping creates logical peers on demand for:
 - `TabPage` tab headers;
 - `MenuItem` instances and nested menu items.
 
-These peers use weak owner/item references where retaining an object would extend UI lifetime. Item
-move operations preserve runtime identity. Removal or owner disposal detaches the peer from its
-parent and makes it hidden. Tree selection is cleared when a selected subtree is removed. The
-implementation does not materialize controls for logical items and does not implement the separate
-virtualization roadmap work.
+These peers use weak owner/item references where retaining an object would extend UI lifetime. The
+control-to-peer notification route also uses a weak owner reference, so an externally retained peer
+does not keep its control alive. Item move operations preserve runtime identity. Removal or owner
+disposal detaches the peer from its parent and makes it hidden. Tree selection is cleared when a
+selected subtree is removed. The implementation does not materialize controls for logical items and
+does not implement the separate virtualization roadmap work.
 
 Example custom semantic child:
 
@@ -175,7 +193,7 @@ Semantic changes map as follows:
 | value | `ValueChange` |
 | enabled, checked, expanded, read-only, or other state | `StateChange` |
 | keyboard focus | `Focus` plus `StateChange` |
-| selection | `Selection` or `SelectionWithin` |
+| selection | `Selection`, `SelectionRemove`, or `SelectionWithin` |
 | child add, remove, reorder, or dispose | `Reorder` |
 | bounds | `LocationChange` |
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of #59 — the shared, platform-neutral accessibility semantic foundation.

## Included

- extend the existing `AccessibleObject` model instead of introducing a second automation hierarchy
- add canonical `AccessibleControlType`
- add canonical `AccessibilityView`
- add canonical `AccessibleActions`
- add canonical `AccessibleRangeValue`
- add stable runtime identity
- add `AutomationId`
- add sensitive/password semantics
- add representative control actions/state/value mappings
- add logical accessibility children for list/tree/tab/menu-style items
- add custom logical child support
- add platform-neutral semantic notifications
- add deterministic semantic tests
- add semantic model documentation

## Compatibility

- existing `AccessibleRole` is preserved for WinForms/MSAA compatibility
- existing Windows MSAA path remains unchanged
- no public Windows UIA types are exposed
- no breaking public API removals or signature changes
- the semantic model remains platform-neutral

## Validation

- `dotnet restore`: passed
- Debug solution build: passed, 0 warnings, 0 errors
- Release solution build: passed, 0 warnings, 0 errors
- `AccessibilitySemanticTests`: 29/29 passed
- all required test projects: 1698/1698 passed
  - `ModernFormsNext.Tests`: 906/906
  - `ModernFormsNext.Designer.Tests`: 622/622
  - `ModernFormsNext.Testing.Tests`: 46/46
  - Windows backend tests: 10/10
  - Android backend tests: 72/72
  - cross-platform tests: 16/16
  - VSIX tests: 26/26
- release documentation script tests: 32 assertions passed
- DocFX: 917 models, 0 warnings, 0 errors
- versioned documentation validation: 4/4 archives passed
- SDK package ApiCompat against published `ModernFormsNext` 1.10.0: no incompatible changes, 0 warnings, 0 errors
  - unresolved `System.Formats.Nrbf` reference messages were informational and did not affect the successful result
- package validation: 9 NuGet packages and 8 symbol packages passed
- `git diff --check`: passed

## Scope boundary

This PR does **not** implement:

- Windows UI Automation provider/patterns
- Android AccessibilityNodeProvider
- TalkBack
- Accessibility Insights validation
- Developer Tools
- TestHost automation
- Agent bridge / MCP
- Command System
- IME
- Lifecycle
- Virtualization

## Issue state

Part of #59 — completes Phase 1 only.

Issue #59 must remain open after this PR.