### PR TITLE
Add Windows UI Automation accessibility backend

### DIFF
--- a/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
+++ b/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
@@ -217,6 +217,25 @@ public sealed class AccessibilitySemanticTests
     }
 
     [Fact]
+    public void MultiSelectListBoxSemanticItemsHonorAddAndRemoveSelectionFlags()
+    {
+        using var root = new VisibleRootControl();
+        using var listBox = root.Controls.Add(new ListBox { SelectionMode = SelectionMode.MultiSimple });
+        listBox.Items.Add("Alpha");
+        listBox.Items.Add("Beta");
+
+        AccessibleObject first = Assert.IsAssignableFrom<AccessibleObject>(listBox.AccessibilityObject.GetChild(0));
+        AccessibleObject second = Assert.IsAssignableFrom<AccessibleObject>(listBox.AccessibilityObject.GetChild(1));
+
+        first.Select(AccessibleSelection.AddSelection);
+        second.Select(AccessibleSelection.AddSelection);
+        Assert.Equal(new[] { 0, 1 }, listBox.Items.SelectedIndexes);
+
+        first.Select(AccessibleSelection.RemoveSelection);
+        Assert.Equal(new[] { 1 }, listBox.Items.SelectedIndexes);
+    }
+
+    [Fact]
     public void EqualListAndComboOccurrencesKeepDistinctIdentityAcrossReorder()
     {
         using var root = new VisibleRootControl();

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- UIAutomationClient is used only by this out-of-process test client. The product graph
+         remains independent of WindowsDesktop/WPF/WinForms reference assemblies. -->
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
+  </ItemGroup>
+
+</Project>

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient/Program.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient/Program.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using System.Windows.Automation;
+
+if (args.Length != 1 || !long.TryParse(args[0], out long rawHandle) || rawHandle == 0)
+    return 2;
+
+AutomationElement root = AutomationElement.FromHandle(new IntPtr(rawHandle));
+AutomationElement? button = root.FindFirst(
+    TreeScope.Descendants,
+    new PropertyCondition(AutomationElement.AutomationIdProperty, "uia.integration.invoke"));
+
+if (button is null)
+{
+    Console.Error.WriteLine($"Root: name='{root.Current.Name}', frameworkId='{root.Current.FrameworkId}', controlType={root.Current.ControlType.Id}");
+    AutomationElement? candidate = TreeWalker.RawViewWalker.GetFirstChild(root);
+    while (candidate is not null)
+    {
+        Console.Error.WriteLine(
+            $"Child: name='{candidate.Current.Name}', automationId='{candidate.Current.AutomationId}', controlType={candidate.Current.ControlType.Id}");
+        candidate = TreeWalker.RawViewWalker.GetNextSibling(candidate);
+    }
+
+    return 3;
+}
+
+string rootNameBeforeInvoke = root.Current.Name;
+string buttonName = button.Current.Name;
+string automationId = button.Current.AutomationId;
+int rootControlType = root.Current.ControlType.Id;
+int buttonControlType = button.Current.ControlType.Id;
+object pattern = button.GetCurrentPattern(InvokePattern.Pattern);
+if (pattern is not InvokePattern invokePattern)
+    return 4;
+
+invokePattern.Invoke();
+button.SetFocus();
+
+var result = new
+{
+    RootNameBeforeInvoke = rootNameBeforeInvoke,
+    RootNameAfterInvoke = root.Current.Name,
+    ButtonName = buttonName,
+    AutomationId = automationId,
+    RootControlType = rootControlType,
+    ButtonControlType = buttonControlType,
+    HasKeyboardFocus = button.Current.HasKeyboardFocus
+};
+
+Console.WriteLine(JsonSerializer.Serialize(result));
+return 0;

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ModernFormsNext\ModernFormsNext.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost/Program.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost/Program.cs
@@ -1,0 +1,30 @@
+using System.Drawing;
+using ModernFormsNext;
+
+using var form = new Form
+{
+    ClientSize = new Size(480, 240),
+    Text = "ModernFormsNext UIA integration window"
+};
+
+var button = new Button
+{
+    AccessibleAutomationId = "uia.integration.invoke",
+    AccessibleName = "Invoke integration action",
+    Bounds = new Rectangle(24, 24, 220, 48),
+    Text = "Invoke"
+};
+
+button.Click += (_, _) =>
+{
+    form.Text = "ModernFormsNext UIA action invoked";
+    Console.WriteLine("INVOKED");
+};
+
+form.Controls.Add(button);
+form.Shown += (_, _) =>
+{
+    Console.WriteLine($"HWND:{form.PlatformHandle.Handle.ToInt64()}");
+};
+
+Application.Run(form);

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/ModernFormsNext.WindowKit.Backend.Windows.Tests.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/ModernFormsNext.WindowKit.Backend.Windows.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -24,6 +24,10 @@
   <ItemGroup>
     <ProjectReference Include="..\ModernFormsNext\ModernFormsNext.csproj" />
     <ProjectReference Include="..\ModernFormsNext.WindowKit.Backend.Windows\ModernFormsNext.WindowKit.Backend.Windows.csproj" />
+    <ProjectReference Include="..\ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient\ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient.csproj"
+                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost\ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost.csproj"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
@@ -1,0 +1,829 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using ModernFormsNext.WindowKit.Backend.Windows.Win32;
+using ModernFormsNext.WindowKit.Platform.Accessibility;
+using Xunit;
+using PlatformRect = ModernFormsNext.WindowKit.Rect;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows.Tests;
+
+public sealed class WindowsUiaProviderTests
+{
+    private const int ActionInvoke = 1 << 0;
+    private const int ActionToggle = 1 << 1;
+    private const int ActionSelect = 1 << 2;
+    private const int ActionExpand = 1 << 3;
+    private const int ActionCollapse = 1 << 4;
+    private const int ActionSetValue = 1 << 5;
+    private const int ActionScrollIntoView = 1 << 9;
+    private const int ActionFocus = 1 << 10;
+
+    private const int StateUnavailable = 0x1;
+    private const int StateSelected = 0x2;
+    private const int StateFocused = 0x4;
+    private const int StateChecked = 0x10;
+    private const int StateMixed = 0x20;
+    private const int StateReadOnly = 0x40;
+    private const int StateExpanded = 0x200;
+    private const int StateCollapsed = 0x400;
+    private const int StateOffscreen = 0x10000;
+    private const int StateFocusable = 0x100000;
+    private const int StateMultiSelectable = 0x1000000;
+
+    [Fact]
+    public void RootProviderMapsCanonicalProperties()
+    {
+        TestAccessibleObject root = Root(
+            name: "Settings",
+            controlType: 23,
+            actions: ActionFocus,
+            state: StateFocusable | StateFocused);
+        root.AutomationId = "SettingsDialog";
+        root.Help = "Application settings";
+        root.ClassName = "SettingsForm";
+        root.Bounds = new PlatformRect(100, 120, 640, 480);
+
+        using WindowsUiaRootProvider provider = Create(root);
+
+        Assert.Equal("Settings", Property(provider, WindowsUiaIds.NameProperty));
+        Assert.Equal("SettingsDialog", Property(provider, WindowsUiaIds.AutomationIdProperty));
+        Assert.Equal(50032, Property(provider, WindowsUiaIds.ControlTypeProperty));
+        Assert.Equal(true, Property(provider, WindowsUiaIds.IsEnabledProperty));
+        Assert.Equal(true, Property(provider, WindowsUiaIds.IsKeyboardFocusableProperty));
+        Assert.Equal(true, Property(provider, WindowsUiaIds.HasKeyboardFocusProperty));
+        Assert.Equal("Application settings", Property(provider, WindowsUiaIds.HelpTextProperty));
+        Assert.Equal("SettingsForm", Property(provider, WindowsUiaIds.ClassNameProperty));
+        Assert.Equal("ModernFormsNext", Property(provider, WindowsUiaIds.FrameworkIdProperty));
+    }
+
+    [Theory]
+    [InlineData(1, 50025)]
+    [InlineData(2, 50032)]
+    [InlineData(3, 50033)]
+    [InlineData(4, 50026)]
+    [InlineData(5, 50020)]
+    [InlineData(6, 50000)]
+    [InlineData(7, 50002)]
+    [InlineData(8, 50013)]
+    [InlineData(9, 50002)]
+    [InlineData(10, 50004)]
+    [InlineData(11, 50003)]
+    [InlineData(12, 50008)]
+    [InlineData(13, 50007)]
+    [InlineData(14, 50023)]
+    [InlineData(15, 50024)]
+    [InlineData(16, 50018)]
+    [InlineData(17, 50019)]
+    [InlineData(18, 50009)]
+    [InlineData(19, 50011)]
+    [InlineData(20, 50015)]
+    [InlineData(21, 50012)]
+    [InlineData(22, 50014)]
+    [InlineData(23, 50032)]
+    [InlineData(24, 50006)]
+    [InlineData(25, 50021)]
+    [InlineData(26, 50038)]
+    public void ControlTypesMapFromCanonicalIds(int canonicalType, int expectedUiaType)
+        => Assert.Equal(expectedUiaType, WindowsUiaControlTypeMapper.Map(canonicalType));
+
+    [Fact]
+    public void FragmentNavigationUsesCanonicalParentsChildrenAndSiblings()
+    {
+        TestAccessibleObject root = Root("Root", controlType: 2);
+        TestAccessibleObject first = root.AddChild(new TestAccessibleObject("Logical item", 13));
+        TestAccessibleObject custom = root.AddChild(new TestAccessibleObject("Custom child", 1));
+        using WindowsUiaRootProvider provider = Create(root);
+
+        var firstProvider = Assert.IsType<WindowsUiaProvider>(provider.Navigate(NavigateDirection.FirstChild));
+        var customProvider = Assert.IsType<WindowsUiaProvider>(firstProvider.Navigate(NavigateDirection.NextSibling));
+
+        Assert.Same(root, Assert.IsType<WindowsUiaRootProvider>(firstProvider.Navigate(NavigateDirection.Parent)).PlatformObject);
+        Assert.Same(custom, customProvider.PlatformObject);
+        Assert.Same(first, Assert.IsType<WindowsUiaProvider>(customProvider.Navigate(NavigateDirection.PreviousSibling)).PlatformObject);
+        Assert.Same(customProvider, provider.Navigate(NavigateDirection.LastChild));
+    }
+
+    [Fact]
+    public void ReorderPreservesProviderIdentityAndRemovalMakesProviderUnavailable()
+    {
+        TestAccessibleObject root = Root("Root", controlType: 2);
+        TestAccessibleObject first = root.AddChild(new TestAccessibleObject("First", 13));
+        TestAccessibleObject second = root.AddChild(new TestAccessibleObject("Second", 13));
+        using WindowsUiaRootProvider provider = Create(root);
+
+        var firstProvider = Assert.IsType<WindowsUiaProvider>(provider.Navigate(NavigateDirection.FirstChild));
+        root.Children.Reverse();
+
+        Assert.Same(firstProvider, provider.Navigate(NavigateDirection.LastChild));
+        root.Children.Remove(first);
+        first.ParentObject = null;
+
+        Assert.Throws<WindowsUiaElementNotAvailableException>(() => firstProvider.GetPropertyValue(WindowsUiaIds.NameProperty));
+        Assert.Same(second, Assert.IsType<WindowsUiaProvider>(provider.Navigate(NavigateDirection.FirstChild)).PlatformObject);
+    }
+
+    [Fact]
+    public void BoundingRectangleUsesPhysicalCanonicalScreenPixelsWithoutDoubleScaling()
+    {
+        TestAccessibleObject root = Root("Root", controlType: 2);
+        root.Bounds = new PlatformRect(150, 225, 450, 300);
+        using WindowsUiaRootProvider provider = Create(root);
+
+        UiaRect bounds = provider.BoundingRectangle;
+
+        Assert.Equal(new UiaRect(150, 225, 450, 300), bounds);
+        Assert.Equal(false, Property(provider, WindowsUiaIds.IsOffscreenProperty));
+        root.State |= StateOffscreen;
+        Assert.Equal(true, Property(provider, WindowsUiaIds.IsOffscreenProperty));
+    }
+
+    [Theory]
+    [InlineData(1, false, false)]
+    [InlineData(2, true, false)]
+    [InlineData(3, true, true)]
+    [InlineData(4, false, false)]
+    public void AccessibilityViewMapsToControlAndContentProperties(
+        int view,
+        bool expectedControl,
+        bool expectedContent)
+    {
+        TestAccessibleObject root = Root("Root", controlType: 2);
+        root.View = view;
+        using WindowsUiaRootProvider provider = Create(root);
+
+        Assert.Equal(expectedControl, Property(provider, WindowsUiaIds.IsControlElementProperty));
+        Assert.Equal(expectedContent, Property(provider, WindowsUiaIds.IsContentElementProperty));
+    }
+
+    [Fact]
+    public void PatternsAreAdvertisedOnlyForCanonicalCapabilities()
+    {
+        TestAccessibleObject node = Root("Node", controlType: 10, actions: ActionInvoke | ActionSetValue);
+        using WindowsUiaRootProvider provider = Create(node);
+
+        Assert.Same(provider, provider.GetPatternProvider(WindowsUiaIds.InvokePattern));
+        Assert.Same(provider, provider.GetPatternProvider(WindowsUiaIds.ValuePattern));
+        Assert.Null(provider.GetPatternProvider(WindowsUiaIds.TogglePattern));
+        Assert.Null(provider.GetPatternProvider(10004));
+    }
+
+    [Fact]
+    public void InvokeRoutesThroughCanonicalAction()
+    {
+        TestAccessibleObject node = Root("Action", controlType: 6, actions: ActionInvoke);
+        using WindowsUiaRootProvider provider = Create(node);
+
+        Assert.Same(provider, provider.GetPatternProvider(WindowsUiaIds.InvokePattern));
+        ((IInvokeProvider)provider).Invoke();
+
+        Assert.Equal(ActionInvoke, node.LastAction);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(StateChecked, 1)]
+    [InlineData(StateMixed, 2)]
+    public void ToggleMapsStateAndRoutesCanonicalAction(int state, int expected)
+    {
+        TestAccessibleObject node = Root("Toggle", controlType: 7, actions: ActionToggle, state: state);
+        using WindowsUiaRootProvider provider = Create(node);
+        var toggle = (IToggleProvider)provider;
+
+        Assert.Equal((ToggleState)expected, toggle.ToggleState);
+        toggle.Toggle();
+        Assert.Equal(ActionToggle, node.LastAction);
+    }
+
+    [Fact]
+    public void ValuePatternRespectsReadOnlyAndPasswordPrivacy()
+    {
+        TestAccessibleObject editable = Root("Editor", controlType: 10, actions: ActionSetValue);
+        editable.Value = "before";
+        using WindowsUiaRootProvider editableProvider = Create(editable);
+        var valueProvider = (IValueProvider)editableProvider;
+
+        Assert.False(valueProvider.IsReadOnly);
+        Assert.Equal("before", valueProvider.Value);
+        valueProvider.SetValue("after");
+        Assert.Equal("after", editable.Value);
+
+        TestAccessibleObject password = Root("Password", controlType: 10, actions: ActionSetValue);
+        password.IsSensitive = true;
+        password.Value = "secret";
+        using WindowsUiaRootProvider passwordProvider = Create(password);
+        var passwordValue = (IValueProvider)passwordProvider;
+
+        Assert.Equal(true, Property(passwordProvider, WindowsUiaIds.IsPasswordProperty));
+        Assert.Throws<WindowsUiaAccessDeniedException>(() => passwordProvider.GetPropertyValue(WindowsUiaIds.ValueProperty));
+        Assert.Throws<WindowsUiaAccessDeniedException>(() => passwordValue.Value);
+        passwordValue.SetValue("replacement");
+        Assert.Equal("replacement", password.Value);
+
+        TestAccessibleObject readOnly = Root("Read only", controlType: 10, state: StateReadOnly);
+        readOnly.Value = "visible";
+        using WindowsUiaRootProvider readOnlyProvider = Create(readOnly);
+        var readOnlyValue = Assert.IsAssignableFrom<IValueProvider>(
+            readOnlyProvider.GetPatternProvider(WindowsUiaIds.ValuePattern));
+        Assert.True(readOnlyValue.IsReadOnly);
+        Assert.Equal("visible", readOnlyValue.Value);
+        Assert.Throws<InvalidOperationException>(() => readOnlyValue.SetValue("rejected"));
+    }
+
+    [Fact]
+    public void RangeValueMapsMetadataAndRoutesSetValue()
+    {
+        TestAccessibleObject node = Root("Volume", controlType: 20, actions: ActionSetValue);
+        node.RangeValue = new PlatformAccessibleRangeValue(25, 0, 100, 1, 10, false);
+        using WindowsUiaRootProvider provider = Create(node);
+        var range = (IRangeValueProvider)provider;
+
+        Assert.Equal(25, range.Value);
+        Assert.Equal(0, range.Minimum);
+        Assert.Equal(100, range.Maximum);
+        Assert.Equal(1, range.SmallChange);
+        Assert.Equal(10, range.LargeChange);
+        Assert.False(range.IsReadOnly);
+        range.SetValue(75);
+        Assert.Equal(75, node.RangeValue?.Value);
+    }
+
+    [Fact]
+    public void ReadOnlyRangeRejectsMutation()
+    {
+        TestAccessibleObject node = Root("Progress", controlType: 21);
+        node.State = StateReadOnly;
+        node.RangeValue = new PlatformAccessibleRangeValue(50, 0, 100, 1, 10, true);
+        using WindowsUiaRootProvider provider = Create(node);
+
+        Assert.Same(provider, provider.GetPatternProvider(WindowsUiaIds.RangeValuePattern));
+        Assert.Throws<InvalidOperationException>(() => ((IRangeValueProvider)provider).SetValue(60));
+    }
+
+    [Theory]
+    [InlineData(StateExpanded, 1)]
+    [InlineData(StateCollapsed, 0)]
+    public void ExpandCollapseMapsStateAndCanonicalActions(int state, int expected)
+    {
+        TestAccessibleObject node = Root("Branch", controlType: 15, actions: ActionExpand | ActionCollapse, state: state);
+        using WindowsUiaRootProvider provider = Create(node);
+        var pattern = (IExpandCollapseProvider)provider;
+
+        Assert.Equal((ExpandCollapseState)expected, pattern.ExpandCollapseState);
+        pattern.Expand();
+        Assert.Equal(ActionExpand, node.LastAction);
+        pattern.Collapse();
+        Assert.Equal(ActionCollapse, node.LastAction);
+    }
+
+    [Fact]
+    public void SelectionContainerReturnsCanonicalSelectedChildren()
+    {
+        TestAccessibleObject list = Root("List", controlType: 12, state: StateMultiSelectable);
+        list.AddChild(new TestAccessibleObject("One", 13));
+        TestAccessibleObject selected = list.AddChild(new TestAccessibleObject("Two", 13) { State = StateSelected });
+        using WindowsUiaRootProvider provider = Create(list);
+        var selection = (ISelectionProvider)provider;
+
+        IRawElementProviderSimple item = Assert.Single(selection.GetSelection());
+
+        Assert.True(selection.CanSelectMultiple);
+        Assert.False(selection.IsSelectionRequired);
+        Assert.Same(selected, Assert.IsType<WindowsUiaProvider>(item).PlatformObject);
+    }
+
+    [Fact]
+    public void SelectionItemUsesCanonicalSelectionPath()
+    {
+        TestAccessibleObject list = Root("List", controlType: 12);
+        TestAccessibleObject item = list.AddChild(new TestAccessibleObject("Item", 13)
+        {
+            SupportedActions = ActionSelect
+        });
+        using WindowsUiaRootProvider provider = Create(list);
+        var itemProvider = Assert.IsType<WindowsUiaProvider>(provider.Navigate(NavigateDirection.FirstChild));
+        var selectionItem = (ISelectionItemProvider)itemProvider;
+
+        Assert.Same(provider, selectionItem.SelectionContainer);
+        selectionItem.Select();
+        Assert.Equal(ActionSelect, item.LastAction);
+    }
+
+    [Fact]
+    public void ScrollItemUsesCanonicalScrollIntoViewAction()
+    {
+        TestAccessibleObject list = Root("List", controlType: 12);
+        TestAccessibleObject item = list.AddChild(new TestAccessibleObject("Item", 13)
+        {
+            SupportedActions = ActionScrollIntoView
+        });
+        using WindowsUiaRootProvider provider = Create(list);
+        var itemProvider = Assert.IsType<WindowsUiaProvider>(provider.Navigate(NavigateDirection.FirstChild));
+
+        Assert.Same(itemProvider, itemProvider.GetPatternProvider(WindowsUiaIds.ScrollItemPattern));
+        ((IScrollItemProvider)itemProvider).ScrollIntoView();
+        Assert.Equal(ActionScrollIntoView, item.LastAction);
+        Assert.Null(provider.GetPatternProvider(10004));
+    }
+
+    [Fact]
+    public void FocusAndHitTestingUseCanonicalSemanticTree()
+    {
+        TestAccessibleObject root = Root("Root", controlType: 2);
+        root.Bounds = new PlatformRect(0, 0, 500, 500);
+        TestAccessibleObject child = root.AddChild(new TestAccessibleObject("Focus target", 6)
+        {
+            Bounds = new PlatformRect(20, 30, 100, 40),
+            State = StateFocusable | StateFocused,
+            SupportedActions = ActionFocus
+        });
+        root.Focused = child;
+        using WindowsUiaRootProvider provider = Create(root);
+
+        Assert.Same(child, Assert.IsType<WindowsUiaProvider>(provider.GetFocus()).PlatformObject);
+        Assert.Same(child, Assert.IsType<WindowsUiaProvider>(provider.ElementProviderFromPoint(25, 35)).PlatformObject);
+
+        var childProvider = Assert.IsType<WindowsUiaProvider>(provider.Navigate(NavigateDirection.FirstChild));
+        childProvider.SetFocus();
+        Assert.Equal(ActionFocus, child.LastAction);
+    }
+
+    [Fact]
+    public async Task BackgroundCallbacksUseDispatcherBoundary()
+    {
+        TestAccessibleObject root = Root("Root", controlType: 2, actions: ActionInvoke);
+        var dispatcher = new RecordingDispatcher();
+        using WindowsUiaRootProvider provider = WindowsUiaRootProvider.Create(new IntPtr(42), root, dispatcher);
+
+        object? name = await Task.Run(() => provider.GetPropertyValue(WindowsUiaIds.NameProperty));
+        await Task.Run(() => ((IInvokeProvider)provider).Invoke());
+
+        Assert.Equal("Root", name);
+        Assert.Equal(2, dispatcher.InvokeCount);
+    }
+
+    [Fact]
+    public void DisposedWindowMakesProviderUnavailable()
+    {
+        WindowsUiaRootProvider provider = Create(Root("Root", controlType: 2));
+        provider.Dispose();
+
+        Assert.Throws<WindowsUiaElementNotAvailableException>(() => provider.GetPropertyValue(WindowsUiaIds.NameProperty));
+
+        int result = provider.AbiGetPropertyValue(WindowsUiaIds.NameProperty, out WindowsUiaVariant value);
+        Assert.Equal(unchecked((int)0x80040201), result);
+        value.Dispose();
+    }
+
+    [Fact]
+    public void CanonicalNotificationsMapToNativeUiaEventsWithoutSensitiveValues()
+    {
+        var eventSink = new RecordingEventSink();
+        TestAccessibleObject node = Root(
+            "Toggle",
+            controlType: 7,
+            actions: ActionToggle,
+            state: StateChecked);
+        using WindowsUiaRootProvider provider = WindowsUiaRootProvider.Create(
+            new IntPtr(42),
+            node,
+            new InlineDispatcher(),
+            eventSink);
+
+        provider.RaiseNotification(node, 0x8005);
+        provider.RaiseNotification(node, 0x800C);
+        provider.RaiseNotification(node, 0x800A);
+        provider.RaiseNotification(node, 0x800B);
+        provider.RaiseNotification(node, 0x8006);
+        provider.RaiseNotification(node, 0x8004);
+        provider.RaiseNotification(node, 0x8002);
+        provider.RaiseNotification(node, 0x8003);
+
+        Assert.Contains(WindowsUiaIds.AutomationFocusChangedEvent, eventSink.AutomationEvents);
+        Assert.Contains(WindowsUiaIds.ElementSelectedEvent, eventSink.AutomationEvents);
+        Assert.Contains(WindowsUiaIds.NameProperty, eventSink.PropertyChanges);
+        Assert.Contains(WindowsUiaIds.IsEnabledProperty, eventSink.PropertyChanges);
+        Assert.Contains(WindowsUiaIds.ToggleStateProperty, eventSink.PropertyChanges);
+        Assert.Contains(WindowsUiaIds.BoundingRectangleProperty, eventSink.PropertyChanges);
+        Assert.Contains(StructureChangeType.ChildrenReordered, eventSink.StructureChanges);
+        Assert.Contains(StructureChangeType.ChildAdded, eventSink.StructureChanges);
+        Assert.Contains(StructureChangeType.ChildRemoved, eventSink.StructureChanges);
+
+        node.Value = "safe-value";
+        provider.RaiseNotification(node, 0x800E);
+        Assert.Contains(WindowsUiaIds.ValueProperty, eventSink.PropertyChanges);
+        Assert.Contains("safe-value", eventSink.Values);
+
+        int propertyChangeCount = eventSink.PropertyChanges.Count;
+        node.IsSensitive = true;
+        node.Value = "must-not-be-emitted";
+        provider.RaiseNotification(node, 0x800E);
+        Assert.Equal(propertyChangeCount, eventSink.PropertyChanges.Count);
+        Assert.DoesNotContain(eventSink.Values, value => Equals(value, "must-not-be-emitted"));
+    }
+
+    [Fact]
+    public void ComCallableWrapperExposesSimpleFragmentRootAndPatternInterfaces()
+    {
+        using WindowsUiaRootProvider provider = Create(Root("Root", controlType: 6, actions: ActionInvoke));
+        IntPtr unknown = WindowsUiaNativeMethods.GetUnknownPointer(provider);
+
+        try
+        {
+            AssertComInterface(unknown, new Guid("D6DD68D1-86FD-4332-8666-9ABEDEA2D24C"));
+            AssertComInterface(unknown, new Guid("F7063DA8-8359-439C-9297-BBC5299A7D87"));
+            AssertComInterface(unknown, new Guid("620CE2A5-AB8F-40A9-86CB-DE3C75599B58"));
+            AssertComInterface(unknown, new Guid("54FCB24B-E18E-47A2-B4D3-ECCBE77599A2"));
+        }
+        finally
+        {
+            _ = Marshal.Release(unknown);
+        }
+    }
+
+    [Fact]
+    public async Task RealHwndIsConsumableThroughTheWindowsUiAutomationClient()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string repositoryRoot = FindRepositoryRoot();
+#if DEBUG
+        const string configuration = "Debug";
+#else
+        const string configuration = "Release";
+#endif
+        string hostPath = System.IO.Path.Combine(
+            repositoryRoot,
+            "ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost",
+            "bin",
+            configuration,
+            "net10.0-windows",
+            "ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost.dll");
+        string clientPath = System.IO.Path.Combine(
+            repositoryRoot,
+            "ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient",
+            "bin",
+            configuration,
+            "net10.0-windows",
+            "ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient.dll");
+
+        Assert.True(File.Exists(hostPath), $"The UIA integration host was not built: {hostPath}");
+        Assert.True(File.Exists(clientPath), $"The UIA integration client was not built: {clientPath}");
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using Process host = StartDotnetProcess(hostPath);
+        IntPtr hwnd = IntPtr.Zero;
+        int? hostExitCode = null;
+
+        try
+        {
+            string? handleLine = await ReadLineStartingWithAsync(host, "HWND:", timeout.Token);
+            Assert.NotNull(handleLine);
+            Assert.True(long.TryParse(handleLine.AsSpan("HWND:".Length), out long rawHandle));
+            hwnd = new IntPtr(rawHandle);
+            Assert.NotEqual(IntPtr.Zero, hwnd);
+
+            using Process client = StartDotnetProcess(clientPath, rawHandle.ToString());
+            Task<string> clientOutputTask = client.StandardOutput.ReadToEndAsync(timeout.Token);
+            Task<string> clientErrorTask = client.StandardError.ReadToEndAsync(timeout.Token);
+            await client.WaitForExitAsync(timeout.Token);
+            string clientOutput = await clientOutputTask;
+            string clientError = await clientErrorTask;
+
+            Assert.True(
+                client.ExitCode == 0,
+                $"The real UIA client exited with {client.ExitCode}: {clientError}");
+
+            using JsonDocument result = JsonDocument.Parse(clientOutput);
+            JsonElement root = result.RootElement;
+            Assert.Equal("ModernFormsNext UIA integration window", root.GetProperty("RootNameBeforeInvoke").GetString());
+            Assert.Equal("ModernFormsNext UIA action invoked", root.GetProperty("RootNameAfterInvoke").GetString());
+            Assert.Equal("Invoke integration action", root.GetProperty("ButtonName").GetString());
+            Assert.Equal("uia.integration.invoke", root.GetProperty("AutomationId").GetString());
+            Assert.Equal(50032, root.GetProperty("RootControlType").GetInt32());
+            Assert.Equal(50000, root.GetProperty("ButtonControlType").GetInt32());
+            Assert.True(root.GetProperty("HasKeyboardFocus").GetBoolean());
+
+            Assert.Equal("INVOKED", await ReadLineStartingWithAsync(host, "INVOKED", timeout.Token));
+        }
+        finally
+        {
+            if (hwnd != IntPtr.Zero)
+                _ = PostMessage(hwnd, 0x0010, IntPtr.Zero, IntPtr.Zero);
+
+            try
+            {
+                await host.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException) when (!host.HasExited)
+            {
+                host.Kill(entireProcessTree: true);
+                await host.WaitForExitAsync();
+            }
+
+            if (host.HasExited)
+                hostExitCode = host.ExitCode;
+        }
+
+        Assert.Equal(0, hostExitCode);
+    }
+
+    private static WindowsUiaRootProvider Create(TestAccessibleObject root)
+        => WindowsUiaRootProvider.Create(new IntPtr(42), root, new InlineDispatcher());
+
+    private static TestAccessibleObject Root(
+        string name,
+        int controlType,
+        int actions = 0,
+        int state = 0)
+        => new(name, controlType)
+        {
+            SupportedActions = actions,
+            State = state,
+            View = 2,
+            Bounds = new PlatformRect(0, 0, 800, 600)
+        };
+
+    private static object? Property(WindowsUiaProvider provider, int propertyId)
+        => provider.GetPropertyValue(propertyId);
+
+    private static void AssertComInterface(IntPtr unknown, Guid interfaceId)
+    {
+        int result = Marshal.QueryInterface(unknown, in interfaceId, out IntPtr instance);
+        try
+        {
+            Assert.Equal(0, result);
+            Assert.NotEqual(IntPtr.Zero, instance);
+        }
+        finally
+        {
+            if (instance != IntPtr.Zero)
+                _ = Marshal.Release(instance);
+        }
+    }
+
+    private static Process StartDotnetProcess(string assemblyPath, string? argument = null)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(assemblyPath);
+        if (argument is not null)
+            startInfo.ArgumentList.Add(argument);
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Unable to start {assemblyPath}.");
+    }
+
+    private static async Task<string?> ReadLineStartingWithAsync(
+        Process process,
+        string prefix,
+        CancellationToken cancellationToken)
+    {
+        while (await process.StandardOutput.ReadLineAsync(cancellationToken) is { } line)
+        {
+            if (line.StartsWith(prefix, StringComparison.Ordinal))
+                return line;
+        }
+
+        return null;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(System.IO.Path.Combine(directory.FullName, "ModernFormsNext.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate the ModernFormsNext repository root.");
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PostMessage(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam);
+
+    private sealed class InlineDispatcher : IWindowsUiaDispatcher
+    {
+        public bool CheckAccess() => true;
+
+        public T Invoke<T>(Func<T> callback, TimeSpan timeout) => callback();
+
+        public void Invoke(Action callback, TimeSpan timeout) => callback();
+    }
+
+    private sealed class RecordingDispatcher : IWindowsUiaDispatcher
+    {
+        private readonly int ownerThreadId = Environment.CurrentManagedThreadId;
+
+        public int InvokeCount { get; private set; }
+
+        public bool CheckAccess() => Environment.CurrentManagedThreadId == ownerThreadId;
+
+        public T Invoke<T>(Func<T> callback, TimeSpan timeout)
+        {
+            InvokeCount++;
+            return callback();
+        }
+
+        public void Invoke(Action callback, TimeSpan timeout)
+        {
+            InvokeCount++;
+            callback();
+        }
+    }
+
+    private sealed class RecordingEventSink : IWindowsUiaEventSink
+    {
+        public bool ClientsAreListening => true;
+
+        public List<int> AutomationEvents { get; } = [];
+
+        public List<int> PropertyChanges { get; } = [];
+
+        public List<object?> Values { get; } = [];
+
+        public List<StructureChangeType> StructureChanges { get; } = [];
+
+        public void RaiseAutomationEvent(WindowsUiaProvider provider, int eventId)
+            => AutomationEvents.Add(eventId);
+
+        public void RaiseAutomationPropertyChangedEvent(
+            WindowsUiaProvider provider,
+            int propertyId,
+            object? oldValue,
+            object? newValue)
+        {
+            PropertyChanges.Add(propertyId);
+            Values.Add(newValue);
+        }
+
+        public void RaiseStructureChangedEvent(
+            WindowsUiaProvider provider,
+            StructureChangeType changeType,
+            int[] runtimeId)
+            => StructureChanges.Add(changeType);
+    }
+
+    private sealed class TestAccessibleObject : IPlatformUiaAccessibleObject
+    {
+        private static long nextRuntimeId;
+
+        public TestAccessibleObject(string name, int controlType)
+        {
+            Name = name;
+            ControlType = controlType;
+            RuntimeId = Interlocked.Increment(ref nextRuntimeId);
+        }
+
+        public List<TestAccessibleObject> Children { get; } = [];
+
+        public TestAccessibleObject? ParentObject { get; set; }
+
+        public IPlatformAccessibleObject? Focused { get; set; }
+
+        public int LastAction { get; private set; }
+
+        public int LastSelectionFlags { get; private set; }
+
+        public long RuntimeId { get; }
+
+        public string? AutomationId { get; set; }
+
+        public int ControlType { get; }
+
+        public int View { get; set; } = 2;
+
+        public string? ClassName { get; set; }
+
+        public PlatformRect Bounds { get; set; }
+
+        public string? DefaultAction => null;
+
+        public string? Description { get; set; }
+
+        public string? Help { get; set; }
+
+        public string? KeyboardShortcut => null;
+
+        public string? Name { get; set; }
+
+        public IPlatformAccessibleObject? Parent => ParentObject;
+
+        public int Role => 0;
+
+        public int State { get; set; }
+
+        public bool IsSensitive { get; set; }
+
+        public PlatformAccessibleRangeValue? RangeValue { get; set; }
+
+        public int SupportedActions { get; set; }
+
+        public string? Value { get; set; }
+
+        public TestAccessibleObject AddChild(TestAccessibleObject child)
+        {
+            child.ParentObject = this;
+            Children.Add(child);
+            return child;
+        }
+
+        public void DoDefaultAction()
+        {
+        }
+
+        public bool PerformAction(int action, object? parameter = null)
+        {
+            if ((SupportedActions & action) == 0)
+                return false;
+
+            LastAction = action;
+            if (action == ActionSetValue)
+            {
+                if (RangeValue is { } range && parameter is double numeric)
+                    RangeValue = range with { Value = numeric };
+                else
+                    Value = parameter as string;
+            }
+            else if (action == ActionSelect)
+            {
+                State |= StateSelected;
+            }
+            else if (action == ActionFocus)
+            {
+                State |= StateFocused;
+            }
+
+            return true;
+        }
+
+        public int GetHelpTopic(out string? fileName)
+        {
+            fileName = null;
+            return 0;
+        }
+
+        public IPlatformAccessibleObject? GetChild(int index)
+            => index >= 0 && index < Children.Count ? Children[index] : null;
+
+        public int GetChildCount() => Children.Count;
+
+        public IPlatformAccessibleObject? GetFocused() => Focused;
+
+        public IPlatformAccessibleObject? GetSelected()
+            => Children.FirstOrDefault(child => (child.State & StateSelected) != 0);
+
+        public IPlatformAccessibleObject? HitTest(int x, int y)
+        {
+            for (int index = Children.Count - 1; index >= 0; index--)
+            {
+                if (Children[index].HitTest(x, y) is { } child)
+                    return child;
+            }
+
+            return x >= Bounds.X
+                && y >= Bounds.Y
+                && x < Bounds.Right
+                && y < Bounds.Bottom
+                    ? this
+                    : null;
+        }
+
+        public IPlatformAccessibleObject? Navigate(PlatformAccessibleNavigation direction)
+        {
+            if (ParentObject is null)
+                return null;
+
+            int index = ParentObject.Children.IndexOf(this);
+            return direction switch
+            {
+                PlatformAccessibleNavigation.Next when index + 1 < ParentObject.Children.Count
+                    => ParentObject.Children[index + 1],
+                PlatformAccessibleNavigation.Previous when index > 0
+                    => ParentObject.Children[index - 1],
+                _ => null
+            };
+        }
+
+        public void Select(int flags)
+        {
+            LastSelectionFlags = flags;
+            if ((flags & 2) != 0 || (flags & 8) != 0)
+                State |= StateSelected;
+            if ((flags & 16) != 0)
+                State &= ~StateSelected;
+            if ((flags & 1) != 0)
+                State |= StateFocused;
+        }
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
@@ -55,6 +55,7 @@ public sealed class WindowsUiaProviderTests
         Assert.Equal("Application settings", Property(provider, WindowsUiaIds.HelpTextProperty));
         Assert.Equal("SettingsForm", Property(provider, WindowsUiaIds.ClassNameProperty));
         Assert.Equal("ModernFormsNext", Property(provider, WindowsUiaIds.FrameworkIdProperty));
+        Assert.Null(Property(provider, WindowsUiaIds.ValueProperty));
     }
 
     [Theory]
@@ -405,7 +406,6 @@ public sealed class WindowsUiaProviderTests
         Assert.Contains(WindowsUiaIds.IsEnabledProperty, eventSink.PropertyChanges);
         Assert.Contains(WindowsUiaIds.ToggleStateProperty, eventSink.PropertyChanges);
         Assert.Contains(WindowsUiaIds.BoundingRectangleProperty, eventSink.PropertyChanges);
-        Assert.Contains(StructureChangeType.ChildrenReordered, eventSink.StructureChanges);
         Assert.Contains(StructureChangeType.ChildAdded, eventSink.StructureChanges);
         Assert.Contains(StructureChangeType.ChildRemoved, eventSink.StructureChanges);
 
@@ -420,6 +420,43 @@ public sealed class WindowsUiaProviderTests
         provider.RaiseNotification(node, 0x800E);
         Assert.Equal(propertyChangeCount, eventSink.PropertyChanges.Count);
         Assert.DoesNotContain(eventSink.Values, value => Equals(value, "must-not-be-emitted"));
+    }
+
+    [Fact]
+    public void ReorderNotificationsDifferentiateAddRemoveAndReorderWithoutCachingNodes()
+    {
+        var eventSink = new RecordingEventSink();
+        TestAccessibleObject root = Root("List", controlType: 12);
+        TestAccessibleObject first = root.AddChild(new TestAccessibleObject("First", 13));
+        TestAccessibleObject second = root.AddChild(new TestAccessibleObject("Second", 13));
+        using WindowsUiaRootProvider provider = WindowsUiaRootProvider.Create(
+            new IntPtr(42),
+            root,
+            new InlineDispatcher(),
+            eventSink);
+
+        root.AddChild(new TestAccessibleObject("Added", 13));
+        provider.RaiseNotification(root, 0x8004);
+        WindowsUiaStructureEvent addEvent = eventSink.StructureEvents[^1];
+        Assert.Equal(StructureChangeType.ChildAdded, addEvent.ChangeType);
+        Assert.Same(provider, addEvent.Provider);
+        Assert.Null(addEvent.RuntimeId);
+
+        root.Children.Remove(first);
+        first.ParentObject = null;
+        provider.RaiseNotification(root, 0x8004);
+        WindowsUiaStructureEvent removeEvent = eventSink.StructureEvents[^1];
+        Assert.Equal(StructureChangeType.ChildRemoved, removeEvent.ChangeType);
+        Assert.Same(provider, removeEvent.Provider);
+        Assert.Equal(WindowsUiaProvider.CreateRuntimeId(first.RuntimeId), removeEvent.RuntimeId);
+
+        root.Children.Reverse();
+        provider.RaiseNotification(root, 0x8004);
+        WindowsUiaStructureEvent reorderEvent = eventSink.StructureEvents[^1];
+        Assert.Equal(StructureChangeType.ChildrenReordered, reorderEvent.ChangeType);
+        Assert.Same(provider, reorderEvent.Provider);
+        Assert.Null(reorderEvent.RuntimeId);
+        Assert.Contains(second, root.Children);
     }
 
     [Fact]
@@ -652,7 +689,10 @@ public sealed class WindowsUiaProviderTests
 
         public List<object?> Values { get; } = [];
 
-        public List<StructureChangeType> StructureChanges { get; } = [];
+        public List<StructureChangeType> StructureChanges
+            => StructureEvents.Select(static change => change.ChangeType).ToList();
+
+        public List<WindowsUiaStructureEvent> StructureEvents { get; } = [];
 
         public void RaiseAutomationEvent(WindowsUiaProvider provider, int eventId)
             => AutomationEvents.Add(eventId);
@@ -670,9 +710,14 @@ public sealed class WindowsUiaProviderTests
         public void RaiseStructureChangedEvent(
             WindowsUiaProvider provider,
             StructureChangeType changeType,
-            int[] runtimeId)
-            => StructureChanges.Add(changeType);
+            int[]? runtimeId)
+            => StructureEvents.Add(new WindowsUiaStructureEvent(provider, changeType, runtimeId));
     }
