### PR TITLE
Add scoped keyboard input bindings and key gestures

### DIFF
--- a/ModernFormsNext.Tests/InputBindingTests.cs
+++ b/ModernFormsNext.Tests/InputBindingTests.cs
@@ -88,6 +88,26 @@ public sealed class InputBindingTests : IDisposable
         Assert.Equal(["inner"], calls);
     }
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void UnavailableInnerBindingsFallThroughToTheFirstAvailableOuterScope(int winningScope)
+    {
+        using var ui = new WindowFixture();
+        var queries = new List<int>();
+        int winner = -1;
+        InputBindingCollection[] scopes = [ui.Focus.InputBindings, ui.Parent.InputBindings, ui.Form.InputBindings, Application.InputBindings];
+        for (int i = 0; i < scopes.Length; i++)
+        {
+            int scope = i;
+            scopes[i].Add(Bind(() => winner = scope, () => { queries.Add(scope); return scope >= winningScope; }));
+        }
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(winningScope, winner);
+        Assert.Equal(Enumerable.Range(0, winningScope + 1), queries);
+    }
+
     [Fact]
     public void FirstAddedAvailableDuplicateWinsAndRemovalRevealsNext()
     {
@@ -197,13 +217,20 @@ public sealed class InputBindingTests : IDisposable
     public void FocusChangeDoesNotRestartLookupAndReleaseCannotClickNewButton()
     {
         using var ui = new WindowFixture();
-        var second = ui.Parent.Controls.Add(new Button { Command = new DelegateCommand(() => Assert.Fail()) });
+        int buttonCalls = 0;
+        var second = ui.Parent.Controls.Add(new Button { Command = new DelegateCommand(() => buttonCalls++) });
         int calls = 0;
         ui.Focus.InputBindings.Add(new KeyBinding(new DelegateCommand(() => { calls++; second.Select(); }), new KeyGesture(Keys.Enter)));
         second.InputBindings.Add(new KeyBinding(new DelegateCommand(() => Assert.Fail()), new KeyGesture(Keys.Enter)));
         Assert.True(ui.Key(Key.Return).Handled);
         Assert.True(second.Selected);
+        ui.Form.KeyUp += (_, e) => e.Handled = false;
         Assert.True(ui.Key(Key.Return, down: false).Handled);
+        Assert.Equal(0, buttonCalls);
+        Assert.Equal(1, calls);
+        second.InputBindings.Clear();
+        ui.Press(Key.Return, RawInputModifiers.None);
+        Assert.Equal(1, buttonCalls); // The consumed release does not swallow a later normal press.
         Assert.Equal(1, calls);
     }
 
@@ -377,9 +404,46 @@ public sealed class InputBindingTests : IDisposable
         global.Diagnostic += (_, _) => Assert.Fail();
         Application.ReleaseInputBindings();
         Assert.Empty(global);
+        global.Report(InputBindingDiagnosticKind.Executed, binding); // Old diagnostic observers were detached.
         Assert.Throws<ObjectDisposedException>(() => global.Add(binding));
         using var control = new Control();
         control.InputBindings.Add(binding);
+    }
+
+    [Fact]
+    public void ApplicationCleanupDoesNotCarryBindingsIntoANewCollection()
+    {
+        using var ui = new WindowFixture();
+        var previous = Application.InputBindings;
+        previous.Add(Bind(() => Assert.Fail()));
+        Application.ReleaseInputBindings();
+        Assert.NotSame(previous, Application.InputBindings);
+        Assert.Empty(Application.InputBindings);
+        Assert.False(ui.Press().Handled);
+        int calls = 0;
+        Application.InputBindings.Add(Bind(() => calls++));
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExecutionMayDetachOrDisposeItsOwnerWithoutActivatingTheNewFocus(bool dispose)
+    {
+        using var ui = new WindowFixture();
+        var second = ui.Parent.Controls.Add(new Button { Command = new DelegateCommand(() => Assert.Fail()) });
+        int calls = 0;
+        ui.Focus.InputBindings.Add(new KeyBinding(new DelegateCommand(() => {
+            calls++;
+            if (dispose) ui.Focus.Dispose(); else ui.Parent.Controls.Remove(ui.Focus);
+            second.Select();
+        }), new KeyGesture(Keys.Enter)));
+        Assert.True(ui.Key(Key.Return).Handled);
+        Assert.True(second.Selected);
+        Assert.True(ui.Key(Key.Return, down: false).Handled);
+        Assert.Equal(1, calls);
+        ui.Focus.Dispose();
     }
 
     [Fact]

--- a/ModernFormsNext.Tests/InputBindingTests.cs
+++ b/ModernFormsNext.Tests/InputBindingTests.cs
@@ -573,6 +573,40 @@ public sealed class InputBindingTests : IDisposable
         if (bindings is not null) Assert.Empty(bindings);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StaleFocusCannotExecuteBindingsFromDetachedOrReparentedControls(bool reparent)
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        ui.Focus.InputBindings.Add(Bind(() => Assert.Fail()));
+        ui.Parent.Controls.Remove(ui.Focus);
+        if (reparent) other.Parent.Controls.Add(ui.Focus);
+        int calls = 0;
+        ui.Form.InputBindings.Add(Bind(() => calls++));
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+        ui.Focus.Dispose();
+    }
+
+    [Fact]
+    public void PredicateCannotExecuteAControlBindingAfterDetachingItsScope()
+    {
+        using var ui = new WindowFixture();
+        ui.Focus.InputBindings.Add(Bind(() => Assert.Fail(), () => {
+            ui.Parent.Controls.Remove(ui.Focus);
+            return true;
+        }));
+        int calls = 0;
+        ui.Form.InputBindings.Add(Bind(() => calls++));
+        Assert.False(ui.Press().Handled);
+        Assert.Equal(0, calls);
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+        ui.Focus.Dispose();
+    }
+
     private sealed class DirectCommand : System.Windows.Input.ICommand
     {
         internal int Queries, Executions;

--- a/ModernFormsNext.Tests/InputBindingTests.cs
+++ b/ModernFormsNext.Tests/InputBindingTests.cs
@@ -552,6 +552,27 @@ public sealed class InputBindingTests : IDisposable
         Assert.Equal(1, command.Executions);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ReleasingBindingsDoesNotInspectAnEmptiedIntegerPropertyStore(bool registered)
+    {
+        using var control = new Control();
+        InputBindingCollection? bindings = null;
+        if (registered)
+        {
+            bindings = control.InputBindings;
+            bindings.Add(Bind(() => Assert.Fail()));
+        }
+        // Removing the last integer property leaves an empty integer array in the existing
+        // store. Binding cleanup owns an object slot and must not search unrelated integers.
+        const int integerKey = 32000;
+        control.Properties.SetInteger(integerKey, 1);
+        control.Properties.RemoveInteger(integerKey);
+        control.ReleaseInputBindings();
+        if (bindings is not null) Assert.Empty(bindings);
+    }
+
     private sealed class DirectCommand : System.Windows.Input.ICommand
     {
         internal int Queries, Executions;

--- a/ModernFormsNext.Tests/InputBindingTests.cs
+++ b/ModernFormsNext.Tests/InputBindingTests.cs
@@ -1,0 +1,632 @@
+using System.Reflection;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.WindowKit;
+using ModernFormsNext.WindowKit.Input;
+using ModernFormsNext.WindowKit.Input.Raw;
+using ModernFormsNext.WindowKit.Platform;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class InputBindingCollectionTests
+{
+    public const string Name = "Input bindings";
+}
+
+[Collection(InputBindingCollectionTests.Name)]
+public sealed class InputBindingTests : IDisposable
+{
+    public InputBindingTests() => Application.ReleaseInputBindings();
+    public void Dispose() => Application.ReleaseInputBindings();
+
+    [Theory]
+    [InlineData(Key.S, RawInputModifiers.Control)]
+    [InlineData(Key.S, RawInputModifiers.Control | RawInputModifiers.Shift)]
+    [InlineData(Key.Z, RawInputModifiers.Control)]
+    [InlineData(Key.F5, RawInputModifiers.None)]
+    public void ExistingRawWindowPipelineExecutesMatchingKeyDown(Key key, RawInputModifiers modifiers)
+    {
+        using var ui = new WindowFixture();
+        int calls = 0, queries = 0, controlEvents = 0;
+        var gesture = key == Key.F5 ? new KeyGesture(Keys.F5) :
+            new KeyGesture(key == Key.Z ? Keys.Z : Keys.S,
+                KeyModifiers.Control | (modifiers.HasFlag(RawInputModifiers.Shift) ? KeyModifiers.Shift : 0));
+        ui.Form.InputBindings.Add(new KeyBinding(new DelegateCommand(() => calls++, () => { queries++; return true; }), gesture));
+        ui.Focus.KeyDown += (_, _) => controlEvents++;
+        Assert.True(ui.Key(key, modifiers).Handled);
+        Assert.Equal(1, queries);
+        Assert.Equal(1, calls);
+        Assert.Equal(0, controlEvents);
+        Assert.True(ui.Key(key, modifiers, down: false).Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void ControlShiftGestureIsDistinct()
+    {
+        using var ui = new WindowFixture();
+        var calls = new List<string>();
+        ui.Form.InputBindings.Add(Bind(() => calls.Add("save")));
+        ui.Form.InputBindings.Add(new KeyBinding(new DelegateCommand(() => calls.Add("save-as")),
+            new KeyGesture(Keys.S, KeyModifiers.Control | KeyModifiers.Shift)));
+        ui.Press(Key.S, RawInputModifiers.Control | RawInputModifiers.Shift);
+        ui.Press();
+        Assert.Equal(["save-as", "save"], calls);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void NearestAvailableScopeWins(int winningScope)
+    {
+        using var ui = new WindowFixture();
+        int winner = -1;
+        InputBindingCollection[] scopes = [ui.Focus.InputBindings, ui.Parent.InputBindings, ui.Form.InputBindings, Application.InputBindings];
+        for (int i = winningScope; i < scopes.Length; i++)
+        {
+            int value = i;
+            scopes[i].Add(Bind(() => winner = value));
+        }
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(winningScope, winner);
+    }
+
+    [Fact]
+    public void NearestAncestorPrecedesMoreDistantAncestor()
+    {
+        using var ui = new WindowFixture();
+        var outer = ui.Form.Controls.Add(new Panel());
+        ui.Form.Controls.Remove(ui.Parent);
+        outer.Controls.Add(ui.Parent);
+        var calls = new List<string>();
+        outer.InputBindings.Add(Bind(() => calls.Add("outer")));
+        ui.Parent.InputBindings.Add(Bind(() => calls.Add("inner")));
+        ui.Press();
+        Assert.Equal(["inner"], calls);
+    }
+
+    [Fact]
+    public void FirstAddedAvailableDuplicateWinsAndRemovalRevealsNext()
+    {
+        using var ui = new WindowFixture();
+        var calls = new List<string>();
+        var first = Bind(() => calls.Add("first"));
+        ui.Focus.InputBindings.Add(first);
+        ui.Focus.InputBindings.Add(Bind(() => calls.Add("second")));
+        ui.Press();
+        ui.Focus.InputBindings.Remove(first);
+        ui.Press();
+        Assert.Equal(["first", "second"], calls);
+    }
+
+    [Fact]
+    public void UnavailableDuplicatesFallThroughWithinScopeThenToWindow()
+    {
+        using var ui = new WindowFixture();
+        var calls = new List<string>();
+        bool secondAvailable = true;
+        ui.Focus.InputBindings.Add(Bind(() => calls.Add("unavailable"), () => false));
+        ui.Focus.InputBindings.Add(Bind(() => calls.Add("second"), () => secondAvailable));
+        ui.Form.InputBindings.Add(Bind(() => calls.Add("window")));
+        ui.Press();
+        secondAvailable = false;
+        ui.Press();
+        Assert.Equal(["second", "window"], calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MissingOrUnavailableCommandDoesNotConsumeInput(bool missing)
+    {
+        using var ui = new WindowFixture();
+        int controlEvents = 0;
+        ui.Focus.InputBindings.Add(new KeyBinding(missing ? null : new DelegateCommand(() => Assert.Fail(), () => false), SaveGesture));
+        ui.Focus.KeyDown += (_, _) => controlEvents++;
+        Assert.False(ui.Press().Handled);
+        Assert.Equal(1, controlEvents);
+    }
+
+    [Fact]
+    public void InvalidDefaultGestureDoesNotConsumeInput()
+    {
+        using var ui = new WindowFixture();
+        ui.Focus.InputBindings.Add(new KeyBinding(new DelegateCommand(() => Assert.Fail()), default));
+        Assert.False(ui.Press().Handled);
+    }
+
+    [Fact]
+    public void WindowPreviewRetainsFirstRefusal()
+    {
+        using var ui = new WindowFixture();
+        ui.Form.InputBindings.Add(Bind(() => Assert.Fail()));
+        ui.Focus.KeyDown += (_, _) => Assert.Fail();
+        ui.Form.KeyDown += (_, e) => e.Handled = true;
+        Assert.True(ui.Press().Handled);
+    }
+
+    [Fact]
+    public void ExistingControlHandledStateReachesTheRawBackend()
+    {
+        using var ui = new WindowFixture();
+        ui.Focus.KeyDown += (_, e) => e.SuppressKeyPress = true;
+        Assert.True(ui.Press().Handled);
+    }
+
+    [Fact]
+    public void ParametersAndReplacementUseTheCurrentBinding()
+    {
+        using var ui = new WindowFixture();
+        var values = new List<object?>();
+        var binding = new KeyBinding(new DelegateCommand(values.Add, value => value is string), SaveGesture);
+        ui.Focus.InputBindings.Add(binding);
+        Assert.False(ui.Press().Handled);
+        binding.CommandParameter = "first";
+        ui.Press();
+        binding.Command = new DelegateCommand(p => values.Add($"replacement:{p}"));
+        binding.CommandParameter = "second";
+        ui.Press();
+        binding.Command = null;
+        Assert.False(ui.Press().Handled);
+        Assert.Equal(new object?[] { "first", "replacement:second" }, values);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExecutionMayRemoveItselfOrAddAnotherBindingWithoutDoubleExecution(bool remove)
+    {
+        using var ui = new WindowFixture();
+        int calls = 0;
+        KeyBinding? first = null;
+        first = Bind(() =>
+        {
+            calls++;
+            if (remove) ui.Focus.InputBindings.Remove(first!);
+            else ui.Focus.InputBindings.Add(Bind(() => calls += 100));
+        });
+        ui.Focus.InputBindings.Add(first);
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void FocusChangeDoesNotRestartLookupAndReleaseCannotClickNewButton()
+    {
+        using var ui = new WindowFixture();
+        var second = ui.Parent.Controls.Add(new Button { Command = new DelegateCommand(() => Assert.Fail()) });
+        int calls = 0;
+        ui.Focus.InputBindings.Add(new KeyBinding(new DelegateCommand(() => { calls++; second.Select(); }), new KeyGesture(Keys.Enter)));
+        second.InputBindings.Add(new KeyBinding(new DelegateCommand(() => Assert.Fail()), new KeyGesture(Keys.Enter)));
+        Assert.True(ui.Key(Key.Return).Handled);
+        Assert.True(second.Selected);
+        Assert.True(ui.Key(Key.Return, down: false).Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void RepeatsExecutePerKeyDownAndKeyUpNeverExecutesBinding()
+    {
+        using var ui = new WindowFixture();
+        int calls = 0;
+        ui.Form.InputBindings.Add(new KeyBinding(new DelegateCommand(() => calls++), new KeyGesture(Keys.F5)));
+        Assert.False(ui.Key(Key.F5, down: false).Handled);
+        for (int i = 0; i < 3; i++) Assert.True(ui.Key(Key.F5).Handled);
+        Assert.True(ui.Key(Key.F5, down: false).Handled);
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public void ConsumedPressKeepsReleaseSuppressedIfAvailabilityChanges()
+    {
+        using var ui = new WindowFixture();
+        bool available = true;
+        int calls = 0;
+        ui.Form.InputBindings.Add(Bind(() => calls++, () => available));
+        Assert.True(ui.Key(Key.S, RawInputModifiers.Control).Handled);
+        available = false;
+        Assert.True(ui.Key(Key.S, RawInputModifiers.Control).Handled);
+        Assert.True(ui.Key(Key.S, down: false).Handled);
+        Assert.False(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void DeactivationDropsSuppressionForMissingKeyUp()
+    {
+        using var ui = new WindowFixture();
+        ui.Form.InputBindings.Add(Bind(() => { }));
+        ui.Key(Key.S, RawInputModifiers.Control);
+        ui.Proxy.Deactivated!();
+        ui.Form.InputBindings.Clear();
+        Assert.False(ui.Press().Handled);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void PredicateMutationRejectsObsoleteSnapshot(int mutation)
+    {
+        using var ui = new WindowFixture();
+        var binding = new KeyBinding(null, SaveGesture);
+        binding.Command = new DelegateCommand(() => Assert.Fail(), () =>
+        {
+            switch (mutation)
+            {
+                case 0: binding.Command = new DelegateCommand(() => Assert.Fail()); break;
+                case 1: binding.CommandParameter = new object(); break;
+                case 2: ui.Focus.InputBindings.Remove(binding); break;
+                case 3: ui.Focus.InputBindings.Add(Bind(() => Assert.Fail())); break;
+            }
+            return true;
+        });
+        ui.Focus.InputBindings.Add(binding);
+        Assert.False(ui.Press().Handled);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExceptionsRemainOriginalAndLaterActivationCanRecover(bool predicate)
+    {
+        using var ui = new WindowFixture();
+        var error = new InvalidOperationException("command failure");
+        bool fail = true;
+        int calls = 0;
+        ui.Form.InputBindings.Add(Bind(() => { if (fail && !predicate) throw error; calls++; }, () => fail && predicate ? throw error : true));
+        Assert.Same(error, Assert.Throws<InvalidOperationException>(() => ui.Key(Key.S, RawInputModifiers.Control)));
+        Assert.Equal(!predicate, ui.Key(Key.S, down: false).Handled);
+        fail = false;
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData("a", Key.A, RawInputModifiers.None)]
+    [InlineData("A", Key.A, RawInputModifiers.Shift)]
+    [InlineData("ą", Key.A, RawInputModifiers.Control | RawInputModifiers.Alt | RawInputModifiers.AltGraph)]
+    [InlineData("é", Key.OemQuotes, RawInputModifiers.None)]
+    public void NormalShiftAltGraphAndCommittedDeadKeyTextStayOnTextPath(string text, Key key, RawInputModifiers modifiers)
+    {
+        using var ui = new WindowFixture();
+        var textBox = ui.Parent.Controls.Add(new TextBox());
+        textBox.Select();
+        ui.Form.InputBindings.Add(new KeyBinding(new DelegateCommand(() => Assert.Fail()), new KeyGesture(Keys.A, KeyModifiers.Control | KeyModifiers.Alt)));
+        Assert.False(ui.Key(key, modifiers).Handled);
+        ui.Text(text, modifiers);
+        Assert.Equal(text, textBox.Text);
+    }
+
+    [Fact]
+    public void ExistingTextEditingControlShortcutIsPreservedWithoutMatchingBinding()
+    {
+        using var ui = new WindowFixture();
+        var text = ui.Parent.Controls.Add(new TextBox { Text = "document" });
+        text.Select();
+        ui.Form.InputBindings.Add(Bind(() => Assert.Fail()));
+        Assert.True(ui.Key(Key.A, RawInputModifiers.Control).Handled);
+        Assert.Equal(text.Text.Length, Math.Abs(text.SelectionEnd - text.SelectionStart));
+    }
+
+    [Fact]
+    public void WindowScopeWorksWithoutSelectedControl()
+    {
+        using var ui = new WindowFixture();
+        ui.Form.adapter.SelectedControl = null;
+        int calls = 0;
+        ui.Form.InputBindings.Add(Bind(() => calls++));
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void DisposedControlReleasesBindingsAndCannotExecuteThem()
+    {
+        using var ui = new WindowFixture();
+        var collection = ui.Focus.InputBindings;
+        var binding = Bind(() => Assert.Fail());
+        collection.Add(binding);
+        ui.Focus.Dispose();
+        Assert.Empty(collection);
+        Assert.Throws<ObjectDisposedException>(() => collection.Add(binding));
+        Assert.False(ui.Press().Handled);
+        ui.Parent.InputBindings.Add(binding); // The disposed source no longer owns the registration.
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ActualWindowCloseOrDisposeReleasesDescendantAndWindowRegistrations(bool dispose)
+    {
+        using var ui = new WindowFixture();
+        var local = ui.Focus.InputBindings;
+        var window = ui.Form.InputBindings;
+        local.Add(Bind(() => Assert.Fail()));
+        window.Add(Bind(() => Assert.Fail()));
+        if (dispose) ui.Form.Dispose(); else ui.Form.Close();
+        Assert.Empty(local);
+        Assert.Empty(window);
+        Assert.Throws<ObjectDisposedException>(() => ui.Form.InputBindings);
+        Assert.False(ui.Press().Handled);
+    }
+
+    [Fact]
+    public void CancelledClosePreservesBindings()
+    {
+        using var ui = new WindowFixture();
+        int calls = 0;
+        ui.Form.Closing += (_, e) => e.Cancel = true;
+        ui.Form.InputBindings.Add(Bind(() => calls++));
+        ui.Form.Close();
+        Assert.Single(ui.Form.InputBindings);
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void ApplicationCleanupReleasesRegistrationsAndDiagnosticSubscribers()
+    {
+        var global = Application.InputBindings;
+        var binding = Bind(() => { });
+        global.Add(binding);
+        global.Diagnostic += (_, _) => Assert.Fail();
+        Application.ReleaseInputBindings();
+        Assert.Empty(global);
+        Assert.Throws<ObjectDisposedException>(() => global.Add(binding));
+        using var control = new Control();
+        control.InputBindings.Add(binding);
+    }
+
+    [Fact]
+    public void OneRegistrationHasOneOwnerAndCanMoveAfterRemoval()
+    {
+        using var first = new Control();
+        using var second = new Control();
+        var binding = Bind(() => { });
+        first.InputBindings.Add(binding);
+        Assert.Throws<ArgumentException>(() => first.InputBindings.Add(binding));
+        Assert.Throws<ArgumentException>(() => second.InputBindings.Add(binding));
+        first.InputBindings.Remove(binding);
+        second.InputBindings.Add(binding);
+        Assert.Single(second.InputBindings);
+        second.InputBindings.Clear();
+        first.InputBindings.Add(binding);
+    }
+
+    [Fact]
+    public void BackgroundRegistrationAndMutationAreRejected()
+    {
+        using var control = new Control();
+        var collection = control.InputBindings;
+        var binding = Bind(() => { });
+        collection.Add(binding);
+        Exception? failure = null;
+        var worker = new Thread(() =>
+        {
+            try
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Clear());
+                Assert.Throws<InvalidOperationException>(() => binding.CommandParameter = "worker");
+            }
+            catch (Exception error) { failure = error; }
+        });
+        worker.Start(); worker.Join();
+        Assert.Null(failure);
+        Assert.Single(collection);
+        Assert.Null(binding.CommandParameter);
+    }
+
+    [Fact]
+    public void DiagnosticsDescribeInvalidDuplicatesUnavailableAndExecution()
+    {
+        using var ui = new WindowFixture();
+        var observations = new List<InputBindingDiagnosticKind>();
+        ui.Form.InputBindings.Diagnostic += (_, e) => observations.Add(e.Kind);
+        ui.Form.InputBindings.Add(new KeyBinding(null, default));
+        ui.Form.InputBindings.Add(Bind(() => Assert.Fail(), () => false));
+        ui.Form.InputBindings.Add(Bind(() => { }));
+        ui.Press();
+        Assert.Equal([InputBindingDiagnosticKind.InvalidBinding, InputBindingDiagnosticKind.DuplicateGesture,
+            InputBindingDiagnosticKind.CommandUnavailable, InputBindingDiagnosticKind.Executed], observations);
+    }
+
+    [Fact]
+    public void ButtonSemanticInvokeAndKeyboardShareTheSameDomainAction()
+    {
+        using var ui = new WindowFixture();
+        var values = new List<object?>();
+        var command = new DelegateCommand(values.Add);
+        ui.Focus.Command = command;
+        ui.Focus.CommandParameter = "document";
+        ui.Focus.InputBindings.Add(new KeyBinding(command, SaveGesture) { CommandParameter = "document" });
+        int clicks = 0;
+        ui.Focus.Click += (_, _) => clicks++;
+        ui.Focus.PerformClick();
+        Assert.True(ui.Focus.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        ui.Press();
+        Assert.Equal(new object?[] { "document", "document", "document" }, values);
+        Assert.Equal(2, clicks); // Keyboard invokes the action without synthesizing Button.Click.
+    }
+
+    [Fact]
+    public void SurfaceHardwareBindingsDoNotInterceptImeEditingKeysOrTextCommits()
+    {
+        using var root = new Panel();
+        var text = root.Controls.Add(new TextBox { Text = "ab", MultiLine = true });
+        using var surface = new SkiaControlSurface(root);
+        text.Select();
+        surface.SetTextSelection(2, 2);
+        int shortcuts = 0;
+        root.InputBindings.Add(new KeyBinding(new DelegateCommand(() => shortcuts++), new KeyGesture(Keys.Left)));
+        surface.ProcessKeyDown(Keys.Left, isTextInput: true);
+        surface.ProcessKeyUp(Keys.Left, isTextInput: true);
+        Assert.Equal(1, surface.GetTextInputState()!.Value.SelectionStart);
+        Assert.Equal(0, shortcuts);
+        surface.ProcessKeyDown(Keys.Left);
+        surface.ProcessKeyUp(Keys.Left);
+        Assert.Equal(1, shortcuts);
+        Assert.Equal(1, surface.GetTextInputState()!.Value.SelectionStart);
+        surface.CommitText("ą");
+        Assert.Equal("aąb", text.Text);
+    }
+
+    [Fact]
+    public void StandaloneSurfaceUsesApplicationFallbackWithNoFocus()
+    {
+        using var root = new Panel();
+        using var surface = new SkiaControlSurface(root);
+        int calls = 0;
+        Application.InputBindings.Add(new KeyBinding(new DelegateCommand(() => calls++), new KeyGesture(Keys.F5)));
+        surface.ProcessKeyDown(Keys.F5);
+        surface.ProcessKeyUp(Keys.F5);
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InactiveControlScopeAllowsWindowFallback(bool hidden)
+    {
+        using var ui = new WindowFixture();
+        ui.Focus.InputBindings.Add(Bind(() => Assert.Fail()));
+        int calls = 0;
+        ui.Form.InputBindings.Add(Bind(() => calls++));
+        if (hidden) ui.Focus.Visible = false; else ui.Focus.Enabled = false;
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void IndexReplacementReleasesOldBindingAndFailedReplacementPreservesOwnership()
+    {
+        using var ui = new WindowFixture();
+        var old = Bind(() => Assert.Fail());
+        var other = Bind(() => Assert.Fail());
+        int calls = 0;
+        var replacement = Bind(() => calls++);
+        ui.Focus.InputBindings.Add(old);
+        ui.Parent.InputBindings.Add(other);
+        Assert.Throws<ArgumentException>(() => ui.Focus.InputBindings[0] = other);
+        Assert.Same(old, ui.Focus.InputBindings[0]);
+        ui.Focus.InputBindings[0] = replacement;
+        ui.Form.InputBindings.Add(old);
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void GestureReplacementAndClearTakeEffectOnTheNextPress()
+    {
+        using var ui = new WindowFixture();
+        int calls = 0;
+        var binding = Bind(() => calls++);
+        ui.Form.InputBindings.Add(binding);
+        binding.Gesture = new KeyGesture(Keys.F5);
+        Assert.False(ui.Press().Handled);
+        Assert.True(ui.Press(Key.F5, RawInputModifiers.None).Handled);
+        ui.Form.InputBindings.Clear();
+        Assert.False(ui.Press(Key.F5, RawInputModifiers.None).Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void ArbitraryICommandGetsOneFreshQueryAndNoEventSubscription()
+    {
+        using var ui = new WindowFixture();
+        var command = new DirectCommand();
+        var parameter = new object();
+        var binding = new KeyBinding(command, SaveGesture) { CommandParameter = parameter };
+        ui.Form.InputBindings.Add(binding);
+        Assert.True(ui.Press().Handled);
+        Assert.Equal(1, command.Queries);
+        Assert.Equal(1, command.Executions);
+        Assert.Same(parameter, command.Parameter);
+        binding.Command = null;
+        binding.CommandParameter = null;
+        Assert.False(ui.Press().Handled);
+        Assert.Equal(1, command.Executions);
+    }
+
+    private sealed class DirectCommand : System.Windows.Input.ICommand
+    {
+        internal int Queries, Executions;
+        internal object? Parameter;
+        public event EventHandler? CanExecuteChanged { add => Assert.Fail(); remove => Assert.Fail(); }
+        public bool CanExecute(object? parameter) { Queries++; return true; }
+        public void Execute(object? parameter) { Executions++; Parameter = parameter; }
+    }
+
+    private static KeyGesture SaveGesture => new(Keys.S, KeyModifiers.Control);
+    private static KeyBinding Bind(Action execute, Func<bool>? canExecute = null) => new(new DelegateCommand(execute, canExecute), SaveGesture);
+
+    // Reuse the existing IWindowImpl input callback seam, as other window tests do with proxies.
+    // This is not a TestHost keyboard simulator and does not claim native OS input evidence.
+    private sealed class WindowFixture : IDisposable
+    {
+        private readonly KeyboardDevice keyboard = new();
+        internal WindowProxy Proxy { get; }
+        internal Form Form { get; }
+        internal Panel Parent { get; }
+        internal Button Focus { get; }
+
+        internal WindowFixture()
+        {
+            var platform = DispatchProxy.Create<IWindowImpl, WindowProxy>();
+            Proxy = (WindowProxy)(object)platform;
+            Form = new Form(platform);
+            Parent = Form.Controls.Add(new Panel { Width = 500, Height = 300 });
+            Focus = Parent.Controls.Add(new Button { Text = "Target" });
+            Focus.Select();
+        }
+
+        internal RawKeyEventArgs Key(Key key, RawInputModifiers modifiers = RawInputModifiers.None, bool down = true)
+        {
+            var e = new RawKeyEventArgs(keyboard, 0, Form.adapter, down ? RawKeyEventType.KeyDown : RawKeyEventType.KeyUp, key, modifiers);
+            Proxy.Input!(e);
+            return e;
+        }
+
+        internal RawKeyEventArgs Press(Key key = WindowKit.Input.Key.S, RawInputModifiers modifiers = RawInputModifiers.Control)
+        {
+            var e = Key(key, modifiers);
+            Key(key, modifiers, down: false);
+            return e;
+        }
+
+        internal void Text(string text, RawInputModifiers modifiers)
+            => Proxy.Input!(new RawTextInputEventArgs(keyboard, 0, Form.adapter, text, modifiers));
+
+        public void Dispose() { Form.Dispose(); Form.adapter.Dispose(); }
+    }
+
+    private class WindowProxy : DispatchProxy
+    {
+        internal Action<RawInputEventArgs>? Input;
+        internal Action? Closed;
+        internal Action? Deactivated;
+        private Size clientSize = new(800, 600);
+
+        protected override object? Invoke(MethodInfo? method, object?[]? args)
+        {
+            switch (method?.Name)
+            {
+                case "set_Input": Input = (Action<RawInputEventArgs>?)args![0]; return null;
+                case "set_Closed": Closed = (Action?)args![0]; return null;
+                case "set_Deactivated": Deactivated = (Action?)args![0]; return null;
+                case "get_ClientSize": return clientSize;
+                case "get_RenderScaling": case "get_DesktopScaling": return 1d;
+                case "get_Position": return PixelPoint.Origin;
+                case "get_Handle": return new PlatformHandle(IntPtr.Zero, "TEST");
+                case "Resize": clientSize = (Size)args![0]!; return null;
+                case "Dispose": Closed?.Invoke(); return null;
+            }
+            return method is not null && method.ReturnType != typeof(void) && method.ReturnType.IsValueType
+                ? Activator.CreateInstance(method.ReturnType) : null;
+        }
+    }
+}

--- a/ModernFormsNext.Tests/KeyGestureTests.cs
+++ b/ModernFormsNext.Tests/KeyGestureTests.cs
@@ -1,0 +1,87 @@
+using ModernFormsNext.WindowKit.Input;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed class KeyGestureTests
+{
+    [Fact]
+    public void EqualGesturesHaveValueEqualityHashAndDiagnosticText()
+    {
+        var first = new KeyGesture(Keys.S, KeyModifiers.Control | KeyModifiers.Shift);
+        var second = new KeyGesture(Keys.S, KeyModifiers.Control | KeyModifiers.Shift);
+        Assert.True(first == second);
+        Assert.False(first != second);
+        Assert.True(first.Equals((object)second));
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+        Assert.NotEqual(first, new KeyGesture(Keys.S, KeyModifiers.Control));
+        Assert.Equal("Ctrl+Shift+S", first.ToString());
+    }
+
+    [Theory]
+    [InlineData(Keys.Control | Keys.S, true)]
+    [InlineData(Keys.Control | Keys.Shift | Keys.S, false)]
+    [InlineData(Keys.Alt | Keys.S, false)]
+    [InlineData(Keys.S, false)]
+    [InlineData(Keys.Control | Keys.Z, false)]
+    [InlineData(Keys.Control | Keys.Meta | Keys.S, false)]
+    public void MatchingRequiresExactKeyAndModifiers(Keys keyData, bool expected)
+        => Assert.Equal(expected, new KeyGesture(Keys.S, KeyModifiers.Control).Matches(new KeyEventArgs(keyData)));
+
+    [Theory]
+    [InlineData(Keys.F5, KeyModifiers.None, Keys.F5)]
+    [InlineData(Keys.D1, KeyModifiers.Control, Keys.Control | Keys.D1)]
+    [InlineData(Keys.Left, KeyModifiers.Shift, Keys.Shift | Keys.Left)]
+    [InlineData(Keys.S, KeyModifiers.Meta, Keys.Meta | Keys.S)]
+    [InlineData(Keys.S, KeyModifiers.Control | KeyModifiers.Alt, Keys.Control | Keys.Alt | Keys.S)]
+    public void FunctionDigitNavigationAndPlatformModifiersMatch(Keys key, KeyModifiers modifiers, Keys keyData)
+        => Assert.True(new KeyGesture(key, modifiers).Matches(new KeyEventArgs(keyData)));
+
+    [Theory]
+    [InlineData(Keys.A)]
+    [InlineData(Keys.C)]
+    [InlineData(Keys.E)]
+    [InlineData(Keys.L)]
+    [InlineData(Keys.N)]
+    [InlineData(Keys.O)]
+    [InlineData(Keys.S)]
+    [InlineData(Keys.X)]
+    [InlineData(Keys.Z)]
+    public void PolishAltGraphNeverMatchesRealControlAltGesture(Keys key)
+    {
+        var gesture = new KeyGesture(key, KeyModifiers.Control | KeyModifiers.Alt);
+        Assert.True(gesture.Matches(new KeyEventArgs(key | Keys.Control | Keys.Alt)));
+        Assert.False(gesture.Matches(new KeyEventArgs(key | Keys.Control | Keys.Alt | Keys.AltGraph)));
+        Assert.False(gesture.Matches(new KeyEventArgs(key | Keys.Alt | Keys.AltGraph)));
+    }
+
+    [Theory]
+    [InlineData(Keys.None, KeyModifiers.None)]
+    [InlineData(Keys.Control | Keys.S, KeyModifiers.None)]
+    [InlineData(Keys.LMenu, KeyModifiers.None)]
+    [InlineData(Keys.LButton, KeyModifiers.Control)]
+    [InlineData(Keys.S, KeyModifiers.AltGraph)]
+    [InlineData(Keys.A, KeyModifiers.None)]
+    [InlineData(Keys.A, KeyModifiers.Shift)]
+    [InlineData(Keys.D1, KeyModifiers.Shift)]
+    [InlineData(Keys.OemQuotes, KeyModifiers.None)]
+    public void InvalidOrTextOnlyGesturesAreRejected(Keys key, KeyModifiers modifiers)
+        => Assert.Throws<ArgumentException>(() => new KeyGesture(key, modifiers));
+
+    [Fact]
+    public void DefaultValueNeverMatchesAndNullEventsAreRejected()
+    {
+        Assert.False(default(KeyGesture).Matches(new KeyEventArgs(Keys.None)));
+        Assert.Equal("<invalid>", default(KeyGesture).ToString());
+        Assert.Throws<ArgumentNullException>(() => default(KeyGesture).Matches(null!));
+    }
+
+    [Fact]
+    public void RawMetaSurvivesTheExistingWindowKitMapper()
+    {
+        var data = WindowKitExtensions.AddModifiers(Keys.S, RawInputModifiers.Control | RawInputModifiers.Meta);
+        Assert.True(new KeyGesture(Keys.S, KeyModifiers.Control | KeyModifiers.Meta).Matches(new KeyEventArgs(data)));
+        Assert.Equal(0x00080000, (int)Keys.AltGraph);
+        Assert.Equal(0x00100000, (int)Keys.Meta);
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidKeyboardBindingTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidKeyboardBindingTests.cs
@@ -1,0 +1,47 @@
+using ModernFormsNext.WindowKit.Backend.Android.Rendering;
+using ModernFormsNext.WindowKit.Input;
+using Xunit;
+
+namespace ModernFormsNext.WindowKit.Backend.Android.Tests;
+
+public class AndroidKeyboardBindingTests
+{
+    [Theory]
+    [InlineData(2, false, false, true)]
+    [InlineData(0, false, false, true)]
+    [InlineData(-1, false, false, false)]
+    [InlineData(2, true, false, false)]
+    [InlineData(2, false, true, false)]
+    [InlineData(-1, true, true, false)]
+    public void SourceClassificationKeepsImeOutOfBindings(int device, bool soft, bool connection, bool hardware)
+    {
+        var modifiers = KeyModifiers.Control | KeyModifiers.Shift | KeyModifiers.Meta;
+        var e = AndroidInputKeyEvent.FromSource(AndroidInputKey.Left, true, modifiers, device, soft, connection);
+        Assert.Equal(hardware, e.IsHardwareKey);
+        Assert.Equal(hardware ? modifiers : KeyModifiers.None, e.Modifiers);
+        Assert.Equal(AndroidInputKey.Left, e.Key);
+        Assert.True(e.IsDown);
+    }
+
+    [Fact]
+    public void ExistingConstructorRetainsEditingDefaultsAndDeconstruction()
+    {
+        var e = new AndroidInputKeyEvent(AndroidInputKey.Enter, false);
+        var (key, down) = e;
+        Assert.Equal(AndroidInputKey.Enter, key);
+        Assert.False(down);
+        Assert.False(e.IsHardwareKey);
+        Assert.Equal(KeyModifiers.None, e.Modifiers);
+    }
+
+    [Fact]
+    public void HardwareRightAltMarkerCannotMatchControlAltGesture()
+    {
+        var e = AndroidInputKeyEvent.FromSource(AndroidInputKey.Left, true,
+            KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.AltGraph, 2, false, false);
+        Assert.True(e.IsHardwareKey);
+        Assert.Equal(KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.AltGraph, e.Modifiers);
+        Assert.False(new KeyGesture(Keys.Left, KeyModifiers.Control | KeyModifiers.Alt)
+            .Matches(new KeyEventArgs(Keys.Left | Keys.Control | Keys.Alt | Keys.AltGraph)));
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android/Platform/Rendering/AndroidSkiaHostView.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Platform/Rendering/AndroidSkiaHostView.cs
@@ -9,6 +9,7 @@ using ICharSequence = Java.Lang.ICharSequence;
 using NativeKeyEvent = Android.Views.KeyEvent;
 using ModernFormsNext.WindowKit.Backend.Android.Accessibility;
 using ModernFormsNext.WindowKit.Platform.Accessibility;
+using ModernFormsNext.WindowKit.Input;
 
 namespace ModernFormsNext.WindowKit.Backend.Android.Rendering;
 
@@ -585,7 +586,7 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         }
     }
 
-    private bool PublishKey(Keycode keyCode, bool isDown)
+    private bool PublishKey(Keycode keyCode, bool isDown, NativeKeyEvent? nativeEvent = null)
     {
         var translated = keyCode switch
         {
@@ -602,7 +603,20 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         if (translated is null)
             return false;
 
-        KeyInput?.Invoke(this, new AndroidInputKeyEvent(translated.Value, isDown));
+        var modifiers = KeyModifiers.None;
+        if (nativeEvent is not null)
+        {
+            if (nativeEvent.IsCtrlPressed) modifiers |= KeyModifiers.Control;
+            if (nativeEvent.IsShiftPressed) modifiers |= KeyModifiers.Shift;
+            if (nativeEvent.IsAltPressed) modifiers |= KeyModifiers.Alt;
+            if (nativeEvent.IsMetaPressed) modifiers |= KeyModifiers.Meta;
+            // As on Windows, right Alt is conservatively reserved for international input.
+            if ((nativeEvent.MetaState & MetaKeyStates.AltRightOn) != 0) modifiers |= KeyModifiers.AltGraph;
+        }
+        KeyInput?.Invoke(this, AndroidInputKeyEvent.FromSource(translated.Value, isDown, modifiers,
+            nativeEvent?.DeviceId ?? -1,
+            nativeEvent is not null && (nativeEvent.Flags & KeyEventFlags.SoftKeyboard) != 0,
+            fromInputConnection: nativeEvent is null));
         NotifyTextStateChanged();
         return true;
     }
@@ -670,12 +684,12 @@ public sealed class AndroidSkiaHostView : SKCanvasView
         Func<bool> baseHandler)
     {
         if (!EnableInputConnectionDiagnostics)
-            return PublishKey(keyCode, isDown) || baseHandler();
+            return PublishKey(keyCode, isDown, keyEvent) || baseHandler();
 
         var before = GetTextInputState();
         var batchDepth = activeInputConnection?.BatchDepth ?? 0;
         var observation = ObserveKeyEvent(keyCode, isDown, "ViewKeyEvent");
-        var result = PublishKey(keyCode, isDown) || baseHandler();
+        var result = PublishKey(keyCode, isDown, keyEvent) || baseHandler();
         WriteInputDiagnostic(
             isDown ? "OnKeyDown" : "OnKeyUp",
             "ViewKeyEvent",

--- a/ModernFormsNext.WindowKit.Backend.Android/Rendering/AndroidInputKeyEvent.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android/Rendering/AndroidInputKeyEvent.cs
@@ -1,6 +1,30 @@
+using ModernFormsNext.WindowKit.Input;
+
 namespace ModernFormsNext.WindowKit.Backend.Android.Rendering;
 
 /// <summary>Describes an Android editing-key transition.</summary>
 /// <param name="Key">The platform-neutral editing or navigation key.</param>
 /// <param name="IsDown"><see langword="true"/> for key down; <see langword="false"/> for key up.</param>
-public readonly record struct AndroidInputKeyEvent(AndroidInputKey Key, bool IsDown);
+public readonly record struct AndroidInputKeyEvent(AndroidInputKey Key, bool IsDown)
+{
+    /// <summary>Gets keyboard modifiers, including the conservative right-Alt/AltGraph marker.</summary>
+    public KeyModifiers Modifiers { get; init; }
+
+    /// <summary>Gets whether this transition came from a physical device through the view key path.</summary>
+    /// <remarks>
+    /// Only hardware transitions are eligible for input bindings. InputConnection/soft-keyboard
+    /// events remain editing input. The existing two-argument constructor defaults to editing input.
+    /// The backend currently forwards only its existing editing/navigation key set.
+    /// </remarks>
+    public bool IsHardwareKey { get; init; }
+
+    // Keep source classification independent of Android runtime objects so all hosts share the
+    // same conservative rule. InputConnection events never become shortcut input, even when an
+    // IME supplies a real-looking device id or modifier flags.
+    internal static AndroidInputKeyEvent FromSource(AndroidInputKey key, bool isDown,
+        KeyModifiers modifiers, int deviceId, bool isSoftKeyboard, bool fromInputConnection)
+    {
+        bool hardware = deviceId >= 0 && !isSoftKeyboard && !fromInputConnection;
+        return new(key, isDown) { IsHardwareKey = hardware, Modifiers = hardware ? modifiers : KeyModifiers.None };
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsKeyboardInputTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsKeyboardInputTests.cs
@@ -1,0 +1,41 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ModernFormsNext.WindowKit.Backend.Windows.Tests;
+
+public sealed class WindowsKeyboardInputTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnicodePacketDoesNotInheritPreviousKeyConsumption(bool available)
+    {
+        using var form = new Form();
+        var editor = form.Controls.Add(new TextBox());
+        int calls = 0;
+        form.InputBindings.Add(new KeyBinding(new DelegateCommand(() => calls++, () => available), new KeyGesture(Keys.F5)));
+        form.Show();
+        try
+        {
+            editor.Select();
+            var hwnd = form.PlatformHandle.Handle;
+            // Exercise the real per-window message path without changing foreground focus or
+            // global keyboard state. A handled key suppresses its character, but a later
+            // VK_PACKET (unmapped as a framework key) starts an independent text input event.
+            SendMessage(hwnd, 0x0100, (IntPtr)0x74, (IntPtr)1); // WM_KEYDOWN / F5
+            SendMessage(hwnd, 0x0102, (IntPtr)'x', (IntPtr)1); // WM_CHAR
+            SendMessage(hwnd, 0x0101, (IntPtr)0x74, IntPtr.Zero);
+            Assert.Equal(available ? "" : "x", editor.Text);
+            Assert.Equal(available ? 1 : 0, calls);
+            SendMessage(hwnd, 0x0100, (IntPtr)0xE7, (IntPtr)1); // WM_KEYDOWN / VK_PACKET
+            SendMessage(hwnd, 0x0102, (IntPtr)'ą', (IntPtr)1);
+            SendMessage(hwnd, 0x0101, (IntPtr)0xE7, IntPtr.Zero);
+            Assert.Equal(available ? "ą" : "xą", editor.Text);
+            Assert.Equal(available ? 1 : 0, calls);
+        }
+        finally { form.Close(); }
+    }
+
+    [DllImport("user32.dll", EntryPoint = "SendMessageW")]
+    private static extern IntPtr SendMessage(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam);
+}

--- a/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -164,6 +164,10 @@ namespace ModernFormsNext.WindowKit.Backend.Windows.Win32
                 case WindowsMessage.WM_KEYDOWN:
                 case WindowsMessage.WM_SYSKEYDOWN:
                     {
+                        // Suppression belongs to the preceding key's translated character only.
+                        // Unmapped keys such as VK_PACKET still start a new text input sequence
+                        // and must not inherit Handled from an earlier shortcut/editing key.
+                        _ignoreWmChar = false;
                         var key = KeyInterop.KeyFromVirtualKey(ToInt32(wParam), ToInt32(lParam));
 
                         if (key != Key.None)

--- a/ModernFormsNext/Application.InputBindings.cs
+++ b/ModernFormsNext/Application.InputBindings.cs
@@ -1,0 +1,37 @@
+namespace ModernFormsNext;
+
+public static partial class Application
+{
+    private static InputBindingCollection? inputBindings;
+
+    /// <summary>Gets runtime keyboard bindings shared by all windows and standalone control surfaces.</summary>
+    /// <remarks>
+    /// Initialize, access and mutate on the application UI thread. This is the final fallback after
+    /// focused-control, ancestor and window bindings. Only input delivered to a framework window or
+    /// surface is observed; these are not system-wide hotkeys. Existing application shutdown paths
+    /// release registrations and diagnostic handlers. Explicitly remove registrations that capture
+    /// shorter-lived objects before shutdown. No command or parameter object is disposed.
+    /// </remarks>
+    /// <example><code>
+    /// Application.InputBindings.Add(new KeyBinding(refresh, new KeyGesture(Keys.F5)));
+    /// </code></example>
+    public static InputBindingCollection InputBindings
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(is_exiting, typeof(Application));
+            var bindings = inputBindings ??= new InputBindingCollection(null);
+            bindings.VerifyAccess();
+            return bindings;
+        }
+    }
+
+    internal static bool IsExiting => is_exiting;
+    internal static InputBindingCollection? InputBindingsInternal => inputBindings;
+
+    internal static void ReleaseInputBindings()
+    {
+        inputBindings?.Release();
+        inputBindings = null;
+    }
+}

--- a/ModernFormsNext/Application.cs
+++ b/ModernFormsNext/Application.cs
@@ -26,7 +26,7 @@ namespace ModernFormsNext
     /// Application.Run(form);
     /// </code>
     /// </example>
-    public static class Application
+    public static partial class Application
     {
         private static CancellationTokenSource? _mainLoopCancellationTokenSource;
         private static bool is_exiting;
@@ -242,6 +242,7 @@ namespace ModernFormsNext
         public static void Exit()
         {
             is_exiting = true;
+            ReleaseInputBindings();
 
             Animations.AnimationScheduler.ShutdownDefaultIfInitialized();
 
@@ -336,6 +337,7 @@ namespace ModernFormsNext
 
             Dispatcher.UIThread.MainLoop(_mainLoopCancellationTokenSource.Token);
 
+            ReleaseInputBindings();
             Animations.AnimationScheduler.ShutdownDefaultIfInitialized();
 
             if (!is_exiting)

--- a/ModernFormsNext/Control.InputBindings.cs
+++ b/ModernFormsNext/Control.InputBindings.cs
@@ -37,7 +37,9 @@ public partial class Control
     internal void ReleaseInputBindings()
     {
         InputBindingsInternal?.Release();
-        Properties.RemoveValue(s_inputBindingsProperty);
+        // This key only stores an object. Do not inspect/remove unrelated integer entries;
+        // other control cleanup paths likewise remove their specific object slots.
+        Properties.RemoveObject(s_inputBindingsProperty);
     }
 
     internal void ReleaseInputBindingsForSubtree()

--- a/ModernFormsNext/Control.InputBindings.cs
+++ b/ModernFormsNext/Control.InputBindings.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using ModernFormsNext.Layout;
+
+namespace ModernFormsNext;
+
+public partial class Control
+{
+    private static readonly int s_inputBindingsProperty = PropertyStore.CreateKey();
+
+    /// <summary>Gets runtime keyboard bindings defined in this control's scope.</summary>
+    /// <remarks>
+    /// Access on the owning UI thread. Lookup starts at the focused control, then nearest ancestors,
+    /// the window and Application. Bindings precede normal control KeyDown handling. First added
+    /// available matches win; unavailable bindings allow fallback. The collection is created lazily.
+    /// Disposal or window closure releases registrations; no rendering/layout is triggered by edits.
+    /// </remarks>
+    /// <example><code>
+    /// editor.InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.S, KeyModifiers.Control)));
+    /// </code></example>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public InputBindingCollection InputBindings
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed || FindWindow()?.InputBindingsClosed == true, this);
+            if (!Properties.TryGetValue(s_inputBindingsProperty, out InputBindingCollection? bindings))
+                bindings = Properties.AddValue(s_inputBindingsProperty, new InputBindingCollection(this));
+            bindings!.VerifyAccess();
+            return bindings;
+        }
+    }
+
+    internal InputBindingCollection? InputBindingsInternal
+        => Properties.TryGetValue(s_inputBindingsProperty, out InputBindingCollection? bindings) ? bindings : null;
+
+    internal void ReleaseInputBindings()
+    {
+        InputBindingsInternal?.Release();
+        Properties.RemoveValue(s_inputBindingsProperty);
+    }
+
+    internal void ReleaseInputBindingsForSubtree()
+    {
+        ReleaseInputBindings();
+        foreach (var child in Controls.GetAllControls(true)) child.ReleaseInputBindingsForSubtree();
+    }
+}

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -2597,6 +2597,7 @@ namespace ModernFormsNext
         protected override void Dispose (bool disposing)
         {
             if (!disposedValue) {
+                ReleaseInputBindings();
                 DisposeInteractionEffects ();
                 CancelOwnedControlAnimations();
                 DisposeLayoutTransitionConfiguration ();

--- a/ModernFormsNext/DataBinding/InputBindingResolver.cs
+++ b/ModernFormsNext/DataBinding/InputBindingResolver.cs
@@ -22,6 +22,9 @@ internal sealed class InputBindingResolver
         }
 
         List<Candidate>? candidates = null;
+        // Existing focus bookkeeping can still point at a control detached/reparented by the
+        // application. A window must never execute bindings from another control tree.
+        if (focused is not null && !IsWithinRoot(focused, root)) focused = null;
         // Snapshot only matching registrations, before calling any application predicate. The
         // usual unmatched key does not allocate a candidate list or initialize empty scopes.
         for (Control? control = focused ?? root; control is not null; control = control.Parent)
@@ -35,23 +38,23 @@ internal sealed class InputBindingResolver
         if (candidates is not null)
             foreach (var candidate in candidates)
             {
-                if (!candidate.IsCurrent || !IsContextActive(root, window)) break;
+                if (!candidate.IsCurrent(root) || !IsContextActive(root, window)) break;
                 var binding = candidate.Binding;
                 ICommand? command = binding.Command;
                 object? parameter = binding.CommandParameter;
                 if (command is null)
                 {
                     candidate.Collection.Report(InputBindingDiagnosticKind.InvalidBinding, binding);
-                    if (!candidate.IsCurrent) break;
+                    if (!candidate.IsCurrent(root)) break;
                     continue;
                 }
 
                 bool available = command.CanExecute(parameter);
-                if (!candidate.IsCurrent || !IsContextActive(root, window)) break;
+                if (!candidate.IsCurrent(root) || !IsContextActive(root, window)) break;
                 if (!available)
                 {
                     candidate.Collection.Report(InputBindingDiagnosticKind.CommandUnavailable, binding);
-                    if (!candidate.IsCurrent) break;
+                    if (!candidate.IsCurrent(root)) break;
                     continue;
                 }
 
@@ -89,6 +92,13 @@ internal sealed class InputBindingResolver
     private static bool IsContextActive(Control root, WindowBase? window)
         => !root.IsDisposed && root.Visible && root.Enabled && window?.InputBindingsClosed != true && !Application.IsExiting;
 
+    private static bool IsWithinRoot(Control control, Control root)
+    {
+        for (Control? current = control; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, root)) return true;
+        return false;
+    }
+
     private static void Collect(InputBindingCollection? collection, KeyEventArgs e, ref List<Candidate>? candidates)
     {
         if (collection is null || collection.Count == 0 || !collection.IsActive) return;
@@ -104,7 +114,8 @@ internal sealed class InputBindingResolver
 
     private readonly record struct Candidate(InputBinding Binding, int BindingVersion, InputBindingCollection Collection, int CollectionVersion)
     {
-        internal bool IsCurrent => Collection.IsActive && Collection.Version == CollectionVersion &&
-            Binding.Version == BindingVersion && ReferenceEquals(Binding.Owner, Collection);
+        internal bool IsCurrent(Control root) => Collection.IsActive && Collection.Version == CollectionVersion &&
+            Binding.Version == BindingVersion && ReferenceEquals(Binding.Owner, Collection) &&
+            (Collection.ControlScope is not Control control || IsWithinRoot(control, root));
     }
 }

--- a/ModernFormsNext/DataBinding/InputBindingResolver.cs
+++ b/ModernFormsNext/DataBinding/InputBindingResolver.cs
@@ -1,0 +1,110 @@
+using System.Windows.Input;
+
+namespace ModernFormsNext.DataBinding;
+
+// Shared behavior at the existing WindowBase and SkiaControlSurface key entry points.
+// This looks up concrete bindings; it neither dispatches events nor routes command handlers.
+internal sealed class InputBindingResolver
+{
+    private HashSet<Keys>? consumedKeys;
+
+    internal bool ProcessKeyDown(KeyEventArgs e, Control? focused, Control root, WindowBase? window)
+    {
+        if (e.Handled) return true;
+        if (!IsContextActive(root, window)) { Reset(); return false; }
+        Keys key = e.KeyData & Keys.KeyCode;
+        if (e.AltGraph)
+        {
+            // International text must never inherit suppression from a previous shortcut
+            // if modifiers change while a physical key is held.
+            consumedKeys?.Remove(key);
+            return false;
+        }
+
+        List<Candidate>? candidates = null;
+        // Snapshot only matching registrations, before calling any application predicate. The
+        // usual unmatched key does not allocate a candidate list or initialize empty scopes.
+        for (Control? control = focused ?? root; control is not null; control = control.Parent)
+        {
+            Collect(control.InputBindingsInternal, e, ref candidates);
+            if (ReferenceEquals(control, root)) break;
+        }
+        Collect(window?.InputBindingsInternal, e, ref candidates);
+        Collect(Application.InputBindingsInternal, e, ref candidates);
+
+        if (candidates is not null)
+            foreach (var candidate in candidates)
+            {
+                if (!candidate.IsCurrent || !IsContextActive(root, window)) break;
+                var binding = candidate.Binding;
+                ICommand? command = binding.Command;
+                object? parameter = binding.CommandParameter;
+                if (command is null)
+                {
+                    candidate.Collection.Report(InputBindingDiagnosticKind.InvalidBinding, binding);
+                    if (!candidate.IsCurrent) break;
+                    continue;
+                }
+
+                bool available = command.CanExecute(parameter);
+                if (!candidate.IsCurrent || !IsContextActive(root, window)) break;
+                if (!available)
+                {
+                    candidate.Collection.Report(InputBindingDiagnosticKind.CommandUnavailable, binding);
+                    if (!candidate.IsCurrent) break;
+                    continue;
+                }
+
+                // Consume before calling application code, including throwing commands. A focus
+                // change or self-removal must not let KeyUp activate another button afterwards.
+                (consumedKeys ??= []).Add(key);
+                e.SuppressKeyPress = true;
+                if (command is DelegateCommand delegated)
+                    delegated.ExecuteCore(parameter);
+                else
+                    command.Execute(parameter);
+                candidate.Collection.Report(InputBindingDiagnosticKind.Executed, binding);
+                return true;
+            }
+
+        // Once a press was consumed, keep its remaining repeats/release out of normal control
+        // input even if availability changes. Each repeat can still resolve an available fallback.
+        if (consumedKeys?.Contains(key) == true)
+        {
+            e.SuppressKeyPress = true;
+            return true;
+        }
+        return false;
+    }
+
+    internal bool ProcessKeyUp(KeyEventArgs e)
+    {
+        if (consumedKeys?.Remove(e.KeyData & Keys.KeyCode) != true) return false;
+        e.SuppressKeyPress = true;
+        return true;
+    }
+
+    internal void Reset() => consumedKeys?.Clear();
+
+    private static bool IsContextActive(Control root, WindowBase? window)
+        => !root.IsDisposed && root.Visible && root.Enabled && window?.InputBindingsClosed != true && !Application.IsExiting;
+
+    private static void Collect(InputBindingCollection? collection, KeyEventArgs e, ref List<Candidate>? candidates)
+    {
+        if (collection is null || collection.Count == 0 || !collection.IsActive) return;
+        collection.VerifyAccess();
+        int version = collection.Version;
+        for (int i = 0; i < collection.Count; i++)
+        {
+            var binding = collection[i];
+            if (binding.Gesture.Matches(e))
+                (candidates ??= []).Add(new Candidate(binding, binding.Version, collection, version));
+        }
+    }
+
+    private readonly record struct Candidate(InputBinding Binding, int BindingVersion, InputBindingCollection Collection, int CollectionVersion)
+    {
+        internal bool IsCurrent => Collection.IsActive && Collection.Version == CollectionVersion &&
+            Binding.Version == BindingVersion && ReferenceEquals(Binding.Owner, Collection);
+    }
+}

--- a/ModernFormsNext/InputBinding.cs
+++ b/ModernFormsNext/InputBinding.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics;
+using System.Windows.Input;
+
+namespace ModernFormsNext;
+
+/// <summary>Associates a concrete application command and parameter with one keyboard gesture.</summary>
+/// <remarks>
+/// This Phase 2 contract performs no command-target or handler routing. Create and mutate a binding
+/// on its UI thread. One binding belongs to at most one collection; share the ICommand between
+/// separate bindings instead. Removal releases ownership without disposing the command or parameter.
+/// There are no CanExecuteChanged subscriptions: keyboard availability is evaluated on activation.
+/// </remarks>
+[DebuggerDisplay("{Gesture}")]
+public abstract class InputBinding
+{
+    private readonly int threadId = Environment.CurrentManagedThreadId;
+    private ICommand? command;
+    private object? parameter;
+    private KeyGesture gesture;
+
+    /// <summary>Initializes a binding to a concrete command and gesture.</summary>
+    /// <param name="command">The command; null represents an inactive binding.</param>
+    /// <param name="gesture">The gesture; its default value represents an inactive binding.</param>
+    protected InputBinding(ICommand? command, KeyGesture gesture)
+    {
+        this.command = command;
+        this.gesture = gesture;
+    }
+
+    /// <summary>Gets or sets the concrete command; null makes this binding inactive.</summary>
+    /// <remarks>Set on the creating UI thread. Replacement affects the next evaluation; no command is disposed.</remarks>
+    public ICommand? Command
+    {
+        get => command;
+        set { VerifyAccess(); if (ReferenceEquals(command, value)) return; command = value; Changed(); }
+    }
+
+    /// <summary>Gets or sets the nullable parameter passed unchanged to CanExecute and Execute.</summary>
+    /// <remarks>Set on the creating UI thread. Mutating a parameter object's contents requires no requery event for keyboard bindings.</remarks>
+    public object? CommandParameter
+    {
+        get => parameter;
+        set { VerifyAccess(); if (ReferenceEquals(parameter, value)) return; parameter = value; Changed(); }
+    }
+
+    /// <summary>Gets or sets the gesture. Its default value makes this binding inactive.</summary>
+    /// <remarks>Set on the creating UI thread. Changes do not trigger layout or rendering.</remarks>
+    public KeyGesture Gesture
+    {
+        get => gesture;
+        set { VerifyAccess(); if (gesture == value) return; gesture = value; Changed(); }
+    }
+
+    internal InputBindingCollection? Owner { get; set; }
+    internal int Version { get; private set; }
+
+    internal void VerifyAccess()
+    {
+        if (Environment.CurrentManagedThreadId != threadId)
+            throw new InvalidOperationException("Input bindings must be accessed on their creating UI thread.");
+        Owner?.VerifyAccess();
+    }
+
+    private void Changed() { Version++; Owner?.BindingChanged(this); }
+}

--- a/ModernFormsNext/InputBindingCollection.cs
+++ b/ModernFormsNext/InputBindingCollection.cs
@@ -1,0 +1,124 @@
+using System.Collections.ObjectModel;
+
+namespace ModernFormsNext;
+
+/// <summary>Owns the ordered input bindings for one control, window or application scope.</summary>
+/// <remarks>
+/// The first added matching available command wins. Unavailable bindings allow later registrations
+/// and outer scopes to match. Duplicate gestures are allowed, but a binding object has one owner.
+/// Read and mutate on the owning UI thread. Clearing/removing releases binding ownership, without
+/// disposing commands or parameters. Scope disposal clears registrations and diagnostics observers.
+/// Bindings are runtime-only and are not serialized by the Designer.
+/// </remarks>
+public sealed class InputBindingCollection : Collection<InputBinding>
+{
+    private readonly int threadId = Environment.CurrentManagedThreadId;
+    private object? scope;
+    private bool disposed;
+
+    internal InputBindingCollection(object? scope) => this.scope = scope;
+
+    /// <summary>Occurs synchronously for invalid/duplicate registrations and matching command outcomes.</summary>
+    /// <remarks>Optional; no diagnostic event args are allocated without a subscriber. Observers must not mutate input state.</remarks>
+    public event EventHandler<InputBindingDiagnosticEventArgs>? Diagnostic;
+
+    internal int Version { get; private set; }
+    internal bool IsActive => !disposed && scope switch
+    {
+        Control control => !control.IsDisposed && control.Enabled && control.Visible,
+        WindowBase window => !window.InputBindingsClosed,
+        _ => !Application.IsExiting
+    };
+
+    internal void VerifyAccess()
+    {
+        ObjectDisposedException.ThrowIf(disposed || scope is Control { IsDisposed: true }, this);
+        if (Environment.CurrentManagedThreadId != threadId)
+            throw new InvalidOperationException("Input binding collections must be accessed on their owning UI thread.");
+    }
+
+    /// <inheritdoc/>
+    protected override void InsertItem(int index, InputBinding item)
+    {
+        VerifyItem(item);
+        base.InsertItem(index, item);
+        item.Owner = this;
+        BindingChanged(item);
+    }
+
+    /// <inheritdoc/>
+    protected override void SetItem(int index, InputBinding item)
+    {
+        VerifyAccess();
+        if (ReferenceEquals(this[index], item)) return;
+        VerifyItem(item);
+        this[index].Owner = null;
+        base.SetItem(index, item);
+        item.Owner = this;
+        BindingChanged(item);
+    }
+
+    /// <inheritdoc/>
+    protected override void RemoveItem(int index)
+    {
+        VerifyAccess();
+        this[index].Owner = null;
+        base.RemoveItem(index);
+        Version++;
+    }
+
+    /// <inheritdoc/>
+    protected override void ClearItems()
+    {
+        VerifyAccess();
+        ClearCore();
+    }
+
+    private void VerifyItem(InputBinding item)
+    {
+        VerifyAccess();
+        ArgumentNullException.ThrowIfNull(item);
+        item.VerifyAccess();
+        if (item.Owner is not null)
+            throw new ArgumentException("An input binding can belong to only one collection and cannot be added twice.", nameof(item));
+    }
+
+    internal void BindingChanged(InputBinding binding)
+    {
+        Version++;
+        if (binding.Command is null || binding.Gesture.Key == Keys.None)
+            Report(InputBindingDiagnosticKind.InvalidBinding, binding);
+        else if (Diagnostic is not null)
+            for (int i = 0; i < Count; i++)
+                if (!ReferenceEquals(this[i], binding) && this[i].Gesture == binding.Gesture)
+                {
+                    Report(InputBindingDiagnosticKind.DuplicateGesture, binding);
+                    break;
+                }
+    }
+
+    internal void Report(InputBindingDiagnosticKind kind, InputBinding binding)
+    {
+        var handler = Diagnostic;
+        if (handler is not null)
+            handler(this, new InputBindingDiagnosticEventArgs(kind, binding));
+    }
+
+    private void ClearCore()
+    {
+        foreach (var binding in Items) binding.Owner = null;
+        base.ClearItems();
+        Version++;
+    }
+
+    // Disposal may also originate from Control's finalizer. Releasing managed references here
+    // does not call application code, dispose commands or require dispatcher work.
+    internal void Release()
+    {
+        if (disposed) return;
+        disposed = true;
+        ClearCore();
+        Diagnostic = null;
+        scope = null;
+    }
+}

--- a/ModernFormsNext/InputBindingCollection.cs
+++ b/ModernFormsNext/InputBindingCollection.cs
@@ -23,6 +23,7 @@ public sealed class InputBindingCollection : Collection<InputBinding>
     public event EventHandler<InputBindingDiagnosticEventArgs>? Diagnostic;
 
     internal int Version { get; private set; }
+    internal Control? ControlScope => scope as Control;
     internal bool IsActive => !disposed && scope switch
     {
         Control control => !control.IsDisposed && control.Enabled && control.Visible,

--- a/ModernFormsNext/InputBindingDiagnosticEventArgs.cs
+++ b/ModernFormsNext/InputBindingDiagnosticEventArgs.cs
@@ -1,0 +1,30 @@
+namespace ModernFormsNext;
+
+/// <summary>Identifies a registration or execution observation from an input-binding collection.</summary>
+public enum InputBindingDiagnosticKind
+{
+    /// <summary>A registration has no command or a default invalid gesture.</summary>
+    InvalidBinding,
+    /// <summary>Another registration in the same collection has the same gesture; insertion order decides precedence.</summary>
+    DuplicateGesture,
+    /// <summary>A matching command returned false from CanExecute; lookup may fall back.</summary>
+    CommandUnavailable,
+    /// <summary>A matching binding's command was invoked successfully.</summary>
+    Executed
+}
+
+/// <summary>Describes an opt-in input-binding diagnostic without formatting parameter contents.</summary>
+/// <remarks>Delivered synchronously on the UI thread. Observers must not mutate input state; their exceptions propagate.</remarks>
+public sealed class InputBindingDiagnosticEventArgs : EventArgs
+{
+    internal InputBindingDiagnosticEventArgs(InputBindingDiagnosticKind kind, InputBinding binding)
+    {
+        Kind = kind;
+        Binding = binding;
+    }
+
+    /// <summary>Gets the observation kind.</summary>
+    public InputBindingDiagnosticKind Kind { get; }
+    /// <summary>Gets the observed binding. This event does not transfer ownership.</summary>
+    public InputBinding Binding { get; }
+}

--- a/ModernFormsNext/KeyBinding.cs
+++ b/ModernFormsNext/KeyBinding.cs
@@ -1,0 +1,22 @@
+using System.Windows.Input;
+
+namespace ModernFormsNext;
+
+/// <summary>Invokes a concrete command when its keyboard gesture wins scoped input-binding lookup.</summary>
+/// <remarks>
+/// Uses KeyDown only, including backend-delivered repeats. Normal Button.Click is not synthesized.
+/// Commands use their current parameter and a fresh CanExecute check. This type adds no routed commands.
+/// </remarks>
+/// <example><code>
+/// form.InputBindings.Add(new KeyBinding(saveCommand, new KeyGesture(Keys.S, KeyModifiers.Control))
+/// {
+///     CommandParameter = document
+/// });
+/// </code></example>
+public sealed class KeyBinding : InputBinding
+{
+    /// <summary>Creates a keyboard binding on the current UI thread.</summary>
+    /// <param name="command">The concrete command, or null for an inactive binding.</param>
+    /// <param name="gesture">The gesture, or its default value for an inactive binding.</param>
+    public KeyBinding(ICommand? command, KeyGesture gesture) : base(command, gesture) { }
+}

--- a/ModernFormsNext/KeyEventArgs.cs
+++ b/ModernFormsNext/KeyEventArgs.cs
@@ -114,6 +114,8 @@ namespace ModernFormsNext
                 keys |= Keys.Shift;
             if (modifiers.HasFlag (RawInputModifiers.AltGraph))
                 keys |= Keys.AltGraph;
+            if (modifiers.HasFlag (RawInputModifiers.Meta))
+                keys |= Keys.Meta;
 
             return keys;
         }

--- a/ModernFormsNext/KeyGesture.cs
+++ b/ModernFormsNext/KeyGesture.cs
@@ -1,0 +1,82 @@
+using ModernFormsNext.WindowKit.Input;
+
+namespace ModernFormsNext;
+
+/// <summary>Identifies one keyboard shortcut by a framework key and exact modifier flags.</summary>
+/// <remarks>
+/// Uses logical key identities supplied by the current backend, not text, scan codes or key chords.
+/// AltGraph is reserved for international text input and never matches a shortcut. Printable keys
+/// require Control, Alt or Meta so ordinary and Shift-modified typing remain available to controls.
+/// The default value is invalid and never matches. This immutable value is safe to share across threads.
+/// </remarks>
+/// <example><code>var save = new KeyGesture(Keys.S, KeyModifiers.Control);</code></example>
+public readonly struct KeyGesture : IEquatable<KeyGesture>
+{
+    private const KeyModifiers SupportedModifiers = KeyModifiers.Control | KeyModifiers.Shift | KeyModifiers.Alt | KeyModifiers.Meta;
+
+    /// <summary>Creates a single-key gesture.</summary>
+    /// <param name="key">A defined non-modifier keyboard key, without embedded modifier flags.</param>
+    /// <param name="modifiers">The exact required modifiers. AltGraph is not supported for shortcuts.</param>
+    /// <exception cref="ArgumentException">The key/modifier combination is invalid or reserved for typing.</exception>
+    public KeyGesture(Keys key, KeyModifiers modifiers = KeyModifiers.None)
+    {
+        if ((modifiers & ~SupportedModifiers) != 0 || !IsKeyboardKey(key))
+            throw new ArgumentException("A gesture requires a keyboard key and supported shortcut modifiers.");
+        if (IsPrintableKey(key) && (modifiers & (KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Meta)) == 0)
+            throw new ArgumentException("Printable shortcut keys require Control, Alt or Meta; unmodified and Shift-only keys are reserved for text input.");
+        Key = key;
+        Modifiers = modifiers;
+    }
+
+    /// <summary>Gets the framework key without modifier flags; None identifies the default invalid value.</summary>
+    public Keys Key { get; }
+
+    /// <summary>Gets the exact modifiers required to match this gesture.</summary>
+    public KeyModifiers Modifiers { get; }
+
+    /// <summary>Tests an existing framework key event without consuming it or evaluating a command.</summary>
+    /// <param name="e">The non-null key event. The caller decides whether its KeyDown or KeyUp stage is relevant.</param>
+    /// <returns>True for the same key and exact modifiers, excluding all AltGraph input.</returns>
+    public bool Matches(KeyEventArgs e)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        return Key != Keys.None && !e.AltGraph && (e.KeyData & Keys.KeyCode) == Key && FromKeys(e.Modifiers) == Modifiers;
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(KeyGesture other) => Key == other.Key && Modifiers == other.Modifiers;
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is KeyGesture other && Equals(other);
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Key, Modifiers);
+    /// <summary>Compares two gesture values for equality.</summary>
+    public static bool operator ==(KeyGesture left, KeyGesture right) => left.Equals(right);
+    /// <summary>Compares two gesture values for inequality.</summary>
+    public static bool operator !=(KeyGesture left, KeyGesture right) => !left.Equals(right);
+
+    /// <summary>Returns a stable diagnostic representation, not a localized label or parseable contract.</summary>
+    public override string ToString()
+        => Key == Keys.None ? "<invalid>" :
+            ((Modifiers & KeyModifiers.Control) != 0 ? "Ctrl+" : "") +
+            ((Modifiers & KeyModifiers.Shift) != 0 ? "Shift+" : "") +
+            ((Modifiers & KeyModifiers.Alt) != 0 ? "Alt+" : "") +
+            ((Modifiers & KeyModifiers.Meta) != 0 ? "Meta+" : "") + Key;
+
+    private static KeyModifiers FromKeys(Keys keys)
+        => ((keys & Keys.Control) != 0 ? KeyModifiers.Control : 0) |
+           ((keys & Keys.Shift) != 0 ? KeyModifiers.Shift : 0) |
+           ((keys & Keys.Alt) != 0 ? KeyModifiers.Alt : 0) |
+           ((keys & Keys.Meta) != 0 ? KeyModifiers.Meta : 0) |
+           // Unknown modifier bits must not accidentally match a known gesture.
+           ((keys & ~(Keys.Control | Keys.Shift | Keys.Alt | Keys.Meta)) != 0 ? (KeyModifiers)(-1) : 0);
+
+    private static bool IsKeyboardKey(Keys key)
+        => (key & Keys.Modifiers) == 0 && Enum.IsDefined(key) && key is not
+            (Keys.None or Keys.LButton or Keys.RButton or Keys.MButton or Keys.XButton1 or Keys.XButton2 or
+             Keys.ShiftKey or Keys.ControlKey or Keys.Menu or Keys.LShiftKey or Keys.RShiftKey or
+             Keys.LControlKey or Keys.RControlKey or Keys.LMenu or Keys.RMenu or Keys.LWin or Keys.RWin or Keys.ProcessKey);
+
+    private static bool IsPrintableKey(Keys key)
+        => key == Keys.Space || key is >= Keys.D0 and <= Keys.Z || key is >= Keys.NumPad0 and <= Keys.Divide ||
+           key is >= Keys.OemSemicolon and <= Keys.OemBackslash;
+}

--- a/ModernFormsNext/Keys.cs
+++ b/ModernFormsNext/Keys.cs
@@ -990,5 +990,9 @@ namespace ModernFormsNext
         /// Control modifier. This flag distinguishes that sequence from a Control shortcut.
         /// </remarks>
         AltGraph = 0x00080000,
+
+        /// <summary>The platform meta modifier, such as the Windows key.</summary>
+        /// <remarks>Backend delivery is subject to shortcuts reserved by the operating system.</remarks>
+        Meta = 0x00100000,
     }
 }

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -26,6 +26,7 @@ public sealed class SkiaControlSurface : IDisposable, IPlatformAccessibilityHost
     private int pointerDragThreshold = 8;
     private int pointerDownRouteDepth;
     private bool disposed;
+    private readonly DataBinding.InputBindingResolver inputBindingResolver = new();
 
     /// <summary>
     /// Creates an adapter for a framework control tree.
@@ -454,25 +455,50 @@ public sealed class SkiaControlSurface : IDisposable, IPlatformAccessibilityHost
     /// <summary>Routes a platform key-down transition to the selected framework control.</summary>
     /// <param name="key">The platform-neutral framework key.</param>
     public void ProcessKeyDown(Keys key)
+        => ProcessKeyDown(key, isTextInput: false);
+
+    /// <summary>Routes an existing key-down transition, distinguishing physical keyboard input from IME editing requests.</summary>
+    /// <param name="key">The framework key with any current modifier flags.</param>
+    /// <param name="isTextInput">True for software keyboard/IME editing requests, which must bypass shortcut lookup.</param>
+    /// <remarks>
+    /// Call on the owning UI thread. Hardware events resolve local/ancestor and application bindings
+    /// before normal control input. A standalone surface has no WindowBase scope. Repeats execute
+    /// once per delivered KeyDown; successful shortcuts consume their corresponding KeyUp.
+    /// Text/composition APIs continue to use the editing path and never evaluate shortcuts.
+    /// </remarks>
+    public void ProcessKeyDown(Keys key, bool isTextInput)
     {
         ThrowIfDisposed();
+        if (Root.IsDisposed) return;
         var selected = FindSelectedControl();
-        if (selected is null)
-            return;
-
         var args = new KeyEventArgs(key);
-        selected.RaiseKeyDown(args);
+        if (!isTextInput && inputBindingResolver.ProcessKeyDown(args, selected, Root, null))
+        {
+            Invalidated?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+        selected?.RaiseKeyDown(args);
         if (!args.SuppressKeyPress && key is Keys.Enter or Keys.Return)
-            selected.RaiseKeyPress(new KeyPressEventArgs("\r", key));
+            selected?.RaiseKeyPress(new KeyPressEventArgs("\r", key));
         Invalidated?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>Routes a platform key-up transition to the selected framework control.</summary>
     /// <param name="key">The platform-neutral framework key.</param>
     public void ProcessKeyUp(Keys key)
+        => ProcessKeyUp(key, isTextInput: false);
+
+    /// <summary>Routes a key-up transition without executing keyboard bindings again.</summary>
+    /// <param name="key">The framework key with any current modifiers.</param>
+    /// <param name="isTextInput">True for software keyboard/IME editing requests that bypass shortcut state.</param>
+    /// <remarks>Call on the owning UI thread. A consumed hardware press cannot activate a button again on release.</remarks>
+    public void ProcessKeyUp(Keys key, bool isTextInput)
     {
         ThrowIfDisposed();
-        FindSelectedControl()?.RaiseKeyUp(new KeyEventArgs(key));
+        if (Root.IsDisposed) return;
+        var args = new KeyEventArgs(key);
+        if (isTextInput || !inputBindingResolver.ProcessKeyUp(args))
+            FindSelectedControl()?.RaiseKeyUp(args);
         Invalidated?.Invoke(this, EventArgs.Empty);
     }
 
@@ -492,6 +518,7 @@ public sealed class SkiaControlSurface : IDisposable, IPlatformAccessibilityHost
 
         CancelAllPointers(invalidate: false);
         disposed = true;
+        inputBindingResolver.Reset();
         foreach (var textBox in observedControls.OfType<TextBox>())
             textBox.document.FinishComposition();
         foreach (var control in observedControls.ToArray())

--- a/ModernFormsNext/WindowBase.InputBindings.cs
+++ b/ModernFormsNext/WindowBase.InputBindings.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+
+namespace ModernFormsNext;
+
+public abstract partial class WindowBase
+{
+    private InputBindingCollection? inputBindings;
+
+    /// <summary>Gets runtime keyboard bindings available throughout this window, including focused children.</summary>
+    /// <remarks>
+    /// Access on the owning UI thread. Window KeyDown preview retains first refusal. Binding lookup
+    /// then checks the focused control and ancestors, this window and Application, before normal
+    /// control input. Actual close/disposal releases this collection and descendant registrations;
+    /// cancelling close preserves them. No native/global hotkey is registered.
+    /// </remarks>
+    /// <example><code>
+    /// form.InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.S, KeyModifiers.Control)));
+    /// </code></example>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public InputBindingCollection InputBindings
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(InputBindingsClosed, this);
+            var bindings = inputBindings ??= new InputBindingCollection(this);
+            bindings.VerifyAccess();
+            return bindings;
+        }
+    }
+
+    internal bool InputBindingsClosed { get; private set; }
+    internal InputBindingCollection? InputBindingsInternal => inputBindings;
+
+    private void ReleaseInputBindings()
+    {
+        if (InputBindingsClosed) return;
+        InputBindingsClosed = true;
+        inputBindings?.Release();
+        inputBindings = null;
+        adapter.ReleaseInputBindingsForSubtree();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        ReleaseInputBindings();
+        base.Dispose(disposing);
+    }
+}

--- a/ModernFormsNext/WindowBase.InputBindings.cs
+++ b/ModernFormsNext/WindowBase.InputBindings.cs
@@ -5,6 +5,7 @@ namespace ModernFormsNext;
 public abstract partial class WindowBase
 {
     private InputBindingCollection? inputBindings;
+    private readonly DataBinding.InputBindingResolver inputBindingResolver = new();
 
     /// <summary>Gets runtime keyboard bindings available throughout this window, including focused children.</summary>
     /// <remarks>
@@ -36,6 +37,7 @@ public abstract partial class WindowBase
     {
         if (InputBindingsClosed) return;
         InputBindingsClosed = true;
+        inputBindingResolver.Reset();
         inputBindings?.Release();
         inputBindings = null;
         adapter.ReleaseInputBindingsForSubtree();

--- a/ModernFormsNext/WindowBase.cs
+++ b/ModernFormsNext/WindowBase.cs
@@ -40,6 +40,7 @@ namespace ModernFormsNext
             window.Paint = DoPaint;
             window.Resized = OnResize;
             window.Closed = () => {
+                ReleaseInputBindings();
                 // A secondary window can close without shutting down the process-wide scheduler.
                 // Release every control-owned animation so callbacks cannot retain its detached
                 // visual tree. The operation is idempotent with the explicit Close path below.
@@ -103,7 +104,8 @@ namespace ModernFormsNext
             }
             
             adapter.CancelOwnedControlAnimationsForSubtree ();
-            window.Dispose (); 
+            ReleaseInputBindings();
+            window.Dispose ();
         }
 
         /// <summary>

--- a/ModernFormsNext/WindowBase.cs
+++ b/ModernFormsNext/WindowBase.cs
@@ -48,6 +48,7 @@ namespace ModernFormsNext
                 Closed?.Invoke (this, EventArgs.Empty);
             };
             window.Deactivated = () => {
+                inputBindingResolver.Reset();
                 // If we're clicking off the form, deactivate any active menus
                 Application.ClosePopups ();
                 Deactivated?.Invoke (this, EventArgs.Empty);
@@ -300,22 +301,30 @@ namespace ModernFormsNext
                 switch (ke.Type) {
                     case RawKeyEventType.KeyDown:
                         var kd_e = new KeyEventArgs(WindowKitExtensions.AddModifiers(WindowKitKeyMapper.ToFormsKey(ke.Key), ke.Modifiers));
-                        OnKeyDown (kd_e);
-
-                        if (kd_e.Handled)
-                            return;
-
-                        adapter.RaiseKeyDown (kd_e);
+                        try {
+                            OnKeyDown (kd_e);
+                            if (!kd_e.Handled && !InputBindingsClosed &&
+                                !inputBindingResolver.ProcessKeyDown(kd_e, adapter.SelectedControl, adapter, this))
+                                adapter.RaiseKeyDown (kd_e);
+                        }
+                        finally {
+                            // The backend already suppresses translated text/default OS input
+                            // for handled keys. Keep managed and raw consumption consistent.
+                            ke.Handled = kd_e.Handled;
+                        }
                         break;
                     case RawKeyEventType.KeyUp:
                         var ku_e = new KeyEventArgs(WindowKitExtensions.AddModifiers(WindowKitKeyMapper.ToFormsKey(ke.Key), ke.Modifiers));
 
-                        OnKeyUp (ku_e);
-
-                        if (ku_e.Handled)
-                            return;
-
-                        adapter.RaiseKeyUp (ku_e);
+                        bool consumedRelease = inputBindingResolver.ProcessKeyUp(ku_e);
+                        try {
+                            OnKeyUp (ku_e);
+                            if (!consumedRelease && !ku_e.Handled && !InputBindingsClosed)
+                                adapter.RaiseKeyUp (ku_e);
+                        }
+                        finally {
+                            ke.Handled = consumedRelease || ku_e.Handled;
+                        }
                         break;
                 }
             } else if (e is RawTextInputEventArgs te) {

--- a/docs/commands-phase2-audit.md
+++ b/docs/commands-phase2-audit.md
@@ -1,0 +1,37 @@
+# Issue #56 Phase 2 input audit
+
+Baseline: `574c5f7880b04440948c9f0e1b6fcc55f62477c4`, verified master = origin/master.
+Scope: input bindings, gestures, scopes and precedence only. Issue #56 stays open.
+
+| Area | Existing behavior | Phase 2 requirement | Proposed integration |
+| --- | --- | --- | --- |
+| Windows key creation | WindowImpl maps WM_KEYDOWN/WM_SYSKEYDOWN and key-up messages to WindowKit RawKeyEventArgs. Key repeats arrive as ordinary KeyDown events; no repeat flag is exposed. | Use this pipeline without hooks. | Execute once per delivered KeyDown, including repeats. No RegisterHotKey or native global hooks. |
+| Window dispatch | WindowBase.OnInput maps WindowKit.Key to Keys, calls window KeyDown first, then ControlAdapter.SelectedControl.RaiseKeyDown. It currently does not copy the managed key's Handled value back to the raw event. | Preserve preview and consume successful shortcuts at the backend. | Keep window preview first; resolve bindings before focused control input; propagate handled state. |
+| Focus/control input | ControlAdapter stores the selected control; controls receive direct input, not a bubbling command route. Button activation occurs on Enter/Space KeyUp. | Local and ancestor lookup, no double activation. | Snapshot matching bindings from the starting focus ancestry, then window/application. Consume the release of a shortcut press so Button KeyUp cannot execute a second action after focus changes. |
+| Text/editing | TextBox/MarkdownEditor handle editing KeyDown separately from committed text. Tab focus navigation lives in ControlAdapter.RaiseKeyPress. Existing editing shortcuts exclude AltGraph. | Preserve typing, composition and ordinary navigation when no binding executes. | Do not match text/IME commits; reserve unmodified/Shift-only printable gestures for text. Explicit configured shortcuts precede normal control KeyDown. |
+| Modifiers | WindowKit.Input.KeyModifiers already has Control, Shift, Alt, Meta and AltGraph. Keys has Control/Shift/Alt/AltGraph flags, but FromInputModifiers drops Meta. | Reuse canonical flags without changing existing values. | KeyGesture uses existing Keys + KeyModifiers. Add only the missing Keys.Meta flag and map the existing raw Meta bit. |
+| AltGr | WindowsKeyboardDevice marks physical RightAlt as AltGraph, preserving synthetic Control+Alt. Existing international text tests include Polish characters. | Ctrl+Alt must not steal AltGr typing. | Never match an AltGraph event to a command gesture. Real Control+Alt without AltGraph can match. No keyboard-layout detection or IME redesign. |
+| Mnemonics/menu | IsMnemonic and label mnemonic rendering exist; menu actions use their existing pointer/event paths. No general ProcessCmdKey-style accelerator resolver was found. | Avoid changing menu/Designer contracts. | Add scoped binding lookup only; leave menu ownership, mnemonics, toolbar actions and VS Designer command targets unchanged. |
+| Form shortcuts | FormShortcutsPanel subscribes to window KeyDown/Up/Press and marks them handled. | Preserve existing application handlers. | A handled window preview prevents binding lookup and control dispatch. |
+| Application lifetime | Application already owns shared resources, Run/Exit, an OnExit event and UI dispatcher. | Application scope and cleanup without a new lifecycle subsystem. | Lazy application collection; clear binding references on existing shutdown paths. |
+| Window/control lifetime | Controls dispose recursively. WindowBase Close and native Closed terminate window lifetime; closing can be cancelled. | No retained command/parameter references after successful closure/disposal. | Clear owned collections on disposal/actual close; leave cancelled close intact. No static control dictionaries or CanExecuteChanged subscriptions for nonvisual bindings. |
+| Android hardware keys | AndroidSkiaHostView.KeyInput publishes only Backspace/Delete/Enter/arrows; AndroidAppHost maps them into SkiaControlSurface.ProcessKeyDown/Up. Modifiers/source are currently discarded. | Bindings where hardware key events already exist. | Preserve hardware modifiers/source on the existing event and use the shared surface resolver. Letters/digits/function keys are not yet forwarded by this native adapter; do not claim full Android shortcut parity. |
+| Android IME | Commit/composition/deletion APIs and InputConnection.SendKeyEvent use editing paths. | Software input must not become a shortcut stream. | Tag existing view hardware events separately; IME editing-key dispatch explicitly skips bindings. No new IME features or #62 work. |
+| TestHost | Existing headless host supplies native-window abstractions and dispatcher draining; it intentionally lacks keyboard simulation. Existing core tests can invoke internal input boundaries and SkiaControlSurface. | Deterministic lookup and real pipeline regression tests. | Test existing boundaries directly; do not add TestHost input simulation or #64 Phase 2 APIs. |
+| Phase 1 | ICommand, DelegateCommand and shared CommandSource already guard execution and preserve Click semantics. | Reuse direct command semantics. | Fresh CanExecute/current parameter check, then DelegateCommand's internal guarded action core or ordinary ICommand.Execute. Keyboard does not synthesize Button.Click. |
+
+## Decisions before implementation
+
+KeyGesture is a value object using the existing platform-neutral enums. InputBinding/KeyBinding
+contain a concrete command, parameter and gesture; no target, routed command or handler route.
+Control, WindowBase (including Form), and Application own collections. Search order is focused
+control, nearest ancestors, window, application; first added available match wins in one scope.
+Unavailable/invalid bindings do not consume an otherwise unconsumed press. Successful bindings
+consume key down/text and its corresponding key up. Repeated KeyDown events reevaluate current
+availability. Mutating execution stops after the one selected action; predicates must be pure,
+and changes to a candidate registration invalidate that evaluation.
+
+Collections and attached bindings use the existing command-source UI-thread affinity policy.
+Diagnostics are opt-in per collection and cover invalid/duplicate registration, matches and
+unavailable commands. No priority framework, parser, chord sequences, global requery, routing,
+async helpers, Developer Tools UI, Designer serialization, #85 or #97 work is included.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -240,6 +240,8 @@ Windows the managed Handled flag now reaches the original raw event, allowing th
 to suppress resulting text. Its corresponding KeyUp is also consumed so changing focus to another
 Button cannot activate that button on release. Window KeyUp observers still see the event; clearing
 Handled there cannot forward an already consumed release to a control. KeyUp never executes a binding.
+Windows character suppression is reset for every new native KeyDown, including unmapped Unicode
+packet keys, so handling an earlier shortcut/editing key cannot discard a later text input sequence.
 
 Every delivered repeated KeyDown reevaluates current bindings and can execute once. Once a press
 executes, remaining repeats/release stay consumed even if the command becomes unavailable; available

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -214,6 +214,8 @@ control dispatch occurs. Otherwise lookup runs before ordinary control KeyDown, 
 4. `Application.InputBindings`.
 
 With no focused control, lookup starts at the root and still checks window/application scopes.
+Stale focus references to controls detached or moved into another tree are treated as no focus;
+detaching a candidate's scope during CanExecute also invalidates that evaluation.
 Standalone `SkiaControlSurface` uses the same rules without a window scope. Inactive, hidden or
 disposed control scopes are skipped. Application bindings apply only to input delivered to a
 framework window/surface; they are not OS-global hotkeys.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -246,6 +246,9 @@ executes, remaining repeats/release stay consumed even if the command becomes un
 fallback bindings can still execute on later repeats. Native window deactivation/closure and surface
 disposal clear remembered presses. AltGraph input always bypasses bindings, including suppression
 left by an earlier shortcut with different modifiers.
+Repeated KeyDown events are separate command invocations, useful for navigation or volume changes.
+Actions such as Save should tolerate repetition or use CanExecute to reject input while unavailable;
+Phase 2 does not add per-gesture repeat flags or an execution lock.
 
 Matching registrations are snapshotted before application predicates run. Adding/removing bindings
 or changing focus during Execute cannot restart the current activation or execute another binding.
@@ -297,6 +300,9 @@ collections and diagnostic subscribers. Cancelled window closure preserves them.
 parameters are application-owned and are never disposed by the collection. Application bindings
 retain their captures until removal/shutdown; remove short-lived captures explicitly. There are
 no static control dictionaries, per-frame scans or allocations for unmatched key lookup.
+The existing Application.Run contract still permits only one main loop per process. Phase 2 does
+not add application restart support: shutdown clears the global collection, and a new process
+starts without old registrations. Tests use the same internal cleanup path for isolated collections.
 
 Subscribe optionally to a collection's `Diagnostic` event for InvalidBinding, DuplicateGesture,
 CommandUnavailable and Executed outcomes. Observations are synchronous, allocate event args only
@@ -304,6 +310,9 @@ when subscribed, and do not format parameter contents. Observers must not mutate
 their exceptions propagate. This is minimal binding diagnostics; command-route diagnostics remain
 Phase 3. Collection changes do not trigger layout/rendering by themselves. Public InputBindings
 properties are hidden from Designer browsing/serialization and remain runtime-only.
+This public observer API lets applications explain conflicting registrations and unavailable
+shortcuts using their own logging. It exposes the binding and outcome, not resolver snapshots,
+scope traversal state or future command-route details.
 
 The existing ControlGallery **Button** section now supports Ctrl+1 / Ctrl+2 with the same save
 command and parameters as its buttons. With focus in the section, the panel's Ctrl+1 saves first

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,13 +1,14 @@
-# Commands (issue #56, Phase 1)
+# Commands and input bindings (issue #56, Phases 1 and 2)
 
 Commands represent reusable application actions. `System.Windows.Input.ICommand` is the contract:
 existing application implementations can be assigned directly. `ModernFormsNext.DelegateCommand`
 is the optional synchronous implementation provided by the framework. Events remain supported;
 an application can use `button.Click` without creating any command.
 
-This phase provides delegate commands, parameters, availability and two action sources: `Button`
-and `NotifyIconMenuItem`. Issue #56 remains open. Keyboard gestures, routed commands, scopes,
-async helpers and Designer integration are **not implemented by this phase**.
+Phase 1 provides delegate commands, parameters, availability and two action sources: `Button`
+and `NotifyIconMenuItem`. Phase 2 adds keyboard gestures and scoped input bindings to concrete
+commands. Issue #56 remains open: routed commands, async helpers and Designer integration are
+**not implemented**.
 
 ## Define once, reuse with different parameters
 
@@ -167,9 +168,151 @@ availability checkbox and an explicit-disable checkbox for the first button. Che
 hover, pressed and keyboard-focus rendering in the existing light/dark themes. This example does
 not modify DemoApp or the generated template experience.
 
+## Keyboard gestures and input bindings (Phase 2)
+
+`KeyGesture` is an immutable value containing the existing framework `Keys` key and
+`ModernFormsNext.WindowKit.Input.KeyModifiers` flags. Equality, hash codes and `Matches(KeyEventArgs)`
+compare the key and exact modifiers. Ctrl+S and Ctrl+Shift+S are distinct. Letters, digits, function
+and navigation keys are supported by the shared model. `ToString()` is for debugging (for example,
+`Ctrl+Shift+S`), not localization or parsing. There is no parser or chord sequence support.
+
+```csharp
+using ModernFormsNext;
+using ModernFormsNext.WindowKit.Input;
+
+var save = new DelegateCommand(
+    parameter => SaveDocument((string)parameter!),
+    parameter => CanSave && parameter is string);
+
+form.InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.S, KeyModifiers.Control)) {
+    CommandParameter = "current document"
+});
+editor.InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.S, KeyModifiers.Control | KeyModifiers.Shift)) {
+    CommandParameter = "selected document"
+});
+var refresh = new KeyBinding(new DelegateCommand(Refresh), new KeyGesture(Keys.F5));
+Application.InputBindings.Add(refresh);
+// Remove global bindings that capture short-lived windows before those windows close.
+Application.InputBindings.Remove(refresh);
+```
+
+`InputBinding` is the abstract shared model; `KeyBinding` is its concrete keyboard binding. Each
+holds a nullable `ICommand`, nullable `CommandParameter` and mutable `KeyGesture`. Parameter objects
+are passed unchanged. A missing command or `default(KeyGesture)` is an inactive registration.
+The gesture constructor rejects unknown/modifier-only keys, embedded modifier flags, AltGraph
+shortcuts, and unmodified/Shift-only printable keys. Configure Enter/navigation/function keys
+carefully: an available binding intentionally takes precedence over the control's default action.
+
+### Lookup order and conflicts
+
+The existing window KeyDown event keeps first refusal. If it sets Handled, no binding lookup or
+control dispatch occurs. Otherwise lookup runs before ordinary control KeyDown, in this order:
+
+1. Focused control's `InputBindings`.
+2. Its nearest ancestor, then each remaining ancestor up to the surface root.
+3. Owning `WindowBase.InputBindings` (including Form).
+4. `Application.InputBindings`.
+
+With no focused control, lookup starts at the root and still checks window/application scopes.
+Standalone `SkiaControlSurface` uses the same rules without a window scope. Inactive, hidden or
+disposed control scopes are skipped. Application bindings apply only to input delivered to a
+framework window/surface; they are not OS-global hotkeys.
+
+Within a collection, the **first added available match** wins. Duplicates are allowed. A null
+command, invalid gesture or `CanExecute == false` allows later registrations and outer scopes
+to provide a fallback. If nothing executes, a fresh key press remains available to normal input.
+This is binding lookup through control ancestry, **not hierarchical command routing**. Every
+binding directly names its ICommand; there is no CommandTarget, CommandBinding or handler route.
+
+### Execution, consumption and mutation
+
+On KeyDown: match gesture, read the current command/parameter, evaluate CanExecute and execute.
+An unchanged DelegateCommand gets one predicate check; its existing internal action entry point
+avoids a redundant check. Other ICommand implementations receive ordinary Execute and can perform
+their own checks. Keyboard execution does not synthesize Button.Click. Assign the same command
+to a Button to share the domain action with pointer, normal button keyboard and accessibility Invoke.
+Button's Phase 1 guard/CanExecute/DialogResult/Click/fresh-CanExecute/Execute sequence is unchanged.
+
+A successful binding sets `SuppressKeyPress` (also Handled) before calling application code. On
+Windows the managed Handled flag now reaches the original raw event, allowing the existing backend
+to suppress resulting text. Its corresponding KeyUp is also consumed so changing focus to another
+Button cannot activate that button on release. Window KeyUp observers still see the event; clearing
+Handled there cannot forward an already consumed release to a control. KeyUp never executes a binding.
+
+Every delivered repeated KeyDown reevaluates current bindings and can execute once. Once a press
+executes, remaining repeats/release stay consumed even if the command becomes unavailable; available
+fallback bindings can still execute on later repeats. Native window deactivation/closure and surface
+disposal clear remembered presses. AltGraph input always bypasses bindings, including suppression
+left by an earlier shortcut with different modifiers.
+
+Matching registrations are snapshotted before application predicates run. Adding/removing bindings
+or changing focus during Execute cannot restart the current activation or execute another binding.
+Predicates must be fast and free of side effects. If a candidate's command/parameter/gesture,
+collection membership/version or lifetime changes during its predicate, the obsolete evaluation
+is abandoned for that event. Subsequent presses use the new state. Predicate/Execute exceptions
+propagate unchanged; an Execute exception still leaves the press consumed. No polling or
+CanExecuteChanged subscription is needed for input bindings: availability is checked on input.
+
+### Modifiers, text and platforms
+
+The existing KeyModifiers model supplies Control, Shift, Alt, Meta and AltGraph. Phase 2 adds only
+the missing `Keys.Meta` flag and raw Meta mapping; previous enum values remain unchanged. Meta
+means the backend's platform modifier, not an automatic Ctrl/Command-key alias.
+
+Windows already marks physical right Alt as AltGraph, even when Control+Alt are also present.
+**AltGraph never matches a gesture**, so Ctrl+Alt bindings do not steal Polish AltGr combinations.
+Plain and Shift-only printable gestures are rejected. Unbound editing keys/shortcuts and text
+commit/composition paths retain their existing behavior. A true Ctrl+Alt event without AltGraph
+can match. No new keyboard-layout detection, dead-key decoder, IME subsystem or #62 work is added.
+Tests of committed accented text do not establish native keyboard-layout or dead-key-device coverage.
+
+Windows uses the existing raw-key → WindowBase → control pipeline, without hooks or RegisterHotKey.
+Android preserves modifiers and source metadata on its existing `AndroidInputKeyEvent`. Only
+physical-device view events are eligible; InputConnection, soft-keyboard and virtual-device
+transitions stay editing input. Hosts forward `isTextInput: !e.IsHardwareKey` to the surface key
+overloads and include the event's modifiers. The cross-platform sample demonstrates this adapter.
+The original two-argument Android event constructor retains editing defaults and deconstruction.
+
+Android's native adapter currently forwards only Backspace/Delete/Enter/arrows. Letters, digits
+and function keys are supported by KeyGesture but **not forwarded by that adapter yet**. There is
+no claim of Windows/Android shortcut parity or physical Android-device verification. Right Alt is
+conservatively marked AltGraph on Android as well. Existing software text editing does not become
+a shortcut stream. TestHost gains no keyboard simulation API.
+
+### Ownership, threading, diagnostics and Designer
+
+Create bindings and first access scope collections on the owning UI thread, following Phase 1's
+command-source affinity policy. Collection mutation and binding property setters reject a different
+thread with InvalidOperationException; they do not dispatch automatically. Lookup/execution also
+runs on the UI thread. There is no background-safe collection or new synchronization policy.
+
+One binding instance can belong to one collection at a time; duplicate registration of that same
+object throws. Separate objects may share gestures, commands and parameters. Removing, replacing
+or clearing a registration releases collection ownership, and the detached binding can be reused.
+The binding itself retains its assigned command/parameter until changed or no longer referenced.
+Disposing a control, actually closing/disposing a window, or application shutdown clears owned
+collections and diagnostic subscribers. Cancelled window closure preserves them. Commands and
+parameters are application-owned and are never disposed by the collection. Application bindings
+retain their captures until removal/shutdown; remove short-lived captures explicitly. There are
+no static control dictionaries, per-frame scans or allocations for unmatched key lookup.
+
+Subscribe optionally to a collection's `Diagnostic` event for InvalidBinding, DuplicateGesture,
+CommandUnavailable and Executed outcomes. Observations are synchronous, allocate event args only
+when subscribed, and do not format parameter contents. Observers must not mutate input state;
+their exceptions propagate. This is minimal binding diagnostics; command-route diagnostics remain
+Phase 3. Collection changes do not trigger layout/rendering by themselves. Public InputBindings
+properties are hidden from Designer browsing/serialization and remain runtime-only.
+
+The existing ControlGallery **Button** section now supports Ctrl+1 / Ctrl+2 with the same save
+command and parameters as its buttons. With focus in the section, the panel's Ctrl+1 saves first
+and Ctrl+2 saves second. Focus **Save second**: its local Ctrl+1 overrides the panel and saves second.
+Uncheck **Allow shared command** to disable both command sources and shortcuts. **Explicitly disable
+first** affects that Button's local enabled intent; it does not change availability of the shared
+command for another source. `KeyGestureTests`, `InputBindingTests` and `AndroidKeyboardBindingTests`
+cover matching, lookup, input integration, mutation, lifecycle and source classification.
+
 ## Deferred work
 
-- Phase 2: KeyGesture, KeyBinding, InputBinding, shortcut precedence and window/application scopes.
 - Phase 3: command targets, hierarchical routing, CommandBinding and diagnostics.
 - Phase 4: task-aware async helpers, deeper menu/toolbar/context-menu integration, Designer
   assignment/serialization, and expanded examples/documentation.
@@ -177,5 +320,5 @@ not modify DemoApp or the generated template experience.
 MenuItem ownership/lifecycle requires separate work before safe event subscriptions can be added
 across Menu, ToolBar, Ribbon and ContextMenu. Command properties on the Phase 1 sources are hidden
 from design-time browsing/serialization. There is no Designer Ctrl+S fix, BindingNavigator port,
-Developer Tools integration, automation bridge, new keyboard shortcut system, release or version
-bump in this phase. See the [baseline audit](commands-phase1-audit.md).
+Developer Tools integration, automation bridge, release or version bump in this phase. See the
+[Phase 1 audit](commands-phase1-audit.md) and [Phase 2 keyboard audit](commands-phase2-audit.md).

--- a/samples/ControlGallery/Panels/ButtonPanel.cs
+++ b/samples/ControlGallery/Panels/ButtonPanel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using ModernFormsNext;
 using ModernFormsNext.Renderers;
+using ModernFormsNext.WindowKit.Input;
 using SkiaSharp;
 
 namespace ControlGallery.Panels
@@ -194,9 +195,24 @@ namespace ControlGallery.Panels
                 Text = "Save first", Left = 100, Top = 480, Width = 140,
                 CommandParameter = "First document", Command = save
             });
-            Controls.Add(new Button {
+            var saveSecond = Controls.Add(new Button {
                 Text = "Save second", Left = 260, Top = 480, Width = 140,
                 CommandParameter = "Second document", Command = save
+            });
+            // Panel shortcuts share the buttons' domain action and parameters. The second
+            // button overrides Ctrl+1 locally to demonstrate nearest-scope precedence.
+            InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.D1, KeyModifiers.Control)) {
+                CommandParameter = "First document"
+            });
+            InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.D2, KeyModifiers.Control)) {
+                CommandParameter = "Second document"
+            });
+            saveSecond.InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.D1, KeyModifiers.Control)) {
+                CommandParameter = "Second document"
+            });
+            Controls.Add(new Label {
+                Text = "Ctrl+1: first; Ctrl+2: second. Focus Save second: Ctrl+1 uses its local binding.",
+                Left = 100, Top = 560, Width = 710, Height = 48
             });
             availability.CheckedChanged += (_, _) => save.RaiseCanExecuteChanged();
             var locallyDisabled = Controls.Add(new CheckBox {

--- a/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/AndroidAppHost.cs
+++ b/samples/ModernFormsNext.CrossPlatform.Sample/Platforms/Android/AndroidAppHost.cs
@@ -219,10 +219,16 @@ public sealed class AndroidAppHost : IDisposable
             _ => throw new ArgumentOutOfRangeException(nameof(e))
         };
 
+        if ((e.Modifiers & ModernFormsNext.WindowKit.Input.KeyModifiers.Control) != 0) key |= Keys.Control;
+        if ((e.Modifiers & ModernFormsNext.WindowKit.Input.KeyModifiers.Shift) != 0) key |= Keys.Shift;
+        if ((e.Modifiers & ModernFormsNext.WindowKit.Input.KeyModifiers.Alt) != 0) key |= Keys.Alt;
+        if ((e.Modifiers & ModernFormsNext.WindowKit.Input.KeyModifiers.Meta) != 0) key |= Keys.Meta;
+        if ((e.Modifiers & ModernFormsNext.WindowKit.Input.KeyModifiers.AltGraph) != 0) key |= Keys.AltGraph;
+
         if (e.IsDown)
-            controlSurface.ProcessKeyDown(key);
+            controlSurface.ProcessKeyDown(key, isTextInput: !e.IsHardwareKey);
         else
-            controlSurface.ProcessKeyUp(key);
+            controlSurface.ProcessKeyUp(key, isTextInput: !e.IsHardwareKey);
         app.UpdateLastInput($"Key {e.Key} {(e.IsDown ? "down" : "up")}");
     }
 


### PR DESCRIPTION
## Summary

Implements Phase 2 of #56 — keyboard gestures and scoped input bindings. Applications can bind a concrete command once at a control, window or application scope and invoke the same domain action from a Button and a keyboard shortcut.

## Foundation

Builds on Phase 1's canonical `System.Windows.Input.ICommand` and `DelegateCommand`. Binding lookup extends the existing WindowBase and SkiaControlSurface keyboard entry points; it introduces no second command system, keyboard dispatcher, global hook or OS hotkey registration. Button's existing guarded Click → fresh CanExecute → Execute behavior remains unchanged.

## API

- `KeyGesture`: framework key, exact existing modifiers, value equality/hash and diagnostic text.
- `InputBinding`, `KeyBinding`, `InputBindingCollection`: concrete command, parameter, gesture and ordered registration ownership.
- `Control.InputBindings`, `WindowBase.InputBindings`, `Application.InputBindings`.
- Additive `Keys.Meta` mapping and small opt-in binding diagnostics; existing enum values are unchanged.
- XML documentation and runtime-only Designer-hidden properties. No parser, chords or routing metadata.

## Resolution

After the existing window KeyDown preview: **focused control → nearest ancestors → window → application**.

The **first added available match** wins within a collection. An unavailable, missing or invalid command permits later registrations and outer scopes to match. Duplicate gestures are allowed; one binding instance can have only one owner. Detached or reparented stale focus references cannot escape the current control tree.

This is lookup of a binding that directly names its ICommand, not hierarchical command-handler routing.

## Input behavior

Bindings execute on KeyDown with the current parameter and a fresh CanExecute check. Each repeated KeyDown is a separate invocation; there is no repeat metadata or execution lock. Successful activation sets SuppressKeyPress/Handled and consumes the corresponding KeyUp, preventing a focus-changing command from activating another Button on release. Later normal presses remain usable.

Matching registrations are snapshotted and validated against owner/lifetime/version changes. Focus changes, self-removal, additions and owner teardown during execution cannot trigger a second lookup in the same event. Stale predicates are abandoned. Exceptions retain the existing synchronous calling-path behavior.

Collections and mutable bindings are UI-thread-affine. Removal/disposal releases registration ownership; actual control/window/application teardown clears owned collections and diagnostic observers. Cancelled close preserves them. Bindings do not subscribe to CanExecuteChanged; global captures should be removed when their shorter lifetime ends. Existing Application.Run remains limited to one main loop per process.

## Text safety

AltGraph never matches a gesture. Real Ctrl+Alt without AltGraph remains supported, and plain/Shift-only printable gestures are rejected. Existing text editing, navigation and committed text retain their normal paths. InputConnection/software-keyboard events bypass shortcut resolution. Windows character suppression resets on every new native KeyDown, including unmapped VK_PACKET, so a previously handled shortcut/editing key cannot discard later Unicode input. Keyboard bindings execute ICommand directly without synthesizing Button.Click.

## Android

Existing Android key events now preserve modifiers and hardware/IME source information. The native adapter still forwards only Backspace/Delete/Enter/arrows; letters, digits and function keys are not forwarded yet. Shared bindings work with the hardware events that reach them. Physical Android hardware/IME device validation and native keyboard-layout/dead-key coverage were not performed; #62 remains separate.

## Validation

Validated commit: `ab1acb49d1b362478d08df70a3690984dc2e8431`.

| Suite | Debug | Release |
| --- | ---: | ---: |
| ModernFormsNext.Tests | 1062 | 1062 |
| Designer.Tests | 622 | 622 |
| Testing.Tests | 53 | 53 |
| Windows backend | 66 | 66 |
| Android backend | 163 | 163 |
| Cross-platform | 16 | 16 |
| VSIX | 26 | 26 |
| **Total passed** | **2008** | **2008** |

Zero failures/skips. Included subsets per configuration: **105 Phase 2** (KeyGesture 32 + InputBinding 63 + Android keyboard 8 + Windows keyboard 2), **64 Phase 1** (12 + 45 + 7), semantic accessibility 32, Windows UIA 54, Android accessibility provider 31.

- Restore and full Debug/Release solution builds pass with zero warnings/errors, including Android targets and VSIX package checks.
- ApiCompat: four core comparisons against Phase 1 master `574c5f7`, both framework targets/configurations, pass.
- DocFX: zero warnings/errors; documentation script tests 32/32; four documentation archives validated.
- Nine NuGet packages and eight symbol packages validated locally at unchanged version 1.10.0.
- ControlGallery: 14 automated UIA/Windows SendInput checks pass, including Button/shortcut parameters, unavailable commands, local-over-ancestor precedence, plain/Shift typing, Ctrl+A replacement and navigation. The command-section screenshot was visually inspected. Window/application fallback is covered by tests; the sample exposes local/ancestor scopes.
- Final diff check passes; no temporary artifacts or local configuration are included.

## Deferred

Phase 3: CommandTarget, RoutedCommand, CommandBinding, hierarchical command routing and route diagnostics.

Phase 4: AsyncCommand/helpers, deeper action controls and Designer support. No Designer Ctrl+S change, #85/#97 implementation, release, tag or version bump.

## Issue state

Part of #56 — completes Phase 2 only.

Issue #56 remains OPEN for Phases 3 and 4.

