### PR TITLE
Add command foundation and reusable command sources

### DIFF
--- a/ModernFormsNext.Testing.Tests/CommandSourceHostTests.cs
+++ b/ModernFormsNext.Testing.Tests/CommandSourceHostTests.cs
@@ -1,0 +1,140 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Testing.Tests;
+
+public sealed class CommandSourceHostTests
+{
+    [Fact]
+    public void ConsumerCanInvokeSharedCommandThroughSemanticButton()
+    {
+        using var host = ModernFormsTestHost.Create();
+        var root = new Panel();
+        var calls = new List<object?>();
+        bool allowed = true;
+        var command = new DelegateCommand(calls.Add, _ => allowed);
+        var first = root.Controls.Add(new Button { Command = command, CommandParameter = "first" });
+        var second = root.Controls.Add(new Button { Command = command, CommandParameter = "second" });
+        host.Show(root, 400, 200);
+
+        Assert.True(first.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(new object?[] { "first" }, calls);
+        allowed = false;
+        command.RaiseCanExecuteChanged();
+        Assert.False(first.Enabled);
+        Assert.False(second.Enabled);
+        Assert.False(second.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        allowed = true;
+        command.RaiseCanExecuteChanged();
+        Assert.True(second.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(new object?[] { "first", "second" }, calls);
+    }
+
+    [Fact]
+    public void BackgroundRequeryEvaluatesAndNotifiesOnlyOnUiThread()
+    {
+        using var host = ModernFormsTestHost.Create();
+        int uiThread = Environment.CurrentManagedThreadId;
+        bool allowed = true;
+        var queryThreads = new List<int>();
+        var eventThreads = new List<int>();
+        var command = new DelegateCommand(() => { }, () =>
+        {
+            queryThreads.Add(Environment.CurrentManagedThreadId);
+            return allowed;
+        });
+        using var button = new Button { Command = command };
+        using var item = new NotifyIconMenuItem { Command = command };
+        button.EnabledChanged += (_, _) => eventThreads.Add(Environment.CurrentManagedThreadId);
+
+        RunBackground(() => { allowed = false; command.RaiseCanExecuteChanged(); });
+        Assert.True(button.Enabled);
+        Assert.True(item.Enabled);
+        Assert.Empty(eventThreads);
+        Assert.Equal(2, queryThreads.Count);
+        host.Dispatcher.Drain();
+        Assert.False(button.Enabled);
+        Assert.False(item.Enabled);
+        Assert.Equal(new[] { uiThread }, eventThreads);
+        Assert.All(queryThreads, id => Assert.Equal(uiThread, id));
+
+        RunBackground(() => { allowed = true; command.RaiseCanExecuteChanged(); });
+        host.Dispatcher.Drain();
+        Assert.True(button.Enabled);
+        Assert.True(item.Enabled);
+        Assert.Empty(host.Dispatcher.UnhandledExceptions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void QueuedOldNotificationCannotTouchReplacementOrDisposedSource(bool dispose)
+    {
+        using var host = ModernFormsTestHost.Create();
+        int oldQueries = 0;
+        int newQueries = 0;
+        var oldCommand = new DelegateCommand(() => { }, () => { oldQueries++; return true; });
+        using var button = new Button { Command = oldCommand };
+        RunBackground(oldCommand.RaiseCanExecuteChanged);
+        if (dispose)
+            button.Dispose();
+        else
+            button.Command = new DelegateCommand(() => { }, () => { newQueries++; return false; });
+        host.Dispatcher.Drain();
+        Assert.Equal(1, oldQueries);
+        Assert.Equal(dispose ? 0 : 1, newQueries);
+        if (!dispose) Assert.False(button.Enabled);
+        Assert.Empty(host.Dispatcher.UnhandledExceptions);
+    }
+
+    [Fact]
+    public void BackgroundPredicateExceptionUsesExistingDispatcherExceptionPathAndRecovers()
+    {
+        using var host = ModernFormsTestHost.Create();
+        var failure = new InvalidOperationException("background requery failed");
+        bool fail = false;
+        var command = new DelegateCommand(() => { }, () => fail ? throw failure : true);
+        using var button = new Button { Command = command };
+        RunBackground(() => { fail = true; command.RaiseCanExecuteChanged(); });
+        host.Dispatcher.Drain();
+        Assert.False(button.Enabled);
+        Assert.Same(failure, Assert.Single(host.Dispatcher.UnhandledExceptions));
+        fail = false;
+        command.RaiseCanExecuteChanged();
+        Assert.True(button.Enabled);
+    }
+
+    [Fact]
+    public void PredicateIsNotPolledByDispatcherDrainsOrEnabledReads()
+    {
+        using var host = ModernFormsTestHost.Create();
+        int queries = 0;
+        var command = new DelegateCommand(() => { }, () => { queries++; return true; });
+        using var button = new Button { Command = command };
+        for (int i = 0; i < 5; i++)
+        {
+            host.Dispatcher.Drain();
+            Assert.True(button.Enabled);
+        }
+        Assert.Equal(1, queries);
+    }
+
+    [Fact]
+    public void DirectBackgroundMutationIsRejectedWithoutChangingBinding()
+    {
+        using var host = ModernFormsTestHost.Create();
+        using var button = new Button { Command = new DelegateCommand(() => { }) };
+        RunBackground(() => Assert.Throws<InvalidOperationException>(() => button.CommandParameter = "invalid thread"));
+        Assert.Null(button.CommandParameter);
+        Assert.True(button.Enabled);
+    }
+
+    private static void RunBackground(Action action)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() => { try { action(); } catch (Exception exception) { failure = exception; } });
+        thread.Start();
+        thread.Join();
+        Assert.Null(failure);
+    }
+}

--- a/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
+++ b/ModernFormsNext.Tests/AccessibilitySemanticTests.cs
@@ -17,6 +17,34 @@ public sealed class AccessibilitySemanticCollection
 public sealed class AccessibilitySemanticTests
 {
     [Fact]
+    public void CommandBackedButtonUsesNormalInvokeAndUnavailableState()
+    {
+        using var root = new VisibleRootControl();
+        bool allowed = false;
+        var calls = new List<string>();
+        var command = new DelegateCommand(p => calls.Add($"execute:{p}"), _ => allowed);
+        using var button = root.Controls.Add(new Button { Command = command, CommandParameter = "save" });
+        button.Click += (_, _) => calls.Add("click");
+        AccessibleObject accessible = button.AccessibilityObject;
+
+        Assert.Equal(AccessibleControlType.Button, accessible.ControlType);
+        AssertHasFlag(accessible.State, AccessibleStates.Unavailable);
+        Assert.False(accessible.PerformAction(AccessibleActions.Invoke));
+        Assert.Empty(calls);
+        allowed = true;
+        command.RaiseCanExecuteChanged();
+        AssertDoesNotHaveFlag(accessible.State, AccessibleStates.Unavailable);
+        AssertHasFlag(accessible.SupportedActions, AccessibleActions.Invoke);
+        Assert.True(accessible.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(["click", "execute:save"], calls);
+        button.Enabled = false;
+        command.RaiseCanExecuteChanged();
+        AssertHasFlag(accessible.State, AccessibleStates.Unavailable);
+        Assert.False(accessible.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(2, calls.Count);
+    }
+
+    [Fact]
     public void ButtonExposesNameTypeAndNormalInvokeAction()
     {
         using var root = new VisibleRootControl();

--- a/ModernFormsNext.Tests/CommandSourceTests.cs
+++ b/ModernFormsNext.Tests/CommandSourceTests.cs
@@ -1,0 +1,439 @@
+using System.Windows.Input;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class CommandSourceTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EventOnlySourceRetainsClick(bool tray)
+    {
+        using var source = new Source(tray);
+        int clicks = 0;
+        source.OnClick(() => clicks++);
+        source.Invoke();
+        Assert.Equal(1, clicks);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClickPrecedesCommandAndExecutionUsesCurrentParameter(bool tray)
+    {
+        using var source = new Source(tray);
+        var calls = new List<string>();
+        source.Parameter = "before";
+        source.Command = new DelegateCommand(p => calls.Add($"execute:{p}"));
+        source.OnClick(() => { calls.Add("click"); source.Parameter = "after"; });
+        source.Invoke();
+        Assert.Equal(["click", "execute:after"], calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AvailabilityTransitionsAndParameterChangesReevaluate(bool tray)
+    {
+        using var source = new Source(tray);
+        var command = new ProbeCommand { Predicate = p => p is string text && text == "valid" };
+        source.Command = command;
+        Assert.False(source.Enabled);
+        source.Parameter = "valid";
+        Assert.True(source.Enabled);
+        source.Invoke();
+        Assert.Equal(new object?[] { "valid" }, command.Executions);
+        source.Parameter = null;
+        Assert.False(source.Enabled);
+        source.Invoke();
+        Assert.Single(command.Executions);
+        command.Predicate = _ => true;
+        command.Raise();
+        Assert.True(source.Enabled);
+        command.Predicate = _ => false;
+        command.Raise();
+        Assert.False(source.Enabled);
+        source.Command = null;
+        Assert.True(source.Enabled);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ReplacementRemovalAndStaleInvocationListsAreIsolated(bool tray)
+    {
+        using var source = new Source(tray);
+        var first = new ProbeCommand();
+        var second = new ProbeCommand();
+        source.Command = first;
+        EventHandler stale = first.Snapshot!;
+        source.Command = second;
+        Assert.Equal(0, first.Subscribers);
+        Assert.Equal(1, second.Subscribers);
+        int queries = second.Queries;
+        first.Predicate = _ => throw new InvalidOperationException("old command must be detached");
+        first.Raise();
+        stale(null, EventArgs.Empty);
+        Assert.Equal(queries, second.Queries);
+        source.Invoke();
+        Assert.Empty(first.Executions);
+        Assert.Single(second.Executions);
+        source.Command = null;
+        Assert.Equal(0, second.Subscribers);
+        source.Invoke();
+        Assert.Single(second.Executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LocalDisabledIntentSurvivesRequeryReplacementAndRemoval(bool tray)
+    {
+        using var source = new Source(tray);
+        source.Enabled = false;
+        var command = new ProbeCommand();
+        source.Command = command;
+        command.Raise();
+        Assert.False(source.Enabled);
+        source.Command = new ProbeCommand();
+        Assert.False(source.Enabled);
+        source.Command = null;
+        Assert.False(source.Enabled);
+        source.Command = command;
+        source.Enabled = true;
+        Assert.True(source.Enabled);
+        source.Enabled = false;
+        command.Raise();
+        source.Invoke();
+        Assert.False(source.Enabled);
+        Assert.Empty(command.Executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LocalTrueCannotOverrideUnavailableCommand(bool tray)
+    {
+        using var source = new Source(tray);
+        source.Command = new ProbeCommand { Predicate = _ => false };
+        source.Enabled = false;
+        source.Enabled = true;
+        Assert.False(source.Enabled);
+        source.Command = null;
+        Assert.True(source.Enabled);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SharedCommandHasIndependentParametersAndDisposal(bool tray)
+    {
+        using var first = new Source(tray);
+        using var second = new Source(tray);
+        var command = new ProbeCommand { Predicate = p => p is not null };
+        first.Parameter = "first";
+        first.Command = command;
+        second.Command = command;
+        Assert.True(first.Enabled);
+        Assert.False(second.Enabled);
+        Assert.Equal(2, command.Subscribers);
+        command.Predicate = _ => false;
+        command.Raise();
+        Assert.False(first.Enabled);
+        Assert.False(second.Enabled);
+        command.Predicate = _ => true;
+        command.Raise();
+        Assert.True(first.Enabled);
+        Assert.True(second.Enabled);
+        first.Dispose();
+        Assert.Equal(1, command.Subscribers);
+        Assert.Null(first.Command);
+        Assert.Null(first.Parameter);
+        second.Invoke();
+        Assert.Equal(new object?[] { null }, command.Executions);
+        second.Dispose();
+        Assert.Equal(0, command.Subscribers);
+        command.Raise();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RepeatedAttachDetachNeverDuplicatesSubscription(bool tray)
+    {
+        using var source = new Source(tray);
+        var command = new ProbeCommand();
+        for (int i = 0; i < 5; i++)
+        {
+            source.Command = command;
+            source.Command = command;
+            Assert.Equal(1, command.Subscribers);
+            int before = command.Queries;
+            command.Raise();
+            Assert.Equal(before + 1, command.Queries);
+            source.Command = null;
+            Assert.Equal(0, command.Subscribers);
+        }
+        source.Command = command;
+        EventHandler stale = command.Snapshot!;
+        source.Dispose();
+        source.Dispose();
+        int queries = command.Queries;
+        stale(command, EventArgs.Empty);
+        Assert.Equal(queries, command.Queries);
+        Assert.Equal(0, command.Subscribers);
+        Assert.Throws<ObjectDisposedException>(() => source.Command = command);
+        Assert.Throws<ObjectDisposedException>(() => source.Parameter = new object());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StaleAvailabilityIsRecheckedBeforeClick(bool tray)
+    {
+        using var source = new Source(tray);
+        int clicks = 0;
+        var command = new ProbeCommand();
+        source.Command = command;
+        source.OnClick(() => clicks++);
+        command.Predicate = _ => false; // Deliberately omit the notification.
+        source.Invoke();
+        Assert.Equal(0, clicks);
+        Assert.Empty(command.Executions);
+        Assert.False(source.Enabled);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClickCanReplaceOrRemoveCommand(bool tray)
+    {
+        using var source = new Source(tray);
+        var first = new ProbeCommand();
+        var second = new ProbeCommand();
+        source.Command = first;
+        source.OnClick(() => source.Command = ReferenceEquals(source.Command, first) ? second : null);
+        source.Invoke();
+        source.Invoke();
+        Assert.Empty(first.Executions);
+        Assert.Single(second.Executions);
+        Assert.Equal(0, first.Subscribers);
+        Assert.Equal(0, second.Subscribers);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void ClickCanDisableOrDisposeSource(bool tray, bool dispose)
+    {
+        using var source = new Source(tray);
+        var command = new ProbeCommand();
+        source.Command = command;
+        source.OnClick(() => { if (dispose) source.Dispose(); else source.Enabled = false; });
+        source.Invoke();
+        Assert.Empty(command.Executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClickCanChangeAvailabilityWithoutNotification(bool tray)
+    {
+        using var source = new Source(tray);
+        var command = new ProbeCommand();
+        source.Command = command;
+        source.OnClick(() => command.Predicate = _ => false);
+        source.Invoke();
+        Assert.Empty(command.Executions);
+        Assert.False(source.Enabled);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExecuteExceptionIsOriginalAndLaterActivationWorks(bool tray)
+    {
+        using var source = new Source(tray);
+        var failure = new InvalidOperationException("execute failed");
+        var command = new ProbeCommand { ExecuteFailure = failure };
+        source.Command = command;
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(source.Invoke));
+        command.ExecuteFailure = null;
+        source.Invoke();
+        Assert.Single(command.Executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClickExceptionPreventsExecution(bool tray)
+    {
+        using var source = new Source(tray);
+        var failure = new InvalidOperationException("click failed");
+        var command = new ProbeCommand();
+        source.Command = command;
+        source.OnClick(() => throw failure);
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(source.Invoke));
+        Assert.Empty(command.Executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PredicateFailureFailsClosedAndRecoversByNotificationOrRemoval(bool tray)
+    {
+        using var source = new Source(tray);
+        var failure = new InvalidOperationException("predicate failed");
+        var command = new ProbeCommand { Predicate = _ => throw failure };
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => source.Command = command));
+        Assert.Same(command, source.Command);
+        Assert.Equal(1, command.Subscribers);
+        int queries = command.Queries;
+        Assert.False(source.Enabled);
+        Assert.False(source.Enabled);
+        Assert.Equal(queries, command.Queries);
+        command.Predicate = _ => true;
+        command.Raise();
+        Assert.True(source.Enabled);
+        command.Predicate = _ => throw failure;
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => source.Parameter = "new"));
+        Assert.Equal("new", source.Parameter);
+        Assert.False(source.Enabled);
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(command.Raise));
+        source.Command = null;
+        Assert.True(source.Enabled);
+        Assert.Equal(0, command.Subscribers);
+    }
+
+    [Fact]
+    public void ParentAndLocalIntentCombineWithCommandWithoutFalseNotifications()
+    {
+        using var parent = new Panel { Enabled = false };
+        using var button = parent.Controls.Add(new Button());
+        var command = new ProbeCommand();
+        button.Command = command;
+        int changes = 0;
+        button.EnabledChanged += (_, _) => changes++;
+        button.Enabled = true;
+        command.Raise();
+        Assert.False(button.Enabled);
+        Assert.Equal(0, changes);
+        parent.Enabled = true;
+        Assert.True(button.Enabled);
+        Assert.Equal(1, changes);
+        command.Predicate = _ => false;
+        command.Raise();
+        Assert.False(button.Enabled);
+        Assert.Equal(2, changes);
+        button.Enabled = true;
+        Assert.Equal(2, changes);
+        button.Command = null;
+        Assert.True(button.Enabled);
+        Assert.Equal(3, changes);
+    }
+
+    [Fact]
+    public void PredicateReentrancyCannotOverwriteReplacementState()
+    {
+        using var button = new Button();
+        var replacement = new ProbeCommand { Predicate = _ => false };
+        var original = new ProbeCommand { Predicate = _ => { button.Command = replacement; return true; } };
+        button.Command = original;
+        Assert.Same(replacement, button.Command);
+        Assert.False(button.Enabled);
+        Assert.Equal(0, original.Subscribers);
+        Assert.Equal(1, replacement.Subscribers);
+    }
+
+    [Fact]
+    public void CommandDisabledDescendantIgnoresParentAvailabilityNotifications()
+    {
+        using var parent = new Panel();
+        using var button = parent.Controls.Add(new Button { Command = new DelegateCommand(() => { }, () => false) });
+        int changes = 0;
+        button.EnabledChanged += (_, _) => changes++;
+        parent.Enabled = false;
+        parent.Enabled = true;
+        Assert.False(button.Enabled);
+        Assert.Equal(0, changes);
+    }
+
+    [Theory]
+    [InlineData(Keys.Enter)]
+    [InlineData(Keys.Space)]
+    public void ExistingButtonActivationKeysUseCommandPath(Keys key)
+    {
+        using var button = new ActionButton();
+        var command = new ProbeCommand();
+        button.Command = command;
+        button.ReleaseKey(key);
+        Assert.Single(command.Executions);
+    }
+
+    [Fact]
+    public void RightClickPreservesEventWithoutExecutingCommand()
+    {
+        using var button = new ActionButton();
+        var command = new ProbeCommand();
+        button.Command = command;
+        int clicks = 0;
+        button.Click += (_, _) => clicks++;
+        button.RightClick();
+        Assert.Equal(1, clicks);
+        Assert.Empty(command.Executions);
+    }
+
+    [Fact]
+    public void DisposedOrDisabledButtonDoesNotInvokeEvents()
+    {
+        using var button = new Button { Enabled = false };
+        int clicks = 0;
+        button.Click += (_, _) => clicks++;
+        button.PerformClick();
+        button.Enabled = true;
+        button.Dispose();
+        button.PerformClick();
+        Assert.Equal(0, clicks);
+    }
+
+    private sealed class ActionButton : Button
+    {
+        internal void ReleaseKey(Keys key) => OnKeyUp(new KeyEventArgs(key));
+        internal void RightClick() => OnClick(new MouseEventArgs(MouseButtons.Right, 1, 0, 0, System.Drawing.Point.Empty));
+    }
+
+    private sealed class ProbeCommand : ICommand
+    {
+        private EventHandler? handlers;
+        internal Predicate<object?> Predicate { get; set; } = _ => true;
+        internal int Queries { get; private set; }
+        internal int Subscribers => handlers?.GetInvocationList().Length ?? 0;
+        internal EventHandler? Snapshot => handlers;
+        internal List<object?> Executions { get; } = [];
+        internal Exception? ExecuteFailure { get; set; }
+        public event EventHandler? CanExecuteChanged { add => handlers += value; remove => handlers -= value; }
+        public bool CanExecute(object? parameter) { Queries++; return Predicate(parameter); }
+        public void Execute(object? parameter)
+        {
+            if (ExecuteFailure is not null) throw ExecuteFailure;
+            Executions.Add(parameter);
+        }
+        internal void Raise() => handlers?.Invoke(null, EventArgs.Empty);
+    }
+
+    // Exercise the same consumer contract through both public action APIs, without internal hooks.
+    private sealed class Source(bool tray) : IDisposable
+    {
+        private readonly Button? button = tray ? null : new Button();
+        private readonly NotifyIconMenuItem? item = tray ? new NotifyIconMenuItem() : null;
+        internal ICommand? Command { get => button is not null ? button.Command : item!.Command; set { if (button is not null) button.Command = value; else item!.Command = value; } }
+        internal object? Parameter { get => button is not null ? button.CommandParameter : item!.CommandParameter; set { if (button is not null) button.CommandParameter = value; else item!.CommandParameter = value; } }
+        internal bool Enabled { get => button is not null ? button.Enabled : item!.Enabled; set { if (button is not null) button.Enabled = value; else item!.Enabled = value; } }
+        internal void OnClick(Action action) { if (button is not null) button.Click += (_, _) => action(); else item!.Click += (_, _) => action(); }
+        internal void Invoke() { if (button is not null) button.PerformClick(); else item!.PerformClick(); }
+        public void Dispose() { button?.Dispose(); item?.Dispose(); }
+    }
+}

--- a/ModernFormsNext.Tests/CommandSourceTests.cs
+++ b/ModernFormsNext.Tests/CommandSourceTests.cs
@@ -34,6 +34,66 @@ public sealed class CommandSourceTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
+    public void DelegateActivationEvaluatesOnceBeforeAndOnceAfterClick(bool tray)
+    {
+        using var source = new Source(tray);
+        var calls = new List<string>();
+        source.Command = new DelegateCommand(() => calls.Add("execute"), () => { calls.Add("query"); return true; });
+        source.OnClick(() => calls.Add("click"));
+        calls.Clear(); // Assignment has its own availability evaluation.
+        source.Invoke();
+        Assert.Equal(["query", "click", "query", "execute"], calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PostClickPredicateReplacementRejectsObsoleteExecution(bool tray)
+    {
+        using var source = new Source(tray);
+        bool clicked = false;
+        int executions = 0;
+        var replacement = new DelegateCommand(() => executions++);
+        source.Command = new DelegateCommand(() => executions++, () =>
+        {
+            if (clicked) source.Command = replacement;
+            return true;
+        });
+        source.OnClick(() => clicked = true);
+        source.Invoke();
+        Assert.Same(replacement, source.Command);
+        Assert.True(source.Enabled);
+        Assert.Equal(0, executions);
+        source.Invoke();
+        Assert.Equal(1, executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PostClickPredicateExceptionFailsClosedAndCanRecover(bool tray)
+    {
+        using var source = new Source(tray);
+        var failure = new InvalidOperationException("post-click predicate failed");
+        bool fail = false;
+        bool failOnClick = true;
+        int executions = 0;
+        var command = new DelegateCommand(() => executions++, () => fail ? throw failure : true);
+        source.Command = command;
+        source.OnClick(() => fail = failOnClick);
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(source.Invoke));
+        Assert.False(source.Enabled);
+        Assert.Equal(0, executions);
+        fail = failOnClick = false;
+        command.RaiseCanExecuteChanged();
+        Assert.True(source.Enabled);
+        source.Invoke();
+        Assert.Equal(1, executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
     public void AvailabilityTransitionsAndParameterChangesReevaluate(bool tray)
     {
         using var source = new Source(tray);

--- a/ModernFormsNext.Tests/CommandTests.cs
+++ b/ModernFormsNext.Tests/CommandTests.cs
@@ -52,6 +52,17 @@ public sealed class CommandTests
     }
 
     [Fact]
+    public void DirectExecutionEvaluatesPredicateOnce()
+    {
+        int queries = 0;
+        int executions = 0;
+        var command = new DelegateCommand(() => executions++, () => { queries++; return true; });
+        command.Execute(null);
+        Assert.Equal(1, queries);
+        Assert.Equal(1, executions);
+    }
+
+    [Fact]
     public void ExplicitRequeryUsesNormalEventSemantics()
     {
         var command = new DelegateCommand(() => { });

--- a/ModernFormsNext.Tests/CommandTests.cs
+++ b/ModernFormsNext.Tests/CommandTests.cs
@@ -1,0 +1,100 @@
+using System.Windows.Input;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class CommandTests
+{
+    [Fact]
+    public void ParameterlessActionUsesICommandContract()
+    {
+        int calls = 0;
+        ICommand command = new DelegateCommand(() => calls++);
+        Assert.True(command.CanExecute(null));
+        command.Execute(new object());
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("document")]
+    [InlineData(42)]
+    public void ParameterIsPassedWithoutConversion(object? parameter)
+    {
+        object? received = new object();
+        var command = new DelegateCommand(p => received = p);
+        command.Execute(parameter);
+        Assert.Same(parameter, received);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ParameterlessPredicateGuardsDirectExecution(bool allowed)
+    {
+        int calls = 0;
+        var command = new DelegateCommand(() => calls++, () => allowed);
+        Assert.Equal(allowed, command.CanExecute(null));
+        command.Execute(null);
+        Assert.Equal(allowed ? 1 : 0, calls);
+    }
+
+    [Fact]
+    public void ParameterPredicateControlsExecution()
+    {
+        var calls = new List<object?>();
+        var command = new DelegateCommand(calls.Add, p => p is int value && value > 0);
+        command.Execute(null);
+        command.Execute("invalid");
+        command.Execute(-1);
+        command.Execute(2);
+        Assert.Equal(new object?[] { 2 }, calls);
+    }
+
+    [Fact]
+    public void ExplicitRequeryUsesNormalEventSemantics()
+    {
+        var command = new DelegateCommand(() => { });
+        int calls = 0;
+        EventHandler handler = (sender, args) =>
+        {
+            Assert.Same(command, sender);
+            Assert.Same(EventArgs.Empty, args);
+            calls++;
+        };
+        command.CanExecuteChanged += handler;
+        command.RaiseCanExecuteChanged();
+        command.CanExecuteChanged -= handler;
+        command.RaiseCanExecuteChanged();
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void NullActionsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DelegateCommand((Action)null!));
+        Assert.Throws<ArgumentNullException>(() => new DelegateCommand((Action<object?>)null!));
+    }
+
+    [Fact]
+    public void OriginalExecuteExceptionPropagates()
+    {
+        var failure = new InvalidOperationException("action failed");
+        var command = new DelegateCommand(() => throw failure);
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => command.Execute(null)));
+    }
+
+    [Fact]
+    public void OriginalPredicateExceptionPropagatesAndDoesNotPoisonCommand()
+    {
+        var failure = new InvalidOperationException("predicate failed");
+        bool fail = true;
+        int calls = 0;
+        var command = new DelegateCommand(() => calls++, () => fail ? throw failure : true);
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => command.CanExecute(null)));
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => command.Execute(null)));
+        fail = false;
+        command.Execute(null);
+        Assert.Equal(1, calls);
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAccessibilityProviderTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAccessibilityProviderTests.cs
@@ -279,6 +279,36 @@ public class AndroidAccessibilityProviderTests
     }
 
     [Fact]
+    public void CommandBackedButtonMapsAvailabilityAndInvokesThroughNormalAction()
+    {
+        using var root = new Panel();
+        bool allowed = false;
+        var calls = new List<string>();
+        var command = new DelegateCommand(parameter => calls.Add($"execute:{parameter}"), _ => allowed);
+        using var button = root.Controls.Add(new Button { Command = command, CommandParameter = "android" });
+        button.Click += (_, _) => calls.Add("click");
+        using var surface = new SkiaControlSurface(root);
+        using var session = new AndroidAccessibilitySession(surface);
+        session.Attach();
+        var peer = Adapt(button.AccessibilityObject);
+        int id = session.Register(peer);
+
+        Assert.False(Read(peer).Enabled);
+        Assert.False(session.Perform(id, ActionClick, null, true));
+        Assert.Empty(calls);
+        allowed = true;
+        command.RaiseCanExecuteChanged();
+        Assert.True(Read(peer).Enabled);
+        Assert.True(session.Perform(id, ActionClick, null, true));
+        Assert.Equal(new[] { "click", "execute:android" }, calls);
+        button.Enabled = false;
+        command.RaiseCanExecuteChanged();
+        Assert.False(Read(peer).Enabled);
+        Assert.False(session.Perform(id, ActionClick, null, true));
+        Assert.Equal(2, calls.Count);
+    }
+
+    [Fact]
     public void RealListBoxDuplicateOccurrencesHaveSeparateIdsAndSelectionWorks()
     {
         using var list = new ListBox { SelectionMode = SelectionMode.MultiSimple };

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient/Program.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationClient/Program.cs
@@ -24,6 +24,11 @@ if (button is null)
 }
 
 string rootNameBeforeInvoke = root.Current.Name;
+AutomationElement? disabledButton = root.FindFirst(
+    TreeScope.Descendants,
+    new PropertyCondition(AutomationElement.AutomationIdProperty, "uia.integration.disabled-command"));
+if (disabledButton is null)
+    return 5;
 string buttonName = button.Current.Name;
 string automationId = button.Current.AutomationId;
 int rootControlType = root.Current.ControlType.Id;
@@ -43,6 +48,7 @@ var result = new
     AutomationId = automationId,
     RootControlType = rootControlType,
     ButtonControlType = buttonControlType,
+    DisabledCommandIsEnabled = disabledButton.Current.IsEnabled,
     HasKeyboardFocus = button.Current.HasKeyboardFocus
 };
 

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost/Program.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests.UiAutomationHost/Program.cs
@@ -15,13 +15,25 @@ var button = new Button
     Text = "Invoke"
 };
 
-button.Click += (_, _) =>
+bool clicked = false;
+button.Click += (_, _) => clicked = true;
+button.CommandParameter = "uia-command";
+button.Command = new DelegateCommand(parameter =>
 {
+    // The real cross-process UIA client must reach Click before the parameterized command.
+    if (!clicked || !Equals(parameter, "uia-command"))
+        throw new InvalidOperationException("UIA did not use the normal Button command path.");
     form.Text = "ModernFormsNext UIA action invoked";
     Console.WriteLine("INVOKED");
-};
+});
 
 form.Controls.Add(button);
+form.Controls.Add(new Button {
+    AccessibleAutomationId = "uia.integration.disabled-command",
+    Text = "Unavailable command",
+    Bounds = new Rectangle(24, 90, 220, 48),
+    Command = new DelegateCommand(() => throw new InvalidOperationException("Unavailable command invoked."), () => false)
+});
 form.Shown += (_, _) =>
 {
     Console.WriteLine($"HWND:{form.PlatformHandle.Handle.ToInt64()}");

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
@@ -541,6 +541,7 @@ public sealed class WindowsUiaProviderTests
             Assert.Equal(50032, root.GetProperty("RootControlType").GetInt32());
             Assert.Equal(50000, root.GetProperty("ButtonControlType").GetInt32());
             Assert.True(root.GetProperty("HasKeyboardFocus").GetBoolean());
+            Assert.False(root.GetProperty("DisabledCommandIsEnabled").GetBoolean());
 
             Assert.Equal("INVOKED", await ReadLineStartingWithAsync(host, "INVOKED", timeout.Token));
         }

--- a/ModernFormsNext/Button.cs
+++ b/ModernFormsNext/Button.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Specialized;
 using System.Drawing;
+using System.ComponentModel;
+using System.Windows.Input;
+using ModernFormsNext.DataBinding;
 using ModernFormsNext.Layout;
 using ModernFormsNext.Renderers;
 using SkiaSharp;
@@ -9,7 +12,7 @@ namespace ModernFormsNext
     /// <summary>
     /// Represents a Button control.
     /// </summary>
-    public class Button : Control, IHaveTextAndImageAlign
+    public class Button : Control, IHaveTextAndImageAlign, ICommandBindingTargetProvider
     {
         private static readonly BitVector32.Section s_stateAutoEllipsis = BitVector32.CreateSection (1);
 
@@ -22,6 +25,51 @@ namespace ModernFormsNext
         private static readonly int s_propTextImageRelation = PropertyStore.CreateKey ();
 
         private BitVector32 _buttonState;
+        private CommandSource? commandSource;
+
+        /// <summary>
+        /// Gets or sets the command executed after <see cref="Control.Click"/> on activation.
+        /// </summary>
+        /// <remarks>
+        /// Assign on the UI thread. Null keeps event-only behavior. Availability contributes to
+        /// effective <see cref="Control.Enabled"/> without changing local enabled intent.
+        /// Replacement/removal detaches the previous command; disposal detaches the current one.
+        /// CanExecute exceptions disable this source and propagate unchanged; a later notification
+        /// or assignment can recover. Background notifications use the existing UI dispatcher.
+        /// The source does not own or dispose the command. Designer serialization is deferred.
+        /// </remarks>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ICommand? Command {
+            get => commandSource?.Command;
+            set {
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+                (commandSource ??= new CommandSource(this)).Command = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the parameter used to evaluate and execute <see cref="Command"/>.
+        /// </summary>
+        /// <remarks>
+        /// Null is supported. Assign on the UI thread; a different reference immediately
+        /// reevaluates CanExecute and may update enabled/rendering/accessibility state. For
+        /// mutation within the same object, raise the command's CanExecuteChanged event.
+        /// The current parameter is used after Click and is released on disposal, without being
+        /// disposed. Exceptions follow the same policy as <see cref="Command"/>.
+        /// </remarks>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public object? CommandParameter {
+            get => commandSource?.Parameter;
+            set {
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+                (commandSource ??= new CommandSource(this)).Parameter = value;
+            }
+        }
+
+        bool ICommandBindingTargetProvider.IsCommandSourceDisposed => IsDisposed;
+        void ICommandBindingTargetProvider.SetCommandEnabled(bool enabled) => SetCommandEnabled(enabled);
 
         /// <summary>
         /// Initializes a new instance of the Button class.
@@ -190,10 +238,25 @@ namespace ModernFormsNext
         /// <inheritdoc/>
         protected override void OnClick (MouseEventArgs e)
         {
+            if (IsDisposed || !Enabled)
+                return;
+            if (e.Button == MouseButtons.Left && commandSource is not null && !commandSource.CanExecute())
+                return;
+
             if (FindForm () is Form form)
                 form.DialogResult = DialogResult;
 
             base.OnClick (e);
+
+            if (e.Button == MouseButtons.Left && !IsDisposed && Enabled)
+                commandSource?.Execute();
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            commandSource?.Dispose();
+            base.Dispose(disposing);
         }
 
         /// <inheritdoc/>
@@ -224,8 +287,16 @@ namespace ModernFormsNext
         }
 
         /// <summary>
-        /// Generates a Click event for the Button.
+        /// Activates the button through its normal Click and command path.
         /// </summary>
+        /// <remarks>
+        /// Call on the UI thread. Disabled or disposed buttons do nothing. When allowed, applies
+        /// DialogResult, raises Click, then reevaluates and executes the current command with the
+        /// current parameter. A Click exception prevents command execution; predicate and execute
+        /// exceptions propagate unchanged. CanExecute is checked before Click as well, so a stale
+        /// enabled snapshot cannot invoke an unavailable command. Visibility is not required for
+        /// programmatic activation. Keyboard and accessibility activation use this same path.
+        /// </remarks>
         public void PerformClick ()
         {
             OnClick (new MouseEventArgs (MouseButtons.Left, 1, 0, 0, Point.Empty));

--- a/ModernFormsNext/Control.States.cs
+++ b/ModernFormsNext/Control.States.cs
@@ -21,6 +21,7 @@ public partial class Control
         IsHovering = 0x00000020,   // Modern.Forms addition
         IsImplicitControl = 0x00000040,   // Modern.Forms addition
         IsSelected = 0x00000080,   // Modern.Forms addition
+        CommandDisabled = 0x00000100,
         //Recreate                = 0x00000010,
         //Modal                   = 0x00000020,
         //AllowDrop               = 0x00000040,

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -727,10 +727,16 @@ namespace ModernFormsNext
         /// <summary>
         /// Gets or sets whether the control can be interacted with.
         /// </summary>
+        /// <remarks>
+        /// The setter records local enabled intent. The getter combines it with the parent's
+        /// effective enabled state and, for command sources, command availability. Command
+        /// reevaluation never overwrites a locally assigned false value. Set this property on
+        /// the UI thread; effective changes update input, focus, rendering and accessibility.
+        /// </remarks>
         public bool Enabled {
             get {
                 // If we aren't enabled, that's easy
-                if (!GetState (States.Enabled))
+                if (!GetState (States.Enabled) || GetState (States.CommandDisabled))
                     return false;
 
                 // If we don't have a Parent, then we're enabled
@@ -745,12 +751,25 @@ namespace ModernFormsNext
                 SetState (States.Enabled, value);
 
                 // See if the computed Enabled actually changed
-                if (old_value != value) {
-                    if (!value)
+                if (old_value != Enabled) {
+                    if (!Enabled)
                         SelectNextIfFocused ();
 
                     OnEnabledChanged (EventArgs.Empty);
                 }
+            }
+        }
+
+        // Keep availability separate from the local States.Enabled bit. Use the same normal
+        // notification path so focus, descendants, visual states and accessibility stay aligned.
+        internal void SetCommandEnabled(bool value)
+        {
+            bool previous = Enabled;
+            SetState(States.CommandDisabled, !value);
+            if (previous != Enabled) {
+                if (!Enabled)
+                    SelectNextIfFocused();
+                OnEnabledChanged(EventArgs.Empty);
             }
         }
 
@@ -1597,7 +1616,7 @@ namespace ModernFormsNext
         [EditorBrowsable (EditorBrowsableState.Advanced)]
         protected virtual void OnParentEnabledChanged (EventArgs e)
         {
-            if (GetState (States.Enabled))
+            if (GetState (States.Enabled) && !GetState (States.CommandDisabled))
                 OnEnabledChanged (e);
         }
 

--- a/ModernFormsNext/DataBinding/CommandSource.cs
+++ b/ModernFormsNext/DataBinding/CommandSource.cs
@@ -65,7 +65,15 @@ internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisp
         object? currentParameter = parameter;
         int currentVersion = version;
         if (current is not null && Refresh() && currentVersion == version && owner.Enabled)
-            current.Execute(currentParameter);
+        {
+            // The sealed framework helper can consume this fresh guarded evaluation. Calling
+            // its public Execute would evaluate again outside our fail-closed/version guard.
+            // Arbitrary ICommand implementations retain their own normal Execute contract.
+            if (current is DelegateCommand delegateCommand)
+                delegateCommand.ExecuteCore(currentParameter);
+            else
+                current.Execute(currentParameter);
+        }
     }
 
     private bool Refresh()

--- a/ModernFormsNext/DataBinding/CommandSource.cs
+++ b/ModernFormsNext/DataBinding/CommandSource.cs
@@ -1,0 +1,167 @@
+using System.Windows.Input;
+
+namespace ModernFormsNext.DataBinding;
+
+// One binding behavior for all action sources. Only the subscription callback may arrive from
+// another thread; all source reads, predicate evaluation and state changes occur on the UI thread.
+internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisposable
+{
+    private readonly int ownerThreadId = Environment.CurrentManagedThreadId;
+    private ICommand? command;
+    private object? parameter;
+    private Subscription? subscription;
+    private int version;
+    private bool disposed;
+
+    internal ICommand? Command
+    {
+        get => command;
+        set
+        {
+            VerifyAccess();
+            if (ReferenceEquals(command, value))
+                return;
+
+            subscription?.Dispose();
+            subscription = null;
+            command = value;
+            version++;
+            if (value is not null)
+                subscription = new Subscription(this, value, ownerThreadId);
+            Refresh();
+        }
+    }
+
+    internal object? Parameter
+    {
+        get => parameter;
+        set
+        {
+            VerifyAccess();
+            if (ReferenceEquals(parameter, value))
+                return;
+
+            parameter = value;
+            version++;
+            Refresh();
+        }
+    }
+
+    internal bool CanExecute()
+    {
+        VerifyAccess();
+        return Refresh() && owner.Enabled;
+    }
+
+    internal void Execute()
+    {
+        VerifyAccess();
+        if (!owner.Enabled)
+            return;
+
+        // Click handlers can replace the command or parameter. Snapshot only after Click, then
+        // reject the snapshot if predicate/EnabledChanged callbacks mutate the binding again.
+        ICommand? current = command;
+        object? currentParameter = parameter;
+        int currentVersion = version;
+        if (current is not null && Refresh() && currentVersion == version && owner.Enabled)
+            current.Execute(currentParameter);
+    }
+
+    private bool Refresh()
+    {
+        if (disposed || owner.IsCommandSourceDisposed)
+            return false;
+
+        int currentVersion = version;
+        bool available;
+        try
+        {
+            available = command?.CanExecute(parameter) ?? true;
+        }
+        catch
+        {
+            // Keep the assignment and its subscription so a later notification/removal can
+            // recover. Never expose a throwing predicate in the Enabled getter.
+            if (!disposed && !owner.IsCommandSourceDisposed && version == currentVersion)
+                owner.SetCommandEnabled(false);
+            throw;
+        }
+
+        if (disposed || owner.IsCommandSourceDisposed || version != currentVersion)
+            return false;
+
+        owner.SetCommandEnabled(available);
+        return available && !disposed && !owner.IsCommandSourceDisposed && version == currentVersion;
+    }
+
+    private void Requery(Subscription sender)
+    {
+        // Event invocation lists and dispatcher queues can outlive detach. Identity, not the
+        // command's Equals implementation or event sender, identifies the current attachment.
+        if (disposed || owner.IsCommandSourceDisposed || !ReferenceEquals(subscription, sender))
+            return;
+        VerifyAccess();
+        Refresh();
+    }
+
+    private void VerifyAccess()
+    {
+        ObjectDisposedException.ThrowIf(disposed || owner.IsCommandSourceDisposed, owner);
+        if (Environment.CurrentManagedThreadId != ownerThreadId)
+            throw new InvalidOperationException("Command source state must be accessed on its owning UI thread.");
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+        disposed = true;
+        version++;
+        subscription?.Dispose();
+        subscription = null;
+        command = null;
+        parameter = null;
+    }
+
+    private sealed class Subscription
+    {
+        private readonly WeakReference<CommandSource> target;
+        private readonly int ownerThreadId;
+        private ICommand? command;
+
+        internal Subscription(CommandSource target, ICommand command, int ownerThreadId)
+        {
+            this.target = new WeakReference<CommandSource>(target);
+            this.command = command;
+            this.ownerThreadId = ownerThreadId;
+            command.CanExecuteChanged += OnCanExecuteChanged;
+        }
+
+        internal void Dispose()
+        {
+            ICommand? previous = Interlocked.Exchange(ref command, null);
+            if (previous is not null)
+                previous.CanExecuteChanged -= OnCanExecuteChanged;
+        }
+
+        private void OnCanExecuteChanged(object? sender, EventArgs e)
+        {
+            if (Environment.CurrentManagedThreadId == ownerThreadId)
+                Deliver();
+            else
+                // Do not capture the source/control/parameter in queued work. Resolve the
+                // application's dispatcher here, after backend startup, instead of caching a
+                // fallback dispatcher when an unattached control is constructed.
+                Application.RunOnUIThread(Deliver);
+        }
+
+        private void Deliver()
+        {
+            if (target.TryGetTarget(out CommandSource? source))
+                source.Requery(this);
+            else
+                Dispose();
+        }
+    }
+}

--- a/ModernFormsNext/DataBinding/ICommandBindingTargetProvider.cs
+++ b/ModernFormsNext/DataBinding/ICommandBindingTargetProvider.cs
@@ -1,129 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Windows.Input;
 
-namespace ModernFormsNext.DataBinding
+namespace ModernFormsNext.DataBinding;
+
+// Shared by visual and non-visual action sources. CommandSource centralizes binding behavior;
+// each source retains local Enabled intent instead of letting requery overwrite that intent.
+internal interface ICommandBindingTargetProvider
 {
-    internal interface ICommandBindingTargetProvider
-    {
-        /// <summary>
-        ///  Occurs when the <see cref="Command"/> property has changed.
-        /// </summary>
-        event EventHandler? CommandChanged;
-
-        /// <summary>
-        ///  Occurs when the execution context of the <see cref="Command"/> was changed.
-        /// </summary>
-        event EventHandler? CommandCanExecuteChanged;
-
-        /// <summary>
-        ///  Gets or sets the Command to invoke, when the implementing Component or Control is triggered by the user.
-        /// </summary>
-        ICommand? Command { get; set; }
-
-        /// <summary>
-        ///  Gets or sets the CommandParameter for the Component or Control.
-        /// </summary>
-        object? CommandParameter { get; set; }
-
-        /// <summary>
-        ///  Gets or sets a value indicating whether the control can respond to user interaction.
-        /// </summary>
-        bool Enabled { get; set; }
-
-        /// <summary>
-        ///  Gets or sets the previous value of the <see cref="Enabled"/> property, so that it can be restored to
-        ///  its original value on assignment of a new command.
-        /// </summary>
-        protected bool? PreviousEnabledStatus { get; set; }
-
-        /// <summary>
-        ///  An implementation should raise the <see cref="CommandChanged"/> event  by calling component's or
-        ///  control's OnRaiseCommandChanged method.
-        /// </summary>
-        /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-        protected void RaiseCommandChanged(EventArgs e);
-
-        /// <summary>
-        ///  An implementation should raise the <see cref="CommandCanExecuteChanged"/> event
-        ///  by calling component's or control's OnCommandCanExecuteChanged method.
-        /// </summary>
-        /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-        protected void RaiseCommandCanExecuteChanged(EventArgs e);
-
-        /// <summary>
-        ///  Method which should be called by a class implementing this interface in the setter of the
-        ///  <see cref="Command"/> property.
-        /// </summary>
-        /// <param name="commandComponent">Instance of the class implementing this interface.</param>
-        /// <param name="newCommand">The new value of the <see cref="Command"/>
-        /// which should be assigned to the property.</param>
-        /// <param name="commandBackingField">
-        ///  The backing field for the <see cref="Command"/> property.
-        /// </param>
-        protected static void CommandSetter(
-            ICommandBindingTargetProvider commandComponent,
-            ICommand? newCommand,
-            ref ICommand? commandBackingField)
-            => commandComponent.CommandSetter(newCommand, ref commandBackingField);
-
-        /// <summary>
-        ///  Method which should be called by the class implementing this interface, when the assigned
-        ///  <see cref="Command"/> should be executed.
-        /// </summary>
-        /// <remarks>
-        ///  <para>
-        ///   As an example, a <see cref="Button"/> should call this method from the same
-        ///   activation path that raises <see cref="Control.Click"/>.
-        ///  </para>
-        /// </remarks>
-        /// <param name="commandComponent"></param>
-        protected static void RequestCommandExecute(ICommandBindingTargetProvider commandComponent)
-        {
-            commandComponent.Command?.Execute(commandComponent.CommandParameter);
-        }
-
-        private void CommandSetter(
-            ICommand? newCommand,
-            ref ICommand? commandBackingField)
-        {
-            if (!Equals(commandBackingField, newCommand))
-            {
-                if (commandBackingField is not null)
-                {
-                    commandBackingField.CanExecuteChanged -= CommandCanExecuteChangedProc;
-
-                    // We need to restore Enabled, should we go from a defined Command to an undefined Command.
-                    if (newCommand is null)
-                    {
-                        if (PreviousEnabledStatus.HasValue)
-                        {
-                            Enabled = PreviousEnabledStatus.Value;
-                            PreviousEnabledStatus = null;
-                        }
-                    }
-                }
-
-                commandBackingField = newCommand;
-                RaiseCommandChanged(EventArgs.Empty);
-
-                if (commandBackingField is null)
-                {
-                    return;
-                }
-
-                commandBackingField.CanExecuteChanged += CommandCanExecuteChangedProc;
-                PreviousEnabledStatus ??= Enabled;
-                Enabled = commandBackingField.CanExecute(CommandParameter);
-            }
-        }
-
-        private void CommandCanExecuteChangedProc([AllowNull] object sender, EventArgs e)
-        {
-            RaiseCommandCanExecuteChanged(e);
-            Enabled = Command?.CanExecute(CommandParameter) ?? false;
-        }
-    }
+    ICommand? Command { get; set; }
+    object? CommandParameter { get; set; }
+    bool Enabled { get; }
+    bool IsCommandSourceDisposed { get; }
+    void SetCommandEnabled(bool enabled);
 }

--- a/ModernFormsNext/DelegateCommand.cs
+++ b/ModernFormsNext/DelegateCommand.cs
@@ -80,8 +80,13 @@ public sealed class DelegateCommand : ICommand
     public void Execute(object? parameter)
     {
         if (CanExecute(parameter))
-            execute(parameter);
+            ExecuteCore(parameter);
     }
+
+    // Framework sources have just evaluated availability and verified their binding snapshot.
+    // Do not introduce another predicate callback after that guard. Direct ICommand callers
+    // still use Execute above and receive its availability check.
+    internal void ExecuteCore(object? parameter) => execute(parameter);
 
     /// <summary>
     /// Notifies subscribers that they should reevaluate <see cref="CanExecute"/>.

--- a/ModernFormsNext/DelegateCommand.cs
+++ b/ModernFormsNext/DelegateCommand.cs
@@ -1,0 +1,96 @@
+using System.Windows.Input;
+
+namespace ModernFormsNext;
+
+/// <summary>
+/// Represents a reusable application action implemented by delegates.
+/// </summary>
+/// <remarks>
+/// This is a synchronous <see cref="ICommand"/> implementation. Delegates and event handlers run
+/// on the calling thread; their original exceptions propagate to the caller. Call
+/// <see cref="RaiseCanExecuteChanged"/> after availability changes. There is no automatic polling.
+/// A command can be shared by several sources with different parameters. The command owns its
+/// delegate references, but does not own or dispose the objects captured by those delegates.
+/// Do not pass async lambdas to the action constructors; task-aware helpers are deferred.
+/// </remarks>
+/// <example>
+/// <code>
+/// bool canSave = true;
+/// var save = new DelegateCommand(p => Console.WriteLine(p), p => canSave);
+/// var button = new Button { Text = "Save", Command = save, CommandParameter = "Document" };
+/// canSave = false;
+/// save.RaiseCanExecuteChanged();
+/// </code>
+/// </example>
+public sealed class DelegateCommand : ICommand
+{
+    private readonly Action<object?> execute;
+    private readonly Predicate<object?>? canExecute;
+
+    /// <summary>
+    /// Initializes a command whose delegates do not require a parameter.
+    /// </summary>
+    /// <param name="execute">The action to perform when execution is allowed.</param>
+    /// <param name="canExecute">The availability predicate, or null to always allow execution.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="execute"/> is null.</exception>
+    public DelegateCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        ArgumentNullException.ThrowIfNull(execute);
+        this.execute = _ => execute();
+        this.canExecute = canExecute is null ? null : _ => canExecute();
+    }
+
+    /// <summary>
+    /// Initializes a command whose delegates receive the source's current parameter.
+    /// </summary>
+    /// <param name="execute">The action to perform; its parameter may be null.</param>
+    /// <param name="canExecute">The parameter-aware predicate, or null to always allow execution.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="execute"/> is null.</exception>
+    public DelegateCommand(Action<object?> execute, Predicate<object?>? canExecute = null)
+    {
+        ArgumentNullException.ThrowIfNull(execute);
+        this.execute = execute;
+        this.canExecute = canExecute;
+    }
+
+    /// <summary>
+    /// Occurs when sources should reevaluate availability with their own current parameters.
+    /// </summary>
+    public event EventHandler? CanExecuteChanged;
+
+    /// <summary>
+    /// Evaluates availability without executing the action.
+    /// </summary>
+    /// <param name="parameter">The source parameter, which may be null.</param>
+    /// <returns>The predicate result, or true when no predicate was supplied.</returns>
+    /// <remarks>
+    /// The predicate should be fast and free of side effects. Sources may call it more than once
+    /// during activation. Predicate exceptions propagate unchanged.
+    /// </remarks>
+    public bool CanExecute(object? parameter) => canExecute?.Invoke(parameter) ?? true;
+
+    /// <summary>
+    /// Executes the action if <see cref="CanExecute"/> currently returns true.
+    /// </summary>
+    /// <param name="parameter">The source parameter, which may be null.</param>
+    /// <remarks>
+    /// A false predicate makes this call a no-op. Predicate and action exceptions propagate
+    /// unchanged. This method does not schedule work or raise <see cref="CanExecuteChanged"/>.
+    /// </remarks>
+    public void Execute(object? parameter)
+    {
+        if (CanExecute(parameter))
+            execute(parameter);
+    }
+
+    /// <summary>
+    /// Notifies subscribers that they should reevaluate <see cref="CanExecute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Uses normal synchronous .NET event semantics: a throwing subscriber stops notification
+    /// and its exception propagates. Framework command sources marshal notifications received
+    /// on a background thread through the existing UI dispatcher; a running UI loop is required
+    /// to process those notifications. This method itself does not synchronize application state.
+    /// </remarks>
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/ModernFormsNext/NotifyIconMenuItem.cs
+++ b/ModernFormsNext/NotifyIconMenuItem.cs
@@ -1,5 +1,7 @@
 using System;
 using System.ComponentModel;
+using System.Windows.Input;
+using ModernFormsNext.DataBinding;
 
 namespace ModernFormsNext
 {
@@ -16,13 +18,58 @@ namespace ModernFormsNext
     /// var item = new NotifyIconMenuItem("Open", (_, _) => mainForm.Show());
     /// </code>
     /// </example>
-    public class NotifyIconMenuItem : Component
+    public class NotifyIconMenuItem : Component, ICommandBindingTargetProvider
     {
         private bool checked_value;
         private bool enabled = true;
         private bool disposed;
         private NotifyIconMenuItemCollection? items;
         private string text = string.Empty;
+        private CommandSource? commandSource;
+        private bool commandEnabled = true;
+
+        /// <summary>
+        /// Gets or sets the command executed after <see cref="Click"/> on activation.
+        /// </summary>
+        /// <remarks>
+        /// Assign on the UI thread. Null preserves event-only behavior. The item shares Button's
+        /// command binding behavior: parameter-aware availability, background requery through the
+        /// UI dispatcher, and detach on replacement/removal/disposal. Predicate exceptions disable
+        /// the item and propagate unchanged; later requery or removal can recover it. The command
+        /// is not owned or disposed by the item. Open native menus retain their existing snapshot
+        /// behavior; activation still rechecks availability. Designer serialization is deferred.
+        /// </remarks>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ICommand? Command {
+            get => commandSource?.Command;
+            set {
+                ThrowIfDisposed();
+                (commandSource ??= new CommandSource(this)).Command = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the nullable parameter used to evaluate and execute <see cref="Command"/>.
+        /// </summary>
+        /// <remarks>
+        /// Assign on the UI thread. A different reference immediately reevaluates availability.
+        /// Mutating the same object requires the command's CanExecuteChanged notification.
+        /// Execution uses the current parameter after Click. Disposal releases, but does not
+        /// dispose, the parameter. Predicate exceptions follow <see cref="Command"/> semantics.
+        /// </remarks>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public object? CommandParameter {
+            get => commandSource?.Parameter;
+            set {
+                ThrowIfDisposed();
+                (commandSource ??= new CommandSource(this)).Parameter = value;
+            }
+        }
+
+        bool ICommandBindingTargetProvider.IsCommandSourceDisposed => disposed;
+        void ICommandBindingTargetProvider.SetCommandEnabled(bool value) => commandEnabled = value;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NotifyIconMenuItem"/> class.
@@ -69,8 +116,13 @@ namespace ModernFormsNext
         /// <summary>
         /// Gets or sets a value indicating whether the item can be selected.
         /// </summary>
+        /// <remarks>
+        /// Set on the UI thread. The setter records local intent; the getter combines it with
+        /// command availability. Requery never overwrites a locally assigned false value.
+        /// Native menus read this effective state when their snapshot is constructed.
+        /// </remarks>
         public bool Enabled {
-            get => enabled;
+            get => enabled && commandEnabled;
             set {
                 ThrowIfDisposed ();
                 enabled = value;
@@ -117,6 +169,11 @@ namespace ModernFormsNext
         /// <summary>
         /// Programmatically raises the <see cref="Click"/> event when the item is enabled.
         /// </summary>
+        /// <remarks>
+        /// Call on the UI thread. Separators do nothing. An available command runs after Click,
+        /// using the current binding and parameter and a fresh CanExecute check. Click, predicate
+        /// and execute exceptions propagate unchanged. A Click exception prevents execution.
+        /// </remarks>
         public void PerformClick ()
         {
             ThrowIfDisposed ();
@@ -135,8 +192,10 @@ namespace ModernFormsNext
         /// </param>
         protected override void Dispose (bool disposing)
         {
-            if (disposing)
+            if (disposing) {
+                commandSource?.Dispose();
                 disposed = true;
+            }
 
             base.Dispose (disposing);
         }
@@ -145,7 +204,17 @@ namespace ModernFormsNext
         /// Raises the <see cref="Click"/> event.
         /// </summary>
         /// <param name="e">The event data.</param>
-        protected virtual void OnClick (EventArgs e) => Click?.Invoke (this, e);
+        protected virtual void OnClick (EventArgs e)
+        {
+            if (disposed || !Enabled || Separator)
+                return;
+            if (commandSource is not null && !commandSource.CanExecute())
+                return;
+
+            Click?.Invoke(this, e);
+            if (!disposed && Enabled)
+                commandSource?.Execute();
+        }
 
         private void ThrowIfDisposed ()
         {

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ for bundle contents and local validation.
 - [UI animations and interaction effects](docs/animations.md)
 - [Markdown viewing](docs/markdown.md) and [Markdown editing](docs/markdown-editor.md)
 - [Data binding](docs/data-binding.md)
+- [Commands and action sources](docs/commands.md)
 - [Styling](docs/styling.md)
 - [Platform-specific architecture](docs/platform-specific-code.md) and
   [platform-specific features](docs/platform-specific-features.md)

--- a/docs-site/toc.yml
+++ b/docs-site/toc.yml
@@ -18,6 +18,8 @@
   href: content/docs/samples.md
 - name: Headless testing
   href: content/docs/testing/testhost.md
+- name: Commands and action sources
+  href: content/docs/commands.md
 - name: Accessibility semantic model
   href: content/docs/accessibility/semantic-model.md
 - name: Android accessibility backend

--- a/docs/commands-phase1-audit.md
+++ b/docs/commands-phase1-audit.md
@@ -1,0 +1,32 @@
+# Issue #56 Phase 1 audit
+
+Baseline: `b290a13da297401c93879b32f755b03a84a2c776` (master and origin/master).
+Scope: command foundation only. Issue #56 remains open.
+
+| Area | Existing behavior | Missing for Phase 1 | Proposed change |
+| --- | --- | --- | --- |
+| ICommand | `DataBinding/ICommandBindingTargetProvider.cs` contains an internal default-interface implementation, but no type implements it at this baseline. The issue's statement that selected controls already expose ICommand is not reflected in this checkout. | A working public consumer and safe lifecycle. | Evolve this binding path into a shared source helper; retain System.Windows.Input.ICommand. |
+| Existing Command | Internal `DataBinding.Command` is a weak native-style ID registry for the public `ICommandExecutor` contract. It is not an application ICommand implementation. | Reusable delegate-based application actions. | Add only `DelegateCommand`; leave the ID registry and ICommandExecutor intact. |
+| Subscription / execution | The unused helper subscribes directly, restores a saved Enabled value on removal, and calls Execute without CanExecute. No disposal, parameter requery, or dispatcher handling is wired to a control. | Deterministic replacement, removal, disposal, parameter evaluation and action-time guards. | Centralize these responsibilities in the existing DataBinding area. Use weak event subscriptions plus explicit detach. |
+| Enabled | Control stores local intent in States.Enabled and combines it with Parent.Enabled. The unused helper overwrites local intent. The setter compares old effective state with the requested local value. | Independent command availability, correct effective notifications. | Preserve the local bit; add a command-disabled bit and compare effective values after changes. |
+| Button | No Command/CommandParameter. OnClick applies DialogResult then raises Click. PerformClick calls OnClick; Space/Enter and semantic accessibility Invoke use PerformClick. | Reference command source. | Add properties, preserve DialogResult/Click order, run current command after Click with availability checks. |
+| Menu / ToolBar / Ribbon / ContextMenu | Share MenuItem, which has Click and owner-dependent Enabled, but no IDisposable lifecycle. | Command lifetime cannot safely be added as a tiny property-only change. | Defer to Phase 4 rather than redesign ownership in Phase 1. |
+| Tray menu | NotifyIconMenuItem has explicit Component disposal and guarded PerformClick. Backend uses that path. | Small representative non-Control action source is feasible. | Reuse the same helper, keeping native menu snapshot behavior unchanged. |
+| Threading / errors | Application.RunOnUIThread posts to WindowKit's dispatcher; direct action exceptions propagate. | Marshal background requery without changing the exception policy. | Post notifications to the existing dispatcher; preserve original exceptions and recoverable fail-closed CanExecute state. |
+| Accessibility | Shared Button peer exposes Invoke and unavailable state; Windows UIA and Android adapters consume shared semantics and PerformAction. | Command-backed regression evidence. | Test this normal action path without changing #59 architecture. |
+| TestHost | Existing ModernFormsTestHost can show controls and explicitly drain its dispatcher. | Consumer command/threading regression. | Add ordinary tests, no input simulation or new host facilities. |
+| Designer / editor actions | DesignerCommandService, VS command targets and MarkdownEditor commands are separate existing features. | Nothing in this phase. | Leave them unchanged. No Ctrl+S fix, serialization, routing, or shortcuts. |
+
+## API decisions
+
+One sealed public `DelegateCommand` implements System.Windows.Input.ICommand. Parameterless
+Action/Func<bool> and parameter-aware Action<object?>/Predicate<object?> overloads cover Phase 1.
+There is no second ICommand, public Command alias, generic conversion policy, command target,
+global manager, routed binding, or async helper. Generic commands are deferred until there is a
+concrete consumer that justifies additional nullability and conversion contracts.
+
+Button is the reference source; NotifyIconMenuItem is the representative non-Control consumer.
+The shared internal helper evolves the unused ICommandBindingTargetProvider path, so there is one
+implementation of parameter requery, subscription lifetime and execution checks.
+
+See [commands.md](commands.md) for the final public contract and examples.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -81,8 +81,15 @@ accessibility Invoke converge on the same normal action path:
 
 Click handlers can replace/remove the command, change its parameter, disable or dispose the
 source. Those changes are respected. A Click handler that throws stops execution. A predicate
-that changes the binding during evaluation invalidates that evaluation; an obsolete binding is
-never executed. Predicates should not rely on such reentrancy as an application design pattern.
+that changes the binding during a source's evaluation invalidates that evaluation; the source
+does not execute its obsolete snapshot. Predicates should not rely on such reentrancy as an
+application design pattern. Application ICommand implementations remain responsible for callbacks
+and state changes inside their own Execute method.
+
+Click precedes execution to preserve the event-based action path and let handlers update or cancel
+the pending command. Executing first would make such changes too late; suppressing Click whenever
+a command is assigned would break event subscribers. Put a reusable application action in Command;
+do not perform the same action again in Click. The framework does not deduplicate application code.
 
 Only left-button activation executes Button commands. Existing right-click/context-menu behavior
 does not execute the command. Programmatic PerformClick does not require visibility; native input
@@ -91,10 +98,17 @@ now does nothing, closing the previous programmatic bypass of the normal disable
 No public member is removed or renamed. NotifyIconMenuItem.PerformClick retains its existing
 ObjectDisposedException behavior after disposal, and separators never activate.
 
-`DelegateCommand.Execute` also checks CanExecute for callers that invoke it directly. Sources
-check availability independently so arbitrary ICommand implementations work safely. Consequently
-a DelegateCommand predicate may run multiple times during activation. Neither the helper nor the
-source assumes an application ICommand finishes its external work when Execute returns.
+For an unchanged, available binding, the source evaluates CanExecute once before Click and once
+after Click. Assignments and notifications during Click can cause additional evaluations.
+`DelegateCommand.Execute` checks CanExecute once for callers that invoke it directly. Framework
+sources use an internal action entry point after their own fresh check, avoiding a redundant third
+evaluation outside the source's binding/exception guard. Arbitrary ICommand implementations receive
+the normal Execute call and may perform their own checks.
+
+The post-Click check closes the gap caused by synchronous Click mutations, including availability
+changes without a notification. It is not an atomic transaction with application state on other
+threads. Neither the helper nor the source assumes an application ICommand finishes its external
+work when Execute returns.
 
 ## Lifetime and exceptions
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,6 +143,9 @@ This semantic path is the existing extension point for future #97 consumers.
 `CommandTests`, `CommandSourceTests`, the command regression in `AccessibilitySemanticTests`, and
 `CommandSourceHostTests` cover the public behavior. Host tests explicitly drain the existing
 dispatcher; no timing sleeps, GC timing assertions, input simulator or new TestHost API is used.
+The existing Windows HWND/UIA integration host also exercises a command-backed Button and a
+disabled command source. Android provider tests invoke a real Button through the existing shared
+surface/session adapter. These automated checks do not claim manual TalkBack or visual validation.
 
 Run `dotnet run --project samples/ControlGallery/ControlGallery.csproj` and open **Button**. The
 small command section has two buttons sharing one command, separate document parameters, a shared

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,164 @@
+# Commands (issue #56, Phase 1)
+
+Commands represent reusable application actions. `System.Windows.Input.ICommand` is the contract:
+existing application implementations can be assigned directly. `ModernFormsNext.DelegateCommand`
+is the optional synchronous implementation provided by the framework. Events remain supported;
+an application can use `button.Click` without creating any command.
+
+This phase provides delegate commands, parameters, availability and two action sources: `Button`
+and `NotifyIconMenuItem`. Issue #56 remains open. Keyboard gestures, routed commands, scopes,
+async helpers and Designer integration are **not implemented by this phase**.
+
+## Define once, reuse with different parameters
+
+```csharp
+using ModernFormsNext;
+using System.Windows.Input;
+
+bool canSave = true;
+var save = new DelegateCommand(
+    execute: parameter => Console.WriteLine($"Save {parameter}"),
+    canExecute: parameter => canSave && parameter is string);
+
+var first = new Button {
+    Text = "Save first", CommandParameter = "First document", Command = save
+};
+var second = new Button {
+    Text = "Save second", CommandParameter = "Second document", Command = save
+};
+var trayItem = new NotifyIconMenuItem("Save first") {
+    CommandParameter = "First document", Command = save
+};
+
+canSave = false;
+save.RaiseCanExecuteChanged(); // Each source reevaluates using its own parameter.
+
+ICommand compatible = save;
+```
+
+For actions without parameters, use `new DelegateCommand(() => Save(), () => CanSave)`.
+The parameter-aware overload takes `Action<object?>` and `Predicate<object?>`. Both constructors
+reject a null execute delegate. A missing predicate means the command is available. Parameter
+values, including null, are passed without reflection or conversion; applications validate the
+types they accept in their predicate. There is no generic command or separate public `Command`
+alias in Phase 1. The unrelated internal `DataBinding.Command` ID registry is unchanged.
+
+## Availability and enabled intent
+
+For a Button:
+
+```text
+effective Enabled = local Enabled intent AND parent Enabled AND command availability
+```
+
+The public setter records local intent. Its getter returns the effective value; it does not call
+`CanExecute`. Assigning `Enabled = false` remains effective across requery, command replacement
+and removal. Assigning `Enabled = true` cannot override an unavailable command or disabled parent.
+`NotifyIconMenuItem` similarly combines local intent with command availability, preserving its
+existing non-Control parent semantics. Open native tray menus keep their existing snapshot
+behavior; execution is still guarded against a command that has become unavailable.
+
+The source reevaluates when a different Command or CommandParameter reference is assigned,
+when it receives CanExecuteChanged, and during an otherwise enabled activation. Assigning the
+same reference is a no-op. If a parameter object changes internally, raise CanExecuteChanged.
+Removing the command removes its availability restriction; the local enabled intent remains.
+The parameter stays assigned for reuse until replaced or the source is disposed.
+
+Predicates should be fast, free of side effects, and tolerate repeated evaluation. There is no
+polling, per-frame evaluation, global requery event or CommandManager. State changes update the
+existing rendering, focus, descendant-enabled and accessibility notification paths. They do not
+request a new layout policy. Existing mouse/keyboard disabled-state guards still apply.
+
+## Activation and event order
+
+Button pointer activation, existing Space/Enter activation, `PerformClick()` and semantic
+accessibility Invoke converge on the same normal action path:
+
+1. Ignore disabled or disposed sources. Check the current command's CanExecute before Click.
+2. Apply the Button's existing DialogResult behavior, then raise Click.
+3. If the source is still alive and enabled, reevaluate the **current** command and parameter and
+   execute it when available.
+
+Click handlers can replace/remove the command, change its parameter, disable or dispose the
+source. Those changes are respected. A Click handler that throws stops execution. A predicate
+that changes the binding during evaluation invalidates that evaluation; an obsolete binding is
+never executed. Predicates should not rely on such reentrancy as an application design pattern.
+
+Only left-button activation executes Button commands. Existing right-click/context-menu behavior
+does not execute the command. Programmatic PerformClick does not require visibility; native input
+and accessibility retain their existing visibility checks. Disabled/disposed Button.PerformClick
+now does nothing, closing the previous programmatic bypass of the normal disabled input guard.
+No public member is removed or renamed. NotifyIconMenuItem.PerformClick retains its existing
+ObjectDisposedException behavior after disposal, and separators never activate.
+
+`DelegateCommand.Execute` also checks CanExecute for callers that invoke it directly. Sources
+check availability independently so arbitrary ICommand implementations work safely. Consequently
+a DelegateCommand predicate may run multiple times during activation. Neither the helper nor the
+source assumes an application ICommand finishes its external work when Execute returns.
+
+## Lifetime and exceptions
+
+Sources subscribe once per command reference. Replacement, removal and disposal detach the old
+handler; stale invocation lists and queued old notifications cannot affect the new binding.
+Event subscriptions hold a weak reference to the source behavior, so a long-lived command does
+not keep an abandoned control alive. Explicit disposal still provides deterministic detach.
+Disposal releases command and parameter references without disposing either object. A shared
+command remains usable by the other sources. The command retains its own delegates/captures for
+its lifetime; application-owned event subscriptions retain normal .NET ownership semantics.
+
+Execute and Click exceptions propagate unchanged through the calling action path. CanExecute
+exceptions likewise propagate, but first make the receiving source unavailable. The command and
+parameter assignment remain installed; a successful later requery, different assignment or
+command removal restores a usable state. Enabled getters remain safe, cached state reads even
+after a failing predicate. There is no catch-all error bus, wrapping or silent failure.
+
+RaiseCanExecuteChanged uses ordinary synchronous multicast-event semantics. A throwing subscriber
+stops that invocation list; later subscribers may not refresh until the next notification. Every
+activation still checks availability. Exceptions in work posted by a background notification go
+through the existing dispatcher exception path, on the UI thread rather than the raising thread.
+
+## Threading and asynchronous work
+
+Create/bind, change parameters/Enabled, activate and dispose sources on their owning UI thread.
+UI-thread CanExecuteChanged is handled synchronously. Background CanExecuteChanged is posted via
+`Application.RunOnUIThread`; the application UI loop must be initialized and running to process
+it. The callback evaluates the current parameter on that UI thread. Notifications pending at
+replacement or disposal are ignored. The helper does not synchronize application data accessed
+by predicates or action delegates; use the application's existing synchronization rules.
+
+`DelegateCommand` is synchronous. Do not pass async lambdas to its Action constructors: those
+would be async void. Task-aware commands, execution state, cancellation and async exception
+helpers belong to Phase 4. Existing application ICommand implementations can start tracked work,
+update their own availability and publish CanExecuteChanged; this foundation adds no execution
+lock, global execution state or dispatcher subsystem that such implementations must adopt.
+
+## Accessibility, testing and samples
+
+An available command-backed Button still exposes semantic Invoke. Unavailable commands map to
+the existing disabled/unavailable state and cannot be invoked. Shared accessibility action
+handling calls PerformClick, so Windows UIA and Android accessibility consume the same normal
+Button/command path. Phase 1 adds no accessibility architecture or agent automation bridge.
+This semantic path is the existing extension point for future #97 consumers.
+
+`CommandTests`, `CommandSourceTests`, the command regression in `AccessibilitySemanticTests`, and
+`CommandSourceHostTests` cover the public behavior. Host tests explicitly drain the existing
+dispatcher; no timing sleeps, GC timing assertions, input simulator or new TestHost API is used.
+
+Run `dotnet run --project samples/ControlGallery/ControlGallery.csproj` and open **Button**. The
+small command section has two buttons sharing one command, separate document parameters, a shared
+availability checkbox and an explicit-disable checkbox for the first button. Check enabled,
+hover, pressed and keyboard-focus rendering in the existing light/dark themes. This example does
+not modify DemoApp or the generated template experience.
+
+## Deferred work
+
+- Phase 2: KeyGesture, KeyBinding, InputBinding, shortcut precedence and window/application scopes.
+- Phase 3: command targets, hierarchical routing, CommandBinding and diagnostics.
+- Phase 4: task-aware async helpers, deeper menu/toolbar/context-menu integration, Designer
+  assignment/serialization, and expanded examples/documentation.
+
+MenuItem ownership/lifecycle requires separate work before safe event subscriptions can be added
+across Menu, ToolBar, Ribbon and ContextMenu. Command properties on the Phase 1 sources are hidden
+from design-time browsing/serialization. There is no Designer Ctrl+S fix, BindingNavigator port,
+Developer Tools integration, automation bridge, new keyboard shortcut system, release or version
+bump in this phase. See the [baseline audit](commands-phase1-audit.md).

--- a/samples/ControlGallery/Panels/ButtonPanel.cs
+++ b/samples/ControlGallery/Panels/ButtonPanel.cs
@@ -178,6 +178,31 @@ namespace ControlGallery.Panels
             RenderManager.SetRenderer<MyCustomRenderedButton> (new MyCustomRenderer ());
 
             Controls.Add (new Button { Text = "Text that is too long to fit in the button", Left = 350, Top = 300, AutoEllipsis = true });
+
+            // Two sources share one action, while each supplies its own parameter. Requery is
+            // explicit and updates both sources through the normal enabled-state path.
+            var availability = Controls.Add(new CheckBox {
+                Text = "Allow shared command", Left = 100, Top = 440, Width = 260, Checked = true
+            });
+            var status = Controls.Add(new Label {
+                Text = "Choose a document", Left = 100, Top = 520, Width = 500, Height = 32
+            });
+            var save = new DelegateCommand(
+                parameter => status.Text = $"Executed: {parameter}",
+                parameter => availability.Checked && parameter is string);
+            var saveFirst = Controls.Add(new Button {
+                Text = "Save first", Left = 100, Top = 480, Width = 140,
+                CommandParameter = "First document", Command = save
+            });
+            Controls.Add(new Button {
+                Text = "Save second", Left = 260, Top = 480, Width = 140,
+                CommandParameter = "Second document", Command = save
+            });
+            availability.CheckedChanged += (_, _) => save.RaiseCanExecuteChanged();
+            var locallyDisabled = Controls.Add(new CheckBox {
+                Text = "Explicitly disable first", Left = 390, Top = 440, Width = 260
+            });
+            locallyDisabled.CheckedChanged += (_, _) => saveFirst.Enabled = !locallyDisabled.Checked;
         }
     }
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of #56 — the runtime command foundation. Applications can define one action, share it between buttons and tray items with different parameters, and update availability without overwriting explicit local disabled state.

## Architecture

Retains `System.Windows.Input.ICommand` and adds the optional synchronous `DelegateCommand`. One internal `DataBinding.CommandSource` centralizes execution guards, parameter requery, weak subscriptions, disposal and dispatcher handling through the simplified existing `ICommandBindingTargetProvider` path. There is no second ICommand abstraction or routed command system.

## Controls

`Button` and `NotifyIconMenuItem` expose `Command` and `CommandParameter`; normal events remain supported. Tray integration uses existing Component disposal and native menu snapshot behavior. Regular menu/toolbar ownership changes are deferred. The existing ControlGallery Button page demonstrates two shared sources, distinct parameters, availability and explicit disabled intent. DemoApp and templates are unchanged.

## Behavior

- Activation checks availability, preserves Button's existing DialogResult behavior, raises Click, then reevaluates and executes the current command/parameter. Click can replace/remove the binding, change availability or parameters, disable or dispose the source. Throwing Click handlers prevent execution.
- An unchanged available binding evaluates CanExecute once before and once after Click. Assignments/notifications may add evaluations. Direct `DelegateCommand.Execute` checks once; framework sources use an internal action core after their guarded check to avoid a redundant third predicate callback. Predicates must be fast and free of side effects.
- A binding change during a source predicate invalidates that evaluation. The fresh post-Click check handles synchronous availability changes; it does not make background application state atomic. Custom ICommand implementations retain responsibility for their own Execute callbacks.
- Effective Button Enabled combines local intent, parent state and command availability. Requery never overwrites local false. Disabled/disposed Button.PerformClick is now a documented no-op.
- Changed parameter references reevaluate immediately. Replacement, removal and disposal detach subscriptions; stale queued notifications are ignored. Background CanExecuteChanged uses the existing UI dispatcher.
- Original exceptions propagate. Predicate failures first disable the receiving source; later requery, assignment or removal can recover. Enabled getters read cached state. Async lambdas must not be passed to synchronous Action constructors.

XML docs, `docs/commands.md`, the baseline audit, README and documentation navigation describe these contracts and limits.

## Validation

Validated commit `eba5d3fa8bd29b0e9c887c644720fc6cb59b4c0f` on Windows, using SDK 10.0.400 allowed by the existing global.json roll-forward policy.

| Suite | Debug | Release |
| --- | ---: | ---: |
| ModernFormsNext.Tests | 967/967 | 967/967 |
| Designer.Tests | 622/622 | 622/622 |
| Testing.Tests | 53/53 | 53/53 |
| Windows backend | 64/64 | 64/64 |
| Android backend | 155/155 | 155/155 |
| Cross-platform sample tests | 16/16 | 16/16 |
| VSIX tests | 26/26 | 26/26 |
| Total | **1903/1903** | **1903/1903** |

Zero failures/skips in both full runs. Included subsets per configuration: CommandTests 12, CommandSourceTests 45, CommandSourceHostTests 7 (**64 dedicated**); semantic accessibility 32; Windows UIA 54; Android accessibility provider 31 and mapper 52 (**83**).

Restore and full Debug/Release solution builds passed with zero warnings/errors, including Android targets and VSIX artifact validation. ApiCompat against baseline b290a13 passed for both framework TFMs in both configurations (4 comparisons). Documentation script tests passed 32 assertions; DocFX reported zero warnings/errors; all 4 documentation archives passed validation. All 9 NuGet and 8 symbol packages passed validation at unchanged version 1.10.0. `git diff --check` passed.

ControlGallery ran successfully. Existing Windows UIA SelectionItem/Invoke/Toggle patterns passed **8/8 sample steps**, covering both parameters, shared CanExecute transitions and local disabled intent across requery. The app closed normally with empty stderr. PowerShell execution policy was not changed. Manual hover/pressed/theme rendering QA, TalkBack/device interaction and Visual Studio Experimental Instance were **NOT EXECUTED**.

The review regression demonstrated an extra third predicate evaluation in both sources before the fix; all 57 core command/source tests then passed after the fix. No validation artifacts or local configuration are included in this PR.

## Accessibility

Semantic Invoke, Windows UIA Invoke (real HWND and separate client) and Android accessibility Invoke use the normal Button command path. Unavailable commands expose disabled state and cannot execute. Regression tests extend existing adapters without changing the accessibility architecture or adding an automation bridge.

## Deferred

- Phase 2: KeyGesture, KeyBinding, InputBinding, scopes and precedence.
- Phase 3: targets, hierarchical routing, CommandBinding and diagnostics.
- Phase 4: AsyncCommand/helpers, deeper menu/toolbar/context-menu integration and Designer support.

## Issue state

Part of #56 — completes Phase 1 only.

Issue #56 must remain OPEN. Phase 2/3/4 are not started by this PR. No release, tag or version bump.