+
+    private sealed record WindowsUiaStructureEvent(
+        WindowsUiaProvider Provider,
+        StructureChangeType ChangeType,
+        int[]? RuntimeId);
 
     private sealed class TestAccessibleObject : IPlatformUiaAccessibleObject
     {

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -10,7 +10,6 @@ using ModernFormsNext.WindowKit.Input.Raw;
 using ModernFormsNext.WindowKit.Platform;
 using ModernFormsNext.WindowKit.Platform.Accessibility;
 using ModernFormsNext.WindowKit.Threading;
-using System.Windows.Automation.Provider;
 //using ModernFormsNext.WindowKit.Backend.Windows.Win32.Automation;
 using ModernFormsNext.WindowKit.Backend.Windows.Win32.Input;
 using ModernFormsNext.WindowKit.Backend.Windows.Win32.Interop;
@@ -782,7 +781,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
                         if (ToInt32(lParam) == objIdClient)
                             return GetMsaaAccessibilityObject(wParam);
 
-                        if (ToInt32(lParam) == AutomationInteropProvider.RootObjectId)
+                        if (ToInt32(lParam) == WindowsUiaIds.RootObject)
                             return GetUiaAccessibilityObject(wParam, lParam);
 
                         break;
@@ -905,7 +904,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
                 _uiaAccessibilityObject = WindowsUiaRootProvider.Create(_hwnd, root, Dispatcher.UIThread);
             }
 
-            return AutomationInteropProvider.ReturnRawElementProvider(
+            return WindowsUiaNativeMethods.ReturnRawElementProvider(
                 _hwnd,
                 wParam,
                 lParam,

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -890,25 +890,37 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
         private IntPtr GetUiaAccessibilityObject(IntPtr wParam, IntPtr lParam)
         {
-            if (_owner is not IPlatformAccessibilityHost host || host.AccessibilityRoot is not { } root)
-                return IntPtr.Zero;
-
-            if (_uiaAccessibilityObject is null
-                || !ReferenceEquals(_uiaAccessibilityObject.PlatformObject, root))
+            try
             {
-                WindowsUiaRootProvider? previous = _uiaAccessibilityObject;
-                previous?.Dispose();
-                if (previous is not null)
-                    Dispatcher.UIThread.Post(previous.Disconnect);
+                if (_owner is not IPlatformAccessibilityHost host || host.AccessibilityRoot is not { } root)
+                    return IntPtr.Zero;
 
-                _uiaAccessibilityObject = WindowsUiaRootProvider.Create(_hwnd, root, Dispatcher.UIThread);
+                if (_uiaAccessibilityObject is null
+                    || !ReferenceEquals(_uiaAccessibilityObject.PlatformObject, root))
+                {
+                    WindowsUiaRootProvider? previous = _uiaAccessibilityObject;
+                    previous?.Dispose();
+                    if (previous is not null)
+                        Dispatcher.UIThread.Post(previous.Disconnect);
+
+                    _uiaAccessibilityObject = WindowsUiaRootProvider.Create(_hwnd, root, Dispatcher.UIThread);
+                }
+
+                return WindowsUiaNativeMethods.ReturnRawElementProvider(
+                    _hwnd,
+                    wParam,
+                    lParam,
+                    _uiaAccessibilityObject);
             }
-
-            return WindowsUiaNativeMethods.ReturnRawElementProvider(
-                _hwnd,
-                wParam,
-                lParam,
-                _uiaAccessibilityObject);
+            catch (Exception exception)
+            {
+                // A managed exception must never cross the unmanaged WndProc callback. Keep the
+                // diagnostic value-free because accessibility properties can contain passwords.
+                Trace.TraceError(
+                    "ModernFormsNext UIA WM_GETOBJECT failed: {0}",
+                    exception.GetType().Name);
+                return IntPtr.Zero;
+            }
         }
 
         internal void TryRaiseUiaNotification(IPlatformAccessibleObject source, int eventId)

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -10,6 +10,7 @@ using ModernFormsNext.WindowKit.Input.Raw;
 using ModernFormsNext.WindowKit.Platform;
 using ModernFormsNext.WindowKit.Platform.Accessibility;
 using ModernFormsNext.WindowKit.Threading;
+using System.Windows.Automation.Provider;
 //using ModernFormsNext.WindowKit.Backend.Windows.Win32.Automation;
 using ModernFormsNext.WindowKit.Backend.Windows.Win32.Input;
 using ModernFormsNext.WindowKit.Backend.Windows.Win32.Interop;
@@ -87,6 +88,10 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
                 case WindowsMessage.WM_DESTROY:
                     {
+                        WindowsUiaRootProvider? uiaAccessibilityObject = _uiaAccessibilityObject;
+                        _uiaAccessibilityObject = null;
+                        uiaAccessibilityObject?.Dispose();
+
                         // The first and foremost thing to do - notify the TopLevel
                         Closed?.Invoke();
                         
@@ -126,6 +131,12 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
 
                         // Schedule cleanup of anything that requires window to be destroyed
                         Dispatcher.UIThread.Post(AfterCloseCleanup);
+                        if (uiaAccessibilityObject is not null)
+                        {
+                            // UiaDisconnectProvider performs an outbound COM call and must not run
+                            // inside an inbound SendMessage callback such as WM_DESTROY.
+                            Dispatcher.UIThread.Post(uiaAccessibilityObject.Disconnect);
+                        }
                         return IntPtr.Zero;
                     }
 
@@ -771,6 +782,9 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
                         if (ToInt32(lParam) == objIdClient)
                             return GetMsaaAccessibilityObject(wParam);
 
+                        if (ToInt32(lParam) == AutomationInteropProvider.RootObjectId)
+                            return GetUiaAccessibilityObject(wParam, lParam);
+
                         break;
                     }
             }
@@ -874,6 +888,32 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
             var interfaceId = WindowsMsaaAccessibleObject.InterfaceId;
             return LresultFromObject(ref interfaceId, wParam, _msaaAccessibilityObject);
         }
+
+        private IntPtr GetUiaAccessibilityObject(IntPtr wParam, IntPtr lParam)
+        {
+            if (_owner is not IPlatformAccessibilityHost host || host.AccessibilityRoot is not { } root)
+                return IntPtr.Zero;
+
+            if (_uiaAccessibilityObject is null
+                || !ReferenceEquals(_uiaAccessibilityObject.PlatformObject, root))
+            {
+                WindowsUiaRootProvider? previous = _uiaAccessibilityObject;
+                previous?.Dispose();
+                if (previous is not null)
+                    Dispatcher.UIThread.Post(previous.Disconnect);
+
+                _uiaAccessibilityObject = WindowsUiaRootProvider.Create(_hwnd, root, Dispatcher.UIThread);
+            }
+
+            return AutomationInteropProvider.ReturnRawElementProvider(
+                _hwnd,
+                wParam,
+                lParam,
+                _uiaAccessibilityObject);
+        }
+
+        internal void TryRaiseUiaNotification(IPlatformAccessibleObject source, int eventId)
+            => _uiaAccessibilityObject?.RaiseNotification(source, eventId);
 
         //private Lazy<IReadOnlyList<RawPointerPoint>?>? CreateLazyIntermediatePoints(POINTER_INFO info)
         //{

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.cs
@@ -67,6 +67,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
         //private readonly Win32NativeControlHost _nativeControlHost;
         private readonly IStorageProvider _storageProvider;
         private WindowsMsaaAccessibleObject? _msaaAccessibilityObject;
+        private WindowsUiaRootProvider? _uiaAccessibilityObject;
         private WndProc _wndProcDelegate;
         private string? _className;
         private IntPtr _hwnd;

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaEventMapper.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaEventMapper.cs
@@ -1,0 +1,118 @@
+using System.Windows.Automation;
+using System.Windows.Automation.Provider;
+using ModernFormsNext.WindowKit.Platform.Accessibility;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows.Win32;
+
+/// <summary>
+/// Translates canonical accessibility notifications to Windows UI Automation events.
+/// </summary>
+internal static class WindowsUiaEventMapper
+{
+    private const int EventShow = 0x8002;
+    private const int EventHide = 0x8003;
+    private const int EventReorder = 0x8004;
+    private const int EventFocus = 0x8005;
+    private const int EventSelection = 0x8006;
+    private const int EventSelectionAdd = 0x8007;
+    private const int EventSelectionRemove = 0x8008;
+    private const int EventSelectionWithin = 0x8009;
+    private const int EventStateChange = 0x800A;
+    private const int EventLocationChange = 0x800B;
+    private const int EventNameChange = 0x800C;
+    private const int EventDescriptionChange = 0x800D;
+    private const int EventValueChange = 0x800E;
+    private const int EventParentChange = 0x800F;
+
+    public static void Raise(
+        WindowsUiaProvider provider,
+        IPlatformAccessibleObject source,
+        int eventId,
+        WindowsUiaProviderContext context)
+    {
+        switch (eventId)
+        {
+            case EventFocus:
+                RaiseEvent(provider, AutomationElementIdentifiers.AutomationFocusChangedEvent);
+                break;
+            case EventNameChange:
+                RaisePropertyChanged(provider, AutomationElementIdentifiers.NameProperty, source.Name ?? string.Empty);
+                break;
+            case EventDescriptionChange:
+                RaisePropertyChanged(
+                    provider,
+                    AutomationElementIdentifiers.HelpTextProperty,
+                    source.Help ?? source.Description ?? string.Empty);
+                break;
+            case EventValueChange when !source.IsSensitive:
+                RaisePropertyChanged(provider, ValuePatternIdentifiers.ValueProperty, source.Value ?? string.Empty);
+                break;
+            case EventStateChange:
+                RaisePropertyChanged(
+                    provider,
+                    AutomationElementIdentifiers.IsEnabledProperty,
+                    (source.State & 0x1) == 0);
+                break;
+            case EventLocationChange:
+                RaisePropertyChanged(
+                    provider,
+                    AutomationElementIdentifiers.BoundingRectangleProperty,
+                    WindowsUiaCoordinateConverter.ToBoundingRectangle(source.Bounds));
+                break;
+            case EventSelection:
+                RaiseEvent(provider, SelectionItemPatternIdentifiers.ElementSelectedEvent);
+                break;
+            case EventSelectionAdd:
+                RaiseEvent(provider, SelectionItemPatternIdentifiers.ElementAddedToSelectionEvent);
+                break;
+            case EventSelectionRemove:
+                RaiseEvent(provider, SelectionItemPatternIdentifiers.ElementRemovedFromSelectionEvent);
+                break;
+            case EventSelectionWithin:
+                RaiseEvent(provider, SelectionPatternIdentifiers.InvalidatedEvent);
+                break;
+            case EventReorder:
+                RaiseStructureChanged(provider, StructureChangeType.ChildrenReordered);
+                break;
+            case EventParentChange:
+                RaiseStructureChanged(provider, StructureChangeType.ChildrenReordered);
+                break;
+            case EventShow:
+                RaisePropertyChanged(provider, AutomationElementIdentifiers.IsOffscreenProperty, false);
+                RaiseStructureChanged(GetStructureParent(provider, source, context), StructureChangeType.ChildAdded);
+                break;
+            case EventHide:
+                RaisePropertyChanged(provider, AutomationElementIdentifiers.IsOffscreenProperty, true);
+                RaiseStructureChanged(GetStructureParent(provider, source, context), StructureChangeType.ChildRemoved);
+                break;
+        }
+    }
+
+    private static WindowsUiaProvider GetStructureParent(
+        WindowsUiaProvider provider,
+        IPlatformAccessibleObject source,
+        WindowsUiaProviderContext context)
+        => source.Parent is { } parent ? context.GetOrCreate(parent) : provider;
+
+    private static void RaisePropertyChanged(
+        IRawElementProviderSimple provider,
+        AutomationProperty property,
+        object newValue)
+        => AutomationInteropProvider.RaiseAutomationPropertyChangedEvent(
+            provider,
+            new AutomationPropertyChangedEventArgs(
+                property,
+                AutomationElement.NotSupported,
+                newValue));
+
+    private static void RaiseEvent(IRawElementProviderSimple provider, AutomationEvent eventId)
+        => AutomationInteropProvider.RaiseAutomationEvent(
+            eventId,
+            provider,
+            new AutomationEventArgs(eventId));
+
+    private static void RaiseStructureChanged(WindowsUiaProvider provider, StructureChangeType changeType)
+        => AutomationInteropProvider.RaiseStructureChangedEvent(
+            provider,
+            new StructureChangedEventArgs(changeType, provider.GetRuntimeId()));
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaEventMapper.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaEventMapper.cs
@@ -73,18 +73,35 @@ internal static class WindowsUiaEventMapper
                 RaiseEvent(eventSink, provider, WindowsUiaIds.SelectionInvalidatedEvent);
                 break;
             case EventReorder:
-                RaiseStructureChanged(eventSink, provider, StructureChangeType.ChildrenReordered);
+                WindowsUiaStructureChange change = provider.ConsumeStructureChange();
+                RaiseStructureChanged(
+                    eventSink,
+                    change.Provider,
+                    change.ChangeType,
+                    change.RuntimeId);
                 break;
             case EventParentChange:
-                RaiseStructureChanged(eventSink, provider, StructureChangeType.ChildrenReordered);
+                RaiseStructureChanged(
+                    eventSink,
+                    GetStructureParent(provider, source, context),
+                    StructureChangeType.ChildrenReordered,
+                    runtimeId: null);
                 break;
             case EventShow:
                 RaisePropertyChanged(eventSink, provider, WindowsUiaIds.IsOffscreenProperty, false);
-                RaiseStructureChanged(eventSink, GetStructureParent(provider, source, context), StructureChangeType.ChildAdded);
+                RaiseStructureChanged(
+                    eventSink,
+                    GetStructureParent(provider, source, context),
+                    StructureChangeType.ChildAdded,
+                    runtimeId: null);
                 break;
             case EventHide:
                 RaisePropertyChanged(eventSink, provider, WindowsUiaIds.IsOffscreenProperty, true);
-                RaiseStructureChanged(eventSink, GetStructureParent(provider, source, context), StructureChangeType.ChildRemoved);
+                RaiseStructureChanged(
+                    eventSink,
+                    GetStructureParent(provider, source, context),
+                    StructureChangeType.ChildRemoved,
+                    provider.GetRuntimeId());
                 break;
         }
     }
@@ -175,11 +192,12 @@ internal static class WindowsUiaEventMapper
     private static void RaiseStructureChanged(
         IWindowsUiaEventSink eventSink,
         WindowsUiaProvider provider,
-        StructureChangeType changeType)
+        StructureChangeType changeType,
+        int[]? runtimeId)
         => eventSink.RaiseStructureChangedEvent(
             provider,
             changeType,
-            provider.GetRuntimeId());
+            runtimeId);
 }
 
 internal interface IWindowsUiaEventSink
@@ -197,7 +215,7 @@ internal interface IWindowsUiaEventSink
     void RaiseStructureChangedEvent(
         WindowsUiaProvider provider,
         StructureChangeType changeType,
-        int[] runtimeId);
+        int[]? runtimeId);
 }
 
 internal sealed class WindowsUiaNativeEventSink : IWindowsUiaEventSink
@@ -223,6 +241,6 @@ internal sealed class WindowsUiaNativeEventSink : IWindowsUiaEventSink
     public void RaiseStructureChangedEvent(
         WindowsUiaProvider provider,
         StructureChangeType changeType,
-        int[] runtimeId)
+        int[]? runtimeId)
         => WindowsUiaNativeMethods.RaiseStructureChangedEvent(provider, changeType, runtimeId);
 }

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaEventMapper.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaEventMapper.cs
@@ -1,5 +1,3 @@
-using System.Windows.Automation;
-using System.Windows.Automation.Provider;
 using ModernFormsNext.WindowKit.Platform.Accessibility;
 
 namespace ModernFormsNext.WindowKit.Backend.Windows.Win32;
@@ -28,62 +26,65 @@ internal static class WindowsUiaEventMapper
         WindowsUiaProvider provider,
         IPlatformAccessibleObject source,
         int eventId,
-        WindowsUiaProviderContext context)
+        WindowsUiaProviderContext context,
+        IWindowsUiaEventSink eventSink)
     {
         switch (eventId)
         {
             case EventFocus:
-                RaiseEvent(provider, AutomationElementIdentifiers.AutomationFocusChangedEvent);
+                RaiseEvent(eventSink, provider, WindowsUiaIds.AutomationFocusChangedEvent);
                 break;
             case EventNameChange:
-                RaisePropertyChanged(provider, AutomationElementIdentifiers.NameProperty, source.Name ?? string.Empty);
+                RaisePropertyChanged(eventSink, provider, WindowsUiaIds.NameProperty, source.Name ?? string.Empty);
                 break;
             case EventDescriptionChange:
                 RaisePropertyChanged(
+                    eventSink,
                     provider,
-                    AutomationElementIdentifiers.HelpTextProperty,
+                    WindowsUiaIds.HelpTextProperty,
                     source.Help ?? source.Description ?? string.Empty);
                 break;
-            case EventValueChange when !source.IsSensitive:
-                RaisePropertyChanged(provider, ValuePatternIdentifiers.ValueProperty, source.Value ?? string.Empty);
+            case EventValueChange when !source.GetIsSensitive():
+                if (source.GetRangeValue() is { } range)
+                    RaisePropertyChanged(eventSink, provider, WindowsUiaIds.RangeValueProperty, range.Value);
+                else
+                    RaisePropertyChanged(eventSink, provider, WindowsUiaIds.ValueProperty, source.Value ?? string.Empty);
                 break;
             case EventStateChange:
-                RaisePropertyChanged(
-                    provider,
-                    AutomationElementIdentifiers.IsEnabledProperty,
-                    (source.State & 0x1) == 0);
+                RaiseStateProperties(eventSink, provider, source);
                 break;
             case EventLocationChange:
                 RaisePropertyChanged(
+                    eventSink,
                     provider,
-                    AutomationElementIdentifiers.BoundingRectangleProperty,
+                    WindowsUiaIds.BoundingRectangleProperty,
                     WindowsUiaCoordinateConverter.ToBoundingRectangle(source.Bounds));
                 break;
             case EventSelection:
-                RaiseEvent(provider, SelectionItemPatternIdentifiers.ElementSelectedEvent);
+                RaiseEvent(eventSink, provider, WindowsUiaIds.ElementSelectedEvent);
                 break;
             case EventSelectionAdd:
-                RaiseEvent(provider, SelectionItemPatternIdentifiers.ElementAddedToSelectionEvent);
+                RaiseEvent(eventSink, provider, WindowsUiaIds.ElementAddedToSelectionEvent);
                 break;
             case EventSelectionRemove:
-                RaiseEvent(provider, SelectionItemPatternIdentifiers.ElementRemovedFromSelectionEvent);
+                RaiseEvent(eventSink, provider, WindowsUiaIds.ElementRemovedFromSelectionEvent);
                 break;
             case EventSelectionWithin:
-                RaiseEvent(provider, SelectionPatternIdentifiers.InvalidatedEvent);
+                RaiseEvent(eventSink, provider, WindowsUiaIds.SelectionInvalidatedEvent);
                 break;
             case EventReorder:
-                RaiseStructureChanged(provider, StructureChangeType.ChildrenReordered);
+                RaiseStructureChanged(eventSink, provider, StructureChangeType.ChildrenReordered);
                 break;
             case EventParentChange:
-                RaiseStructureChanged(provider, StructureChangeType.ChildrenReordered);
+                RaiseStructureChanged(eventSink, provider, StructureChangeType.ChildrenReordered);
                 break;
             case EventShow:
-                RaisePropertyChanged(provider, AutomationElementIdentifiers.IsOffscreenProperty, false);
-                RaiseStructureChanged(GetStructureParent(provider, source, context), StructureChangeType.ChildAdded);
+                RaisePropertyChanged(eventSink, provider, WindowsUiaIds.IsOffscreenProperty, false);
+                RaiseStructureChanged(eventSink, GetStructureParent(provider, source, context), StructureChangeType.ChildAdded);
                 break;
             case EventHide:
-                RaisePropertyChanged(provider, AutomationElementIdentifiers.IsOffscreenProperty, true);
-                RaiseStructureChanged(GetStructureParent(provider, source, context), StructureChangeType.ChildRemoved);
+                RaisePropertyChanged(eventSink, provider, WindowsUiaIds.IsOffscreenProperty, true);
+                RaiseStructureChanged(eventSink, GetStructureParent(provider, source, context), StructureChangeType.ChildRemoved);
                 break;
         }
     }
@@ -94,25 +95,134 @@ internal static class WindowsUiaEventMapper
         WindowsUiaProviderContext context)
         => source.Parent is { } parent ? context.GetOrCreate(parent) : provider;
 
+    private static void RaiseStateProperties(
+        IWindowsUiaEventSink eventSink,
+        WindowsUiaProvider provider,
+        IPlatformAccessibleObject source)
+    {
+        const int stateUnavailable = 0x1;
+        const int stateSelected = 0x2;
+        const int stateChecked = 0x10;
+        const int stateMixed = 0x20;
+        const int stateExpanded = 0x200;
+        const int stateCollapsed = 0x400;
+        const int actionSelect = 1 << 2;
+        const int actionExpand = 1 << 3;
+        const int actionCollapse = 1 << 4;
+
+        int state = source.State;
+        int actions = source.GetSupportedActions();
+        int controlType = source.GetControlType();
+
+        RaisePropertyChanged(
+            eventSink,
+            provider,
+            WindowsUiaIds.IsEnabledProperty,
+            (state & stateUnavailable) == 0);
+
+        if (controlType is 7 or 8 or 9)
+        {
+            int toggleState = (state & stateMixed) != 0
+                ? (int)ToggleState.Indeterminate
+                : (state & stateChecked) != 0
+                    ? (int)ToggleState.On
+                    : (int)ToggleState.Off;
+            RaisePropertyChanged(eventSink, provider, WindowsUiaIds.ToggleStateProperty, toggleState);
+        }
+
+        if ((actions & (actionExpand | actionCollapse)) != 0
+            || (state & (stateExpanded | stateCollapsed)) != 0)
+        {
+            int expandCollapseState = (state & stateExpanded) != 0
+                ? (int)ExpandCollapseState.Expanded
+                : (state & stateCollapsed) != 0
+                    ? (int)ExpandCollapseState.Collapsed
+                    : (int)ExpandCollapseState.LeafNode;
+            RaisePropertyChanged(
+                eventSink,
+                provider,
+                WindowsUiaIds.ExpandCollapseStateProperty,
+                expandCollapseState);
+        }
+
+        if ((actions & actionSelect) != 0 || (state & stateSelected) != 0)
+        {
+            RaisePropertyChanged(
+                eventSink,
+                provider,
+                WindowsUiaIds.SelectionItemIsSelectedProperty,
+                (state & stateSelected) != 0);
+        }
+    }
+
     private static void RaisePropertyChanged(
-        IRawElementProviderSimple provider,
-        AutomationProperty property,
+        IWindowsUiaEventSink eventSink,
+        WindowsUiaProvider provider,
+        int propertyId,
         object newValue)
-        => AutomationInteropProvider.RaiseAutomationPropertyChangedEvent(
+        => eventSink.RaiseAutomationPropertyChangedEvent(
             provider,
-            new AutomationPropertyChangedEventArgs(
-                property,
-                AutomationElement.NotSupported,
-                newValue));
+            propertyId,
+            oldValue: null,
+            newValue);
 
-    private static void RaiseEvent(IRawElementProviderSimple provider, AutomationEvent eventId)
-        => AutomationInteropProvider.RaiseAutomationEvent(
-            eventId,
-            provider,
-            new AutomationEventArgs(eventId));
+    private static void RaiseEvent(
+        IWindowsUiaEventSink eventSink,
+        WindowsUiaProvider provider,
+        int eventId)
+        => eventSink.RaiseAutomationEvent(provider, eventId);
 
-    private static void RaiseStructureChanged(WindowsUiaProvider provider, StructureChangeType changeType)
-        => AutomationInteropProvider.RaiseStructureChangedEvent(
+    private static void RaiseStructureChanged(
+        IWindowsUiaEventSink eventSink,
+        WindowsUiaProvider provider,
+        StructureChangeType changeType)
+        => eventSink.RaiseStructureChangedEvent(
             provider,
-            new StructureChangedEventArgs(changeType, provider.GetRuntimeId()));
+            changeType,
+            provider.GetRuntimeId());
+}
+
+internal interface IWindowsUiaEventSink
+{
+    bool ClientsAreListening { get; }
+
+    void RaiseAutomationEvent(WindowsUiaProvider provider, int eventId);
+
+    void RaiseAutomationPropertyChangedEvent(
+        WindowsUiaProvider provider,
+        int propertyId,
+        object? oldValue,
+        object? newValue);
+
+    void RaiseStructureChangedEvent(
+        WindowsUiaProvider provider,
+        StructureChangeType changeType,
+        int[] runtimeId);
+}
+
+internal sealed class WindowsUiaNativeEventSink : IWindowsUiaEventSink
+{
+    public static WindowsUiaNativeEventSink Instance { get; } = new();
+
+    public bool ClientsAreListening => WindowsUiaNativeMethods.ClientsAreListening;
+
+    public void RaiseAutomationEvent(WindowsUiaProvider provider, int eventId)
+        => WindowsUiaNativeMethods.RaiseAutomationEvent(provider, eventId);
+
+    public void RaiseAutomationPropertyChangedEvent(
+        WindowsUiaProvider provider,
+        int propertyId,
+        object? oldValue,
+        object? newValue)
+        => WindowsUiaNativeMethods.RaiseAutomationPropertyChangedEvent(
+            provider,
+            propertyId,
+            oldValue,
+            newValue);
+
+    public void RaiseStructureChangedEvent(
+        WindowsUiaProvider provider,
+        StructureChangeType changeType,
+        int[] runtimeId)
+        => WindowsUiaNativeMethods.RaiseStructureChangedEvent(provider, changeType, runtimeId);
 }

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaInterop.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaInterop.cs
@@ -1,0 +1,731 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows.Win32;
+
+// These declarations mirror the provider-side interfaces in UIAutomationCore.h. Keeping the
+// native boundary local to the Windows backend avoids imposing WindowsDesktop/WPF/WinForms
+// reference assemblies on the platform-neutral framework graph.
+
+internal interface IRawElementProviderSimple
+{
+    ProviderOptions ProviderOptions { get; }
+
+    [return: MarshalAs(UnmanagedType.Interface)]
+    object? GetPatternProvider(int patternId);
+
+    [return: MarshalAs(UnmanagedType.Struct)]
+    object? GetPropertyValue(int propertyId);
+
+    IRawElementProviderSimple? HostRawElementProvider { get; }
+}
+
+internal interface IRawElementProviderFragment
+{
+    IRawElementProviderFragment? Navigate(NavigateDirection direction);
+
+    [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_I4)]
+    int[] GetRuntimeId();
+
+    UiaRect BoundingRectangle { get; }
+
+    [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
+    IRawElementProviderSimple[]? GetEmbeddedFragmentRoots();
+
+    void SetFocus();
+
+    IRawElementProviderFragmentRoot FragmentRoot { get; }
+}
+
+internal interface IRawElementProviderFragmentRoot
+{
+    IRawElementProviderFragment? ElementProviderFromPoint(double x, double y);
+
+    IRawElementProviderFragment? GetFocus();
+}
+
+internal interface IInvokeProvider
+{
+    void Invoke();
+}
+
+internal interface IToggleProvider
+{
+    void Toggle();
+
+    ToggleState ToggleState { get; }
+}
+
+internal interface IValueProvider
+{
+    void SetValue([MarshalAs(UnmanagedType.LPWStr)] string value);
+
+    string Value { get; }
+
+    bool IsReadOnly
+    {
+        [return: MarshalAs(UnmanagedType.Bool)]
+        get;
+    }
+}
+
+internal interface IRangeValueProvider
+{
+    void SetValue(double value);
+
+    double Value { get; }
+
+    bool IsReadOnly
+    {
+        [return: MarshalAs(UnmanagedType.Bool)]
+        get;
+    }
+
+    double Maximum { get; }
+
+    double Minimum { get; }
+
+    double LargeChange { get; }
+
+    double SmallChange { get; }
+}
+
+internal interface IExpandCollapseProvider
+{
+    void Expand();
+
+    void Collapse();
+
+    ExpandCollapseState ExpandCollapseState { get; }
+}
+
+internal interface ISelectionProvider
+{
+    [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
+    IRawElementProviderSimple[] GetSelection();
+
+    bool CanSelectMultiple
+    {
+        [return: MarshalAs(UnmanagedType.Bool)]
+        get;
+    }
+
+    bool IsSelectionRequired
+    {
+        [return: MarshalAs(UnmanagedType.Bool)]
+        get;
+    }
+}
+
+internal interface ISelectionItemProvider
+{
+    void Select();
+
+    void AddToSelection();
+
+    void RemoveFromSelection();
+
+    bool IsSelected
+    {
+        [return: MarshalAs(UnmanagedType.Bool)]
+        get;
+    }
+
+    IRawElementProviderSimple? SelectionContainer { get; }
+}
+
+internal interface IScrollItemProvider
+{
+    void ScrollIntoView();
+}
+
+// ABI-shaped interfaces use only blittable values and native pointers. This keeps the source-
+// generated COM boundary independent of runtime marshalling and makes the HRESULT behavior of
+// every callback explicit.
+
+[GeneratedComInterface]
+[Guid("D6DD68D1-86FD-4332-8666-9ABEDEA2D24C")]
+internal partial interface IRawElementProviderSimpleAbi
+{
+    [PreserveSig] int AbiGetProviderOptions(out ProviderOptions value);
+    [PreserveSig] int AbiGetPatternProvider(int patternId, out IntPtr provider);
+    [PreserveSig] int AbiGetPropertyValue(int propertyId, out WindowsUiaVariant value);
+    [PreserveSig] int AbiGetHostRawElementProvider(out IntPtr provider);
+}
+
+[GeneratedComInterface]
+[Guid("F7063DA8-8359-439C-9297-BBC5299A7D87")]
+internal partial interface IRawElementProviderFragmentAbi
+{
+    [PreserveSig] int AbiNavigate(NavigateDirection direction, out IntPtr provider);
+    [PreserveSig] int AbiGetRuntimeId(out IntPtr runtimeId);
+    [PreserveSig] int AbiGetBoundingRectangle(out UiaRect bounds);
+    [PreserveSig] int AbiGetEmbeddedFragmentRoots(out IntPtr roots);
+    [PreserveSig] int AbiSetFocus();
+    [PreserveSig] int AbiGetFragmentRoot(out IntPtr provider);
+}
+
+[GeneratedComInterface]
+[Guid("620CE2A5-AB8F-40A9-86CB-DE3C75599B58")]
+internal partial interface IRawElementProviderFragmentRootAbi
+{
+    [PreserveSig] int AbiElementProviderFromPoint(double x, double y, out IntPtr provider);
+    [PreserveSig] int AbiGetFocus(out IntPtr provider);
+}
+
+[GeneratedComInterface]
+[Guid("54FCB24B-E18E-47A2-B4D3-ECCBE77599A2")]
+internal partial interface IInvokeProviderAbi
+{
+    [PreserveSig] int AbiInvoke();
+}
+
+[GeneratedComInterface]
+[Guid("56D00BD0-C4F4-433C-A836-1A52A57E0892")]
+internal partial interface IToggleProviderAbi
+{
+    [PreserveSig] int AbiToggle();
+    [PreserveSig] int AbiGetToggleState(out ToggleState value);
+}
+
+[GeneratedComInterface]
+[Guid("C7935180-6FB3-4201-B174-7DF73ADBF64A")]
+internal partial interface IValueProviderAbi
+{
+    [PreserveSig] int AbiSetValue(IntPtr value);
+    [PreserveSig] int AbiGetValue(out IntPtr value);
+    [PreserveSig] int AbiGetIsReadOnly(out int value);
+}
+
+[GeneratedComInterface]
+[Guid("36DC7AEF-33E6-4691-AFE1-2BE7274B3D33")]
+internal partial interface IRangeValueProviderAbi
+{
+    [PreserveSig] int AbiSetValue(double value);
+    [PreserveSig] int AbiGetValue(out double value);
+    [PreserveSig] int AbiGetIsReadOnly(out int value);
+    [PreserveSig] int AbiGetMaximum(out double value);
+    [PreserveSig] int AbiGetMinimum(out double value);
+    [PreserveSig] int AbiGetLargeChange(out double value);
+    [PreserveSig] int AbiGetSmallChange(out double value);
+}
+
+[GeneratedComInterface]
+[Guid("D847D3A5-CAB0-4A98-8C32-ECB45C59AD24")]
+internal partial interface IExpandCollapseProviderAbi
+{
+    [PreserveSig] int AbiExpand();
+    [PreserveSig] int AbiCollapse();
+    [PreserveSig] int AbiGetExpandCollapseState(out ExpandCollapseState value);
+}
+
+[GeneratedComInterface]
+[Guid("FB8B03AF-3BDF-48D4-BD36-1A65793BE168")]
+internal partial interface ISelectionProviderAbi
+{
+    [PreserveSig] int AbiGetSelection(out IntPtr providers);
+    [PreserveSig] int AbiGetCanSelectMultiple(out int value);
+    [PreserveSig] int AbiGetIsSelectionRequired(out int value);
+}
+
+[GeneratedComInterface]
+[Guid("2ACAD808-B2D4-452D-A407-91FF1AD167B2")]
+internal partial interface ISelectionItemProviderAbi
+{
+    [PreserveSig] int AbiSelect();
+    [PreserveSig] int AbiAddToSelection();
+    [PreserveSig] int AbiRemoveFromSelection();
+    [PreserveSig] int AbiGetIsSelected(out int value);
+    [PreserveSig] int AbiGetSelectionContainer(out IntPtr provider);
+}
+
+[GeneratedComInterface]
+[Guid("2360C714-4BF1-4B26-BA65-9B21316127EB")]
+internal partial interface IScrollItemProviderAbi
+{
+    [PreserveSig] int AbiScrollIntoView();
+}
+
+[Flags]
+internal enum ProviderOptions
+{
+    ClientSideProvider = 0x1,
+    ServerSideProvider = 0x2,
+    NonClientAreaProvider = 0x4,
+    OverrideProvider = 0x8,
+    ProviderOwnsSetFocus = 0x10,
+    UseComThreading = 0x20
+}
+
+internal enum NavigateDirection
+{
+    Parent,
+    NextSibling,
+    PreviousSibling,
+    FirstChild,
+    LastChild
+}
+
+internal enum ToggleState
+{
+    Off,
+    On,
+    Indeterminate
+}
+
+internal enum ExpandCollapseState
+{
+    Collapsed,
+    Expanded,
+    PartiallyExpanded,
+    LeafNode
+}
+
+internal enum StructureChangeType
+{
+    ChildAdded,
+    ChildRemoved,
+    ChildrenInvalidated,
+    ChildrenBulkAdded,
+    ChildrenBulkRemoved,
+    ChildrenReordered
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal readonly struct UiaRect : IEquatable<UiaRect>
+{
+    public UiaRect(double left, double top, double width, double height)
+    {
+        Left = left;
+        Top = top;
+        Width = width;
+        Height = height;
+    }
+
+    public double Left { get; }
+
+    public double Top { get; }
+
+    public double Width { get; }
+
+    public double Height { get; }
+
+    public bool Equals(UiaRect other)
+        => Left.Equals(other.Left)
+            && Top.Equals(other.Top)
+            && Width.Equals(other.Width)
+            && Height.Equals(other.Height);
+
+    public override bool Equals(object? obj) => obj is UiaRect other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(Left, Top, Width, Height);
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 16)]
+internal struct WindowsUiaVariant : IDisposable
+{
+    [FieldOffset(0)]
+    private ushort variantType;
+
+    [FieldOffset(8)]
+    private short booleanValue;
+
+    [FieldOffset(8)]
+    private int integerValue;
+
+    [FieldOffset(8)]
+    private double doubleValue;
+
+    [FieldOffset(8)]
+    private IntPtr pointerValue;
+
+    public static WindowsUiaVariant FromObject(object? value)
+        => value switch
+        {
+            null => default,
+            string text => new WindowsUiaVariant
+            {
+                variantType = (ushort)VarEnum.VT_BSTR,
+                pointerValue = Marshal.StringToBSTR(text)
+            },
+            bool flag => new WindowsUiaVariant
+            {
+                variantType = (ushort)VarEnum.VT_BOOL,
+                booleanValue = flag ? (short)-1 : (short)0
+            },
+            int number => new WindowsUiaVariant
+            {
+                variantType = (ushort)VarEnum.VT_I4,
+                integerValue = number
+            },
+            double number => new WindowsUiaVariant
+            {
+                variantType = (ushort)VarEnum.VT_R8,
+                doubleValue = number
+            },
+            UiaRect bounds => new WindowsUiaVariant
+            {
+                variantType = (ushort)(VarEnum.VT_ARRAY | VarEnum.VT_R8),
+                pointerValue = WindowsUiaNativeMethods.CreateSafeArray(
+                    [bounds.Left, bounds.Top, bounds.Width, bounds.Height])
+            },
+            _ => throw new NotSupportedException(
+                $"The value type {value.GetType().Name} cannot be returned through UI Automation.")
+        };
+
+    public void Dispose()
+    {
+        if (variantType != (ushort)VarEnum.VT_EMPTY)
+            _ = WindowsUiaNativeMethods.ClearVariant(ref this);
+    }
+}
+
+internal static class WindowsUiaIds
+{
+    public const int RootObject = -25;
+    public const int AppendRuntimeId = 3;
+
+    public const int InvokePattern = 10000;
+    public const int SelectionPattern = 10001;
+    public const int ValuePattern = 10002;
+    public const int RangeValuePattern = 10003;
+    public const int ExpandCollapsePattern = 10005;
+    public const int SelectionItemPattern = 10010;
+    public const int TogglePattern = 10015;
+    public const int ScrollItemPattern = 10017;
+
+    public const int BoundingRectangleProperty = 30001;
+    public const int ControlTypeProperty = 30003;
+    public const int NameProperty = 30005;
+    public const int HasKeyboardFocusProperty = 30008;
+    public const int IsKeyboardFocusableProperty = 30009;
+    public const int IsEnabledProperty = 30010;
+    public const int AutomationIdProperty = 30011;
+    public const int ClassNameProperty = 30012;
+    public const int HelpTextProperty = 30013;
+    public const int IsControlElementProperty = 30016;
+    public const int IsContentElementProperty = 30017;
+    public const int IsPasswordProperty = 30019;
+    public const int IsOffscreenProperty = 30022;
+    public const int FrameworkIdProperty = 30024;
+    public const int ValueProperty = 30045;
+    public const int RangeValueProperty = 30047;
+    public const int ExpandCollapseStateProperty = 30070;
+    public const int SelectionItemIsSelectedProperty = 30079;
+    public const int ToggleStateProperty = 30086;
+
+    public const int AutomationFocusChangedEvent = 20005;
+    public const int ElementAddedToSelectionEvent = 20010;
+    public const int ElementRemovedFromSelectionEvent = 20011;
+    public const int ElementSelectedEvent = 20012;
+    public const int SelectionInvalidatedEvent = 20013;
+}
+
+internal sealed class WindowsUiaElementNotAvailableException : COMException
+{
+    private const int ErrorElementNotAvailable = unchecked((int)0x80040201);
+
+    public WindowsUiaElementNotAvailableException(string message)
+        : base(message, ErrorElementNotAvailable)
+    {
+    }
+
+    public WindowsUiaElementNotAvailableException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        HResult = ErrorElementNotAvailable;
+    }
+}
+
+internal sealed class WindowsUiaElementNotEnabledException : COMException
+{
+    private const int ErrorElementNotEnabled = unchecked((int)0x80040200);
+
+    public WindowsUiaElementNotEnabledException()
+        : base("The UI Automation element is not enabled.", ErrorElementNotEnabled)
+    {
+    }
+}
+
+internal sealed class WindowsUiaAccessDeniedException : COMException
+{
+    private const int ErrorAccessDenied = unchecked((int)0x80070005);
+
+    public WindowsUiaAccessDeniedException()
+        : base("The value of a password element is not available.", ErrorAccessDenied)
+    {
+    }
+}
+
+internal static class WindowsUiaNativeMethods
+{
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+    private static readonly Guid SimpleProviderInterfaceId = typeof(IRawElementProviderSimpleAbi).GUID;
+    private static readonly Guid FragmentProviderInterfaceId = typeof(IRawElementProviderFragmentAbi).GUID;
+    private static readonly Guid FragmentRootProviderInterfaceId = typeof(IRawElementProviderFragmentRootAbi).GUID;
+
+    [DllImport("uiautomationcore.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UiaClientsAreListening();
+
+    [DllImport("uiautomationcore.dll")]
+    private static extern IntPtr UiaReturnRawElementProvider(
+        IntPtr hwnd,
+        IntPtr wParam,
+        IntPtr lParam,
+        IntPtr provider);
+
+    [DllImport("uiautomationcore.dll")]
+    private static extern int UiaHostProviderFromHwnd(
+        IntPtr hwnd,
+        out IntPtr provider);
+
+    [DllImport("uiautomationcore.dll")]
+    private static extern int UiaRaiseAutomationEvent(
+        IntPtr provider,
+        int eventId);
+
+    [DllImport("uiautomationcore.dll")]
+    private static extern int UiaRaiseAutomationPropertyChangedEvent(
+        IntPtr provider,
+        int propertyId,
+        WindowsUiaVariant oldValue,
+        WindowsUiaVariant newValue);
+
+    [DllImport("uiautomationcore.dll")]
+    private static extern int UiaRaiseStructureChangedEvent(
+        IntPtr provider,
+        StructureChangeType structureChangeType,
+        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] int[] runtimeId,
+        int runtimeIdLength);
+
+    [DllImport("uiautomationcore.dll")]
+    private static extern int UiaDisconnectProvider(
+        IntPtr provider);
+
+    [DllImport("oleaut32.dll")]
+    private static extern IntPtr SafeArrayCreateVector(
+        VarEnum variantType,
+        int lowerBound,
+        uint elementCount);
+
+    [DllImport("oleaut32.dll")]
+    private static extern int SafeArrayAccessData(IntPtr safeArray, out IntPtr data);
+
+    [DllImport("oleaut32.dll")]
+    private static extern int SafeArrayUnaccessData(IntPtr safeArray);
+
+    [DllImport("oleaut32.dll")]
+    private static extern int SafeArrayPutElement(IntPtr safeArray, ref int index, IntPtr value);
+
+    [DllImport("oleaut32.dll")]
+    private static extern int SafeArrayDestroy(IntPtr safeArray);
+
+    [DllImport("oleaut32.dll")]
+    private static extern int VariantClear(ref WindowsUiaVariant value);
+
+    public static bool ClientsAreListening
+    {
+        get
+        {
+            try
+            {
+                return UiaClientsAreListening();
+            }
+            catch (DllNotFoundException)
+            {
+                return false;
+            }
+        }
+    }
+
+    public static IntPtr ReturnRawElementProvider(
+        IntPtr hwnd,
+        IntPtr wParam,
+        IntPtr lParam,
+        WindowsUiaProvider provider)
+    {
+        IntPtr providerPointer = GetComInterfacePointer(provider, SimpleProviderInterfaceId);
+        try
+        {
+            return UiaReturnRawElementProvider(hwnd, wParam, lParam, providerPointer);
+        }
+        finally
+        {
+            _ = Marshal.Release(providerPointer);
+        }
+    }
+
+    public static IntPtr HostProviderFromHwnd(IntPtr hwnd)
+    {
+        Marshal.ThrowExceptionForHR(UiaHostProviderFromHwnd(hwnd, out IntPtr provider));
+        return provider;
+    }
+
+    public static void RaiseAutomationEvent(WindowsUiaProvider provider, int eventId)
+    {
+        IntPtr providerPointer = GetComInterfacePointer(provider, SimpleProviderInterfaceId);
+        try
+        {
+            Marshal.ThrowExceptionForHR(UiaRaiseAutomationEvent(providerPointer, eventId));
+        }
+        finally
+        {
+            _ = Marshal.Release(providerPointer);
+        }
+    }
+
+    public static void RaiseAutomationPropertyChangedEvent(
+        WindowsUiaProvider provider,
+        int propertyId,
+        object? oldValue,
+        object? newValue)
+    {
+        IntPtr providerPointer = GetComInterfacePointer(provider, SimpleProviderInterfaceId);
+        using WindowsUiaVariant oldVariant = WindowsUiaVariant.FromObject(oldValue);
+        using WindowsUiaVariant newVariant = WindowsUiaVariant.FromObject(newValue);
+        try
+        {
+            Marshal.ThrowExceptionForHR(
+                UiaRaiseAutomationPropertyChangedEvent(
+                    providerPointer,
+                    propertyId,
+                    oldVariant,
+                    newVariant));
+        }
+        finally
+        {
+            _ = Marshal.Release(providerPointer);
+        }
+    }
+
+    public static void RaiseStructureChangedEvent(
+        WindowsUiaProvider provider,
+        StructureChangeType changeType,
+        int[] runtimeId)
+    {
+        IntPtr providerPointer = GetComInterfacePointer(provider, SimpleProviderInterfaceId);
+        try
+        {
+            Marshal.ThrowExceptionForHR(
+                UiaRaiseStructureChangedEvent(
+                    providerPointer,
+                    changeType,
+                    runtimeId,
+                    runtimeId.Length));
+        }
+        finally
+        {
+            _ = Marshal.Release(providerPointer);
+        }
+    }
+
+    public static void DisconnectProvider(WindowsUiaProvider provider)
+    {
+        IntPtr providerPointer = GetComInterfacePointer(provider, SimpleProviderInterfaceId);
+        try
+        {
+            _ = UiaDisconnectProvider(providerPointer);
+        }
+        catch (DllNotFoundException)
+        {
+            // UIAutomationCore is present on supported Windows desktops. Teardown remains safe on
+            // deliberately stripped-down Windows test images.
+        }
+        finally
+        {
+            _ = Marshal.Release(providerPointer);
+        }
+    }
+
+    public static IntPtr GetFragmentProviderPointer(WindowsUiaProvider provider)
+        => GetComInterfacePointer(provider, FragmentProviderInterfaceId);
+
+    public static IntPtr GetFragmentRootProviderPointer(WindowsUiaRootProvider provider)
+        => GetComInterfacePointer(provider, FragmentRootProviderInterfaceId);
+
+    public static IntPtr GetUnknownPointer(WindowsUiaProvider provider)
+        => ComWrappers.GetOrCreateComInterfaceForObject(provider, CreateComInterfaceFlags.None);
+
+    public static IntPtr CreateSafeArray(int[] values)
+        => CreateBlittableSafeArray(VarEnum.VT_I4, values, static (source, destination) =>
+            Marshal.Copy(source, 0, destination, source.Length));
+
+    public static IntPtr CreateSafeArray(double[] values)
+        => CreateBlittableSafeArray(VarEnum.VT_R8, values, static (source, destination) =>
+            Marshal.Copy(source, 0, destination, source.Length));
+
+    public static IntPtr CreateSafeArray(IReadOnlyList<WindowsUiaProvider> providers)
+    {
+        IntPtr safeArray = SafeArrayCreateVector(VarEnum.VT_UNKNOWN, 0, checked((uint)providers.Count));
+        if (safeArray == IntPtr.Zero)
+            throw new OutOfMemoryException("Unable to allocate a UI Automation provider array.");
+
+        try
+        {
+            for (int index = 0; index < providers.Count; index++)
+            {
+                IntPtr providerPointer = GetUnknownPointer(providers[index]);
+                try
+                {
+                    Marshal.ThrowExceptionForHR(SafeArrayPutElement(safeArray, ref index, providerPointer));
+                }
+                finally
+                {
+                    _ = Marshal.Release(providerPointer);
+                }
+            }
+
+            return safeArray;
+        }
+        catch
+        {
+            _ = SafeArrayDestroy(safeArray);
+            throw;
+        }
+    }
+
+    public static int ClearVariant(ref WindowsUiaVariant value) => VariantClear(ref value);
+
+    private static IntPtr GetComInterfacePointer(WindowsUiaProvider provider, Guid interfaceId)
+    {
+        IntPtr unknown = GetUnknownPointer(provider);
+        try
+        {
+            Marshal.ThrowExceptionForHR(Marshal.QueryInterface(unknown, in interfaceId, out IntPtr result));
+            return result;
+        }
+        finally
+        {
+            _ = Marshal.Release(unknown);
+        }
+    }
+
+    private static IntPtr CreateBlittableSafeArray<T>(
+        VarEnum variantType,
+        T[] values,
+        Action<T[], IntPtr> copy)
+    {
+        IntPtr safeArray = SafeArrayCreateVector(variantType, 0, checked((uint)values.Length));
+        if (safeArray == IntPtr.Zero)
+            throw new OutOfMemoryException("Unable to allocate a UI Automation value array.");
+
+        bool accessed = false;
+        try
+        {
+            Marshal.ThrowExceptionForHR(SafeArrayAccessData(safeArray, out IntPtr data));
+            accessed = true;
+            copy(values, data);
+            Marshal.ThrowExceptionForHR(SafeArrayUnaccessData(safeArray));
+            accessed = false;
+            return safeArray;
+        }
+        catch
+        {
+            if (accessed)
+                _ = SafeArrayUnaccessData(safeArray);
+            _ = SafeArrayDestroy(safeArray);
+            throw;
+        }
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaInterop.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaInterop.cs
@@ -496,7 +496,7 @@ internal static class WindowsUiaNativeMethods
     private static extern int UiaRaiseStructureChangedEvent(
         IntPtr provider,
         StructureChangeType structureChangeType,
-        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] int[] runtimeId,
+        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] int[]? runtimeId,
         int runtimeIdLength);
 
     [DllImport("uiautomationcore.dll")]
@@ -602,7 +602,7 @@ internal static class WindowsUiaNativeMethods
     public static void RaiseStructureChangedEvent(
         WindowsUiaProvider provider,
         StructureChangeType changeType,
-        int[] runtimeId)
+        int[]? runtimeId)
     {
         IntPtr providerPointer = GetComInterfacePointer(provider, SimpleProviderInterfaceId);
         try
@@ -612,7 +612,7 @@ internal static class WindowsUiaNativeMethods
                     providerPointer,
                     changeType,
                     runtimeId,
-                    runtimeId.Length));
+                    runtimeId?.Length ?? 0));
         }
         finally
         {

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.Com.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.Com.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows.Win32;
+
+internal partial class WindowsUiaProvider
+{
+    public int AbiGetProviderOptions(out ProviderOptions value)
+        => TryGet(() => ProviderOptions, out value);
+
+    public int AbiGetPatternProvider(int patternId, out IntPtr provider)
+        => TryGet(
+            () => GetPatternProvider(patternId) is null
+                ? IntPtr.Zero
+                : WindowsUiaNativeMethods.GetUnknownPointer(this),
+            out provider);
+
+    public int AbiGetPropertyValue(int propertyId, out WindowsUiaVariant value)
+        => TryGet(
+            () => WindowsUiaVariant.FromObject(GetPropertyValue(propertyId)),
+            out value);
+
+    public int AbiGetHostRawElementProvider(out IntPtr provider)
+        => TryGet(
+            () => IsRoot
+                ? WindowsUiaNativeMethods.HostProviderFromHwnd(Context.Hwnd)
+                : IntPtr.Zero,
+            out provider);
+
+    public int AbiNavigate(NavigateDirection direction, out IntPtr provider)
+        => TryGet(
+            () => Navigate(direction) is WindowsUiaProvider target
+                ? WindowsUiaNativeMethods.GetFragmentProviderPointer(target)
+                : IntPtr.Zero,
+            out provider);
+
+    public int AbiGetRuntimeId(out IntPtr runtimeId)
+        => TryGet(
+            () => WindowsUiaNativeMethods.CreateSafeArray(GetRuntimeId()),
+            out runtimeId);
+
+    public int AbiGetBoundingRectangle(out UiaRect bounds)
+        => TryGet(() => BoundingRectangle, out bounds);
+
+    public int AbiGetEmbeddedFragmentRoots(out IntPtr roots)
+    {
+        roots = IntPtr.Zero;
+        return 0;
+    }
+
+    public int AbiSetFocus()
+        => Try(SetFocus);
+
+    public int AbiGetFragmentRoot(out IntPtr provider)
+        => TryGet(
+            () => WindowsUiaNativeMethods.GetFragmentRootProviderPointer(Context.Root),
+            out provider);
+
+    public int AbiInvoke()
+        => Try(() => ((IInvokeProvider)this).Invoke());
+
+    public int AbiToggle()
+        => Try(() => ((IToggleProvider)this).Toggle());
+
+    public int AbiGetToggleState(out ToggleState value)
+        => TryGet(() => ToggleState, out value);
+
+    public int AbiSetValue(IntPtr value)
+        => Try(() => ((IValueProvider)this).SetValue(Marshal.PtrToStringUni(value) ?? string.Empty));
+
+    public int AbiGetValue(out IntPtr value)
+        => TryGet(
+            () => Marshal.StringToBSTR(((IValueProvider)this).Value),
+            out value);
+
+    public int AbiGetIsReadOnly(out int value)
+        => TryGet(() => ((IValueProvider)this).IsReadOnly ? 1 : 0, out value);
+
+    int IRangeValueProviderAbi.AbiSetValue(double value)
+        => Try(() => ((IRangeValueProvider)this).SetValue(value));
+
+    int IRangeValueProviderAbi.AbiGetValue(out double value)
+        => TryGet(() => ((IRangeValueProvider)this).Value, out value);
+
+    int IRangeValueProviderAbi.AbiGetIsReadOnly(out int value)
+        => TryGet(() => ((IRangeValueProvider)this).IsReadOnly ? 1 : 0, out value);
+
+    public int AbiGetMaximum(out double value)
+        => TryGet(() => ((IRangeValueProvider)this).Maximum, out value);
+
+    public int AbiGetMinimum(out double value)
+        => TryGet(() => ((IRangeValueProvider)this).Minimum, out value);
+
+    public int AbiGetLargeChange(out double value)
+        => TryGet(() => ((IRangeValueProvider)this).LargeChange, out value);
+
+    public int AbiGetSmallChange(out double value)
+        => TryGet(() => ((IRangeValueProvider)this).SmallChange, out value);
+
+    public int AbiExpand()
+        => Try(() => ((IExpandCollapseProvider)this).Expand());
+
+    public int AbiCollapse()
+        => Try(() => ((IExpandCollapseProvider)this).Collapse());
+
+    public int AbiGetExpandCollapseState(out ExpandCollapseState value)
+        => TryGet(() => ExpandCollapseState, out value);
+
+    public int AbiGetSelection(out IntPtr providers)
+        => TryGet(
+            () => WindowsUiaNativeMethods.CreateSafeArray(
+                ((ISelectionProvider)this).GetSelection()
+                    .Cast<WindowsUiaProvider>()
+                    .ToArray()),
+            out providers);
+
+    public int AbiGetCanSelectMultiple(out int value)
+        => TryGet(() => ((ISelectionProvider)this).CanSelectMultiple ? 1 : 0, out value);
+
+    public int AbiGetIsSelectionRequired(out int value)
+        => TryGet(() => ((ISelectionProvider)this).IsSelectionRequired ? 1 : 0, out value);
+
+    public int AbiSelect()
+        => Try(() => ((ISelectionItemProvider)this).Select());
+
+    public int AbiAddToSelection()
+        => Try(() => ((ISelectionItemProvider)this).AddToSelection());
+
+    public int AbiRemoveFromSelection()
+        => Try(() => ((ISelectionItemProvider)this).RemoveFromSelection());
+
+    public int AbiGetIsSelected(out int value)
+        => TryGet(() => ((ISelectionItemProvider)this).IsSelected ? 1 : 0, out value);
+
+    public int AbiGetSelectionContainer(out IntPtr provider)
+        => TryGet(
+            () => ((ISelectionItemProvider)this).SelectionContainer is WindowsUiaProvider target
+                ? WindowsUiaNativeMethods.GetUnknownPointer(target)
+                : IntPtr.Zero,
+            out provider);
+
+    public int AbiScrollIntoView()
+        => Try(() => ((IScrollItemProvider)this).ScrollIntoView());
+
+    protected static int Try(Action callback)
+    {
+        try
+        {
+            callback();
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            // Values are deliberately excluded because callbacks can handle passwords and other
+            // user-entered content. The exception type retains diagnostic value without leakage.
+            Trace.TraceError("ModernFormsNext UIA callback failed: {0}", exception.GetType().Name);
+            return exception.HResult;
+        }
+    }
+
+    protected static int TryGet<T>(Func<T> callback, out T value)
+    {
+        try
+        {
+            value = callback();
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            value = default!;
+            Trace.TraceError("ModernFormsNext UIA callback failed: {0}", exception.GetType().Name);
+            return exception.HResult;
+        }
+    }
+}
+
+internal sealed partial class WindowsUiaRootProvider
+{
+    public int AbiElementProviderFromPoint(double x, double y, out IntPtr provider)
+        => TryGet(
+            () => ElementProviderFromPoint(x, y) is WindowsUiaProvider target
+                ? WindowsUiaNativeMethods.GetFragmentProviderPointer(target)
+                : IntPtr.Zero,
+            out provider);
+
+    public int AbiGetFocus(out IntPtr provider)
+        => TryGet(
+            () => GetFocus() is WindowsUiaProvider target
+                ? WindowsUiaNativeMethods.GetFragmentProviderPointer(target)
+                : IntPtr.Zero,
+            out provider);
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.cs
@@ -1,0 +1,780 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Provider;
+using ModernFormsNext.WindowKit.Platform.Accessibility;
+using ModernFormsNext.WindowKit.Threading;
+using UiaRect = System.Windows.Rect;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows.Win32;
+
+/// <summary>
+/// Adapts one canonical ModernFormsNext semantic object to the managed Windows UI Automation
+/// provider contracts.
+/// </summary>
+/// <remarks>
+/// Pattern interfaces are implemented by the wrapper but are returned from
+/// <see cref="GetPatternProvider(int)"/> only when the canonical semantic object advertises the
+/// corresponding capability. All framework state is read or mutated through the UI dispatcher.
+/// </remarks>
+internal class WindowsUiaProvider :
+    IRawElementProviderSimple,
+    IRawElementProviderFragment,
+    IInvokeProvider,
+    IToggleProvider,
+    IValueProvider,
+    IRangeValueProvider,
+    IExpandCollapseProvider,
+    ISelectionProvider,
+    ISelectionItemProvider,
+    IScrollItemProvider
+{
+    private const int ActionInvoke = 1 << 0;
+    private const int ActionToggle = 1 << 1;
+    private const int ActionSelect = 1 << 2;
+    private const int ActionExpand = 1 << 3;
+    private const int ActionCollapse = 1 << 4;
+    private const int ActionSetValue = 1 << 5;
+    private const int ActionScrollIntoView = 1 << 9;
+    private const int ActionFocus = 1 << 10;
+
+    private const int SelectionTakeFocus = 1;
+    private const int SelectionTakeSelection = 2;
+    private const int SelectionAdd = 8;
+    private const int SelectionRemove = 16;
+
+    private const int StateUnavailable = 0x1;
+    private const int StateSelected = 0x2;
+    private const int StateFocused = 0x4;
+    private const int StateChecked = 0x10;
+    private const int StateMixed = 0x20;
+    private const int StateReadOnly = 0x40;
+    private const int StateExpanded = 0x200;
+    private const int StateCollapsed = 0x400;
+    private const int StateInvisible = 0x8000;
+    private const int StateOffscreen = 0x10000;
+    private const int StateFocusable = 0x100000;
+    private const int StateMultiSelectable = 0x1000000;
+
+    private const int ViewRaw = 1;
+    private const int ViewControl = 2;
+    private const int ViewContent = 3;
+    private const int ViewHidden = 4;
+
+    private readonly WeakReference<IPlatformAccessibleObject> target;
+
+    internal WindowsUiaProvider(
+        WindowsUiaProviderContext context,
+        IPlatformAccessibleObject platformObject,
+        bool isRoot)
+    {
+        Context = context;
+        target = new WeakReference<IPlatformAccessibleObject>(platformObject);
+        IsRoot = isRoot;
+    }
+
+    /// <summary>
+    /// Gets the provider context shared by every element in this HWND fragment.
+    /// </summary>
+    protected WindowsUiaProviderContext Context { get; }
+
+    /// <summary>
+    /// Gets whether this provider represents the fragment root.
+    /// </summary>
+    protected bool IsRoot { get; }
+
+    /// <summary>
+    /// Gets the current semantic object for tests and cache identity checks.
+    /// </summary>
+    internal IPlatformAccessibleObject PlatformObject
+        => Read(static node => node);
+
+    /// <inheritdoc/>
+    public ProviderOptions ProviderOptions => ProviderOptions.ServerSideProvider;
+
+    /// <inheritdoc/>
+    public virtual IRawElementProviderSimple? HostRawElementProvider => null;
+
+    /// <inheritdoc/>
+    public object? GetPatternProvider(int patternId)
+    {
+        return Read(node =>
+        {
+            int actions = node.SupportedActions;
+
+            if (patternId == InvokePatternIdentifiers.Pattern.Id && HasAction(actions, ActionInvoke))
+                return this;
+            if (patternId == TogglePatternIdentifiers.Pattern.Id && HasAction(actions, ActionToggle))
+                return this;
+            if (patternId == ValuePatternIdentifiers.Pattern.Id && SupportsValue(node, actions))
+                return this;
+            if (patternId == RangeValuePatternIdentifiers.Pattern.Id && node.RangeValue is not null)
+                return this;
+            if (patternId == ExpandCollapsePatternIdentifiers.Pattern.Id && SupportsExpandCollapse(node, actions))
+                return this;
+            if (patternId == SelectionPatternIdentifiers.Pattern.Id && IsSelectionContainer(node))
+                return this;
+            if (patternId == SelectionItemPatternIdentifiers.Pattern.Id && HasAction(actions, ActionSelect))
+                return this;
+            if (patternId == ScrollItemPatternIdentifiers.Pattern.Id && HasAction(actions, ActionScrollIntoView))
+                return this;
+
+            return null;
+        });
+    }
+
+    /// <inheritdoc/>
+    public object? GetPropertyValue(int propertyId)
+    {
+        return Read(node =>
+        {
+            int state = node.State;
+
+            if (propertyId == AutomationElementIdentifiers.NameProperty.Id)
+                return node.Name ?? string.Empty;
+            if (propertyId == AutomationElementIdentifiers.AutomationIdProperty.Id)
+                return node.AutomationId ?? string.Empty;
+            if (propertyId == AutomationElementIdentifiers.ControlTypeProperty.Id)
+                return WindowsUiaControlTypeMapper.Map(node.ControlType);
+            if (propertyId == AutomationElementIdentifiers.IsEnabledProperty.Id)
+                return !HasState(state, StateUnavailable);
+            if (propertyId == AutomationElementIdentifiers.IsKeyboardFocusableProperty.Id)
+                return HasState(state, StateFocusable) || HasAction(node.SupportedActions, ActionFocus);
+            if (propertyId == AutomationElementIdentifiers.HasKeyboardFocusProperty.Id)
+                return HasState(state, StateFocused);
+            if (propertyId == AutomationElementIdentifiers.BoundingRectangleProperty.Id)
+                return WindowsUiaCoordinateConverter.ToBoundingRectangle(node.Bounds);
+            if (propertyId == AutomationElementIdentifiers.IsOffscreenProperty.Id)
+                return IsOffscreen(node, state);
+            if (propertyId == AutomationElementIdentifiers.HelpTextProperty.Id)
+                return node.Help ?? node.Description ?? string.Empty;
+            if (propertyId == AutomationElementIdentifiers.IsPasswordProperty.Id)
+                return node.IsSensitive || HasState(state, unchecked((int)0x20000000));
+            if (propertyId == AutomationElementIdentifiers.IsControlElementProperty.Id)
+                return IsControlElement(node.View);
+            if (propertyId == AutomationElementIdentifiers.IsContentElementProperty.Id)
+                return IsContentElement(node.View);
+            if (propertyId == AutomationElementIdentifiers.ClassNameProperty.Id)
+                return node.ClassName ?? WindowsUiaControlTypeMapper.GetClassName(node.ControlType);
+            if (propertyId == AutomationElementIdentifiers.FrameworkIdProperty.Id)
+                return "ModernFormsNext";
+            if (propertyId == ValuePatternIdentifiers.ValueProperty.Id)
+            {
+                if (node.IsSensitive)
+                    throw new InvalidOperationException("The value of a password element is not available.");
+
+                return node.Value ?? string.Empty;
+            }
+
+            return AutomationElement.NotSupported;
+        });
+    }
+
+    /// <inheritdoc/>
+    public virtual IRawElementProviderFragment? Navigate(NavigateDirection direction)
+    {
+        return Read(node =>
+        {
+            IPlatformAccessibleObject? result = direction switch
+            {
+                NavigateDirection.Parent => node.Parent,
+                NavigateDirection.FirstChild => node.GetChildCount() > 0 ? node.GetChild(0) : null,
+                NavigateDirection.LastChild => node.GetChildCount() > 0 ? node.GetChild(node.GetChildCount() - 1) : null,
+                NavigateDirection.NextSibling => node.Navigate(PlatformAccessibleNavigation.Next),
+                NavigateDirection.PreviousSibling => node.Navigate(PlatformAccessibleNavigation.Previous),
+                _ => null
+            };
+
+            return result is null ? null : Context.GetOrCreate(result);
+        });
+    }
+
+    /// <inheritdoc/>
+    public int[] GetRuntimeId()
+    {
+        return Read(node =>
+        {
+            long id = node.RuntimeId;
+            if (id == 0)
+                id = RuntimeHelpers.GetHashCode(node);
+
+            return new int[]
+            {
+                AutomationInteropProvider.AppendRuntimeId,
+                unchecked((int)(id & uint.MaxValue)),
+                unchecked((int)(id >> 32))
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public UiaRect BoundingRectangle
+        => Read(static node => WindowsUiaCoordinateConverter.ToBoundingRectangle(node.Bounds));
+
+    /// <inheritdoc/>
+    public IRawElementProviderSimple[]? GetEmbeddedFragmentRoots() => null;
+
+    /// <inheritdoc/>
+    public void SetFocus()
+    {
+        Mutate(node =>
+        {
+            if (HasAction(node.SupportedActions, ActionFocus) && node.PerformAction(ActionFocus))
+                return;
+
+            // Logical items can route focus through their canonical Select implementation even
+            // when they do not own a Control or advertise the general Focus action.
+            node.Select(SelectionTakeFocus);
+        });
+    }
+
+    /// <inheritdoc/>
+    public IRawElementProviderFragmentRoot FragmentRoot => Context.Root;
+
+    /// <inheritdoc/>
+    void IInvokeProvider.Invoke()
+        => PerformRequiredAction(ActionInvoke);
+
+    /// <inheritdoc/>
+    public ToggleState ToggleState
+        => Read(static node =>
+        {
+            int state = node.State;
+            if (HasState(state, StateMixed))
+                return ToggleState.Indeterminate;
+            if (HasState(state, StateChecked))
+                return ToggleState.On;
+            return ToggleState.Off;
+        });
+
+    /// <inheritdoc/>
+    void IToggleProvider.Toggle()
+        => PerformRequiredAction(ActionToggle);
+
+    /// <inheritdoc/>
+    string IValueProvider.Value
+        => Read(static node => node.IsSensitive
+            ? throw new InvalidOperationException("The value of a password element is not available.")
+            : node.Value ?? string.Empty);
+
+    /// <inheritdoc/>
+    bool IValueProvider.IsReadOnly
+        => Read(static node => HasState(node.State, StateReadOnly)
+            || !HasAction(node.SupportedActions, ActionSetValue));
+
+    /// <inheritdoc/>
+    void IValueProvider.SetValue(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        Mutate(node =>
+        {
+            if (HasState(node.State, StateUnavailable))
+                throw new ElementNotEnabledException();
+            if (HasState(node.State, StateReadOnly) || !HasAction(node.SupportedActions, ActionSetValue))
+                throw new InvalidOperationException("The semantic value is read-only.");
+            if (!node.PerformAction(ActionSetValue, value))
+                throw new InvalidOperationException("The semantic object rejected the value.");
+        });
+    }
+
+    /// <inheritdoc/>
+    double IRangeValueProvider.Value => ReadRange(static range => range.Value);
+
+    /// <inheritdoc/>
+    bool IRangeValueProvider.IsReadOnly => ReadRange(static range => range.IsReadOnly);
+
+    /// <inheritdoc/>
+    double IRangeValueProvider.Maximum => ReadRange(static range => range.Maximum);
+
+    /// <inheritdoc/>
+    double IRangeValueProvider.Minimum => ReadRange(static range => range.Minimum);
+
+    /// <inheritdoc/>
+    double IRangeValueProvider.LargeChange => ReadRange(static range => range.LargeChange);
+
+    /// <inheritdoc/>
+    double IRangeValueProvider.SmallChange => ReadRange(static range => range.SmallChange);
+
+    /// <inheritdoc/>
+    void IRangeValueProvider.SetValue(double value)
+    {
+        Mutate(node =>
+        {
+            PlatformAccessibleRangeValue range = node.RangeValue
+                ?? throw new InvalidOperationException("The semantic object does not expose a numeric range.");
+
+            if (HasState(node.State, StateUnavailable))
+                throw new ElementNotEnabledException();
+            if (range.IsReadOnly || !HasAction(node.SupportedActions, ActionSetValue))
+                throw new InvalidOperationException("The semantic range is read-only.");
+            if (double.IsNaN(value) || value < range.Minimum || value > range.Maximum)
+                throw new ArgumentOutOfRangeException(nameof(value));
+            if (!node.PerformAction(ActionSetValue, value))
+                throw new InvalidOperationException("The semantic object rejected the range value.");
+        });
+    }
+
+    /// <inheritdoc/>
+    public ExpandCollapseState ExpandCollapseState
+        => Read(static node =>
+        {
+            int state = node.State;
+            if (HasState(state, StateExpanded))
+                return ExpandCollapseState.Expanded;
+            if (HasState(state, StateCollapsed))
+                return ExpandCollapseState.Collapsed;
+            return ExpandCollapseState.LeafNode;
+        });
+
+    /// <inheritdoc/>
+    void IExpandCollapseProvider.Expand()
+        => PerformRequiredAction(ActionExpand);
+
+    /// <inheritdoc/>
+    void IExpandCollapseProvider.Collapse()
+        => PerformRequiredAction(ActionCollapse);
+
+    /// <inheritdoc/>
+    bool ISelectionProvider.CanSelectMultiple
+        => Read(static node => HasState(node.State, StateMultiSelectable));
+
+    /// <inheritdoc/>
+    bool ISelectionProvider.IsSelectionRequired => false;
+
+    /// <inheritdoc/>
+    IRawElementProviderSimple[] ISelectionProvider.GetSelection()
+    {
+        return Read(node =>
+        {
+            var selected = new List<IRawElementProviderSimple>();
+            int count = node.GetChildCount();
+            for (int index = 0; index < count; index++)
+            {
+                if (node.GetChild(index) is { } child && HasState(child.State, StateSelected))
+                    selected.Add(Context.GetOrCreate(child));
+            }
+
+            return selected.ToArray();
+        });
+    }
+
+    /// <inheritdoc/>
+    bool ISelectionItemProvider.IsSelected
+        => Read(static node => HasState(node.State, StateSelected));
+
+    /// <inheritdoc/>
+    IRawElementProviderSimple? ISelectionItemProvider.SelectionContainer
+        => Read(node => node.Parent is { } parent ? Context.GetOrCreate(parent) : null);
+
+    /// <inheritdoc/>
+    void ISelectionItemProvider.Select()
+        => PerformRequiredAction(ActionSelect);
+
+    /// <inheritdoc/>
+    void ISelectionItemProvider.AddToSelection()
+    {
+        Mutate(node =>
+        {
+            if (HasState(node.State, StateSelected))
+                return;
+            if (node.Parent is not { } parent || !HasState(parent.State, StateMultiSelectable))
+                throw new InvalidOperationException("The selection container does not support multiple selection.");
+
+            node.Select(SelectionAdd);
+        });
+    }
+
+    /// <inheritdoc/>
+    void ISelectionItemProvider.RemoveFromSelection()
+    {
+        Mutate(node =>
+        {
+            if (!HasState(node.State, StateSelected))
+                return;
+            if (node.Parent is not { } parent || !HasState(parent.State, StateMultiSelectable))
+                throw new InvalidOperationException("The selection container does not support multiple selection.");
+
+            node.Select(SelectionRemove);
+        });
+    }
+
+    /// <inheritdoc/>
+    void IScrollItemProvider.ScrollIntoView()
+        => PerformRequiredAction(ActionScrollIntoView);
+
+    /// <summary>
+    /// Reads a semantic value on the owning UI thread.
+    /// </summary>
+    protected T Read<T>(Func<IPlatformAccessibleObject, T> callback)
+        => Context.Read(target, IsRoot, callback);
+
+    /// <summary>
+    /// Mutates semantic state on the owning UI thread.
+    /// </summary>
+    protected void Mutate(Action<IPlatformAccessibleObject> callback)
+        => Context.Mutate(target, IsRoot, callback);
+
+    private static bool HasAction(int actions, int action) => (actions & action) != 0;
+
+    private static bool HasState(int state, int flag) => (state & flag) != 0;
+
+    private static bool SupportsValue(IPlatformAccessibleObject node, int actions)
+        => node.RangeValue is null && HasAction(actions, ActionSetValue);
+
+    private static bool SupportsExpandCollapse(IPlatformAccessibleObject node, int actions)
+        => HasAction(actions, ActionExpand)
+            || HasAction(actions, ActionCollapse)
+            || HasState(node.State, StateExpanded)
+            || HasState(node.State, StateCollapsed);
+
+    private static bool IsSelectionContainer(IPlatformAccessibleObject node)
+        => node.ControlType is 11 or 12 or 14 or 16;
+
+    private static bool IsControlElement(int view)
+        => view is ViewControl or ViewContent;
+
+    private static bool IsContentElement(int view)
+        => view == ViewContent;
+
+    private static bool IsOffscreen(IPlatformAccessibleObject node, int state)
+        => HasState(state, StateInvisible)
+            || HasState(state, StateOffscreen)
+            || node.Bounds.Width <= 0
+            || node.Bounds.Height <= 0;
+
+    private T ReadRange<T>(Func<PlatformAccessibleRangeValue, T> selector)
+        => Read(node => selector(node.RangeValue
+            ?? throw new InvalidOperationException("The semantic object does not expose a numeric range.")));
+
+    private void PerformRequiredAction(int action)
+    {
+        Mutate(node =>
+        {
+            if (HasState(node.State, StateUnavailable))
+                throw new ElementNotEnabledException();
+            if (!HasAction(node.SupportedActions, action) || !node.PerformAction(action))
+                throw new InvalidOperationException("The semantic action is not available.");
+        });
+    }
+}
+
+/// <summary>
+/// Represents the fragment root associated with one ModernFormsNext HWND.
+/// </summary>
+internal sealed class WindowsUiaRootProvider : WindowsUiaProvider, IRawElementProviderFragmentRoot, IDisposable
+{
+    private WindowsUiaRootProvider(WindowsUiaProviderContext context, IPlatformAccessibleObject root)
+        : base(context, root, isRoot: true)
+    {
+    }
+
+    /// <summary>
+    /// Creates a UIA fragment root and initializes its lifecycle-bound provider cache.
+    /// </summary>
+    public static WindowsUiaRootProvider Create(
+        IntPtr hwnd,
+        IPlatformAccessibleObject root,
+        Dispatcher dispatcher)
+    {
+        var context = new WindowsUiaProviderContext(hwnd, dispatcher);
+        var provider = new WindowsUiaRootProvider(context, root);
+        context.Initialize(root, provider);
+        return provider;
+    }
+
+    /// <inheritdoc/>
+    public override IRawElementProviderSimple HostRawElementProvider
+        => AutomationInteropProvider.HostProviderFromHandle(Context.Hwnd);
+
+    /// <inheritdoc/>
+    public override IRawElementProviderFragment? Navigate(NavigateDirection direction)
+        => direction == NavigateDirection.Parent
+            ? HostRawElementProvider as IRawElementProviderFragment
+            : base.Navigate(direction);
+
+    /// <inheritdoc/>
+    public IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
+    {
+        return Read(node => node.HitTest((int)Math.Round(x), (int)Math.Round(y)) is { } hit
+            ? Context.GetOrCreate(hit)
+            : null);
+    }
+
+    /// <inheritdoc/>
+    public IRawElementProviderFragment? GetFocus()
+    {
+        return Read(node => node.GetFocused() is { } focused
+            ? Context.GetOrCreate(focused)
+            : null);
+    }
+
+    /// <summary>
+    /// Raises a native UIA notification for a canonical semantic event when clients are listening.
+    /// </summary>
+    public void RaiseNotification(IPlatformAccessibleObject source, int eventId)
+        => Context.RaiseNotification(source, eventId);
+
+    /// <inheritdoc/>
+    public void Dispose() => Context.Dispose();
+
+    /// <summary>
+    /// Disconnects this provider from UIAutomationCore after the window message that destroyed the
+    /// HWND has returned.
+    /// </summary>
+    public void Disconnect() => WindowsUiaNativeMethods.DisconnectProvider(this);
+}
+
+/// <summary>
+/// Owns the dispatcher, weak identity cache, and lifecycle of one HWND UIA fragment.
+/// </summary>
+internal sealed class WindowsUiaProviderContext : IDisposable
+{
+    private static readonly TimeSpan DispatcherTimeout = TimeSpan.FromSeconds(10);
+    private readonly ConditionalWeakTable<IPlatformAccessibleObject, WindowsUiaProvider> providers = new();
+    private readonly Dispatcher dispatcher;
+    private bool disposed;
+
+    public WindowsUiaProviderContext(IntPtr hwnd, Dispatcher dispatcher)
+    {
+        Hwnd = hwnd;
+        this.dispatcher = dispatcher;
+    }
+
+    public IntPtr Hwnd { get; }
+
+    public WindowsUiaRootProvider Root { get; private set; } = null!;
+
+    public void Initialize(IPlatformAccessibleObject root, WindowsUiaRootProvider provider)
+    {
+        Root = provider;
+        providers.Add(root, provider);
+    }
+
+    public WindowsUiaProvider GetOrCreate(IPlatformAccessibleObject node)
+    {
+        ThrowIfDisposed();
+        return providers.GetValue(node, value => new WindowsUiaProvider(this, value, isRoot: false));
+    }
+
+    public T Read<T>(
+        WeakReference<IPlatformAccessibleObject> target,
+        bool isRoot,
+        Func<IPlatformAccessibleObject, T> callback)
+        => OnUiThread(() =>
+        {
+            IPlatformAccessibleObject node = Resolve(target, isRoot);
+            return callback(node);
+        });
+
+    public void Mutate(
+        WeakReference<IPlatformAccessibleObject> target,
+        bool isRoot,
+        Action<IPlatformAccessibleObject> callback)
+        => OnUiThread(() => callback(Resolve(target, isRoot)));
+
+    public void RaiseNotification(IPlatformAccessibleObject source, int eventId)
+    {
+        if (disposed || !AutomationInteropProvider.ClientsAreListening)
+            return;
+
+        try
+        {
+            WindowsUiaProvider provider = GetOrCreate(source);
+            WindowsUiaEventMapper.Raise(provider, source, eventId, this);
+        }
+        catch (ElementNotAvailableException)
+        {
+            // A semantic object can be removed between the shared notification and provider lookup.
+        }
+        catch (Exception exception)
+        {
+            // Do not include semantic values in diagnostics: they may contain user-entered or
+            // password data. UIA event failures must not escape the native window callback.
+            Debug.WriteLine($"ModernFormsNext UIA notification failed: {exception.GetType().Name}");
+        }
+    }
+
+    public void Dispose() => disposed = true;
+
+    private T OnUiThread<T>(Func<T> callback)
+    {
+        ThrowIfDisposed();
+
+        try
+        {
+            return dispatcher.CheckAccess()
+                ? callback()
+                : dispatcher.Invoke(callback, DispatcherPriority.Send, CancellationToken.None, DispatcherTimeout);
+        }
+        catch (ElementNotAvailableException)
+        {
+            throw;
+        }
+        catch (TimeoutException exception)
+        {
+            throw new ElementNotAvailableException("The ModernFormsNext UI thread did not accept the automation request.", exception);
+        }
+        catch (OperationCanceledException exception)
+        {
+            throw new ElementNotAvailableException("The ModernFormsNext dispatcher is shutting down.", exception);
+        }
+    }
+
+    private void OnUiThread(Action callback)
+    {
+        ThrowIfDisposed();
+
+        try
+        {
+            if (dispatcher.CheckAccess())
+                callback();
+            else
+                dispatcher.Invoke(callback, DispatcherPriority.Send, CancellationToken.None, DispatcherTimeout);
+        }
+        catch (ElementNotAvailableException)
+        {
+            throw;
+        }
+        catch (TimeoutException exception)
+        {
+            throw new ElementNotAvailableException("The ModernFormsNext UI thread did not accept the automation request.", exception);
+        }
+        catch (OperationCanceledException exception)
+        {
+            throw new ElementNotAvailableException("The ModernFormsNext dispatcher is shutting down.", exception);
+        }
+    }
+
+    private IPlatformAccessibleObject Resolve(
+        WeakReference<IPlatformAccessibleObject> target,
+        bool isRoot)
+    {
+        ThrowIfDisposed();
+        if (!target.TryGetTarget(out IPlatformAccessibleObject? node))
+            throw new ElementNotAvailableException("The semantic object is no longer available.");
+        if (!isRoot && node.Parent is null)
+            throw new ElementNotAvailableException("The semantic object is detached from its accessibility tree.");
+
+        return node;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (disposed || Hwnd == IntPtr.Zero)
+            throw new ElementNotAvailableException("The native window is no longer available.");
+    }
+}
+
+/// <summary>
+/// Maps canonical control type identifiers to Windows UI Automation control type identifiers.
+/// </summary>
+internal static class WindowsUiaControlTypeMapper
+{
+    public static int Map(int controlType)
+        => controlType switch
+        {
+            2 => ControlType.Window.Id,
+            3 => ControlType.Pane.Id,
+            4 => ControlType.Group.Id,
+            5 => ControlType.Text.Id,
+            6 => ControlType.Button.Id,
+            7 => ControlType.CheckBox.Id,
+            8 => ControlType.RadioButton.Id,
+            9 => ControlType.CheckBox.Id,
+            10 => ControlType.Edit.Id,
+            11 => ControlType.ComboBox.Id,
+            12 => ControlType.List.Id,
+            13 => ControlType.ListItem.Id,
+            14 => ControlType.Tree.Id,
+            15 => ControlType.TreeItem.Id,
+            16 => ControlType.Tab.Id,
+            17 => ControlType.TabItem.Id,
+            18 => ControlType.Menu.Id,
+            19 => ControlType.MenuItem.Id,
+            20 => ControlType.Slider.Id,
+            21 => ControlType.ProgressBar.Id,
+            22 => ControlType.ScrollBar.Id,
+            23 => ControlType.Window.Id,
+            24 => ControlType.Image.Id,
+            25 => ControlType.ToolBar.Id,
+            26 => ControlType.Separator.Id,
+            _ => ControlType.Custom.Id
+        };
+
+    public static string GetClassName(int controlType)
+        => controlType switch
+        {
+            2 => "Form",
+            23 => "Dialog",
+            3 => "Pane",
+            4 => "Group",
+            5 => "Text",
+            6 => "Button",
+            7 => "CheckBox",
+            8 => "RadioButton",
+            9 => "Switch",
+            10 => "TextBox",
+            11 => "ComboBox",
+            12 => "List",
+            13 => "ListItem",
+            14 => "TreeView",
+            15 => "TreeItem",
+            16 => "TabControl",
+            17 => "TabItem",
+            18 => "Menu",
+            19 => "MenuItem",
+            20 => "TrackBar",
+            21 => "ProgressBar",
+            22 => "ScrollBar",
+            24 => "Image",
+            25 => "ToolBar",
+            26 => "Separator",
+            _ => "Custom"
+        };
+}
+
+/// <summary>
+/// Converts canonical screen bounds to the physical screen rectangle expected by Windows UIA.
+/// </summary>
+internal static class WindowsUiaCoordinateConverter
+{
+    public static UiaRect ToBoundingRectangle(WindowKit.Rect bounds)
+    {
+        // The ModernFormsNext Windows host's PointToScreen path already applies RenderScaling and
+        // returns physical desktop pixels. Applying DPI scaling again here would double-scale UIA
+        // rectangles at 125%, 150%, and other non-default monitor scales.
+        if (!double.IsFinite(bounds.X)
+            || !double.IsFinite(bounds.Y)
+            || !double.IsFinite(bounds.Width)
+            || !double.IsFinite(bounds.Height)
+            || bounds.Width <= 0
+            || bounds.Height <= 0)
+        {
+            return UiaRect.Empty;
+        }
+
+        return new UiaRect(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+    }
+}
+
+internal static class WindowsUiaNativeMethods
+{
+    [DllImport("uiautomationcore.dll")]
+    private static extern int UiaDisconnectProvider(
+        [MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider);
+
+    public static void DisconnectProvider(IRawElementProviderSimple provider)
+    {
+        try
+        {
+            _ = UiaDisconnectProvider(provider);
+        }
+        catch (DllNotFoundException)
+        {
+            // UIAutomationCore is part of supported Windows desktop installations. Keep teardown
+            // resilient for stripped-down test images where it is intentionally unavailable.
+        }
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.cs
@@ -1,12 +1,8 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Windows;
-using System.Windows.Automation;
-using System.Windows.Automation.Provider;
+using System.Runtime.InteropServices.Marshalling;
 using ModernFormsNext.WindowKit.Platform.Accessibility;
 using ModernFormsNext.WindowKit.Threading;
-using UiaRect = System.Windows.Rect;
 
 namespace ModernFormsNext.WindowKit.Backend.Windows.Win32;
 
@@ -19,7 +15,8 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32;
 /// <see cref="GetPatternProvider(int)"/> only when the canonical semantic object advertises the
 /// corresponding capability. All framework state is read or mutated through the UI dispatcher.
 /// </remarks>
-internal class WindowsUiaProvider :
+[GeneratedComClass]
+internal partial class WindowsUiaProvider :
     IRawElementProviderSimple,
     IRawElementProviderFragment,
     IInvokeProvider,
@@ -29,7 +26,17 @@ internal class WindowsUiaProvider :
     IExpandCollapseProvider,
     ISelectionProvider,
     ISelectionItemProvider,
-    IScrollItemProvider
+    IScrollItemProvider,
+    IRawElementProviderSimpleAbi,
+    IRawElementProviderFragmentAbi,
+    IInvokeProviderAbi,
+    IToggleProviderAbi,
+    IValueProviderAbi,
+    IRangeValueProviderAbi,
+    IExpandCollapseProviderAbi,
+    ISelectionProviderAbi,
+    ISelectionItemProviderAbi,
+    IScrollItemProviderAbi
 {
     private const int ActionInvoke = 1 << 0;
     private const int ActionToggle = 1 << 1;
@@ -100,25 +107,25 @@ internal class WindowsUiaProvider :
     /// <inheritdoc/>
     public object? GetPatternProvider(int patternId)
     {
-        return Read(node =>
+        return Read<object?>(node =>
         {
-            int actions = node.SupportedActions;
+            int actions = node.GetSupportedActions();
 
-            if (patternId == InvokePatternIdentifiers.Pattern.Id && HasAction(actions, ActionInvoke))
+            if (patternId == WindowsUiaIds.InvokePattern && HasAction(actions, ActionInvoke))
                 return this;
-            if (patternId == TogglePatternIdentifiers.Pattern.Id && HasAction(actions, ActionToggle))
+            if (patternId == WindowsUiaIds.TogglePattern && HasAction(actions, ActionToggle))
                 return this;
-            if (patternId == ValuePatternIdentifiers.Pattern.Id && SupportsValue(node, actions))
+            if (patternId == WindowsUiaIds.ValuePattern && SupportsValue(node, actions))
                 return this;
-            if (patternId == RangeValuePatternIdentifiers.Pattern.Id && node.RangeValue is not null)
+            if (patternId == WindowsUiaIds.RangeValuePattern && node.GetRangeValue() is not null)
                 return this;
-            if (patternId == ExpandCollapsePatternIdentifiers.Pattern.Id && SupportsExpandCollapse(node, actions))
+            if (patternId == WindowsUiaIds.ExpandCollapsePattern && SupportsExpandCollapse(node, actions))
                 return this;
-            if (patternId == SelectionPatternIdentifiers.Pattern.Id && IsSelectionContainer(node))
+            if (patternId == WindowsUiaIds.SelectionPattern && IsSelectionContainer(node))
                 return this;
-            if (patternId == SelectionItemPatternIdentifiers.Pattern.Id && HasAction(actions, ActionSelect))
+            if (patternId == WindowsUiaIds.SelectionItemPattern && HasAction(actions, ActionSelect))
                 return this;
-            if (patternId == ScrollItemPatternIdentifiers.Pattern.Id && HasAction(actions, ActionScrollIntoView))
+            if (patternId == WindowsUiaIds.ScrollItemPattern && HasAction(actions, ActionScrollIntoView))
                 return this;
 
             return null;
@@ -128,47 +135,47 @@ internal class WindowsUiaProvider :
     /// <inheritdoc/>
     public object? GetPropertyValue(int propertyId)
     {
-        return Read(node =>
+        return Read<object?>(node =>
         {
             int state = node.State;
 
-            if (propertyId == AutomationElementIdentifiers.NameProperty.Id)
+            if (propertyId == WindowsUiaIds.NameProperty)
                 return node.Name ?? string.Empty;
-            if (propertyId == AutomationElementIdentifiers.AutomationIdProperty.Id)
-                return node.AutomationId ?? string.Empty;
-            if (propertyId == AutomationElementIdentifiers.ControlTypeProperty.Id)
-                return WindowsUiaControlTypeMapper.Map(node.ControlType);
-            if (propertyId == AutomationElementIdentifiers.IsEnabledProperty.Id)
+            if (propertyId == WindowsUiaIds.AutomationIdProperty)
+                return node.GetAutomationId() ?? string.Empty;
+            if (propertyId == WindowsUiaIds.ControlTypeProperty)
+                return WindowsUiaControlTypeMapper.Map(node.GetControlType());
+            if (propertyId == WindowsUiaIds.IsEnabledProperty)
                 return !HasState(state, StateUnavailable);
-            if (propertyId == AutomationElementIdentifiers.IsKeyboardFocusableProperty.Id)
-                return HasState(state, StateFocusable) || HasAction(node.SupportedActions, ActionFocus);
-            if (propertyId == AutomationElementIdentifiers.HasKeyboardFocusProperty.Id)
+            if (propertyId == WindowsUiaIds.IsKeyboardFocusableProperty)
+                return HasState(state, StateFocusable) || HasAction(node.GetSupportedActions(), ActionFocus);
+            if (propertyId == WindowsUiaIds.HasKeyboardFocusProperty)
                 return HasState(state, StateFocused);
-            if (propertyId == AutomationElementIdentifiers.BoundingRectangleProperty.Id)
+            if (propertyId == WindowsUiaIds.BoundingRectangleProperty)
                 return WindowsUiaCoordinateConverter.ToBoundingRectangle(node.Bounds);
-            if (propertyId == AutomationElementIdentifiers.IsOffscreenProperty.Id)
+            if (propertyId == WindowsUiaIds.IsOffscreenProperty)
                 return IsOffscreen(node, state);
-            if (propertyId == AutomationElementIdentifiers.HelpTextProperty.Id)
+            if (propertyId == WindowsUiaIds.HelpTextProperty)
                 return node.Help ?? node.Description ?? string.Empty;
-            if (propertyId == AutomationElementIdentifiers.IsPasswordProperty.Id)
-                return node.IsSensitive || HasState(state, unchecked((int)0x20000000));
-            if (propertyId == AutomationElementIdentifiers.IsControlElementProperty.Id)
-                return IsControlElement(node.View);
-            if (propertyId == AutomationElementIdentifiers.IsContentElementProperty.Id)
-                return IsContentElement(node.View);
-            if (propertyId == AutomationElementIdentifiers.ClassNameProperty.Id)
-                return node.ClassName ?? WindowsUiaControlTypeMapper.GetClassName(node.ControlType);
-            if (propertyId == AutomationElementIdentifiers.FrameworkIdProperty.Id)
+            if (propertyId == WindowsUiaIds.IsPasswordProperty)
+                return node.GetIsSensitive() || HasState(state, unchecked((int)0x20000000));
+            if (propertyId == WindowsUiaIds.IsControlElementProperty)
+                return IsControlElement(node.GetAccessibilityView());
+            if (propertyId == WindowsUiaIds.IsContentElementProperty)
+                return IsContentElement(node.GetAccessibilityView());
+            if (propertyId == WindowsUiaIds.ClassNameProperty)
+                return node.GetClassName() ?? WindowsUiaControlTypeMapper.GetClassName(node.GetControlType());
+            if (propertyId == WindowsUiaIds.FrameworkIdProperty)
                 return "ModernFormsNext";
-            if (propertyId == ValuePatternIdentifiers.ValueProperty.Id)
+            if (propertyId == WindowsUiaIds.ValueProperty)
             {
-                if (node.IsSensitive)
-                    throw new InvalidOperationException("The value of a password element is not available.");
+                if (node.GetIsSensitive())
+                    throw new WindowsUiaAccessDeniedException();
 
                 return node.Value ?? string.Empty;
             }
 
-            return AutomationElement.NotSupported;
+            return null;
         });
     }
 
@@ -196,13 +203,13 @@ internal class WindowsUiaProvider :
     {
         return Read(node =>
         {
-            long id = node.RuntimeId;
+            long id = node.GetRuntimeId();
             if (id == 0)
                 id = RuntimeHelpers.GetHashCode(node);
 
             return new int[]
             {
-                AutomationInteropProvider.AppendRuntimeId,
+                WindowsUiaIds.AppendRuntimeId,
                 unchecked((int)(id & uint.MaxValue)),
                 unchecked((int)(id >> 32))
             };
@@ -221,7 +228,7 @@ internal class WindowsUiaProvider :
     {
         Mutate(node =>
         {
-            if (HasAction(node.SupportedActions, ActionFocus) && node.PerformAction(ActionFocus))
+            if (HasAction(node.GetSupportedActions(), ActionFocus) && node.PerformUiaAction(ActionFocus))
                 return;
 
             // Logical items can route focus through their canonical Select implementation even
@@ -255,14 +262,14 @@ internal class WindowsUiaProvider :
 
     /// <inheritdoc/>
     string IValueProvider.Value
-        => Read(static node => node.IsSensitive
-            ? throw new InvalidOperationException("The value of a password element is not available.")
+        => Read(static node => node.GetIsSensitive()
+            ? throw new WindowsUiaAccessDeniedException()
             : node.Value ?? string.Empty);
 
     /// <inheritdoc/>
     bool IValueProvider.IsReadOnly
         => Read(static node => HasState(node.State, StateReadOnly)
-            || !HasAction(node.SupportedActions, ActionSetValue));
+            || !HasAction(node.GetSupportedActions(), ActionSetValue));
 
     /// <inheritdoc/>
     void IValueProvider.SetValue(string value)
@@ -271,10 +278,10 @@ internal class WindowsUiaProvider :
         Mutate(node =>
         {
             if (HasState(node.State, StateUnavailable))
-                throw new ElementNotEnabledException();
-            if (HasState(node.State, StateReadOnly) || !HasAction(node.SupportedActions, ActionSetValue))
+                throw new WindowsUiaElementNotEnabledException();
+            if (HasState(node.State, StateReadOnly) || !HasAction(node.GetSupportedActions(), ActionSetValue))
                 throw new InvalidOperationException("The semantic value is read-only.");
-            if (!node.PerformAction(ActionSetValue, value))
+            if (!node.PerformUiaAction(ActionSetValue, value))
                 throw new InvalidOperationException("The semantic object rejected the value.");
         });
     }
@@ -302,16 +309,16 @@ internal class WindowsUiaProvider :
     {
         Mutate(node =>
         {
-            PlatformAccessibleRangeValue range = node.RangeValue
+            PlatformAccessibleRangeValue range = node.GetRangeValue()
                 ?? throw new InvalidOperationException("The semantic object does not expose a numeric range.");
 
             if (HasState(node.State, StateUnavailable))
-                throw new ElementNotEnabledException();
-            if (range.IsReadOnly || !HasAction(node.SupportedActions, ActionSetValue))
+                throw new WindowsUiaElementNotEnabledException();
+            if (range.IsReadOnly || !HasAction(node.GetSupportedActions(), ActionSetValue))
                 throw new InvalidOperationException("The semantic range is read-only.");
             if (double.IsNaN(value) || value < range.Minimum || value > range.Maximum)
                 throw new ArgumentOutOfRangeException(nameof(value));
-            if (!node.PerformAction(ActionSetValue, value))
+            if (!node.PerformUiaAction(ActionSetValue, value))
                 throw new InvalidOperationException("The semantic object rejected the range value.");
         });
     }
@@ -421,7 +428,8 @@ internal class WindowsUiaProvider :
     private static bool HasState(int state, int flag) => (state & flag) != 0;
 
     private static bool SupportsValue(IPlatformAccessibleObject node, int actions)
-        => node.RangeValue is null && HasAction(actions, ActionSetValue);
+        => node.GetRangeValue() is null
+            && (HasAction(actions, ActionSetValue) || node.GetControlType() == 10);
 
     private static bool SupportsExpandCollapse(IPlatformAccessibleObject node, int actions)
         => HasAction(actions, ActionExpand)
@@ -430,7 +438,7 @@ internal class WindowsUiaProvider :
             || HasState(node.State, StateCollapsed);
 
     private static bool IsSelectionContainer(IPlatformAccessibleObject node)
-        => node.ControlType is 11 or 12 or 14 or 16;
+        => node.GetControlType() is 11 or 12 or 14 or 16;
 
     private static bool IsControlElement(int view)
         => view is ViewControl or ViewContent;
@@ -445,7 +453,7 @@ internal class WindowsUiaProvider :
             || node.Bounds.Height <= 0;
 
     private T ReadRange<T>(Func<PlatformAccessibleRangeValue, T> selector)
-        => Read(node => selector(node.RangeValue
+        => Read(node => selector(node.GetRangeValue()
             ?? throw new InvalidOperationException("The semantic object does not expose a numeric range.")));
 
     private void PerformRequiredAction(int action)
@@ -453,8 +461,8 @@ internal class WindowsUiaProvider :
         Mutate(node =>
         {
             if (HasState(node.State, StateUnavailable))
-                throw new ElementNotEnabledException();
-            if (!HasAction(node.SupportedActions, action) || !node.PerformAction(action))
+                throw new WindowsUiaElementNotEnabledException();
+            if (!HasAction(node.GetSupportedActions(), action) || !node.PerformUiaAction(action))
                 throw new InvalidOperationException("The semantic action is not available.");
         });
     }
@@ -463,7 +471,12 @@ internal class WindowsUiaProvider :
 /// <summary>
 /// Represents the fragment root associated with one ModernFormsNext HWND.
 /// </summary>
-internal sealed class WindowsUiaRootProvider : WindowsUiaProvider, IRawElementProviderFragmentRoot, IDisposable
+[GeneratedComClass]
+internal sealed partial class WindowsUiaRootProvider :
+    WindowsUiaProvider,
+    IRawElementProviderFragmentRoot,
+    IRawElementProviderFragmentRootAbi,
+    IDisposable
 {
     private WindowsUiaRootProvider(WindowsUiaProviderContext context, IPlatformAccessibleObject root)
         : base(context, root, isRoot: true)
@@ -477,22 +490,32 @@ internal sealed class WindowsUiaRootProvider : WindowsUiaProvider, IRawElementPr
         IntPtr hwnd,
         IPlatformAccessibleObject root,
         Dispatcher dispatcher)
+        => Create(hwnd, root, new WindowsUiaDispatcher(dispatcher));
+
+    /// <summary>
+    /// Creates a UIA fragment root using an explicit dispatcher boundary.
+    /// </summary>
+    internal static WindowsUiaRootProvider Create(
+        IntPtr hwnd,
+        IPlatformAccessibleObject root,
+        IWindowsUiaDispatcher dispatcher,
+        IWindowsUiaEventSink? eventSink = null)
     {
-        var context = new WindowsUiaProviderContext(hwnd, dispatcher);
+        var context = new WindowsUiaProviderContext(
+            hwnd,
+            dispatcher,
+            eventSink ?? WindowsUiaNativeEventSink.Instance);
         var provider = new WindowsUiaRootProvider(context, root);
         context.Initialize(root, provider);
         return provider;
     }
 
     /// <inheritdoc/>
-    public override IRawElementProviderSimple HostRawElementProvider
-        => AutomationInteropProvider.HostProviderFromHandle(Context.Hwnd);
+    public override IRawElementProviderSimple? HostRawElementProvider => null;
 
     /// <inheritdoc/>
     public override IRawElementProviderFragment? Navigate(NavigateDirection direction)
-        => direction == NavigateDirection.Parent
-            ? HostRawElementProvider as IRawElementProviderFragment
-            : base.Navigate(direction);
+        => direction == NavigateDirection.Parent ? null : base.Navigate(direction);
 
     /// <inheritdoc/>
     public IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
@@ -533,13 +556,18 @@ internal sealed class WindowsUiaProviderContext : IDisposable
 {
     private static readonly TimeSpan DispatcherTimeout = TimeSpan.FromSeconds(10);
     private readonly ConditionalWeakTable<IPlatformAccessibleObject, WindowsUiaProvider> providers = new();
-    private readonly Dispatcher dispatcher;
+    private readonly IWindowsUiaDispatcher dispatcher;
+    private readonly IWindowsUiaEventSink eventSink;
     private bool disposed;
 
-    public WindowsUiaProviderContext(IntPtr hwnd, Dispatcher dispatcher)
+    public WindowsUiaProviderContext(
+        IntPtr hwnd,
+        IWindowsUiaDispatcher dispatcher,
+        IWindowsUiaEventSink eventSink)
     {
         Hwnd = hwnd;
         this.dispatcher = dispatcher;
+        this.eventSink = eventSink;
     }
 
     public IntPtr Hwnd { get; }
@@ -576,15 +604,15 @@ internal sealed class WindowsUiaProviderContext : IDisposable
 
     public void RaiseNotification(IPlatformAccessibleObject source, int eventId)
     {
-        if (disposed || !AutomationInteropProvider.ClientsAreListening)
+        if (disposed || !eventSink.ClientsAreListening)
             return;
 
         try
         {
             WindowsUiaProvider provider = GetOrCreate(source);
-            WindowsUiaEventMapper.Raise(provider, source, eventId, this);
+            WindowsUiaEventMapper.Raise(provider, source, eventId, this, eventSink);
         }
-        catch (ElementNotAvailableException)
+        catch (WindowsUiaElementNotAvailableException)
         {
             // A semantic object can be removed between the shared notification and provider lookup.
         }
@@ -592,7 +620,7 @@ internal sealed class WindowsUiaProviderContext : IDisposable
         {
             // Do not include semantic values in diagnostics: they may contain user-entered or
             // password data. UIA event failures must not escape the native window callback.
-            Debug.WriteLine($"ModernFormsNext UIA notification failed: {exception.GetType().Name}");
+            Trace.TraceError("ModernFormsNext UIA notification failed: {0}", exception.GetType().Name);
         }
     }
 
@@ -606,19 +634,19 @@ internal sealed class WindowsUiaProviderContext : IDisposable
         {
             return dispatcher.CheckAccess()
                 ? callback()
-                : dispatcher.Invoke(callback, DispatcherPriority.Send, CancellationToken.None, DispatcherTimeout);
+                : dispatcher.Invoke(callback, DispatcherTimeout);
         }
-        catch (ElementNotAvailableException)
+        catch (WindowsUiaElementNotAvailableException)
         {
             throw;
         }
         catch (TimeoutException exception)
         {
-            throw new ElementNotAvailableException("The ModernFormsNext UI thread did not accept the automation request.", exception);
+            throw new WindowsUiaElementNotAvailableException("The ModernFormsNext UI thread did not accept the automation request.", exception);
         }
         catch (OperationCanceledException exception)
         {
-            throw new ElementNotAvailableException("The ModernFormsNext dispatcher is shutting down.", exception);
+            throw new WindowsUiaElementNotAvailableException("The ModernFormsNext dispatcher is shutting down.", exception);
         }
     }
 
@@ -631,19 +659,19 @@ internal sealed class WindowsUiaProviderContext : IDisposable
             if (dispatcher.CheckAccess())
                 callback();
             else
-                dispatcher.Invoke(callback, DispatcherPriority.Send, CancellationToken.None, DispatcherTimeout);
+                dispatcher.Invoke(callback, DispatcherTimeout);
         }
-        catch (ElementNotAvailableException)
+        catch (WindowsUiaElementNotAvailableException)
         {
             throw;
         }
         catch (TimeoutException exception)
         {
-            throw new ElementNotAvailableException("The ModernFormsNext UI thread did not accept the automation request.", exception);
+            throw new WindowsUiaElementNotAvailableException("The ModernFormsNext UI thread did not accept the automation request.", exception);
         }
         catch (OperationCanceledException exception)
         {
-            throw new ElementNotAvailableException("The ModernFormsNext dispatcher is shutting down.", exception);
+            throw new WindowsUiaElementNotAvailableException("The ModernFormsNext dispatcher is shutting down.", exception);
         }
     }
 
@@ -653,9 +681,9 @@ internal sealed class WindowsUiaProviderContext : IDisposable
     {
         ThrowIfDisposed();
         if (!target.TryGetTarget(out IPlatformAccessibleObject? node))
-            throw new ElementNotAvailableException("The semantic object is no longer available.");
+            throw new WindowsUiaElementNotAvailableException("The semantic object is no longer available.");
         if (!isRoot && node.Parent is null)
-            throw new ElementNotAvailableException("The semantic object is detached from its accessibility tree.");
+            throw new WindowsUiaElementNotAvailableException("The semantic object is detached from its accessibility tree.");
 
         return node;
     }
@@ -663,8 +691,41 @@ internal sealed class WindowsUiaProviderContext : IDisposable
     private void ThrowIfDisposed()
     {
         if (disposed || Hwnd == IntPtr.Zero)
-            throw new ElementNotAvailableException("The native window is no longer available.");
+            throw new WindowsUiaElementNotAvailableException("The native window is no longer available.");
     }
+}
+
+/// <summary>
+/// Provides the narrow dispatcher operations needed at the native UIA callback boundary.
+/// </summary>
+internal interface IWindowsUiaDispatcher
+{
+    bool CheckAccess();
+
+    T Invoke<T>(Func<T> callback, TimeSpan timeout);
+
+    void Invoke(Action callback, TimeSpan timeout);
+}
+
+/// <summary>
+/// Routes UIA callbacks through the framework's canonical UI dispatcher.
+/// </summary>
+internal sealed class WindowsUiaDispatcher : IWindowsUiaDispatcher
+{
+    private readonly Dispatcher dispatcher;
+
+    public WindowsUiaDispatcher(Dispatcher dispatcher)
+    {
+        this.dispatcher = dispatcher;
+    }
+
+    public bool CheckAccess() => dispatcher.CheckAccess();
+
+    public T Invoke<T>(Func<T> callback, TimeSpan timeout)
+        => dispatcher.Invoke(callback, DispatcherPriority.Send, CancellationToken.None, timeout);
+
+    public void Invoke(Action callback, TimeSpan timeout)
+        => dispatcher.Invoke(callback, DispatcherPriority.Send, CancellationToken.None, timeout);
 }
 
 /// <summary>
@@ -675,32 +736,32 @@ internal static class WindowsUiaControlTypeMapper
     public static int Map(int controlType)
         => controlType switch
         {
-            2 => ControlType.Window.Id,
-            3 => ControlType.Pane.Id,
-            4 => ControlType.Group.Id,
-            5 => ControlType.Text.Id,
-            6 => ControlType.Button.Id,
-            7 => ControlType.CheckBox.Id,
-            8 => ControlType.RadioButton.Id,
-            9 => ControlType.CheckBox.Id,
-            10 => ControlType.Edit.Id,
-            11 => ControlType.ComboBox.Id,
-            12 => ControlType.List.Id,
-            13 => ControlType.ListItem.Id,
-            14 => ControlType.Tree.Id,
-            15 => ControlType.TreeItem.Id,
-            16 => ControlType.Tab.Id,
-            17 => ControlType.TabItem.Id,
-            18 => ControlType.Menu.Id,
-            19 => ControlType.MenuItem.Id,
-            20 => ControlType.Slider.Id,
-            21 => ControlType.ProgressBar.Id,
-            22 => ControlType.ScrollBar.Id,
-            23 => ControlType.Window.Id,
-            24 => ControlType.Image.Id,
-            25 => ControlType.ToolBar.Id,
-            26 => ControlType.Separator.Id,
-            _ => ControlType.Custom.Id
+            2 => 50032,
+            3 => 50033,
+            4 => 50026,
+            5 => 50020,
+            6 => 50000,
+            7 => 50002,
+            8 => 50013,
+            9 => 50002,
+            10 => 50004,
+            11 => 50003,
+            12 => 50008,
+            13 => 50007,
+            14 => 50023,
+            15 => 50024,
+            16 => 50018,
+            17 => 50019,
+            18 => 50009,
+            19 => 50011,
+            20 => 50015,
+            21 => 50012,
+            22 => 50014,
+            23 => 50032,
+            24 => 50006,
+            25 => 50021,
+            26 => 50038,
+            _ => 50025
         };
 
     public static string GetClassName(int controlType)
@@ -752,29 +813,9 @@ internal static class WindowsUiaCoordinateConverter
             || bounds.Width <= 0
             || bounds.Height <= 0)
         {
-            return UiaRect.Empty;
+            return new UiaRect(0, 0, 0, 0);
         }
 
         return new UiaRect(bounds.X, bounds.Y, bounds.Width, bounds.Height);
-    }
-}
-
-internal static class WindowsUiaNativeMethods
-{
-    [DllImport("uiautomationcore.dll")]
-    private static extern int UiaDisconnectProvider(
-        [MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider);
-
-    public static void DisconnectProvider(IRawElementProviderSimple provider)
-    {
-        try
-        {
-            _ = UiaDisconnectProvider(provider);
-        }
-        catch (DllNotFoundException)
-        {
-            // UIAutomationCore is part of supported Windows desktop installations. Keep teardown
-            // resilient for stripped-down test images where it is intentionally unavailable.
-        }
     }
 }

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowsUiaProvider.cs
@@ -71,6 +71,7 @@ internal partial class WindowsUiaProvider :
     private const int ViewHidden = 4;
 
     private readonly WeakReference<IPlatformAccessibleObject> target;
+    private long[] lastChildRuntimeIds;
 
     internal WindowsUiaProvider(
         WindowsUiaProviderContext context,
@@ -80,6 +81,7 @@ internal partial class WindowsUiaProvider :
         Context = context;
         target = new WeakReference<IPlatformAccessibleObject>(platformObject);
         IsRoot = isRoot;
+        lastChildRuntimeIds = CaptureChildRuntimeIds(platformObject);
     }
 
     /// <summary>
@@ -172,7 +174,9 @@ internal partial class WindowsUiaProvider :
                 if (node.GetIsSensitive())
                     throw new WindowsUiaAccessDeniedException();
 
-                return node.Value ?? string.Empty;
+                return SupportsValue(node, node.GetSupportedActions())
+                    ? node.Value ?? string.Empty
+                    : null;
             }
 
             return null;
@@ -200,21 +204,7 @@ internal partial class WindowsUiaProvider :
 
     /// <inheritdoc/>
     public int[] GetRuntimeId()
-    {
-        return Read(node =>
-        {
-            long id = node.GetRuntimeId();
-            if (id == 0)
-                id = RuntimeHelpers.GetHashCode(node);
-
-            return new int[]
-            {
-                WindowsUiaIds.AppendRuntimeId,
-                unchecked((int)(id & uint.MaxValue)),
-                unchecked((int)(id >> 32))
-            };
-        });
-    }
+        => Read(node => CreateRuntimeId(GetEffectiveRuntimeId(node)));
 
     /// <inheritdoc/>
     public UiaRect BoundingRectangle
@@ -239,6 +229,53 @@ internal partial class WindowsUiaProvider :
 
     /// <inheritdoc/>
     public IRawElementProviderFragmentRoot FragmentRoot => Context.Root;
+
+    /// <summary>
+    /// Compares the current canonical children with the event snapshot kept by this provider so a
+    /// shared Reorder notification can become the narrowest correct UIA structure-change event.
+    /// The snapshot contains runtime IDs only and does not form a second semantic hierarchy.
+    /// </summary>
+    internal WindowsUiaStructureChange ConsumeStructureChange()
+    {
+        return Read(node =>
+        {
+            long[] currentIds = CaptureChildRuntimeIds(node);
+            HashSet<long> previousSet = lastChildRuntimeIds.ToHashSet();
+            HashSet<long> currentSet = currentIds.ToHashSet();
+            long[] added = currentIds
+                .Where(id => !previousSet.Contains(id))
+                .ToArray();
+            long[] removed = lastChildRuntimeIds
+                .Where(id => !currentSet.Contains(id))
+                .ToArray();
+
+            lastChildRuntimeIds = currentIds;
+
+            if (added.Length == 1 && removed.Length == 0)
+            {
+                return new WindowsUiaStructureChange(
+                    this,
+                    StructureChangeType.ChildAdded,
+                    RuntimeId: null);
+            }
+
+            if (removed.Length == 1 && added.Length == 0)
+            {
+                return new WindowsUiaStructureChange(
+                    this,
+                    StructureChangeType.ChildRemoved,
+                    CreateRuntimeId(removed[0]));
+            }
+
+            if (added.Length > 0 && removed.Length == 0)
+                return new WindowsUiaStructureChange(this, StructureChangeType.ChildrenBulkAdded, RuntimeId: null);
+
+            if (removed.Length > 0 && added.Length == 0)
+                return new WindowsUiaStructureChange(this, StructureChangeType.ChildrenBulkRemoved, RuntimeId: null);
+
+            return new WindowsUiaStructureChange(this, StructureChangeType.ChildrenReordered, RuntimeId: null);
+        });
+    }
 
     /// <inheritdoc/>
     void IInvokeProvider.Invoke()
@@ -452,6 +489,33 @@ internal partial class WindowsUiaProvider :
             || node.Bounds.Width <= 0
             || node.Bounds.Height <= 0;
 
+    internal static int[] CreateRuntimeId(long id)
+        =>
+        [
+            WindowsUiaIds.AppendRuntimeId,
+            unchecked((int)(id & uint.MaxValue)),
+            unchecked((int)(id >> 32))
+        ];
+
+    private static long GetEffectiveRuntimeId(IPlatformAccessibleObject node)
+    {
+        long id = node.GetRuntimeId();
+        return id == 0 ? RuntimeHelpers.GetHashCode(node) : id;
+    }
+
+    private static long[] CaptureChildRuntimeIds(IPlatformAccessibleObject node)
+    {
+        int count = node.GetChildCount();
+        var runtimeIds = new List<long>(count);
+        for (int index = 0; index < count; index++)
+        {
+            if (node.GetChild(index) is { } child)
+                runtimeIds.Add(GetEffectiveRuntimeId(child));
+        }
+
+        return runtimeIds.ToArray();
+    }
+
     private T ReadRange<T>(Func<PlatformAccessibleRangeValue, T> selector)
         => Read(node => selector(node.GetRangeValue()
             ?? throw new InvalidOperationException("The semantic object does not expose a numeric range.")));
@@ -467,6 +531,11 @@ internal partial class WindowsUiaProvider :
         });
     }
 }
+
+internal readonly record struct WindowsUiaStructureChange(
+    WindowsUiaProvider Provider,
+    StructureChangeType ChangeType,
+    int[]? RuntimeId);
 
 /// <summary>
 /// Represents the fragment root associated with one ModernFormsNext HWND.

--- a/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
@@ -43,12 +43,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<!-- UIAutomationProvider and UIAutomationTypes expose the stable managed definitions of
-		     the native Windows UI Automation provider contracts. No WPF or WinForms controls are used. -->
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<Folder Include="Generated\" />
 	</ItemGroup>
 

--- a/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
@@ -38,8 +38,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Drawing.Common" Version="10.0.10" />
+		<PackageReference Include="System.Drawing.Common" Version="10.0.10" NoWarn="NU1510" />
 		<PackageReference Include="SkiaSharp" Version="3.119.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- UIAutomationProvider and UIAutomationTypes expose the stable managed definitions of
+		     the native Windows UI Automation provider contracts. No WPF or WinForms controls are used. -->
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
+++ b/ModernFormsNext.WindowKit.Backend.Windows/ModernFormsNext.WindowKit.Backend.Windows.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Drawing.Common" Version="10.0.10" NoWarn="NU1510" />
+		<PackageReference Include="System.Drawing.Common" Version="10.0.10" />
 		<PackageReference Include="SkiaSharp" Version="3.119.2" />
 	</ItemGroup>
 

--- a/ModernFormsNext.WindowKit.Backend.Windows/WindowsAccessibilityService.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/WindowsAccessibilityService.cs
@@ -15,7 +15,7 @@ namespace ModernFormsNext.WindowKit.Backend.Windows
     /// windows. Win32 accessibility notifications therefore target the owning top-level window's
     /// client object unless the shared caller supplies a more specific native object identifier.
     /// </remarks>
-    internal sealed class WindowsAccessibilityService : IPlatformAccessibilityService
+    internal sealed class WindowsAccessibilityService : IPlatformUiaAccessibilityService
     {
         private const int ObjIdClient = unchecked((int)0xFFFFFFFC);
 

--- a/ModernFormsNext.WindowKit.Backend.Windows/WindowsAccessibilityService.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/WindowsAccessibilityService.cs
@@ -2,6 +2,7 @@ using System;
 using ModernFormsNext.WindowKit.Platform;
 using ModernFormsNext.WindowKit.Platform.Accessibility;
 using ModernFormsNext.WindowKit.Platform.Services;
+using ModernFormsNext.WindowKit.Backend.Windows.Win32;
 using static ModernFormsNext.WindowKit.Backend.Windows.Win32.Interop.UnmanagedMethods;
 
 namespace ModernFormsNext.WindowKit.Backend.Windows
@@ -35,6 +36,22 @@ namespace ModernFormsNext.WindowKit.Backend.Windows
 
             var nativeObjectId = objectId == 0 ? ObjIdClient : objectId;
             NotifyWinEvent((uint)eventId, handle, nativeObjectId, childId);
+        }
+
+        /// <inheritdoc/>
+        public void NotifyClients(
+            IWindowBaseImpl owner,
+            IPlatformAccessibleObject source,
+            int eventId,
+            int objectId,
+            int childId)
+        {
+            NotifyClients(owner, eventId, objectId, childId);
+
+            // UIA providers are created lazily by WM_GETOBJECT. A normal accessibility
+            // notification must not instantiate a provider when no UIA client has queried the HWND.
+            if (owner is WindowImpl window)
+                window.TryRaiseUiaNotification(source, eventId);
         }
     }
 }

--- a/ModernFormsNext.WindowKit/Platform/Accessibility/IPlatformAccessibilityHost.cs
+++ b/ModernFormsNext.WindowKit/Platform/Accessibility/IPlatformAccessibilityHost.cs
@@ -32,6 +32,40 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
     public interface IPlatformAccessibleObject
     {
         /// <summary>
+        /// Gets the stable process-local semantic runtime identifier.
+        /// </summary>
+        /// <remarks>
+        /// A value of <c>0</c> indicates that the implementation predates runtime identifiers.
+        /// Platform adapters should preserve a non-zero value for the lifetime of the represented
+        /// semantic object.
+        /// </remarks>
+        long RuntimeId => 0;
+
+        /// <summary>
+        /// Gets the developer-defined automation identifier for the object.
+        /// </summary>
+        string? AutomationId => null;
+
+        /// <summary>
+        /// Gets the canonical platform-neutral control type identifier.
+        /// </summary>
+        /// <remarks>
+        /// The integer is supplied by the shared accessibility model so WindowKit does not define
+        /// a second semantic control-type enumeration.
+        /// </remarks>
+        int ControlType => 0;
+
+        /// <summary>
+        /// Gets the canonical platform-neutral accessibility view identifier.
+        /// </summary>
+        int View => 0;
+
+        /// <summary>
+        /// Gets a backend-safe class name for diagnostics and native automation properties.
+        /// </summary>
+        string? ClassName => null;
+
+        /// <summary>
         /// Gets the object bounds in screen coordinates, measured in logical pixels.
         /// </summary>
         Rect Bounds { get; }
@@ -77,6 +111,22 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
         int State { get; }
 
         /// <summary>
+        /// Gets whether the object contains sensitive content that native automation providers
+        /// must not disclose.
+        /// </summary>
+        bool IsSensitive => false;
+
+        /// <summary>
+        /// Gets optional numeric range metadata for the object.
+        /// </summary>
+        PlatformAccessibleRangeValue? RangeValue => null;
+
+        /// <summary>
+        /// Gets the canonical platform-neutral action flags supported by the object.
+        /// </summary>
+        int SupportedActions => 0;
+
+        /// <summary>
         /// Gets or sets the current value exposed by the object.
         /// </summary>
         string? Value { get; set; }
@@ -85,6 +135,14 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
         /// Performs the object's default action when one is available.
         /// </summary>
         void DoDefaultAction();
+
+        /// <summary>
+        /// Performs one canonical platform-neutral semantic action.
+        /// </summary>
+        /// <param name="action">Exactly one action flag supplied by the shared accessibility model.</param>
+        /// <param name="parameter">Optional action data, such as a string or numeric value.</param>
+        /// <returns><see langword="true"/> when the action was accepted; otherwise <see langword="false"/>.</returns>
+        bool PerformAction(int action, object? parameter = null) => false;
 
         /// <summary>
         /// Gets the help topic identifier and help file associated with this object.
@@ -139,6 +197,23 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
         /// <param name="flags">The selection behavior flags.</param>
         void Select(int flags);
     }
+
+    /// <summary>
+    /// Describes backend-neutral numeric range metadata exposed by an accessible object.
+    /// </summary>
+    /// <param name="Value">The current value.</param>
+    /// <param name="Minimum">The minimum supported value.</param>
+    /// <param name="Maximum">The maximum supported value.</param>
+    /// <param name="SmallChange">The small increment used by keyboard or automation actions.</param>
+    /// <param name="LargeChange">The large increment used by page-style actions.</param>
+    /// <param name="IsReadOnly">Whether automation clients may change the value.</param>
+    public readonly record struct PlatformAccessibleRangeValue(
+        double Value,
+        double Minimum,
+        double Maximum,
+        double SmallChange,
+        double LargeChange,
+        bool IsReadOnly);
 
     /// <summary>
     /// Specifies common platform-neutral directions for accessibility tree navigation.

--- a/ModernFormsNext.WindowKit/Platform/Accessibility/IPlatformAccessibilityHost.cs
+++ b/ModernFormsNext.WindowKit/Platform/Accessibility/IPlatformAccessibilityHost.cs
@@ -32,40 +32,6 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
     public interface IPlatformAccessibleObject
     {
         /// <summary>
-        /// Gets the stable process-local semantic runtime identifier.
-        /// </summary>
-        /// <remarks>
-        /// A value of <c>0</c> indicates that the implementation predates runtime identifiers.
-        /// Platform adapters should preserve a non-zero value for the lifetime of the represented
-        /// semantic object.
-        /// </remarks>
-        long RuntimeId => 0;
-
-        /// <summary>
-        /// Gets the developer-defined automation identifier for the object.
-        /// </summary>
-        string? AutomationId => null;
-
-        /// <summary>
-        /// Gets the canonical platform-neutral control type identifier.
-        /// </summary>
-        /// <remarks>
-        /// The integer is supplied by the shared accessibility model so WindowKit does not define
-        /// a second semantic control-type enumeration.
-        /// </remarks>
-        int ControlType => 0;
-
-        /// <summary>
-        /// Gets the canonical platform-neutral accessibility view identifier.
-        /// </summary>
-        int View => 0;
-
-        /// <summary>
-        /// Gets a backend-safe class name for diagnostics and native automation properties.
-        /// </summary>
-        string? ClassName => null;
-
-        /// <summary>
         /// Gets the object bounds in screen coordinates, measured in logical pixels.
         /// </summary>
         Rect Bounds { get; }
@@ -111,22 +77,6 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
         int State { get; }
 
         /// <summary>
-        /// Gets whether the object contains sensitive content that native automation providers
-        /// must not disclose.
-        /// </summary>
-        bool IsSensitive => false;
-
-        /// <summary>
-        /// Gets optional numeric range metadata for the object.
-        /// </summary>
-        PlatformAccessibleRangeValue? RangeValue => null;
-
-        /// <summary>
-        /// Gets the canonical platform-neutral action flags supported by the object.
-        /// </summary>
-        int SupportedActions => 0;
-
-        /// <summary>
         /// Gets or sets the current value exposed by the object.
         /// </summary>
         string? Value { get; set; }
@@ -135,14 +85,6 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
         /// Performs the object's default action when one is available.
         /// </summary>
         void DoDefaultAction();
-
-        /// <summary>
-        /// Performs one canonical platform-neutral semantic action.
-        /// </summary>
-        /// <param name="action">Exactly one action flag supplied by the shared accessibility model.</param>
-        /// <param name="parameter">Optional action data, such as a string or numeric value.</param>
-        /// <returns><see langword="true"/> when the action was accepted; otherwise <see langword="false"/>.</returns>
-        bool PerformAction(int action, object? parameter = null) => false;
 
         /// <summary>
         /// Gets the help topic identifier and help file associated with this object.
@@ -197,23 +139,6 @@ namespace ModernFormsNext.WindowKit.Platform.Accessibility
         /// <param name="flags">The selection behavior flags.</param>
         void Select(int flags);
     }
-
-    /// <summary>
-    /// Describes backend-neutral numeric range metadata exposed by an accessible object.
-    /// </summary>
-    /// <param name="Value">The current value.</param>
-    /// <param name="Minimum">The minimum supported value.</param>
-    /// <param name="Maximum">The maximum supported value.</param>
-    /// <param name="SmallChange">The small increment used by keyboard or automation actions.</param>
-    /// <param name="LargeChange">The large increment used by page-style actions.</param>
-    /// <param name="IsReadOnly">Whether automation clients may change the value.</param>
-    public readonly record struct PlatformAccessibleRangeValue(
-        double Value,
-        double Minimum,
-        double Maximum,
-        double SmallChange,
-        double LargeChange,
-        bool IsReadOnly);
 
     /// <summary>
     /// Specifies common platform-neutral directions for accessibility tree navigation.

--- a/ModernFormsNext.WindowKit/Platform/Accessibility/IPlatformUiaAccessibleObject.cs
+++ b/ModernFormsNext.WindowKit/Platform/Accessibility/IPlatformUiaAccessibleObject.cs
@@ -1,0 +1,71 @@
+namespace ModernFormsNext.WindowKit.Platform.Accessibility;
+
+/// <summary>
+/// Supplies the additional canonical semantics consumed by native UI Automation backends without
+/// expanding the public WindowKit accessibility contract.
+/// </summary>
+internal interface IPlatformUiaAccessibleObject : IPlatformAccessibleObject
+{
+    long RuntimeId { get; }
+
+    string? AutomationId { get; }
+
+    int ControlType { get; }
+
+    int View { get; }
+
+    string? ClassName { get; }
+
+    bool IsSensitive { get; }
+
+    PlatformAccessibleRangeValue? RangeValue { get; }
+
+    int SupportedActions { get; }
+
+    bool PerformAction(int action, object? parameter = null);
+}
+
+/// <summary>
+/// Carries canonical numeric range metadata across the internal framework/backend boundary.
+/// </summary>
+internal readonly record struct PlatformAccessibleRangeValue(
+    double Value,
+    double Minimum,
+    double Maximum,
+    double SmallChange,
+    double LargeChange,
+    bool IsReadOnly);
+
+internal static class PlatformUiaAccessibleObjectExtensions
+{
+    public static long GetRuntimeId(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.RuntimeId ?? 0;
+
+    public static string? GetAutomationId(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.AutomationId;
+
+    public static int GetControlType(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.ControlType ?? 0;
+
+    public static int GetAccessibilityView(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.View ?? 0;
+
+    public static string? GetClassName(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.ClassName;
+
+    public static bool GetIsSensitive(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.IsSensitive ?? false;
+
+    public static PlatformAccessibleRangeValue? GetRangeValue(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.RangeValue;
+
+    public static int GetSupportedActions(this IPlatformAccessibleObject value)
+        => (value as IPlatformUiaAccessibleObject)?.SupportedActions ?? 0;
+
+    public static bool PerformUiaAction(
+        this IPlatformAccessibleObject value,
+        int action,
+        object? parameter = null)
+        => value is IPlatformUiaAccessibleObject uiaValue
+            && uiaValue.PerformAction(action, parameter);
+}

--- a/ModernFormsNext.WindowKit/Platform/Services/IPlatformAccessibilityService.cs
+++ b/ModernFormsNext.WindowKit/Platform/Services/IPlatformAccessibilityService.cs
@@ -29,5 +29,27 @@ namespace ModernFormsNext.WindowKit.Platform.Services
         /// accessibility notification APIs are associated with the owning window handle.
         /// </remarks>
         void NotifyClients(IWindowBaseImpl owner, int eventId, int objectId, int childId);
+
+        /// <summary>
+        /// Notifies the platform accessibility layer that a specific semantic object changed.
+        /// </summary>
+        /// <param name="owner">The platform window that owns the notifying object.</param>
+        /// <param name="source">The semantic object that raised the notification.</param>
+        /// <param name="eventId">The platform-neutral event identifier.</param>
+        /// <param name="objectId">The platform object identifier.</param>
+        /// <param name="childId">The child identifier, or <c>0</c> for <paramref name="source"/>.</param>
+        /// <remarks>
+        /// The default implementation preserves compatibility with accessibility services that
+        /// only support window-level notifications. Backends with element-level automation should
+        /// override this member and retain neither <paramref name="source"/> nor its owner beyond
+        /// the notification call.
+        /// </remarks>
+        void NotifyClients(
+            IWindowBaseImpl owner,
+            Platform.Accessibility.IPlatformAccessibleObject source,
+            int eventId,
+            int objectId,
+            int childId)
+            => NotifyClients(owner, eventId, objectId, childId);
     }
 }

--- a/ModernFormsNext.WindowKit/Platform/Services/IPlatformAccessibilityService.cs
+++ b/ModernFormsNext.WindowKit/Platform/Services/IPlatformAccessibilityService.cs
@@ -30,26 +30,20 @@ namespace ModernFormsNext.WindowKit.Platform.Services
         /// </remarks>
         void NotifyClients(IWindowBaseImpl owner, int eventId, int objectId, int childId);
 
-        /// <summary>
-        /// Notifies the platform accessibility layer that a specific semantic object changed.
-        /// </summary>
-        /// <param name="owner">The platform window that owns the notifying object.</param>
-        /// <param name="source">The semantic object that raised the notification.</param>
-        /// <param name="eventId">The platform-neutral event identifier.</param>
-        /// <param name="objectId">The platform object identifier.</param>
-        /// <param name="childId">The child identifier, or <c>0</c> for <paramref name="source"/>.</param>
-        /// <remarks>
-        /// The default implementation preserves compatibility with accessibility services that
-        /// only support window-level notifications. Backends with element-level automation should
-        /// override this member and retain neither <paramref name="source"/> nor its owner beyond
-        /// the notification call.
-        /// </remarks>
+    }
+
+    /// <summary>
+    /// Adds element-level notification routing for platform backends that support native UI
+    /// Automation providers. This contract remains internal so the public WindowKit API stays
+    /// unchanged.
+    /// </summary>
+    internal interface IPlatformUiaAccessibilityService : IPlatformAccessibilityService
+    {
         void NotifyClients(
             IWindowBaseImpl owner,
             Platform.Accessibility.IPlatformAccessibleObject source,
             int eventId,
             int objectId,
-            int childId)
-            => NotifyClients(owner, eventId, objectId, childId);
+            int childId);
     }
 }

--- a/ModernFormsNext.WindowKit/Properties/AssemblyInfo.cs
+++ b/ModernFormsNext.WindowKit/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ModernFormsNext.Testing")]
+[assembly: InternalsVisibleTo("ModernFormsNext")]
+[assembly: InternalsVisibleTo("ModernFormsNext.WindowKit.Backend.Windows")]
+[assembly: InternalsVisibleTo("ModernFormsNext.WindowKit.Backend.Windows.Tests")]

--- a/ModernFormsNext.slnx
+++ b/ModernFormsNext.slnx
@@ -19,6 +19,8 @@
     <Project Path="ModernFormsNext.VisualStudioExtension.Vsix.Tests/ModernFormsNext.VisualStudioExtension.Vsix.Tests.csproj" />
     <Project Path="ModernFormsNext.WindowKit.Backend.Android.Tests/ModernFormsNext.WindowKit.Backend.Android.Tests.csproj" />
     <Project Path="ModernFormsNext.WindowKit.Backend.Windows.Tests/ModernFormsNext.WindowKit.Backend.Windows.Tests.csproj" />
+    <Project Path="ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient.csproj" />
+    <Project Path="ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost.csproj" />
     <Project Path="ModernFormsNext.Tests/ModernFormsNext.Tests.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
+++ b/ModernFormsNext/Accessibility/Control.ControlAccessibleObject.LogicalChildren.cs
@@ -388,6 +388,12 @@ public partial class Control
                 if ((flags & AccessibleSelection.TakeSelection) != 0)
                     PerformAction(AccessibleActions.Select);
 
+                if ((flags & AccessibleSelection.AddSelection) != 0)
+                    Owner?.SetAccessibilitySelection(Index, selected: true);
+
+                if ((flags & AccessibleSelection.RemoveSelection) != 0)
+                    Owner?.SetAccessibilitySelection(Index, selected: false);
+
                 if ((flags & AccessibleSelection.TakeFocus) != 0)
                     Owner?.Select();
             }

--- a/ModernFormsNext/Accessibility/PlatformAccessibleObjectAdapter.cs
+++ b/ModernFormsNext/Accessibility/PlatformAccessibleObjectAdapter.cs
@@ -13,7 +13,7 @@ namespace ModernFormsNext.Accessibility;
 /// contracts. Backend projects consume <see cref="IPlatformAccessibleObject"/> and do not need a
 /// reference back to the main ModernFormsNext assembly.
 /// </remarks>
-internal sealed class PlatformAccessibleObjectAdapter : IPlatformAccessibleObject
+internal sealed class PlatformAccessibleObjectAdapter : IPlatformUiaAccessibleObject
 {
     private static readonly ConditionalWeakTable<AccessibleObject, PlatformAccessibleObjectAdapter> s_cache = new();
     private readonly AccessibleObject accessible_object;

--- a/ModernFormsNext/Accessibility/PlatformAccessibleObjectAdapter.cs
+++ b/ModernFormsNext/Accessibility/PlatformAccessibleObjectAdapter.cs
@@ -32,6 +32,24 @@ internal sealed class PlatformAccessibleObjectAdapter : IPlatformAccessibleObjec
         => accessibleObject is null ? null : s_cache.GetValue(accessibleObject, static value => new PlatformAccessibleObjectAdapter(value));
 
     /// <inheritdoc/>
+    public long RuntimeId => accessible_object.RuntimeId;
+
+    /// <inheritdoc/>
+    public string? AutomationId => accessible_object.AutomationId;
+
+    /// <inheritdoc/>
+    public int ControlType => (int)accessible_object.ControlType;
+
+    /// <inheritdoc/>
+    public int View => (int)accessible_object.View;
+
+    /// <inheritdoc/>
+    public string? ClassName
+        => accessible_object is Control.ControlAccessibleObject { Owner: { } owner }
+            ? owner.GetType().Name
+            : accessible_object.ControlType.ToString();
+
+    /// <inheritdoc/>
     public Rect Bounds => ToRect(accessible_object.Bounds);
 
     /// <inheritdoc/>
@@ -63,6 +81,24 @@ internal sealed class PlatformAccessibleObjectAdapter : IPlatformAccessibleObjec
     public int State => (int)accessible_object.State;
 
     /// <inheritdoc/>
+    public bool IsSensitive => accessible_object.IsSensitive;
+
+    /// <inheritdoc/>
+    public PlatformAccessibleRangeValue? RangeValue
+        => accessible_object.RangeValue is { } range
+            ? new PlatformAccessibleRangeValue(
+                range.Value,
+                range.Minimum,
+                range.Maximum,
+                range.SmallChange,
+                range.LargeChange,
+                range.IsReadOnly)
+            : null;
+
+    /// <inheritdoc/>
+    public int SupportedActions => (int)accessible_object.SupportedActions;
+
+    /// <inheritdoc/>
     public string? Value
     {
         get => accessible_object.Value;
@@ -71,6 +107,10 @@ internal sealed class PlatformAccessibleObjectAdapter : IPlatformAccessibleObjec
 
     /// <inheritdoc/>
     public void DoDefaultAction() => accessible_object.DoDefaultAction();
+
+    /// <inheritdoc/>
+    public bool PerformAction(int action, object? parameter = null)
+        => accessible_object.PerformAction((AccessibleActions)action, parameter);
 
     /// <inheritdoc/>
     public int GetHelpTopic(out string? fileName) => accessible_object.GetHelpTopic(out fileName);

--- a/ModernFormsNext/Control.Accessibility.cs
+++ b/ModernFormsNext/Control.Accessibility.cs
@@ -323,6 +323,11 @@ public partial class Control
         if (service is null || owner is null)
             return;
 
-        service.NotifyClients(owner.window, (int)accEvent, objectID, childID);
+        service.NotifyClients(
+            owner.window,
+            PlatformAccessibleObjectAdapter.From(AccessibilityObject)!,
+            (int)accEvent,
+            objectID,
+            childID);
     }
 }

--- a/ModernFormsNext/Control.Accessibility.cs
+++ b/ModernFormsNext/Control.Accessibility.cs
@@ -323,11 +323,18 @@ public partial class Control
         if (service is null || owner is null)
             return;
 
-        service.NotifyClients(
-            owner.window,
-            PlatformAccessibleObjectAdapter.From(AccessibilityObject)!,
-            (int)accEvent,
-            objectID,
-            childID);
+        if (service is IPlatformUiaAccessibilityService uiaService)
+        {
+            uiaService.NotifyClients(
+                owner.window,
+                PlatformAccessibleObjectAdapter.From(AccessibilityObject)!,
+                (int)accEvent,
+                objectID,
+                childID);
+        }
+        else
+        {
+            service.NotifyClients(owner.window, (int)accEvent, objectID, childID);
+        }
     }
 }

--- a/ModernFormsNext/ListBox.cs
+++ b/ModernFormsNext/ListBox.cs
@@ -419,6 +419,31 @@ namespace ModernFormsNext
             NotifyAccessibilityClients (AccessibleEvents.ValueChange);
         }
 
+        // UI Automation selection-item operations must use the same collection state and event
+        // path as pointer/keyboard selection. Keep this internal so it does not become a second
+        // public selection API alongside SelectedIndex and SelectionMode.
+        internal bool SetAccessibilitySelection(int index, bool selected)
+        {
+            if (SelectionMode is not (SelectionMode.MultiSimple or SelectionMode.MultiExtended)
+                || index < 0
+                || index >= Items.Count)
+            {
+                return false;
+            }
+
+            bool isSelected = Items.SelectedIndexes.Contains(index);
+            if (isSelected == selected)
+                return true;
+
+            if (selected)
+                Items.AddSelectedIndex(index, single: false);
+            else
+                Items.RemoveSelectedIndex(index);
+
+            OnSelectedIndexChanged(EventArgs.Empty);
+            return true;
+        }
+
         /// <summary>
         /// Gets the scaled height each item occupies.
         /// </summary>

--- a/docs/accessibility/semantic-model.md
+++ b/docs/accessibility/semantic-model.md
@@ -219,10 +219,12 @@ transport. Phase 1 does not add another set of public semantic enums to WindowKi
 the existing `IPlatformAccessibleObject` contract. The Windows `WM_GETOBJECT`/MSAA path continues to
 consume names, roles, states, values, bounds, hierarchy, navigation, selection, and default actions.
 
-The remaining issue phases are intentionally separate:
+The remaining issue phases are intentionally separate. The Windows Phase 2 implementation is now
+available for manual inspection; see [Windows UI Automation backend](windows-ui-automation.md).
 
-- **Phase 2 — Windows:** native UI Automation provider, patterns, UIA event translation, and observed
-  validation with accessibility inspection tools.
+- **Phase 2 — Windows:** native UI Automation provider, common patterns, UIA event translation, and
+  automated real-HWND/client coverage are implemented. Accessibility Insights, Inspect.exe, and
+  screen-reader validation remain manual.
 - **Phase 3 — Android:** `AccessibilityNodeProvider` mapping, native events/focus, and TalkBack
   validation.
 - **Phase 4 — broader coverage:** deeper control and virtualized-item coverage, diagnostics,

--- a/docs/accessibility/windows-ui-automation.md
+++ b/docs/accessibility/windows-ui-automation.md
@@ -96,8 +96,12 @@ boundary instead of escaping through the native callback.
 Canonical notifications map to UIA focus, property, selection, and structure notifications.
 Name/help/value/range/bounds/enabled/toggle/expand/selection state are mapped to their corresponding
 UIA property IDs. Password value notifications are suppressed. Reorder notifications use
-`ChildrenReordered`; explicit show/hide notifications additionally map to child-added/removed and
-offscreen changes. Native events are raised only after UIAutomationCore reports a listening client.
+an event-only snapshot of child runtime IDs to distinguish `ChildAdded`, `ChildRemoved`, bulk
+changes, and `ChildrenReordered` without retaining semantic nodes or building another hierarchy.
+The native runtime-ID argument is supplied only for `ChildRemoved`, as required by
+`UiaRaiseStructureChangedEvent`; explicit show/hide notifications additionally map to
+child-added/removed and offscreen changes. Native events are raised only after UIAutomationCore
+reports a listening client.
 
 ## Automated validation
 

--- a/docs/accessibility/windows-ui-automation.md
+++ b/docs/accessibility/windows-ui-automation.md
@@ -1,0 +1,143 @@
+# Windows UI Automation backend
+
+ModernFormsNext exposes its canonical accessibility tree to Windows UI Automation (UIA) through
+the Windows WindowKit backend. This implementation is Windows-only. It does not change the semantic
+source of truth in `ModernFormsNext.Accessibility`, and it does not add public UIA types to the
+shared framework API.
+
+## Architecture
+
+The data path is:
+
+```text
+Control
+  -> ControlAccessibleObject / logical AccessibleObject
+  -> PlatformAccessibleObjectAdapter
+  -> WindowsUiaProvider
+  -> UIAutomationCore.dll
+  -> UIA client
+```
+
+`WM_GETOBJECT` keeps the existing `OBJID_CLIENT` MSAA response. A request for
+`UiaRootObjectId` lazily creates a UIA fragment root and returns it through
+`UiaReturnRawElementProvider`. Providers are not created merely because a window exists or a
+semantic notification is raised.
+
+The COM declarations and generated `ComWrappers` live entirely in the Windows backend. Their ABI
+is shaped after the provider interfaces in `UIAutomationCore.h`; the product does not reference
+WPF or WinForms UI controls and does not transitively require WindowsDesktop reference assemblies.
+
+## Tree, identity, bounds, and views
+
+Each provider wraps an existing canonical semantic object. It does not require a `Control`, so
+logical list, tree, tab, menu, and custom children participate in the same fragment. Parent, child,
+sibling, hit-test, and focus navigation delegate to the canonical object.
+
+Provider wrappers are cached per HWND with weak semantic keys. A living semantic object keeps the
+same provider and runtime ID across reorder operations. A detached child returns
+`UIA_E_ELEMENTNOTAVAILABLE`; destroying the HWND invalidates the context and disconnects its root
+provider after the inbound window message has returned.
+
+Canonical Windows bounds already pass through the backend's scaled `PointToScreen` path and are
+physical desktop pixels. The UIA converter therefore validates the rectangle but deliberately does
+not apply DPI scaling a second time. Empty, invisible, offscreen, and zero-area objects report
+`IsOffscreen`.
+
+`AccessibilityView.Control` is a UIA control element, `Content` is both a control and content
+element, while `Raw` and `Hidden` are excluded from normal control/content views. The raw fragment
+still preserves canonical relationships for client tooling that explicitly requests it.
+
+## Properties and patterns
+
+The backend maps `Name`, `AutomationId`, canonical control type, enabled/focus state, screen bounds,
+offscreen state, help text, password state, control/content view, class name, and
+`FrameworkId = ModernFormsNext`. Control types come from `AccessibleControlType`, never CLR type
+name inference.
+
+Pattern availability follows canonical capabilities:
+
+| UIA pattern | Canonical source |
+| --- | --- |
+| Invoke | `AccessibleActions.Invoke` |
+| Toggle | `AccessibleActions.Toggle` and checked/mixed state |
+| Value | Edit semantics; mutation requires `AccessibleActions.SetValue` |
+| RangeValue | `AccessibleRangeValue`; progress is read-only |
+| ExpandCollapse | expand/collapse actions and expanded/collapsed state |
+| Selection | supported selection-container control types |
+| SelectionItem | `AccessibleActions.Select` and the canonical parent |
+| ScrollItem | `AccessibleActions.ScrollIntoView` |
+
+`Invoke`, `Toggle`, value changes, range changes, expand/collapse, selection, scrolling into view,
+and focus all route through the canonical action or selection path. They do not invoke framework
+events or mutate control fields directly. List-box add/remove selection honors its real
+single/multiple selection mode.
+
+Full `TextPattern` is deferred because the shared model does not yet expose stable text ranges.
+Full `ScrollPattern` is also deferred until the shared controls have a canonical scroll viewport
+contract; advertising it now would create behavior that controls cannot honor. Logical items do
+expose `ScrollItemPattern` where `ScrollIntoView` is real.
+
+## Privacy, threading, and failures
+
+Password controls report `IsPassword = true`. Their plaintext is never returned through the Value
+property or Value pattern getter; the getter fails predictably, while an enabled editable password
+control can still accept a replacement through the normal canonical `SetValue` action. Native
+callbacks report `E_ACCESSDENIED` for password reads. UIA
+diagnostics include exception types only and never include names or values.
+
+All semantic reads and mutations cross the framework dispatcher. Calls already on the UI thread
+execute directly; other callers use the existing synchronous dispatcher path with a bounded
+timeout. Detached nodes, destroyed windows, shutdown dispatchers, disabled controls, unsupported
+actions, and invalid values are translated to deterministic HRESULT failures at the generated COM
+boundary instead of escaping through the native callback.
+
+## Events
+
+Canonical notifications map to UIA focus, property, selection, and structure notifications.
+Name/help/value/range/bounds/enabled/toggle/expand/selection state are mapped to their corresponding
+UIA property IDs. Password value notifications are suppressed. Reorder notifications use
+`ChildrenReordered`; explicit show/hide notifications additionally map to child-added/removed and
+offscreen changes. Native events are raised only after UIAutomationCore reports a listening client.
+
+## Automated validation
+
+`WindowsUiaProviderTests` covers properties, control types, views, pattern availability and
+behavior, logical/custom navigation, reorder/removal identity, password redaction, range metadata,
+selection, focus, dispatcher routing, event mapping, COM interface exposure, and disposal.
+
+The real integration smoke uses two test-only processes. The host creates and shows a real
+ModernFormsNext HWND. An isolated Windows UIA client calls `AutomationElement.FromHandle`, finds a
+semantic child, queries properties, obtains `InvokePattern`, invokes the control, sets focus, and
+then the test closes the window and verifies a clean process exit. This intentionally avoids a
+synthetic `WM_GETOBJECT` message.
+
+## Manual inspection checklist
+
+This checklist is evidence for a human validation session; repository builds and automated tests do
+not mark it complete.
+
+1. Start `samples/ControlGallery` on Windows.
+2. Open Accessibility Insights for Windows or Inspect.exe.
+3. Locate the ModernFormsNext top-level window.
+4. Inspect raw, control, and content trees.
+5. Verify Button name, type, bounds, focus, and Invoke.
+6. Verify CheckBox Toggle and checked state.
+7. Verify RadioButton selection.
+8. Verify normal TextBox Value and editing.
+9. Verify password TextBox redaction and `IsPassword`.
+10. Verify ComboBox ExpandCollapse and selection.
+11. Verify ListBox and ListView logical children and selection.
+12. Verify TreeView hierarchy, expand/collapse, selection, and scroll-into-view.
+13. Verify TabControl and tab-item selection.
+14. Verify TrackBar RangeValue and mutation.
+15. Verify ProgressBar read-only RangeValue.
+16. Verify menu/submenu hierarchy and actions.
+17. Observe keyboard focus events while tabbing.
+18. Toggle enabled/disabled state and observe property changes.
+19. Exercise single and multiple selection modes.
+20. Add, remove, and reorder logical items and observe structure changes.
+21. Inspect a custom semantic child that has no backing `Control`.
+22. Close and reopen the window and confirm stale elements disappear without client or app crashes.
+
+Screen-reader smoke testing remains a separate manual step. Android accessibility, TalkBack, Linux,
+macOS, developer tooling, agent automation, and broader Phase 4 coverage are outside this backend.

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -19,6 +19,7 @@ namespace ControlGallery
             tree.Style.Border.Width = 0;
             tree.Style.Border.Right.Width = 1;
 
+            tree.Items.Add ("Accessibility", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Button", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Animations", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Animated layout", ImageLoader.Get ("swatches.png"));
@@ -107,6 +108,8 @@ namespace ControlGallery
         private Panel? CreatePanel (string text)
         {
             switch (text) {
+                case "Accessibility":
+                    return new AccessibilityPanel ();
                 case "Animations":
                     return new AnimationSchedulerPanel ();
                 case "Animated layout":

--- a/samples/ControlGallery/Panels/AccessibilityPanel.cs
+++ b/samples/ControlGallery/Panels/AccessibilityPanel.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using ModernFormsNext;
+using ModernFormsNext.Accessibility;
+
+namespace ControlGallery.Panels;
+
+/// <summary>
+/// Provides a focused development surface for manual accessibility and UI Automation validation.
+/// </summary>
+public sealed class AccessibilityPanel : Panel
+{
+    private readonly ListBox dynamicList;
+    private readonly Button dynamicTarget;
+    private readonly Button hiddenTarget;
+    private readonly Label status;
+    private int addedItemNumber;
+
+    /// <summary>
+    /// Initializes the accessibility validation controls and their stable automation identifiers.
+    /// </summary>
+    public AccessibilityPanel()
+    {
+        Controls.Add(new Label
+        {
+            Left = 20,
+            Top = 20,
+            Width = 300,
+            Text = "Dynamic logical items"
+        });
+
+        dynamicList = Controls.Add(new ListBox
+        {
+            Left = 20,
+            Top = 50,
+            Width = 240,
+            Height = 170,
+            SelectionMode = SelectionMode.One,
+            AccessibleName = "Dynamic accessibility test list",
+            AccessibleAutomationId = "controlgallery.accessibility.dynamic-list"
+        });
+        dynamicList.Items.AddRange("Alpha", "Bravo", "Charlie");
+
+        AddActionButton(290, 50, "Add item", "controlgallery.accessibility.add", AddItem);
+        AddActionButton(290, 90, "Remove item", "controlgallery.accessibility.remove", RemoveItem);
+        AddActionButton(290, 130, "Move last first", "controlgallery.accessibility.reorder", ReorderItems);
+
+        dynamicTarget = Controls.Add(new Button
+        {
+            Left = 20,
+            Top = 255,
+            Width = 180,
+            Text = "Dynamic target",
+            AccessibleName = "Dynamic target",
+            AccessibleAutomationId = "controlgallery.accessibility.dynamic-target"
+        });
+
+        AddActionButton(220, 255, "Rename target", "controlgallery.accessibility.rename", RenameTarget);
+        AddActionButton(390, 255, "Toggle enabled", "controlgallery.accessibility.enabled", ToggleTargetEnabled);
+        AddActionButton(560, 255, "Toggle visible", "controlgallery.accessibility.visible", ToggleTargetVisible);
+
+        hiddenTarget = Controls.Add(new Button
+        {
+            Left = 20,
+            Top = 300,
+            Width = 180,
+            Text = "Hidden target",
+            Visible = false,
+            AccessibleName = "Hidden target",
+            AccessibleAutomationId = "controlgallery.accessibility.hidden-target"
+        });
+
+        AddActionButton(220, 300, "Show hidden", "controlgallery.accessibility.show-hidden", ToggleHiddenTarget);
+
+        Controls.Add(new Label
+        {
+            Left = 20,
+            Top = 365,
+            Width = 430,
+            Text = "Custom semantic surface (one child without a Control instance)"
+        });
+
+        Controls.Add(new CustomSemanticSurface(OnCustomSemanticAction)
+        {
+            Left = 20,
+            Top = 395,
+            Width = 430,
+            Height = 70,
+            AccessibleName = "Custom semantic surface",
+            AccessibleAutomationId = "controlgallery.accessibility.custom-surface"
+        });
+
+        status = Controls.Add(new Label
+        {
+            Left = 20,
+            Top = 485,
+            Width = 600,
+            Text = "Ready",
+            AccessibleAutomationId = "controlgallery.accessibility.status"
+        });
+    }
+
+    private void AddActionButton(int left, int top, string text, string automationId, Action action)
+    {
+        Button button = Controls.Add(new Button
+        {
+            Left = left,
+            Top = top,
+            Width = 150,
+            Text = text,
+            AccessibleAutomationId = automationId
+        });
+        button.Click += (_, _) => action();
+    }
+
+    private void AddItem()
+    {
+        addedItemNumber++;
+        dynamicList.Items.Add($"Added {addedItemNumber}");
+        status.Text = "Item added";
+    }
+
+    private void RemoveItem()
+    {
+        if (dynamicList.Items.Count == 0)
+            return;
+
+        dynamicList.Items.RemoveAt(dynamicList.Items.Count - 1);
+        status.Text = "Item removed";
+    }
+
+    private void ReorderItems()
+    {
+        if (dynamicList.Items.Count < 2)
+            return;
+
+        dynamicList.Items.Move(dynamicList.Items.Count - 1, 0);
+        status.Text = "Items reordered";
+    }
+
+    private void RenameTarget()
+    {
+        dynamicTarget.AccessibleName = dynamicTarget.AccessibleName == "Dynamic target"
+            ? "Dynamic target renamed"
+            : "Dynamic target";
+        status.Text = "Accessible name changed";
+    }
+
+    private void ToggleTargetEnabled()
+    {
+        dynamicTarget.Enabled = !dynamicTarget.Enabled;
+        status.Text = "Enabled state changed";
+    }
+
+    private void ToggleTargetVisible()
+    {
+        dynamicTarget.Visible = !dynamicTarget.Visible;
+        status.Text = "Visible state changed";
+    }
+
+    private void ToggleHiddenTarget()
+    {
+        hiddenTarget.Visible = !hiddenTarget.Visible;
+        status.Text = "Hidden target visibility changed";
+    }
+
+    private void OnCustomSemanticAction()
+        => status.Text = "Custom semantic child invoked";
+
+    private sealed class CustomSemanticSurface : Control
+    {
+        private readonly Action invoke;
+
+        public CustomSemanticSurface(Action invoke)
+        {
+            this.invoke = invoke;
+            Style.Border.Width = 1;
+            Style.Border.Color = Theme.BorderMidColor;
+            Style.BackgroundColor = Theme.ControlLowColor;
+        }
+
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new CustomSemanticSurfaceAccessibleObject(this, invoke);
+    }
+
+    private sealed class CustomSemanticSurfaceAccessibleObject : Control.ControlAccessibleObject
+    {
+        private readonly CustomSemanticChild child;
+
+        public CustomSemanticSurfaceAccessibleObject(CustomSemanticSurface owner, Action invoke)
+            : base(owner)
+        {
+            child = new CustomSemanticChild(this, invoke);
+        }
+
+        public override AccessibleControlType ControlType => AccessibleControlType.Group;
+
+        public override AccessibleRole Role => AccessibleRole.Grouping;
+
+        protected override IEnumerable<AccessibleObject> GetAccessibilityChildren()
+        {
+            // This node deliberately has no corresponding Control. It validates that platform
+            // providers consume the canonical logical tree rather than reconstructing controls.
+            yield return child;
+        }
+    }
+
+    private sealed class CustomSemanticChild : AccessibleObject
+    {
+        private readonly WeakReference<AccessibleObject> parent;
+        private readonly Action invoke;
+
+        public CustomSemanticChild(AccessibleObject parent, Action invoke)
+        {
+            this.parent = new WeakReference<AccessibleObject>(parent);
+            this.invoke = invoke;
+            AutomationId = "controlgallery.accessibility.custom-action";
+        }
+
+        public override Rectangle Bounds
+        {
+            get
+            {
+                Rectangle parentBounds = Parent?.Bounds ?? Rectangle.Empty;
+                return new Rectangle(
+                    parentBounds.Left + 12,
+                    parentBounds.Top + 12,
+                    Math.Max(0, parentBounds.Width - 24),
+                    Math.Max(0, parentBounds.Height - 24));
+            }
+        }
+
+        public override AccessibleControlType ControlType => AccessibleControlType.Button;
+
+        public override string? Name
+        {
+            get => "Invoke custom semantic action";
+            set { }
+        }
+
+        public override AccessibleObject? Parent
+            => parent.TryGetTarget(out AccessibleObject? value) ? value : null;
+
+        public override AccessibleRole Role => AccessibleRole.PushButton;
+
+        public override AccessibleActions SupportedActions => AccessibleActions.Invoke;
+
+        public override bool PerformAction(AccessibleActions action, object? parameter = null)
+        {
+            if (action != AccessibleActions.Invoke || parameter is not null)
+                return false;
+
+            invoke();
+            return true;
+        }
+    }
+}

--- a/samples/ControlGallery/Panels/TextBoxPanel.cs
+++ b/samples/ControlGallery/Panels/TextBoxPanel.cs
@@ -17,7 +17,15 @@ namespace ControlGallery.Panels
             multi.Style.FontSize = 16;
 
             Controls.Add (new TextBox { Left = 10, Top = 315, Width = 150, Text = "Disabled", Enabled = false });
-            Controls.Add (new TextBox { Left = 10, Top = 355, Width = 150, Placeholder = "Password", PasswordCharacter = (char)0x25CF });
+            Controls.Add (new TextBox {
+                Left = 10,
+                Top = 355,
+                Width = 150,
+                Placeholder = "Password",
+                PasswordCharacter = (char)0x25CF,
+                AccessibleName = "Password test input",
+                AccessibleAutomationId = "controlgallery.textbox.password"
+            });
             
             var padded = Controls.Add (new TextBox { Text = "With Padding", Left = 200, Top = 10, Width = 150, Padding = new Padding (5) });
             padded.Style.ForegroundColor = SKColors.Red;


### PR DESCRIPTION
## Summary

Implements Phase 2 of #59 — Windows UI Automation support on top of the canonical accessibility semantic model introduced in Phase 1.

## Architecture

- Reuses `AccessibleObject` and `ControlAccessibleObject` as the single semantic source of truth.
- Adds no second semantic tree and does not reconstruct the tree from controls or reflection.
- Keeps the platform-neutral public shared API unchanged through an internal WindowKit transport extension.
- Implements native UIA provider integration only in the Windows backend.
- Preserves the existing MSAA `OBJID_CLIENT` path alongside UIA.

## Windows UI Automation

- Routes `WM_GETOBJECT` requests for `UiaRootObjectId` through `UiaReturnRawElementProvider` while retaining `LresultFromObject` for MSAA.
- Uses source-generated COM provider contracts for simple, fragment, fragment-root, and supported pattern interfaces.
- Exposes root, control-backed fragment, and logical-child providers, including semantic children without a `Control` instance.
- Preserves stable provider identity and runtime IDs across reorder operations and invalidates detached/destroyed elements.
- Dispatches all semantic reads and mutations through the UI thread with a bounded timeout.
- Converts callback failures to HRESULTs, contains `WM_GETOBJECT` failures inside WndProc, and avoids logging user values.
- Disconnects the HWND provider after native destruction has returned.

## Properties

Maps `Name`, `AutomationId`, `ControlType`, enabled/focus and focusable state, screen bounds, offscreen state, `HelpText`, `IsPassword`, class/framework identity, and raw/control/content view membership.

## Patterns

- Invoke
- Toggle
- Value
- RangeValue
- ExpandCollapse
- Selection
- SelectionItem
- ScrollItem

Full `ScrollPattern` is deferred until the shared controls expose a canonical viewport contract. `TextPattern` is deferred until the shared model exposes stable text ranges.

## Events

Maps canonical notifications for focus, name/value/state, selection, structure, and bounds changes to native UIA events and property notifications. Password value notifications are suppressed.

## Validation

- Restore: PASS.
- Debug solution build: PASS, 0 warnings / 0 errors (16.11 s).
- Release solution build: PASS, 0 warnings / 0 errors (54.90 s).
- `WindowsUiaProviderTests`: 54/54 passed.
- `AccessibilitySemanticTests`: 30/30 passed.
- All required test projects: 1753/1753 passed, 0 failed, 0 skipped:
  - `ModernFormsNext.Tests`: 907/907
  - Windows backend tests: 64/64
  - `ModernFormsNext.Testing.Tests`: 46/46
  - Designer tests: 622/622
  - Android tests: 72/72
  - cross-platform tests: 16/16
  - VSIX tests: 26/26
- Real out-of-process UIA client validation: PASS for `AutomationElement.FromHandle`, root/tree lookup, property queries, Button Invoke, SetFocus, a logical child, password redaction through property and ValuePattern paths, and clean host/client shutdown.
- Release documentation script tests: 32 assertions passed.
- DocFX: 833 API files, 918 models, 909 HTML files, 0 warnings / 0 errors; 4 documentation archives validated.
- Strict ApiCompat: 4 assembly comparisons passed.
- Package validation: 9 NuGet packages and 8 symbol packages passed.
- Windows backend trim/AOT/single-file analyzers: PASS, 0 warnings / 0 errors.
- `git diff --check`: PASS.
- Privacy search for the final test value: 0 occurrences in the repository and generated validation artifacts.

## Packaging

There is no production dependency on WPF or WinForms. `Microsoft.WindowsDesktop.App` is used only by the non-packable out-of-process test client and is not part of the production package dependency graph. The Windows backend package retains only its existing WindowKit, SkiaSharp, and System.Drawing.Common dependencies. Shared and Android projects remain unaffected.

## Manual tools

- Accessibility Insights: not available / not executed.
- Inspect.exe: not available / not executed.
- Screen reader smoke: not executed.

## Scope

Part of #59 — completes Phase 2 only. Android accessibility, TalkBack, full `TextPattern`, full `ScrollPattern`, broader diagnostics, release work, and unrelated issues remain deferred.
