### PR TITLE
Add routed commands and hierarchical command bindings

### DIFF
--- a/ModernFormsNext.Testing.Tests/RoutedCommandHostTests.cs
+++ b/ModernFormsNext.Testing.Tests/RoutedCommandHostTests.cs
@@ -1,0 +1,61 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Testing.Tests;
+
+public sealed class RoutedCommandHostTests
+{
+    [Fact]
+    public void BackgroundRequeryUsesExistingDispatcherAndSemanticActivation()
+    {
+        using var host = ModernFormsTestHost.Create();
+        var root = new Panel();
+        var command = new RoutedCommand("Save");
+        var button = root.Controls.Add(new Button { Command = command });
+        int uiThread = Environment.CurrentManagedThreadId, executions = 0;
+        bool available = true;
+        var threads = new List<int>();
+        root.CommandBindings.Add(new(command, (_, e) => { executions++; e.Handled = true; },
+            (_, e) => { threads.Add(Environment.CurrentManagedThreadId); e.CanExecute = available; }));
+        host.Show(root, 400, 200);
+        Assert.True(button.Enabled);
+        RunBackground(() => { available = false; command.RaiseCanExecuteChanged(); });
+        Assert.True(button.Enabled);
+        host.Dispatcher.Drain();
+        Assert.False(button.Enabled);
+        Assert.False(button.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        RunBackground(() => { available = true; command.RaiseCanExecuteChanged(); });
+        host.Dispatcher.Drain();
+        Assert.True(button.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(1, executions);
+        Assert.All(threads, thread => Assert.Equal(uiThread, thread));
+        Assert.Empty(host.Dispatcher.UnhandledExceptions);
+    }
+
+    [Fact]
+    public void QueuedRoutedNotificationCannotQueryDisposedButton()
+    {
+        using var host = ModernFormsTestHost.Create();
+        var root = new Panel();
+        var command = new RoutedCommand();
+        int queries = 0;
+        root.CommandBindings.Add(new(command, (_, _) => { }, (_, e) => { queries++; e.CanExecute = true; }));
+        var button = root.Controls.Add(new Button { Command = command });
+        host.Show(root, 400, 200);
+        RunBackground(command.RaiseCanExecuteChanged);
+        button.Dispose();
+        int beforeDrain = queries;
+        host.Dispatcher.Drain();
+        Assert.Equal(beforeDrain, queries);
+        Assert.Empty(host.Dispatcher.UnhandledExceptions);
+    }
+
+    private static void RunBackground(Action action)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() => { try { action(); } catch (Exception exception) { failure = exception; } });
+        thread.Start();
+        thread.Join();
+        if (failure is not null) throw new Xunit.Sdk.XunitException(failure.ToString());
+    }
+}

--- a/ModernFormsNext.Tests/CommandRoutingTests.FinalReview.cs
+++ b/ModernFormsNext.Tests/CommandRoutingTests.FinalReview.cs
@@ -1,0 +1,210 @@
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed partial class CommandRoutingTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StaleDetachedOrDisposedFocusUsesWindowRootForRoutedKeyboard(bool dispose)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Form.CommandBindings.Add(Bind(command, (_, e) => { Assert.Same(ui.Form.adapter, e.Target); calls++; }));
+        ui.Form.InputBindings.Add(new KeyBinding(command, SaveGesture));
+        if (dispose) ui.Focus.Dispose(); else ui.Focus.Parent = null;
+        // Exercise stale backend focus bookkeeping explicitly, including disposed controls that
+        // still retain their Parent reference. Gesture precedence itself must remain unchanged.
+        ui.Form.adapter.SelectedControl = ui.Focus;
+
+        Assert.True(ui.Key().Handled);
+        Assert.Equal(1, calls);
+        if (!dispose) ui.Focus.Dispose();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DisposingPreviouslyVisitedOwnerStopsRouteEvenAfterTargetWasReparented(bool duringQuery)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        int windowExecutions = 0;
+        ui.Parent.CommandBindings.Add(Bind(command, (_, _) => ui.Form.Controls.Add(ui.Focus), handled: false));
+        ui.Form.CommandBindings.Add(new(command, (_, _) => {
+            windowExecutions++;
+            if (!duringQuery) ui.Parent.Dispose();
+        }, (_, e) => {
+            if (duringQuery) ui.Parent.Dispose();
+            e.CanExecute = true;
+        }));
+        Application.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail("Disposed route must not reach application fallback.")));
+
+        command.Execute(null, ui.Focus);
+
+        Assert.False(ui.Focus.IsDisposed);
+        Assert.True(ui.Parent.IsDisposed);
+        Assert.Equal(duringQuery ? 0 : 1, windowExecutions);
+    }
+
+    [Fact]
+    public void DisposingUnvisitedOwnerDuringQueryAbortsBeforeSelectedExecution()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        ui.Focus.CommandBindings.Add(new(command, (_, _) => Assert.Fail(), (_, e) => {
+            ui.Form.Controls.Add(ui.Focus);
+            ui.Parent.Dispose();
+            e.CanExecute = true;
+        }));
+
+        Assert.False(command.CanExecute(null, ui.Focus));
+        Assert.False(ui.Focus.IsDisposed);
+    }
+
+    [Fact]
+    public void UnhandledExecutionVisitsAllOwnersOnceAndSkipsUnavailableLaterBinding()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var calls = new List<string>();
+        var owners = new[] { "target", "parent", "window", "application" };
+        var scopes = Scopes(ui);
+        for (int i = 0; i < scopes.Length; i++)
+        {
+            string owner = owners[i];
+            scopes[i].Add(new(command, (_, _) => calls.Add(owner + " execute"),
+                (_, e) => { calls.Add(owner + " query"); e.CanExecute = true; }));
+            scopes[i].Add(new(command, (_, _) => Assert.Fail(), (_, _) => calls.Add(owner + " unavailable")));
+        }
+
+        command.Execute(null, ui.Focus);
+
+        Assert.Equal(owners.SelectMany(owner => new[] { owner + " query", owner + " execute", owner + " unavailable" }), calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NestedAvailabilityQueriesKeepParametersTargetsAndExecutionCursorsIndependent(bool sameCommand)
+    {
+        using var ui = new WindowFixture();
+        var next = ui.Parent.Controls.Add(new Button());
+        var outer = new RoutedCommand("outer");
+        var inner = sameCommand ? outer : new RoutedCommand("inner");
+        var calls = new List<string>();
+        next.CommandBindings.Add(new(inner, (_, _) => Assert.Fail("A nested query must not execute."), (_, e) => {
+            Assert.Equal("inner parameter", e.Parameter);
+            Assert.Same(next, e.Target);
+            calls.Add("inner query");
+            e.CanExecute = true;
+        }));
+        ui.Focus.CommandBindings.Add(new(outer, (_, e) => {
+            Assert.Equal("outer parameter", e.Parameter);
+            Assert.Same(ui.Focus, e.Target);
+            calls.Add("outer execute");
+            e.Handled = true;
+        }, (_, e) => {
+            calls.Add("outer query");
+            e.CanExecute = inner.CanExecute("inner parameter", next);
+        }));
+
+        outer.Execute("outer parameter", ui.Focus);
+
+        Assert.Equal(["outer query", "inner query", "outer execute"], calls);
+    }
+
+    [Fact]
+    public void NestedDiagnosticQueryDoesNotReplaceOuterRouteOrDiagnosticTarget()
+    {
+        using var ui = new WindowFixture();
+        var next = ui.Parent.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        int nestedQueries = 0, executions = 0;
+        next.CommandBindings.Add(new(command, (_, _) => Assert.Fail(), (_, e) => { nestedQueries++; e.CanExecute = true; }));
+        ui.Focus.CommandBindings.Add(Bind(command, (_, e) => { Assert.Same(ui.Focus, e.Target); executions++; }));
+        bool observing = false;
+        command.Diagnostic += (_, e) => {
+            if (observing || e.Kind != CommandRoutingDiagnosticKind.BindingFound) return;
+            observing = true;
+            try { Assert.True(command.CanExecute(null, next)); }
+            finally { observing = false; }
+            Assert.Same(ui.Focus, e.Target);
+        };
+
+        command.Execute(null, ui.Focus);
+
+        Assert.Equal(1, nestedQueries);
+        Assert.Equal(1, executions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InnerCommandFailureCanBeCaughtWithoutCorruptingOuterContinuation(bool queryFailure)
+    {
+        using var ui = new WindowFixture();
+        var outer = new RoutedCommand();
+        var inner = new RoutedCommand();
+        var failure = new InvalidOperationException("private inner failure");
+        bool fail = true;
+        int continuations = 0, innerExecutions = 0;
+        ui.Focus.CommandBindings.Add(new(inner, (_, e) => {
+            if (fail && !queryFailure) throw failure;
+            innerExecutions++;
+            e.Handled = true;
+        }, (_, e) => { if (fail && queryFailure) throw failure; e.CanExecute = true; }));
+        ui.Focus.CommandBindings.Add(Bind(outer, (_, _) => {
+            if (fail) Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => inner.Execute(null, ui.Focus)));
+            else inner.Execute(null, ui.Focus);
+        }, handled: false));
+        ui.Parent.CommandBindings.Add(Bind(outer, (_, _) => continuations++));
+
+        outer.Execute(null, ui.Focus);
+        fail = false;
+        outer.Execute(null, ui.Focus);
+
+        Assert.Equal(2, continuations);
+        Assert.Equal(1, innerExecutions);
+    }
+
+    [Fact]
+    public void DiagnosticObserverFailurePropagatesAndNextInvocationRecovers()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        int calls = 0;
+        var failure = new InvalidOperationException("observer");
+        EventHandler<CommandRoutingDiagnosticEventArgs> observer = (_, _) => throw failure;
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => calls++));
+        command.Diagnostic += observer;
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => command.Execute(null, ui.Focus)));
+        Assert.Equal(0, calls);
+        command.Diagnostic -= observer;
+        command.Execute(null, ui.Focus);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void RoutedKeyTargetMutationDuringQueryRejectsStaleExecutionAndUsesNewTargetOnNextPress()
+    {
+        using var ui = new WindowFixture();
+        var next = ui.Parent.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        var binding = new KeyBinding(command, SaveGesture) { CommandTarget = ui.Focus };
+        int calls = 0;
+        ui.Focus.CommandBindings.Add(new(command, (_, _) => Assert.Fail(), (_, e) => {
+            binding.CommandTarget = next;
+            e.CanExecute = true;
+        }));
+        next.CommandBindings.Add(Bind(command, (_, e) => { Assert.Same(next, e.Target); calls++; }));
+        ui.Form.InputBindings.Add(binding);
+
+        Assert.False(ui.Key().Handled);
+        Assert.Equal(0, calls);
+        Assert.True(ui.Key().Handled);
+        Assert.Equal(1, calls);
+    }
+}

--- a/ModernFormsNext.Tests/CommandRoutingTests.LifetimeAndDiagnostics.cs
+++ b/ModernFormsNext.Tests/CommandRoutingTests.LifetimeAndDiagnostics.cs
@@ -1,0 +1,204 @@
+using System.ComponentModel;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed partial class CommandRoutingTests
+{
+    [Fact]
+    public void BindingHasOneOwnerAndCanBeRemovedReplacedAndTransferred()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var first = Bind(command, (_, _) => { });
+        var second = Bind(command, (_, _) => { });
+        ui.Focus.CommandBindings.Add(first);
+        Assert.Throws<ArgumentException>(() => ui.Focus.CommandBindings.Add(first));
+        Assert.Throws<ArgumentException>(() => ui.Parent.CommandBindings.Add(first));
+        ui.Focus.CommandBindings[0] = first;
+        ui.Focus.CommandBindings[0] = second;
+        ui.Parent.CommandBindings.Add(first);
+        ui.Focus.CommandBindings.Clear();
+        ui.Parent.CommandBindings.Add(second);
+        Assert.Equal([first, second], ui.Parent.CommandBindings);
+    }
+
+    [Fact]
+    public void DisposingAnOwnerReleasesBindingsWithoutDisposingTheirCommand()
+    {
+        using var ui = new WindowFixture();
+        using var owner = new Panel();
+        var command = new RoutedCommand();
+        int calls = 0;
+        var binding = Bind(command, (_, _) => calls++);
+        var collection = owner.CommandBindings;
+        collection.Add(binding);
+        owner.Dispose();
+        Assert.Empty(collection);
+        Assert.Throws<ObjectDisposedException>(() => collection.Add(binding));
+        ui.Parent.CommandBindings.Add(binding);
+        command.Execute(null, ui.Focus);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void DisposingCapturedOwnerDuringExecutionStopsLaterHandlers()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => ui.Parent.Dispose(), handled: false));
+        ui.Form.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        command.Execute(null, ui.Focus);
+        Assert.True(ui.Focus.IsDisposed);
+    }
+
+    [Fact]
+    public void FocusChangeDoesNotRetargetUnhandledExecution()
+    {
+        using var ui = new WindowFixture();
+        var next = ui.Form.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => next.Select(), handled: false));
+        ui.Parent.CommandBindings.Add(Bind(command, (_, e) => { Assert.Same(ui.Focus, e.Target); calls++; }));
+        next.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(1, calls);
+        Assert.True(next.Focused);
+    }
+
+    [Fact]
+    public void ApplicationCleanupReleasesOwnershipAndFreshCollectionHasNoInheritedHandlers()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var binding = Bind(command, (_, _) => { });
+        var old = Application.CommandBindings;
+        old.Add(binding);
+        Assert.True(command.CanExecute(null, ui.Focus));
+        Application.ReleaseCommandBindings();
+        Assert.Empty(old);
+        Assert.Throws<ObjectDisposedException>(() => old.Add(binding));
+        Assert.NotSame(old, Application.CommandBindings);
+        Assert.Empty(Application.CommandBindings);
+        Assert.False(command.CanExecute(null, ui.Focus));
+        ui.Form.CommandBindings.Add(binding);
+        Assert.True(command.CanExecute(null, ui.Focus));
+    }
+
+    [Fact]
+    public void CancelledClosePreservesBindingsWhileActualCloseReleasesEveryScope()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var local = ui.Focus.CommandBindings;
+        var window = ui.Form.CommandBindings;
+        local.Add(Bind(command, (_, _) => { }));
+        window.Add(Bind(command, (_, _) => { }));
+        EventHandler<CancelEventArgs> cancel = (_, e) => e.Cancel = true;
+        ui.Form.Closing += cancel;
+        ui.Form.Close();
+        Assert.Single(local);
+        Assert.Single(window);
+        Assert.True(command.CanExecute(null, ui.Focus));
+        ui.Form.Closing -= cancel;
+        ui.Form.Close();
+        Assert.Empty(local);
+        Assert.Empty(window);
+        Assert.Throws<ObjectDisposedException>(() => ui.Form.CommandBindings);
+        Assert.Throws<ObjectDisposedException>(() => ui.Focus.CommandBindings);
+        Assert.False(command.CanExecute(null, ui.Focus));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void BackgroundRoutingAndCollectionMutationsAreRejected(int operation)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var collection = ui.Focus.CommandBindings;
+        var binding = Bind(command, (_, _) => Assert.Fail());
+        Exception? failure = null;
+        var thread = new Thread(() => {
+            try
+            {
+                switch (operation)
+                {
+                    case 0: command.CanExecute(null, ui.Focus); break;
+                    case 1: command.Execute(null, ui.Focus); break;
+                    case 2: collection.Add(binding); break;
+                    case 3: collection.Clear(); break;
+                }
+            }
+            catch (Exception exception) { failure = exception; }
+        });
+        thread.Start();
+        thread.Join();
+        Assert.IsType<InvalidOperationException>(failure);
+    }
+
+    [Fact]
+    public void DiagnosticsIdentifyVisitedNodesBindingQueryExecutionAndHandledOwner()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var binding = Bind(command, (_, _) => { });
+        Application.CommandBindings.Add(binding);
+        var events = new List<CommandRoutingDiagnosticEventArgs>();
+        command.Diagnostic += (_, e) => events.Add(e);
+        command.Execute(42, ui.Focus);
+        var expected = new List<object>();
+        for (Control? node = ui.Focus; node is not ControlAdapter; node = node!.Parent) expected.Add(node!);
+        expected.Add(ui.Form);
+        expected.Add(typeof(Application));
+        Assert.Equal(expected, events.Where(e => e.Kind == CommandRoutingDiagnosticKind.NodeVisited).Select(e => e.Owner));
+        Assert.Contains(events, e => e.Kind == CommandRoutingDiagnosticKind.BindingFound && ReferenceEquals(binding, e.Binding));
+        Assert.Contains(events, e => e.Kind == CommandRoutingDiagnosticKind.CanExecuteEvaluated && e.CanExecute == true);
+        Assert.Contains(events, e => e.Kind == CommandRoutingDiagnosticKind.Executed && Equals(e.Owner, typeof(Application)));
+        Assert.Equal(CommandRoutingDiagnosticKind.Handled, events[^1].Kind);
+        Assert.Equal(typeof(Application), events[^1].Owner);
+        Assert.All(events, e => { Assert.Same(command, e.Command); Assert.Same(ui.Focus, e.Target); Assert.Equal(typeof(int), e.ParameterType); });
+    }
+
+    [Fact]
+    public void DiagnosticsNeverStringifyParameterOrCopyUserText()
+    {
+        using var ui = new WindowFixture();
+        ui.Focus.Text = "private control text";
+        var command = new RoutedCommand("Save");
+        var parameter = new SensitiveParameter();
+        var events = new List<CommandRoutingDiagnosticEventArgs>();
+        command.Diagnostic += (_, e) => events.Add(e);
+        ui.Focus.CommandBindings.Add(Bind(command, (_, e) => Assert.Same(parameter, e.Parameter)));
+        command.Execute(parameter, ui.Focus);
+        command.Execute(parameter, null);
+        Assert.Equal(0, parameter.Stringifications);
+        Assert.All(events, e => Assert.Equal(typeof(SensitiveParameter), e.ParameterType));
+        Assert.DoesNotContain("private control text", string.Join(";", events.Select(e => e.FailureReason)));
+        Assert.Null(typeof(CommandRoutingDiagnosticEventArgs).GetProperty("Parameter"));
+        Assert.Null(typeof(CommandRoutingDiagnosticEventArgs).GetProperty("Route"));
+        Assert.Contains(events, e => e.Kind == CommandRoutingDiagnosticKind.Failed && e.FailureReason == "No target context.");
+    }
+
+    [Fact]
+    public void RuntimePropertiesAreHiddenFromDesignerSerialization()
+    {
+        using var ui = new WindowFixture();
+        foreach (var pair in new[] { (typeof(Control), "CommandBindings"), (typeof(WindowBase), "CommandBindings"), (typeof(Button), "CommandTarget") })
+        {
+            var property = TypeDescriptor.GetProperties(pair.Item1)[pair.Item2]!;
+            Assert.False(property.IsBrowsable);
+            Assert.Equal(DesignerSerializationVisibility.Hidden,
+                ((DesignerSerializationVisibilityAttribute)property.Attributes[typeof(DesignerSerializationVisibilityAttribute)]!).Visibility);
+        }
+    }
+
+    private sealed class SensitiveParameter
+    {
+        internal int Stringifications;
+        public override string ToString() { Stringifications++; throw new InvalidOperationException("Do not log me"); }
+    }
+}

--- a/ModernFormsNext.Tests/CommandRoutingTests.Sources.cs
+++ b/ModernFormsNext.Tests/CommandRoutingTests.Sources.cs
@@ -1,0 +1,305 @@
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.WindowKit;
+using ModernFormsNext.WindowKit.Input;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+public sealed partial class CommandRoutingTests
+{
+    [Fact]
+    public void ButtonDefaultsToItsOwnSourceRegardlessOfFocusInEitherWindow()
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        var command = new RoutedCommand();
+        var calls = new List<Control>();
+        ui.Form.CommandBindings.Add(Bind(command, (_, e) => {
+            Assert.Same(ui.Focus, e.Source);
+            calls.Add(e.Target);
+        }));
+        ui.Focus.Command = command;
+        ui.Parent.Controls.Add(new Button()).Select();
+        other.Focus.Select();
+        ui.Focus.PerformClick();
+        Assert.Equal([ui.Focus], calls);
+    }
+
+    [Fact]
+    public void ExplicitButtonTargetUsesItsRouteAndPreservesSourceAndParameter()
+    {
+        using var ui = new WindowFixture();
+        var target = ui.Form.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        var parameter = new object();
+        int calls = 0;
+        target.CommandBindings.Add(Bind(command, (_, e) => {
+            Assert.Same(target, e.Target);
+            Assert.Same(ui.Focus, e.Source);
+            Assert.Same(parameter, e.Parameter);
+            calls++;
+        }));
+        ui.Focus.CommandTarget = target;
+        ui.Focus.CommandParameter = parameter;
+        ui.Focus.Command = command;
+        Assert.True(ui.Focus.Enabled);
+        ui.Focus.PerformClick();
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExplicitWrongWindowTargetIsUnavailableForButtonAndKeyBinding(bool keyboard)
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        var command = new RoutedCommand();
+        other.Form.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        ui.Form.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        if (keyboard)
+        {
+            ui.Form.InputBindings.Add(new KeyBinding(command, SaveGesture) { CommandTarget = other.Focus });
+            Assert.False(ui.Key().Handled);
+        }
+        else
+        {
+            ui.Focus.CommandTarget = other.Focus;
+            ui.Focus.Command = command;
+            Assert.False(ui.Focus.Enabled);
+            ui.Focus.PerformClick();
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExplicitDetachedOrDisposedTargetDoesNotFallBackToButton(bool disposed)
+    {
+        using var ui = new WindowFixture();
+        using var target = new Button();
+        if (disposed) target.Dispose();
+        var command = new RoutedCommand();
+        ui.Form.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        ui.Focus.CommandTarget = target;
+        ui.Focus.Command = command;
+        Assert.False(ui.Focus.Enabled);
+        ui.Focus.PerformClick();
+    }
+
+    [Fact]
+    public void KeyboardPrefersFocusOverBindingScope()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Focus.CommandBindings.Add(Bind(command, (_, e) => {
+            Assert.Same(ui.Focus, e.Target);
+            Assert.Same(ui.Parent, e.Source);
+            calls++;
+        }));
+        ui.Parent.InputBindings.Add(new KeyBinding(command, SaveGesture));
+        Assert.True(ui.Key().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void KeyboardExplicitTargetOverridesFocus()
+    {
+        using var ui = new WindowFixture();
+        var target = ui.Form.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        int calls = 0;
+        target.CommandBindings.Add(Bind(command, (_, e) => { Assert.Same(target, e.Target); calls++; }));
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        ui.Form.InputBindings.Add(new KeyBinding(command, SaveGesture) { CommandTarget = target });
+        Assert.True(ui.Key().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WindowKeyboardFallsBackToItsRootWhenFocusIsMissingOrInAnotherWindow(bool wrongWindow)
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        ui.Form.adapter.SelectedControl = wrongWindow ? other.Focus : null;
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Form.CommandBindings.Add(Bind(command, (_, e) => { Assert.Same(ui.Form.adapter, e.Target); calls++; }));
+        other.Focus.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        ui.Form.InputBindings.Add(new KeyBinding(command, SaveGesture));
+        Assert.True(ui.Key().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void SurfaceRootBindingSuppliesSourceTargetWithoutSelectedControl()
+    {
+        using var root = new Panel();
+        using var surface = new SkiaControlSurface(root);
+        var command = new RoutedCommand();
+        int calls = 0;
+        root.CommandBindings.Add(Bind(command, (_, e) => {
+            Assert.Same(root, e.Target); Assert.Same(root, e.Source); calls++;
+        }));
+        root.InputBindings.Add(new KeyBinding(command, SaveGesture));
+        surface.ProcessKeyDown(Keys.Control | Keys.S);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void UnavailableRoutedBindingAllowsOrdinaryInputBindingFallback()
+    {
+        using var ui = new WindowFixture();
+        int calls = 0;
+        ui.Focus.InputBindings.Add(new KeyBinding(new RoutedCommand(), SaveGesture));
+        ui.Form.InputBindings.Add(new KeyBinding(new DelegateCommand(() => calls++), SaveGesture));
+        Assert.True(ui.Key().Handled);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void RoutedKeyboardRepeatsExecuteAndReleaseIsConsumedAfterFocusChange()
+    {
+        using var ui = new WindowFixture();
+        var next = ui.Parent.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Form.CommandBindings.Add(Bind(command, (_, _) => { calls++; next.Select(); }));
+        next.KeyUp += (_, _) => Assert.Fail();
+        ui.Form.InputBindings.Add(new KeyBinding(command, SaveGesture));
+        Assert.True(ui.Key().Handled);
+        Assert.True(ui.Key().Handled);
+        Assert.True(ui.Key(down: false).Handled);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void AccessibilityInvokeUsesButtonClickOrderingAndAvailabilityRecovery()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        bool allowed = true;
+        var calls = new List<string>();
+        ui.Form.CommandBindings.Add(new(command, (_, e) => { calls.Add("execute"); e.Handled = true; },
+            (_, e) => { calls.Add("query"); e.CanExecute = allowed; }));
+        ui.Focus.Command = command;
+        ui.Focus.Click += (_, _) => calls.Add("click");
+        calls.Clear();
+        Assert.True(ui.Focus.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        Assert.Equal(["query", "click", "query", "execute"], calls);
+        allowed = false;
+        command.RaiseCanExecuteChanged();
+        Assert.False(ui.Focus.Enabled);
+        Assert.False(ui.Focus.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+        Assert.True(ui.Focus.AccessibilityObject.State.HasFlag(AccessibleStates.Unavailable));
+        allowed = true;
+        command.RaiseCanExecuteChanged();
+        Assert.True(ui.Focus.Enabled);
+        Assert.True(ui.Focus.AccessibilityObject.PerformAction(AccessibleActions.Invoke));
+    }
+
+    [Fact]
+    public void CollectionEditsRequeryButtonWithoutASeparateCommandManager()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        ui.Focus.Command = command;
+        Assert.False(ui.Focus.Enabled);
+        var binding = Bind(command, (_, _) => { });
+        ui.Form.CommandBindings.Add(binding);
+        Assert.True(ui.Focus.Enabled);
+        ui.Form.CommandBindings.Remove(binding);
+        Assert.False(ui.Focus.Enabled);
+        ui.Form.CommandBindings.Add(binding);
+        Assert.True(ui.Focus.Enabled);
+        ui.Form.CommandBindings.Clear();
+        Assert.False(ui.Focus.Enabled);
+    }
+
+    [Fact]
+    public void AttachingAndReparentingAncestorRefreshesRoutedSourcesInItsSubtree()
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        var command = new RoutedCommand();
+        ui.Form.CommandBindings.Add(Bind(command, (_, _) => { }));
+        using var panel = new Panel();
+        var button = panel.Controls.Add(new Button { Command = command });
+        Assert.False(button.Enabled);
+        ui.Form.Controls.Add(panel);
+        Assert.True(button.Enabled);
+        other.Form.Controls.Add(panel);
+        Assert.False(button.Enabled);
+        ui.Form.Controls.Add(panel);
+        Assert.True(button.Enabled);
+    }
+
+    [Fact]
+    public void ClickCanReplaceRoutedTargetBeforeFreshGuardedExecution()
+    {
+        using var ui = new WindowFixture();
+        var next = ui.Form.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        next.CommandBindings.Add(Bind(command, (_, e) => { Assert.Same(next, e.Target); calls++; }));
+        ui.Focus.Command = command;
+        ui.Focus.Click += (_, _) => ui.Focus.CommandTarget = next;
+        ui.Focus.PerformClick();
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void OrdinaryDelegateIgnoresCommandTargetWithoutExtraPredicateCalls()
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        int queries = 0, executions = 0;
+        var command = new DelegateCommand(() => executions++, () => { queries++; return true; });
+        ui.Focus.Command = command;
+        Assert.Equal(1, queries);
+        ui.Focus.CommandTarget = other.Focus;
+        Assert.Equal(1, queries);
+        ui.Focus.PerformClick();
+        Assert.Equal(3, queries);
+        Assert.Equal(1, executions);
+        ui.Form.InputBindings.Add(new KeyBinding(command, SaveGesture) { CommandTarget = other.Focus });
+        ui.Key();
+        Assert.Equal(4, queries);
+        Assert.Equal(2, executions);
+    }
+
+    private static KeyGesture SaveGesture => new(Keys.S, KeyModifiers.Control);
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ChangingIgnoredTargetInsideOrdinaryPredicateDoesNotInvalidateTheCommand(bool keyboard)
+    {
+        using var ui = new WindowFixture();
+        using var target = new Button();
+        KeyBinding? binding = null;
+        int calls = 0;
+        var command = new DelegateCommand(() => calls++, () => {
+            if (keyboard) binding!.CommandTarget = target;
+            else ui.Focus.CommandTarget = target;
+            return true;
+        });
+        if (keyboard)
+        {
+            binding = new KeyBinding(command, SaveGesture);
+            ui.Form.InputBindings.Add(binding);
+            Assert.True(ui.Key().Handled);
+        }
+        else
+        {
+            ui.Focus.Command = command;
+            ui.Focus.CommandTarget = null;
+            ui.Focus.PerformClick();
+        }
+        Assert.Equal(1, calls);
+    }
+}

--- a/ModernFormsNext.Tests/CommandRoutingTests.cs
+++ b/ModernFormsNext.Tests/CommandRoutingTests.cs
@@ -1,0 +1,335 @@
+using System.Reflection;
+using System.Windows.Input;
+using ModernFormsNext.WindowKit;
+using ModernFormsNext.WindowKit.Input;
+using ModernFormsNext.WindowKit.Input.Raw;
+using ModernFormsNext.WindowKit.Platform;
+using Xunit;
+
+namespace ModernFormsNext.Tests;
+
+[Collection(InputBindingCollectionTests.Name)]
+public sealed partial class CommandRoutingTests : IDisposable
+{
+    public CommandRoutingTests() { Application.ReleaseCommandBindings(); Application.ReleaseInputBindings(); }
+    public void Dispose() { Application.ReleaseCommandBindings(); Application.ReleaseInputBindings(); }
+
+    [Fact]
+    public void CommandHasReferenceIdentityAndNoTargetlessAmbientContext()
+    {
+        var command = new RoutedCommand("Save");
+        ICommand contract = Assert.IsAssignableFrom<ICommand>(command);
+        Assert.Equal("Save", command.Name);
+        Assert.NotEqual(command, new RoutedCommand("Save"));
+        Application.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        Assert.False(contract.CanExecute(null));
+        contract.Execute(null);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void DirectTargetFindsNearestAvailableControlParentWindowOrApplication(int firstScope)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var parameter = new object();
+        int winner = -1;
+        var scopes = Scopes(ui);
+        for (int i = firstScope; i < scopes.Length; i++)
+        {
+            int scope = i;
+            scopes[i].Add(Bind(command, (_, e) => {
+                Assert.Same(command, e.Command);
+                Assert.Same(parameter, e.Parameter);
+                Assert.Same(ui.Focus, e.Target);
+                Assert.Null(e.Source);
+                winner = scope;
+            }));
+        }
+        Assert.True(command.CanExecute(parameter, ui.Focus));
+        Assert.Equal(-1, winner);
+        command.Execute(parameter, ui.Focus);
+        Assert.Equal(firstScope, winner);
+    }
+
+    [Fact]
+    public void NearestAncestorWinsBeforeOuterAncestor()
+    {
+        using var ui = new WindowFixture();
+        var outer = ui.Form.Controls.Add(new Panel());
+        outer.Controls.Add(ui.Parent);
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Parent.CommandBindings.Add(Bind(command, (_, _) => calls++));
+        outer.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NoMatchingOrNoAvailabilityHandlerIsUnavailable(bool register)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand("Save");
+        ui.Focus.CommandBindings.Add(Bind(new RoutedCommand("Save"), (_, _) => Assert.Fail()));
+        if (register) ui.Focus.CommandBindings.Add(new CommandBinding(command, (_, _) => Assert.Fail()));
+        Assert.False(command.CanExecute(null, ui.Focus));
+        command.Execute(null, ui.Focus);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FalseQueryFallsThroughUnlessExplicitlyHandled(bool veto)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        int calls = 0;
+        ui.Focus.CommandBindings.Add(new(command, (_, _) => Assert.Fail(), (_, e) => e.Handled = veto));
+        ui.Parent.CommandBindings.Add(Bind(command, (_, _) => calls++));
+        Assert.Equal(!veto, command.CanExecute(null, ui.Focus));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(veto ? 0 : 1, calls);
+    }
+
+    [Fact]
+    public void DuplicateBindingsContinueInInsertionOrderUntilExecutionHandled()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var calls = new List<int>();
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => calls.Add(1), handled: false));
+        ui.Focus.CommandBindings.Add(new(command, (_, _) => Assert.Fail(), (_, _) => { }));
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => calls.Add(2)));
+        ui.Parent.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        command.Execute(null, ui.Focus);
+        Assert.Equal([1, 2], calls);
+    }
+
+    [Fact]
+    public void UnhandledExecutionBubblesAndQueriesEachLaterBindingBeforeExecutingIt()
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var calls = new List<string>();
+        ui.Focus.CommandBindings.Add(new(command, (_, _) => calls.Add("local execute"),
+            (_, e) => { calls.Add("local query"); e.CanExecute = true; e.Handled = true; }));
+        ui.Form.CommandBindings.Add(new(command, (_, e) => { calls.Add("window execute"); e.Handled = true; },
+            (_, e) => { calls.Add("window query"); e.CanExecute = true; }));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(["local query", "local execute", "window query", "window execute"], calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DetachedOrDisposedTargetsAreRejected(bool dispose)
+    {
+        using var target = new Button();
+        var command = new RoutedCommand();
+        target.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        if (dispose) target.Dispose();
+        Assert.False(command.CanExecute(null, target));
+        command.Execute(null, target);
+    }
+
+    [Fact]
+    public void ExistingStandaloneSurfaceRootsPermitRoutingAndDetachRejectsIt()
+    {
+        using var root = new Panel();
+        var target = root.Controls.Add(new Button());
+        var command = new RoutedCommand();
+        int calls = 0;
+        root.CommandBindings.Add(Bind(command, (_, _) => calls++));
+        using (var surface = new SkiaControlSurface(root)) command.Execute(null, target);
+        command.Execute(null, target);
+        Assert.Equal(1, calls);
+        Assert.False(command.CanExecute(null, target));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CapturedRouteSurvivesReparentOrRemovalInExecution(bool remove)
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        var command = new RoutedCommand();
+        var calls = new List<string>();
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => {
+            calls.Add("target");
+            if (remove) ui.Focus.Parent = null; else other.Parent.Controls.Add(ui.Focus);
+        }, handled: false));
+        ui.Parent.CommandBindings.Add(Bind(command, (_, _) => calls.Add("original parent")));
+        other.Parent.CommandBindings.Add(Bind(command, (_, _) => calls.Add("new parent")));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(["target", "original parent"], calls);
+        ui.Focus.CommandBindings.Clear();
+        command.Execute(null, ui.Focus);
+        Assert.Equal(remove ? new[] { "target", "original parent" } : ["target", "original parent", "new parent"], calls);
+        if (remove) ui.Focus.Dispose();
+    }
+
+    [Fact]
+    public void QueryAndExecutionShareSnapshotEvenWhenQueryChangesParents()
+    {
+        using var ui = new WindowFixture();
+        using var other = new WindowFixture();
+        var command = new RoutedCommand();
+        var calls = new List<string>();
+        ui.Focus.CommandBindings.Add(new(command, (_, _) => calls.Add("target"), (_, e) => {
+            other.Parent.Controls.Add(ui.Focus); e.CanExecute = true;
+        }));
+        ui.Parent.CommandBindings.Add(Bind(command, (_, _) => calls.Add("original")));
+        other.Parent.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(["target", "original"], calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BindingEditsAffectNextInvocationNotCapturedRegistrations(bool add)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var calls = new List<string>();
+        var later = Bind(command, (_, _) => calls.Add("parent"));
+        if (!add) ui.Parent.CommandBindings.Add(later);
+        bool first = true;
+        ui.Focus.CommandBindings.Add(Bind(command, (_, _) => {
+            calls.Add("target");
+            if (!first) return;
+            first = false;
+            if (add) ui.Parent.CommandBindings.Add(later); else ui.Parent.CommandBindings.Remove(later);
+        }, handled: false));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(add ? new[] { "target" } : ["target", "parent"], calls);
+        calls.Clear();
+        command.Execute(null, ui.Focus);
+        Assert.Equal(add ? new[] { "target", "parent" } : ["target"], calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClosingWindowDuringQueryOrExecutionStopsTheCapturedRoute(bool duringQuery)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        int executed = 0;
+        ui.Focus.CommandBindings.Add(new(command, (_, _) => { executed++; ui.Form.Close(); }, (_, e) => {
+            e.CanExecute = true;
+            if (duringQuery) ui.Form.Close();
+        }));
+        Application.CommandBindings.Add(Bind(command, (_, _) => Assert.Fail()));
+        command.Execute(null, ui.Focus);
+        Assert.Equal(duringQuery ? 0 : 1, executed);
+        Assert.False(command.CanExecute(null, ui.Focus));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void HandlerExceptionsPropagateUnchangedAndDoNotCorruptNextInvocation(bool query)
+    {
+        using var ui = new WindowFixture();
+        var command = new RoutedCommand();
+        var failure = new InvalidOperationException("sensitive exception content");
+        bool fail = true;
+        int calls = 0;
+        ui.Focus.CommandBindings.Add(new(command, (_, e) => {
+            if (fail && !query) throw failure;
+            calls++; e.Handled = true;
+        }, (_, e) => { if (fail && query) throw failure; e.CanExecute = true; }));
+        command.Diagnostic += (_, e) => { if (e.Kind == CommandRoutingDiagnosticKind.Failed) throw new Exception("observer"); };
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => command.Execute(null, ui.Focus)));
+        fail = false;
+        command.Execute(null, ui.Focus);
+        Assert.Equal(1, calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NestedAndRecursiveCommandsUseIndependentInvocationState(bool sameCommand)
+    {
+        using var ui = new WindowFixture();
+        var outer = new RoutedCommand("outer");
+        var inner = sameCommand ? outer : new RoutedCommand("inner");
+        var calls = new List<int>();
+        ui.Focus.CommandBindings.Add(Bind(outer, (_, e) => {
+            int depth = (int)e.Parameter!;
+            calls.Add(depth);
+            if (depth == 0) inner.Execute(1, ui.Focus);
+            calls.Add(depth + 10);
+        }));
+        if (!sameCommand) ui.Focus.CommandBindings.Add(Bind(inner, (_, _) => { calls.Add(1); calls.Add(11); }));
+        outer.Execute(0, ui.Focus);
+        Assert.Equal([0, 1, 11, 10], calls);
+    }
+
+    private static CommandBinding Bind(RoutedCommand command, EventHandler<ExecutedCommandEventArgs> execute, bool handled = true)
+        => new(command, (s, e) => { execute(s, e); e.Handled = handled; }, (_, e) => e.CanExecute = true);
+
+    private static CommandBindingCollection[] Scopes(WindowFixture ui)
+        => [ui.Focus.CommandBindings, ui.Parent.CommandBindings, ui.Form.CommandBindings, Application.CommandBindings];
+
+    // Existing backend callback seam: no production input simulator or separate command tree.
+    private sealed class WindowFixture : IDisposable
+    {
+        private readonly KeyboardDevice keyboard = new();
+        internal WindowProxy Proxy { get; }
+        internal Form Form { get; }
+        internal Panel Parent { get; }
+        internal Button Focus { get; }
+
+        internal WindowFixture()
+        {
+            var platform = DispatchProxy.Create<IWindowImpl, WindowProxy>();
+            Proxy = (WindowProxy)(object)platform;
+            Form = new Form(platform);
+            Parent = Form.Controls.Add(new Panel { Width = 500, Height = 300 });
+            Focus = Parent.Controls.Add(new Button { Text = "Target" });
+            Focus.Select();
+        }
+
+        internal RawKeyEventArgs Key(bool down = true)
+        {
+            var e = new RawKeyEventArgs(keyboard, 0, Form.adapter,
+                down ? RawKeyEventType.KeyDown : RawKeyEventType.KeyUp, WindowKit.Input.Key.S, RawInputModifiers.Control);
+            Proxy.Input!(e);
+            return e;
+        }
+
+        public void Dispose() { Form.Dispose(); Form.adapter.Dispose(); }
+    }
+
+    private class WindowProxy : DispatchProxy
+    {
+        internal Action<RawInputEventArgs>? Input;
+        private Action? closed;
+        private Size size = new(800, 600);
+        protected override object? Invoke(MethodInfo? method, object?[]? args)
+        {
+            switch (method?.Name)
+            {
+                case "set_Input": Input = (Action<RawInputEventArgs>?)args![0]; return null;
+                case "set_Closed": closed = (Action?)args![0]; return null;
+                case "get_ClientSize": return size;
+                case "get_RenderScaling": case "get_DesktopScaling": return 1d;
+                case "get_Position": return PixelPoint.Origin;
+                case "get_Handle": return new PlatformHandle(IntPtr.Zero, "TEST");
+                case "Resize": size = (Size)args![0]!; return null;
+                case "Dispose": closed?.Invoke(); return null;
+            }
+            return method is not null && method.ReturnType != typeof(void) && method.ReturnType.IsValueType
+                ? Activator.CreateInstance(method.ReturnType) : null;
+        }
+    }
+}

--- a/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAccessibilityProviderTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Android.Tests/AndroidAccessibilityProviderTests.cs
@@ -309,6 +309,46 @@ public class AndroidAccessibilityProviderTests
     }
 
     [Fact]
+    public void RoutedCommandButtonInvokeUsesNormalActivationAndAvailabilityRecovery()
+    {
+        using var root = new Panel();
+        var command = new RoutedCommand("Save");
+        var parameter = new object();
+        var calls = new List<string>();
+        bool allowed = false;
+        root.CommandBindings.Add(new(command, (_, e) => {
+            Assert.Same(parameter, e.Parameter);
+            calls.Add("execute");
+            e.Handled = true;
+        }, (_, e) => { calls.Add("query"); e.CanExecute = allowed; }));
+        var button = root.Controls.Add(new Button { Command = command, CommandParameter = parameter });
+        button.Click += (_, _) => calls.Add("click");
+        using var surface = new SkiaControlSurface(root);
+        using var session = new AndroidAccessibilitySession(surface);
+        session.Attach();
+        var peer = Adapt(button.AccessibilityObject);
+        int id = session.Register(peer);
+        calls.Clear();
+
+        Assert.False(Read(peer).Enabled);
+        Assert.False(session.Perform(id, ActionClick, null, true));
+        Assert.Empty(calls);
+        allowed = true;
+        command.RaiseCanExecuteChanged();
+        calls.Clear();
+        Assert.True(Read(peer).Enabled);
+        Assert.True(session.Perform(id, ActionClick, null, true));
+        Assert.Equal(["query", "click", "query", "execute"], calls);
+
+        allowed = false;
+        command.RaiseCanExecuteChanged();
+        calls.Clear();
+        Assert.False(Read(peer).Enabled);
+        Assert.False(session.Perform(id, ActionClick, null, true));
+        Assert.Empty(calls);
+    }
+
+    [Fact]
     public void RealListBoxDuplicateOccurrencesHaveSeparateIdsAndSelectionWorks()
     {
         using var list = new ListBox { SelectionMode = SelectionMode.MultiSimple };

--- a/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
+++ b/ModernFormsNext.WindowKit.Backend.Windows.Tests/WindowsUiaProviderTests.cs
@@ -181,6 +181,46 @@ public sealed class WindowsUiaProviderTests
         Assert.Equal(ActionInvoke, node.LastAction);
     }
 
+    [Fact]
+    public void RoutedCommandButtonInvokeUsesNormalActivationAndAvailabilityRecovery()
+    {
+        using var root = new Panel();
+        var command = new RoutedCommand("Save");
+        var parameter = new object();
+        var calls = new List<string>();
+        bool allowed = false;
+        root.CommandBindings.Add(new(command, (_, e) => {
+            Assert.Same(parameter, e.Parameter);
+            calls.Add("execute");
+            e.Handled = true;
+        }, (_, e) => { calls.Add("query"); e.CanExecute = allowed; }));
+        var button = root.Controls.Add(new Button { Command = command, CommandParameter = parameter });
+        button.Click += (_, _) => calls.Add("click");
+        using var surface = new SkiaControlSurface(root);
+        using var provider = WindowsUiaRootProvider.Create(new IntPtr(42),
+            ((IPlatformAccessibilityHost)surface).AccessibilityRoot!, new InlineDispatcher());
+        var action = Assert.IsType<WindowsUiaProvider>(provider.Navigate(NavigateDirection.FirstChild));
+        calls.Clear();
+
+        Assert.Equal(false, action.GetPropertyValue(WindowsUiaIds.IsEnabledProperty));
+        Assert.Throws<WindowsUiaElementNotEnabledException>(() => ((IInvokeProvider)action).Invoke());
+        Assert.Empty(calls);
+        allowed = true;
+        command.RaiseCanExecuteChanged();
+        calls.Clear();
+        Assert.Equal(true, action.GetPropertyValue(WindowsUiaIds.IsEnabledProperty));
+        Assert.Same(action, action.GetPatternProvider(WindowsUiaIds.InvokePattern));
+        ((IInvokeProvider)action).Invoke();
+        Assert.Equal(["query", "click", "query", "execute"], calls);
+
+        allowed = false;
+        command.RaiseCanExecuteChanged();
+        calls.Clear();
+        Assert.Equal(false, action.GetPropertyValue(WindowsUiaIds.IsEnabledProperty));
+        Assert.Throws<WindowsUiaElementNotEnabledException>(() => ((IInvokeProvider)action).Invoke());
+        Assert.Empty(calls);
+    }
+
     [Theory]
     [InlineData(0, 0)]
     [InlineData(StateChecked, 1)]

--- a/ModernFormsNext/Application.CommandBindings.cs
+++ b/ModernFormsNext/Application.CommandBindings.cs
@@ -1,0 +1,32 @@
+namespace ModernFormsNext;
+
+public static partial class Application
+{
+    private static CommandBindingCollection? commandBindings;
+
+    /// <summary>Gets terminal fallback handlers shared by application windows and control surfaces.</summary>
+    /// <remarks>
+    /// Access on the application UI thread. This terminal scope is visited after a valid target's
+    /// control/window route; it does not make targetless calls available. Sender is typeof(Application).
+    /// Shutdown releases registrations. Remove bindings capturing shorter-lived objects explicitly.
+    /// No command is disposed and no global service/command registry is created.
+    /// </remarks>
+    public static CommandBindingCollection CommandBindings
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(IsExiting, typeof(Application));
+            var bindings = commandBindings ??= new CommandBindingCollection(null);
+            bindings.VerifyAccess();
+            return bindings;
+        }
+    }
+
+    internal static CommandBindingCollection? CommandBindingsInternal => commandBindings;
+
+    internal static void ReleaseCommandBindings()
+    {
+        commandBindings?.Release();
+        commandBindings = null;
+    }
+}

--- a/ModernFormsNext/Application.cs
+++ b/ModernFormsNext/Application.cs
@@ -243,6 +243,7 @@ namespace ModernFormsNext
         {
             is_exiting = true;
             ReleaseInputBindings();
+            ReleaseCommandBindings();
 
             Animations.AnimationScheduler.ShutdownDefaultIfInitialized();
 
@@ -338,6 +339,7 @@ namespace ModernFormsNext
             Dispatcher.UIThread.MainLoop(_mainLoopCancellationTokenSource.Token);
 
             ReleaseInputBindings();
+            ReleaseCommandBindings();
             Animations.AnimationScheduler.ShutdownDefaultIfInitialized();
 
             if (!is_exiting)

--- a/ModernFormsNext/Button.cs
+++ b/ModernFormsNext/Button.cs
@@ -71,6 +71,25 @@ namespace ModernFormsNext
         bool ICommandBindingTargetProvider.IsCommandSourceDisposed => IsDisposed;
         void ICommandBindingTargetProvider.SetCommandEnabled(bool enabled) => SetCommandEnabled(enabled);
 
+        /// <summary>Gets or sets an explicit control target used only for RoutedCommand.</summary>
+        /// <remarks>
+        /// Null routes from this Button, regardless of focus. An explicit target must belong to the
+        /// same window or standalone surface. Invalid targets are unavailable. Ordinary ICommand
+        /// ignores this property. Set on the UI thread; changing a routed target requeries availability
+        /// and can update enabled, rendering and accessibility state. Designer serialization is deferred.
+        /// </remarks>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Control? CommandTarget {
+            get => commandSource?.Target;
+            set {
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+                (commandSource ??= new CommandSource(this)).Target = value;
+            }
+        }
+
+        internal override void RefreshRoutedCommandSource() => commandSource?.RefreshRouted();
+
         /// <summary>
         /// Initializes a new instance of the Button class.
         /// </summary>

--- a/ModernFormsNext/CanExecuteCommandEventArgs.cs
+++ b/ModernFormsNext/CanExecuteCommandEventArgs.cs
@@ -1,0 +1,26 @@
+namespace ModernFormsNext;
+
+/// <summary>Describes one binding's availability query during command routing.</summary>
+/// <remarks>
+/// Initial CanExecute and Handled are false. True selects this binding. False with Handled false
+/// continues searching; false with Handled true vetoes the remaining route. The execution phase
+/// has its own Handled value. Handlers run synchronously on the UI thread and should be fast.
+/// </remarks>
+public sealed class CanExecuteCommandEventArgs : EventArgs
+{
+    internal CanExecuteCommandEventArgs(RoutedCommand command, object? parameter, Control target, Control? source)
+        => (Command, Parameter, Target, Source) = (command, parameter, target, source);
+
+    /// <summary>Gets the command being queried.</summary>
+    public RoutedCommand Command { get; }
+    /// <summary>Gets the caller's parameter unchanged; it can contain sensitive data and may be null.</summary>
+    public object? Parameter { get; }
+    /// <summary>Gets the target captured when this invocation began.</summary>
+    public Control Target { get; }
+    /// <summary>Gets the originating control, or null for direct target calls and non-control scopes.</summary>
+    public Control? Source { get; }
+    /// <summary>Gets or sets whether this binding may execute. Defaults to false.</summary>
+    public bool CanExecute { get; set; }
+    /// <summary>Gets or sets whether this query stops searching, including when CanExecute is false.</summary>
+    public bool Handled { get; set; }
+}

--- a/ModernFormsNext/CommandBinding.cs
+++ b/ModernFormsNext/CommandBinding.cs
@@ -1,0 +1,36 @@
+namespace ModernFormsNext;
+
+/// <summary>Associates a routed command with synchronous handlers on one control, window or application scope.</summary>
+/// <remarks>
+/// Create and register on the UI thread. A binding has reference identity and at most one collection
+/// owner. Its command and delegates are immutable, so an invocation can safely snapshot registrations.
+/// Removing a binding affects the next invocation; owner disposal stops the current route. Removing
+/// or disposing its owner does not dispose the command or objects captured by the delegates.
+/// </remarks>
+public sealed class CommandBinding
+{
+    /// <summary>Creates a command handler registration.</summary>
+    /// <param name="command">The routed command identified by reference, never by name.</param>
+    /// <param name="executed">The action handler. Set Handled to stop further execution.</param>
+    /// <param name="canExecute">The availability handler; null makes this registration unavailable.</param>
+    /// <exception cref="ArgumentNullException">The command or execution handler is null.</exception>
+    public CommandBinding(RoutedCommand command, EventHandler<ExecutedCommandEventArgs> executed,
+        EventHandler<CanExecuteCommandEventArgs>? canExecute = null)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(executed);
+        command.VerifyAccess();
+        Command = command;
+        Executed = executed;
+        CanExecute = canExecute;
+    }
+
+    /// <summary>Gets the routed command matched by reference identity.</summary>
+    public RoutedCommand Command { get; }
+    /// <summary>Gets the execution handler invoked with the route owner as sender.</summary>
+    public EventHandler<ExecutedCommandEventArgs> Executed { get; }
+    /// <summary>Gets the availability handler; null is unavailable, never implicitly true.</summary>
+    public EventHandler<CanExecuteCommandEventArgs>? CanExecute { get; }
+
+    internal CommandBindingCollection? Owner { get; set; }
+}

--- a/ModernFormsNext/CommandBindingCollection.cs
+++ b/ModernFormsNext/CommandBindingCollection.cs
@@ -1,0 +1,105 @@
+using System.Collections.ObjectModel;
+
+namespace ModernFormsNext;
+
+/// <summary>Owns ordered runtime command handlers for one control, window or application.</summary>
+/// <remarks>
+/// Access and mutate on the creating UI thread. Duplicate commands are visited in insertion order
+/// until handled. Unlike InputBindings, these registrations map a command to route handlers, not
+/// a gesture to a command. An invocation snapshots registrations; edits affect the next invocation.
+/// Edits requery affected commands and can update source enabled/rendering/accessibility state.
+/// Removing a binding releases its ownership without disposing its command or delegate captures.
+/// </remarks>
+public sealed class CommandBindingCollection : Collection<CommandBinding>
+{
+    private readonly int threadId = Environment.CurrentManagedThreadId;
+    private object? scope;
+    internal bool IsReleased { get; private set; }
+
+    internal CommandBindingCollection(object? scope) => this.scope = scope;
+
+    internal void VerifyAccess()
+    {
+        ObjectDisposedException.ThrowIf(IsReleased || scope is Control { IsDisposed: true } ||
+            scope is WindowBase { InputBindingsClosed: true }, this);
+        if (threadId != Environment.CurrentManagedThreadId)
+            throw new InvalidOperationException("Command binding collections must be accessed on their owning UI thread.");
+    }
+
+    private void VerifyItem(CommandBinding item)
+    {
+        VerifyAccess();
+        ArgumentNullException.ThrowIfNull(item);
+        item.Command.VerifyAccess();
+        if (item.Owner is not null)
+            throw new ArgumentException("A command binding can belong to only one collection and cannot be added twice.", nameof(item));
+    }
+
+    /// <inheritdoc/>
+    protected override void InsertItem(int index, CommandBinding item)
+    {
+        VerifyItem(item);
+        base.InsertItem(index, item);
+        item.Owner = this;
+        item.Command.RaiseCanExecuteChanged();
+    }
+
+    /// <inheritdoc/>
+    protected override void SetItem(int index, CommandBinding item)
+    {
+        VerifyAccess();
+        if (ReferenceEquals(this[index], item)) return;
+        VerifyItem(item);
+        var previous = this[index];
+        base.SetItem(index, item);
+        previous.Owner = null;
+        item.Owner = this;
+        previous.Command.RaiseCanExecuteChanged();
+        if (!ReferenceEquals(previous.Command, item.Command)) item.Command.RaiseCanExecuteChanged();
+    }
+
+    /// <inheritdoc/>
+    protected override void RemoveItem(int index)
+    {
+        VerifyAccess();
+        var previous = this[index];
+        base.RemoveItem(index);
+        previous.Owner = null;
+        previous.Command.RaiseCanExecuteChanged();
+    }
+
+    /// <inheritdoc/>
+    protected override void ClearItems()
+    {
+        VerifyAccess();
+        var commands = new HashSet<RoutedCommand>();
+        foreach (var binding in Items) commands.Add(binding.Command);
+        ClearCore();
+        foreach (var command in commands) command.RaiseCanExecuteChanged();
+    }
+
+    internal CommandBinding[] Snapshot(RoutedCommand command)
+    {
+        VerifyAccess();
+        List<CommandBinding>? matches = null;
+        foreach (var binding in Items)
+            if (ReferenceEquals(binding.Command, command)) (matches ??= []).Add(binding);
+        return matches?.ToArray() ?? [];
+    }
+
+    private void ClearCore()
+    {
+        foreach (var binding in Items) binding.Owner = null;
+        base.ClearItems();
+    }
+
+    // Control finalization can also release collections. Never invoke application delegates or
+    // dispatcher work here. Existing weak source subscriptions do not retain disposed controls.
+    internal void Release()
+    {
+        if (IsReleased) return;
+        IsReleased = true;
+        ClearCore();
+        scope = null;
+    }
+}

--- a/ModernFormsNext/CommandRoutingDiagnosticEventArgs.cs
+++ b/ModernFormsNext/CommandRoutingDiagnosticEventArgs.cs
@@ -1,0 +1,49 @@
+namespace ModernFormsNext;
+
+/// <summary>Identifies an opt-in command route diagnostic transition.</summary>
+public enum CommandRoutingDiagnosticKind
+{
+    /// <summary>A captured control, window or application scope is being visited.</summary>
+    NodeVisited,
+    /// <summary>A registration matched the command by reference.</summary>
+    BindingFound,
+    /// <summary>A binding's availability handler returned.</summary>
+    CanExecuteEvaluated,
+    /// <summary>An execution handler returned successfully.</summary>
+    Executed,
+    /// <summary>A query or execution handler stopped traversal.</summary>
+    Handled,
+    /// <summary>Target validation, availability, lifetime or a handler prevented completion.</summary>
+    Failed
+}
+
+/// <summary>Provides one route transition without logging user text or parameter values.</summary>
+/// <remarks>
+/// No route snapshot, parameter value, control text or exception message is included. Owners and
+/// bindings are identities, not formatted strings. Consumers should not retain these references
+/// beyond their required lifetime. Events are synchronous, opt-in and raised on the routing UI thread.
+/// </remarks>
+public sealed class CommandRoutingDiagnosticEventArgs : EventArgs
+{
+    internal CommandRoutingDiagnosticEventArgs(CommandRoutingDiagnosticKind kind, RoutedCommand command,
+        Control? target, object? owner, CommandBinding? binding, Type? parameterType, bool? canExecute, string? failureReason)
+        => (Kind, Command, Target, Owner, Binding, ParameterType, CanExecute, FailureReason) =
+            (kind, command, target, owner, binding, parameterType, canExecute, failureReason);
+
+    /// <summary>Gets the transition kind.</summary>
+    public CommandRoutingDiagnosticKind Kind { get; }
+    /// <summary>Gets the routed command identity.</summary>
+    public RoutedCommand Command { get; }
+    /// <summary>Gets the captured target, or null if none was supplied.</summary>
+    public Control? Target { get; }
+    /// <summary>Gets the visited Control, WindowBase, typeof(Application) terminal, or null before traversal.</summary>
+    public object? Owner { get; }
+    /// <summary>Gets the matched registration, or null when no binding has been visited.</summary>
+    public CommandBinding? Binding { get; }
+    /// <summary>Gets only the CLR parameter type; null means a null parameter.</summary>
+    public Type? ParameterType { get; }
+    /// <summary>Gets the query result when applicable.</summary>
+    public bool? CanExecute { get; }
+    /// <summary>Gets a framework-defined failure reason, never user text or an exception message.</summary>
+    public string? FailureReason { get; }
+}

--- a/ModernFormsNext/Control.CommandBindings.cs
+++ b/ModernFormsNext/Control.CommandBindings.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using ModernFormsNext.Layout;
+
+namespace ModernFormsNext;
+
+public partial class Control
+{
+    private static readonly int s_commandBindingsProperty = PropertyStore.CreateKey();
+
+    /// <summary>Gets runtime routed command handlers defined on this control.</summary>
+    /// <remarks>
+    /// Access on the UI thread. Routing visits target then ancestors, window and application.
+    /// Collection edits requery affected commands; disposal releases registrations. This runtime
+    /// collection is created lazily and is not serialized by the Designer.
+    /// </remarks>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public CommandBindingCollection CommandBindings
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed || FindWindow()?.InputBindingsClosed == true, this);
+            if (!Properties.TryGetValue(s_commandBindingsProperty, out CommandBindingCollection? bindings))
+                bindings = Properties.AddValue(s_commandBindingsProperty, new CommandBindingCollection(this));
+            bindings!.VerifyAccess();
+            return bindings;
+        }
+    }
+
+    internal CommandBindingCollection? CommandBindingsInternal
+        => Properties.TryGetValue(s_commandBindingsProperty, out CommandBindingCollection? bindings) ? bindings : null;
+
+    // Only existing native/surface roots override this. It is not a second hierarchy or registry.
+    internal virtual bool IsCommandRoutingRoot => false;
+    internal virtual void RefreshRoutedCommandSource() { }
+
+    internal void RefreshRoutedCommandSourcesForSubtree()
+    {
+        RefreshRoutedCommandSource();
+        // Source requery can invoke application predicates. Snapshot children before visiting them.
+        foreach (var child in Controls.GetAllControls(true).ToArray())
+            if (!child.IsDisposed) child.RefreshRoutedCommandSourcesForSubtree();
+    }
+
+    internal void ReleaseCommandBindings()
+    {
+        CommandBindingsInternal?.Release();
+        Properties.RemoveObject(s_commandBindingsProperty);
+    }
+
+    internal void ReleaseCommandBindingsForSubtree()
+    {
+        ReleaseCommandBindings();
+        foreach (var child in Controls.GetAllControls(true)) child.ReleaseCommandBindingsForSubtree();
+    }
+}

--- a/ModernFormsNext/Control.cs
+++ b/ModernFormsNext/Control.cs
@@ -100,6 +100,7 @@ namespace ModernFormsNext
             if (previousParent is not null && value is null)
                 CancelOwnedControlAnimationsForSubtree();
             RefreshResourceBindingsForSubtree ();
+            RefreshRoutedCommandSourcesForSubtree();
             OnParentChanged (EventArgs.Empty);
 
             if (GetAnyDisposingInHierarchy ())
@@ -2598,6 +2599,7 @@ namespace ModernFormsNext
         {
             if (!disposedValue) {
                 ReleaseInputBindings();
+                ReleaseCommandBindings();
                 DisposeInteractionEffects ();
                 CancelOwnedControlAnimations();
                 DisposeLayoutTransitionConfiguration ();

--- a/ModernFormsNext/ControlAdapter.cs
+++ b/ModernFormsNext/ControlAdapter.cs
@@ -34,6 +34,8 @@ namespace ModernFormsNext
 
         public WindowBase ParentForm { get; }
 
+        internal override bool IsCommandRoutingRoot => true;
+
         /// <inheritdoc/>
         public IPlatformAccessibleObject? AccessibilityRoot => PlatformAccessibleObjectAdapter.From(AccessibilityObject);
 

--- a/ModernFormsNext/DataBinding/CommandRouting.cs
+++ b/ModernFormsNext/DataBinding/CommandRouting.cs
@@ -69,11 +69,26 @@ internal static class CommandRouting
 
         private bool IsAlive(Node? node = null)
         {
-            // Reparent/remove must not re-resolve Parent or focus. Lifetime is the exception:
-            // captured owners that have been disposed must never receive callbacks.
-            if (!target.IsDisposed && !target.Disposing && source?.IsDisposed != true && !root.IsDisposed &&
-                window?.InputBindingsClosed != true && !Application.IsExiting &&
-                node?.Collection?.IsReleased != true && node?.Owner is not Control { IsDisposed: true }) return true;
+            // Do not re-resolve Parent or focus. A handler can move the target elsewhere and then
+            // dispose an earlier or later captured ancestor without disposing the target itself.
+            // Check the whole snapshot without allocations before allowing further callbacks.
+            bool alive = !target.IsDisposed && !target.Disposing &&
+                source is not { IsDisposed: true } and not { Disposing: true } &&
+                !root.IsDisposed && !root.Disposing && window?.InputBindingsClosed != true && !Application.IsExiting;
+            if (alive)
+            {
+                foreach (var captured in nodes)
+                {
+                    if (captured.Collection?.IsReleased == true ||
+                        captured.Owner is Control { IsDisposed: true } or Control { Disposing: true })
+                    {
+                        alive = false;
+                        node = captured;
+                        break;
+                    }
+                }
+            }
+            if (alive) return true;
             Report(CommandRoutingDiagnosticKind.Failed, node, failureReason: "A captured target or owner was disposed or closed.");
             return false;
         }

--- a/ModernFormsNext/DataBinding/CommandRouting.cs
+++ b/ModernFormsNext/DataBinding/CommandRouting.cs
@@ -1,0 +1,151 @@
+namespace ModernFormsNext.DataBinding;
+
+// Handler routing is independent of input-binding lookup. Each invocation owns its snapshot,
+// query cursor and arguments, including nested/recursive calls. There is no shared route state.
+internal static class CommandRouting
+{
+    internal static Control? FindRoot(Control? control)
+    {
+        for (var current = control; current is not null; current = current.Parent)
+            if (current.IsCommandRoutingRoot) return current;
+        return null;
+    }
+
+    internal static bool IsWithin(Control control, Control boundary)
+    {
+        for (Control? current = control; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, boundary)) return true;
+        return false;
+    }
+
+    internal static Invocation? Prepare(RoutedCommand command, object? parameter, Control? target,
+        Control? source = null, Control? boundary = null)
+    {
+        command.VerifyAccess();
+        var root = FindRoot(target);
+        if (target is null || root is null || target.IsDisposed || target.Disposing || root.IsDisposed ||
+            source?.IsDisposed == true || Application.IsExiting ||
+            root is ControlAdapter { ParentForm.InputBindingsClosed: true } ||
+            (boundary is not null && !IsWithin(target, boundary)))
+        {
+            command.Report(CommandRoutingDiagnosticKind.Failed, target, parameter,
+                failureReason: target is null ? "No target context." : "Target is detached, disposed, closed or outside the source tree.");
+            return null;
+        }
+
+        List<Node> nodes = [];
+        // Represent the native adapter by its WindowBase. The standalone surface's borrowed root
+        // is already in the chain; its infrastructure parent is not an application handler scope.
+        for (var current = target; !ReferenceEquals(current, root); current = current.Parent!)
+            nodes.Add(Capture(current, current.CommandBindingsInternal, command));
+        WindowBase? window = (root as ControlAdapter)?.ParentForm;
+        if (window is not null) nodes.Add(Capture(window, window.CommandBindingsInternal, command));
+        nodes.Add(Capture(typeof(Application), Application.CommandBindingsInternal, command));
+        var invocation = new Invocation(command, parameter, target, source, root, window, nodes.ToArray());
+        return invocation.FindNextAvailable() ? invocation : null;
+    }
+
+    private static Node Capture(object owner, CommandBindingCollection? collection, RoutedCommand command)
+        => new(owner, collection, collection?.Snapshot(command) ?? []);
+
+    internal sealed class Invocation
+    {
+        private readonly RoutedCommand command;
+        private readonly object? parameter;
+        private readonly Control target;
+        private readonly Control? source;
+        private readonly Control root;
+        private readonly WindowBase? window;
+        private readonly Node[] nodes;
+        private int nodeIndex, bindingIndex;
+        private Node? selectedNode;
+        private CommandBinding? selectedBinding;
+        private bool executed;
+
+        internal Invocation(RoutedCommand command, object? parameter, Control target, Control? source,
+            Control root, WindowBase? window, Node[] nodes)
+            => (this.command, this.parameter, this.target, this.source, this.root, this.window, this.nodes) =
+                (command, parameter, target, source, root, window, nodes);
+
+        private bool IsAlive(Node? node = null)
+        {
+            // Reparent/remove must not re-resolve Parent or focus. Lifetime is the exception:
+            // captured owners that have been disposed must never receive callbacks.
+            if (!target.IsDisposed && !target.Disposing && source?.IsDisposed != true && !root.IsDisposed &&
+                window?.InputBindingsClosed != true && !Application.IsExiting &&
+                node?.Collection?.IsReleased != true && node?.Owner is not Control { IsDisposed: true }) return true;
+            Report(CommandRoutingDiagnosticKind.Failed, node, failureReason: "A captured target or owner was disposed or closed.");
+            return false;
+        }
+
+        internal bool FindNextAvailable()
+        {
+            while (nodeIndex < nodes.Length)
+            {
+                Node node = nodes[nodeIndex];
+                if (!IsAlive(node)) return false;
+                if (bindingIndex == 0) Report(CommandRoutingDiagnosticKind.NodeVisited, node);
+                while (bindingIndex < node.Bindings.Length)
+                {
+                    var binding = node.Bindings[bindingIndex++];
+                    if (!IsAlive(node)) return false;
+                    Report(CommandRoutingDiagnosticKind.BindingFound, node, binding);
+                    var args = new CanExecuteCommandEventArgs(command, parameter, target, source);
+                    try { binding.CanExecute?.Invoke(node.Owner, args); }
+                    catch { ReportHandlerFailure(node, binding); throw; }
+                    Report(CommandRoutingDiagnosticKind.CanExecuteEvaluated, node, binding, args.CanExecute);
+                    if (args.Handled) Report(CommandRoutingDiagnosticKind.Handled, node, binding, args.CanExecute);
+                    if (!IsAlive(node)) return false;
+                    if (args.CanExecute)
+                    {
+                        selectedNode = node;
+                        selectedBinding = binding;
+                        return true;
+                    }
+                    if (args.Handled)
+                    {
+                        Report(CommandRoutingDiagnosticKind.Failed, node, binding, false, "CanExecute vetoed the remaining route.");
+                        return false;
+                    }
+                }
+                nodeIndex++;
+                bindingIndex = 0;
+            }
+            if (!executed) Report(CommandRoutingDiagnosticKind.Failed, failureReason: "No available command binding.");
+            return false;
+        }
+
+        internal void Execute()
+        {
+            command.VerifyAccess();
+            do
+            {
+                if (selectedNode is not { } node || selectedBinding is not { } binding || !IsAlive(node)) return;
+                var args = new ExecutedCommandEventArgs(command, parameter, target, source);
+                try { binding.Executed(node.Owner, args); }
+                catch { ReportHandlerFailure(node, binding); throw; }
+                executed = true;
+                Report(CommandRoutingDiagnosticKind.Executed, node, binding);
+                if (args.Handled)
+                {
+                    Report(CommandRoutingDiagnosticKind.Handled, node, binding);
+                    return;
+                }
+            } while (FindNextAvailable());
+        }
+
+        private void Report(CommandRoutingDiagnosticKind kind, Node? node = null, CommandBinding? binding = null,
+            bool? available = null, string? failureReason = null)
+            => command.Report(kind, target, parameter, node?.Owner, binding, available, failureReason);
+
+        private void ReportHandlerFailure(Node node, CommandBinding binding)
+        {
+            // Never replace an application exception with a diagnostic observer exception.
+            // Do not include exception messages, Data or parameter values in diagnostics.
+            try { Report(CommandRoutingDiagnosticKind.Failed, node, binding, failureReason: "A command handler threw an exception."); }
+            catch { }
+        }
+    }
+
+    internal sealed record Node(object Owner, CommandBindingCollection? Collection, CommandBinding[] Bindings);
+}

--- a/ModernFormsNext/DataBinding/CommandRouting.cs
+++ b/ModernFormsNext/DataBinding/CommandRouting.cs
@@ -90,6 +90,7 @@ internal static class CommandRouting
                     var binding = node.Bindings[bindingIndex++];
                     if (!IsAlive(node)) return false;
                     Report(CommandRoutingDiagnosticKind.BindingFound, node, binding);
+                    if (!IsAlive(node)) return false;
                     var args = new CanExecuteCommandEventArgs(command, parameter, target, source);
                     try { binding.CanExecute?.Invoke(node.Owner, args); }
                     catch { ReportHandlerFailure(node, binding); throw; }

--- a/ModernFormsNext/DataBinding/CommandSource.cs
+++ b/ModernFormsNext/DataBinding/CommandSource.cs
@@ -12,6 +12,8 @@ internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisp
     private Subscription? subscription;
     private int version;
     private bool disposed;
+    private Control? target;
+    private bool refreshingRouted;
 
     internal ICommand? Command
     {
@@ -47,6 +49,27 @@ internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisp
         }
     }
 
+    internal Control? Target
+    {
+        get => target;
+        set
+        {
+            VerifyAccess();
+            if (ReferenceEquals(target, value)) return;
+            target = value;
+            if (command is RoutedCommand)
+            {
+                version++;
+                Refresh();
+            }
+        }
+    }
+
+    internal void RefreshRouted()
+    {
+        if (command is RoutedCommand && !disposed && !refreshingRouted) Refresh();
+    }
+
     internal bool CanExecute()
     {
         VerifyAccess();
@@ -64,20 +87,25 @@ internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisp
         ICommand? current = command;
         object? currentParameter = parameter;
         int currentVersion = version;
-        if (current is not null && Refresh() && currentVersion == version && owner.Enabled)
+        if (current is not null && Refresh(out var invocation) && currentVersion == version && owner.Enabled)
         {
             // The sealed framework helper can consume this fresh guarded evaluation. Calling
             // its public Execute would evaluate again outside our fail-closed/version guard.
             // Arbitrary ICommand implementations retain their own normal Execute contract.
-            if (current is DelegateCommand delegateCommand)
+            if (invocation is not null)
+                invocation.Execute();
+            else if (current is DelegateCommand delegateCommand)
                 delegateCommand.ExecuteCore(currentParameter);
             else
                 current.Execute(currentParameter);
         }
     }
 
-    private bool Refresh()
+    private bool Refresh() => Refresh(out _);
+
+    private bool Refresh(out CommandRouting.Invocation? invocation)
     {
+        invocation = null;
         if (disposed || owner.IsCommandSourceDisposed)
             return false;
 
@@ -85,7 +113,25 @@ internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisp
         bool available;
         try
         {
-            available = command?.CanExecute(parameter) ?? true;
+            if (command is RoutedCommand routed)
+            {
+                // Collection edits in a predicate can synchronously notify this same source.
+                // Keep the current snapshot; never overwrite it with shared/reentrant route state.
+                if (refreshingRouted) return false;
+                refreshingRouted = true;
+                try
+                {
+                    var source = owner as Control;
+                    var root = CommandRouting.FindRoot(source);
+                    invocation = source is not null && root is not null
+                        ? CommandRouting.Prepare(routed, parameter, target ?? source, source, root)
+                        : null;
+                    available = invocation is not null;
+                }
+                finally { refreshingRouted = false; }
+            }
+            else
+                available = command?.CanExecute(parameter) ?? true;
         }
         catch
         {
@@ -109,6 +155,7 @@ internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisp
         // command's Equals implementation or event sender, identifies the current attachment.
         if (disposed || owner.IsCommandSourceDisposed || !ReferenceEquals(subscription, sender))
             return;
+        if (refreshingRouted) return;
         VerifyAccess();
         Refresh();
     }
@@ -130,6 +177,7 @@ internal sealed class CommandSource(ICommandBindingTargetProvider owner) : IDisp
         subscription = null;
         command = null;
         parameter = null;
+        target = null;
     }
 
     private sealed class Subscription

--- a/ModernFormsNext/DataBinding/InputBindingResolver.cs
+++ b/ModernFormsNext/DataBinding/InputBindingResolver.cs
@@ -56,7 +56,10 @@ internal sealed class InputBindingResolver
                 if (command is RoutedCommand routed)
                 {
                     var source = candidate.Collection.ControlScope;
-                    var target = binding.CommandTarget ?? focused ?? source ?? root;
+                    // A disposed control can retain Parent and stale native focus bookkeeping.
+                    // It is not an implicit routed target; explicit targets still fail closed.
+                    var target = binding.CommandTarget ??
+                        (focused is { IsDisposed: false, Disposing: false } ? focused : null) ?? source ?? root;
                     invocation = CommandRouting.Prepare(routed, parameter, target, source, root);
                     available = invocation is not null;
                 }

--- a/ModernFormsNext/DataBinding/InputBindingResolver.cs
+++ b/ModernFormsNext/DataBinding/InputBindingResolver.cs
@@ -49,7 +49,19 @@ internal sealed class InputBindingResolver
                     continue;
                 }
 
-                bool available = command.CanExecute(parameter);
+                // Gesture precedence ends here. Routed commands receive this input context, while
+                // ordinary ICommand retains the Phase 1/2 direct call and evaluation count.
+                CommandRouting.Invocation? invocation = null;
+                bool available;
+                if (command is RoutedCommand routed)
+                {
+                    var source = candidate.Collection.ControlScope;
+                    var target = binding.CommandTarget ?? focused ?? source ?? root;
+                    invocation = CommandRouting.Prepare(routed, parameter, target, source, root);
+                    available = invocation is not null;
+                }
+                else
+                    available = command.CanExecute(parameter);
                 if (!candidate.IsCurrent(root) || !IsContextActive(root, window)) break;
                 if (!available)
                 {
@@ -62,7 +74,9 @@ internal sealed class InputBindingResolver
                 // change or self-removal must not let KeyUp activate another button afterwards.
                 (consumedKeys ??= []).Add(key);
                 e.SuppressKeyPress = true;
-                if (command is DelegateCommand delegated)
+                if (invocation is not null)
+                    invocation.Execute();
+                else if (command is DelegateCommand delegated)
                     delegated.ExecuteCore(parameter);
                 else
                     command.Execute(parameter);

--- a/ModernFormsNext/ExecutedCommandEventArgs.cs
+++ b/ModernFormsNext/ExecutedCommandEventArgs.cs
@@ -1,0 +1,20 @@
+namespace ModernFormsNext;
+
+/// <summary>Describes synchronous execution of an available command binding.</summary>
+/// <remarks>Setting Handled stops the captured route. Otherwise later available bindings may execute.</remarks>
+public sealed class ExecutedCommandEventArgs : EventArgs
+{
+    internal ExecutedCommandEventArgs(RoutedCommand command, object? parameter, Control target, Control? source)
+        => (Command, Parameter, Target, Source) = (command, parameter, target, source);
+
+    /// <summary>Gets the command being executed.</summary>
+    public RoutedCommand Command { get; }
+    /// <summary>Gets the caller's unchanged, possibly sensitive parameter; it may be null.</summary>
+    public object? Parameter { get; }
+    /// <summary>Gets the target captured at invocation entry, even if a handler reparents it.</summary>
+    public Control Target { get; }
+    /// <summary>Gets the originating control, or null when no control source was supplied.</summary>
+    public Control? Source { get; }
+    /// <summary>Gets or sets whether execution stops after this handler. Defaults to false.</summary>
+    public bool Handled { get; set; }
+}

--- a/ModernFormsNext/InputBinding.cs
+++ b/ModernFormsNext/InputBinding.cs
@@ -5,7 +5,7 @@ namespace ModernFormsNext;
 
 /// <summary>Associates a concrete application command and parameter with one keyboard gesture.</summary>
 /// <remarks>
-/// This Phase 2 contract performs no command-target or handler routing. Create and mutate a binding
+/// Gesture lookup selects a concrete command; RoutedCommand handler routing is a separate stage. Create and mutate a binding
 /// on its UI thread. One binding belongs to at most one collection; share the ICommand between
 /// separate bindings instead. Removal releases ownership without disposing the command or parameter.
 /// There are no CanExecuteChanged subscriptions: keyboard availability is evaluated on activation.
@@ -17,6 +17,7 @@ public abstract class InputBinding
     private ICommand? command;
     private object? parameter;
     private KeyGesture gesture;
+    private Control? target;
 
     /// <summary>Initializes a binding to a concrete command and gesture.</summary>
     /// <param name="command">The command; null represents an inactive binding.</param>
@@ -41,6 +42,26 @@ public abstract class InputBinding
     {
         get => parameter;
         set { VerifyAccess(); if (ReferenceEquals(parameter, value)) return; parameter = value; Changed(); }
+    }
+
+    /// <summary>Gets or sets an explicit target used only when Command is a RoutedCommand.</summary>
+    /// <remarks>
+    /// Null selects valid focus, then the binding's control scope, then the keyboard entry root.
+    /// An explicit target outside that root, detached or disposed is unavailable without fallback.
+    /// Ordinary ICommand ignores this property. Set on the creating UI thread; no layout/rendering
+    /// is triggered. The binding retains this reference until changed or collected; removing it
+    /// from its owner releases the collection's reference to the binding.
+    /// </remarks>
+    public Control? CommandTarget
+    {
+        get => target;
+        set
+        {
+            VerifyAccess();
+            if (ReferenceEquals(target, value)) return;
+            target = value;
+            if (command is RoutedCommand) Changed();
+        }
     }
 
     /// <summary>Gets or sets the gesture. Its default value makes this binding inactive.</summary>

--- a/ModernFormsNext/RoutedCommand.cs
+++ b/ModernFormsNext/RoutedCommand.cs
@@ -1,0 +1,92 @@
+using System.Windows.Input;
+using ModernFormsNext.DataBinding;
+
+namespace ModernFormsNext;
+
+/// <summary>Identifies an action whose handlers are resolved through the current control hierarchy.</summary>
+/// <remarks>
+/// Commands compare by reference, not Name. Create and route on the creating UI thread. The target
+/// overloads are canonical; parameter-only ICommand calls have no source/window context and are
+/// unavailable. Button and InputBinding supply context automatically. There is no global focus,
+/// command registry, automatic polling, preview/tunnel phase or asynchronous execution state.
+/// Each invocation snapshots its route; handler exceptions propagate unchanged.
+/// </remarks>
+/// <example><code>
+/// var save = new RoutedCommand("Save");
+/// form.CommandBindings.Add(new CommandBinding(save,
+///     (_, e) =&gt; { SaveDocument(e.Parameter); e.Handled = true; },
+///     (_, e) =&gt; e.CanExecute = documentIsOpen));
+/// var button = form.Controls.Add(new Button { Text = "Save", Command = save });
+/// </code></example>
+public sealed class RoutedCommand : ICommand
+{
+    private readonly int threadId = Environment.CurrentManagedThreadId;
+
+    /// <summary>Creates an identity without capturing a target or registering global state.</summary>
+    /// <param name="name">An optional immutable name intended for application diagnostics.</param>
+    public RoutedCommand(string? name = null) => Name = name;
+
+    /// <summary>Gets the optional debug name; equal names do not make commands equal.</summary>
+    public string? Name { get; }
+
+    /// <summary>Occurs when sources should reevaluate their own current target and parameter.</summary>
+    public event EventHandler? CanExecuteChanged;
+
+    /// <summary>Occurs for opt-in route transitions and failures.</summary>
+    /// <remarks>
+    /// No diagnostic args are allocated without observers. Observers must be fast and must not
+    /// mutate UI state. Observer exceptions normally propagate; an original command handler
+    /// exception takes precedence over an exception while reporting that failure.
+    /// </remarks>
+    public event EventHandler<CommandRoutingDiagnosticEventArgs>? Diagnostic;
+
+    /// <summary>Returns false because a parameter-only call supplies no routing context.</summary>
+    /// <param name="parameter">The optional application parameter.</param>
+    /// <returns>False. Use the target overload or a framework command source.</returns>
+    public bool CanExecute(object? parameter) => CanExecute(parameter, null);
+
+    /// <summary>Does nothing because a parameter-only call supplies no routing context.</summary>
+    /// <param name="parameter">The optional application parameter.</param>
+    public void Execute(object? parameter) => Execute(parameter, null);
+
+    /// <summary>Queries the first available registration on a captured target-to-root route.</summary>
+    /// <param name="parameter">The nullable parameter passed unchanged to handlers.</param>
+    /// <param name="target">An attached control; null, detached, disposed or closed targets are unavailable.</param>
+    /// <returns>True when a binding allows execution before any explicit veto.</returns>
+    /// <remarks>Call on the creating UI thread. Queries do not execute actions or change focus.</remarks>
+    public bool CanExecute(object? parameter, Control? target)
+        => CommandRouting.Prepare(this, parameter, target) is not null;
+
+    /// <summary>Queries and executes available handlers using one stable route snapshot.</summary>
+    /// <param name="parameter">The nullable parameter passed unchanged to handlers.</param>
+    /// <param name="target">An attached control; unavailable targets make execution a no-op.</param>
+    /// <remarks>
+    /// Call on the creating UI thread. Executed.Handled stops further handlers. Reparenting,
+    /// focus and registration changes affect subsequent invocations; disposal/close stops this one.
+    /// No task is scheduled and original application exceptions propagate.
+    /// </remarks>
+    public void Execute(object? parameter, Control? target)
+        => CommandRouting.Prepare(this, parameter, target)?.Execute();
+
+    /// <summary>Notifies sources after application state affecting CanExecute changes.</summary>
+    /// <remarks>
+    /// Uses normal synchronous event semantics, including exception propagation. Like DelegateCommand,
+    /// background notifications are marshalled by framework sources through the existing dispatcher.
+    /// This method itself does not synchronize application state or access the control tree.
+    /// </remarks>
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+
+    internal void VerifyAccess()
+    {
+        if (Environment.CurrentManagedThreadId != threadId)
+            throw new InvalidOperationException("Routed commands must be accessed on their creating UI thread.");
+    }
+
+    internal void Report(CommandRoutingDiagnosticKind kind, Control? target, object? parameter,
+        object? owner = null, CommandBinding? binding = null, bool? canExecute = null, string? failureReason = null)
+    {
+        var handler = Diagnostic;
+        if (handler is not null)
+            handler(this, new(kind, this, target, owner, binding, parameter?.GetType(), canExecute, failureReason));
+    }
+}

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -790,6 +790,8 @@ public sealed class SkiaControlSurface : IDisposable, IPlatformAccessibilityHost
 
     private sealed class SurfaceRootControl : Control, IControlSurfaceAccessibilitySink
     {
+        internal override bool IsCommandRoutingRoot => true;
+
         public Action<IPlatformAccessibleObject, int, int, int>? AccessibilityNotification { get; set; }
 
         public void NotifyAccessibility(IPlatformAccessibleObject source, int eventId, int objectId, int childId)

--- a/ModernFormsNext/WindowBase.CommandBindings.cs
+++ b/ModernFormsNext/WindowBase.CommandBindings.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+
+namespace ModernFormsNext;
+
+public abstract partial class WindowBase
+{
+    private CommandBindingCollection? commandBindings;
+
+    /// <summary>Gets runtime handlers visited after the target's control ancestors in this window.</summary>
+    /// <remarks>
+    /// Access on the UI thread. The route stops at this window; Form.Owner and popup ownership are
+    /// not traversed. Actual close/disposal releases registrations; cancelled close preserves them.
+    /// Edits requery affected commands and may update action-source enabled/rendering state.
+    /// </remarks>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public CommandBindingCollection CommandBindings
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(InputBindingsClosed, this);
+            var bindings = commandBindings ??= new CommandBindingCollection(this);
+            bindings.VerifyAccess();
+            return bindings;
+        }
+    }
+
+    internal CommandBindingCollection? CommandBindingsInternal => commandBindings;
+
+    private void ReleaseCommandBindings()
+    {
+        commandBindings?.Release();
+        commandBindings = null;
+        adapter.ReleaseCommandBindingsForSubtree();
+    }
+}

--- a/ModernFormsNext/WindowBase.InputBindings.cs
+++ b/ModernFormsNext/WindowBase.InputBindings.cs
@@ -37,6 +37,7 @@ public abstract partial class WindowBase
     {
         if (InputBindingsClosed) return;
         InputBindingsClosed = true;
+        ReleaseCommandBindings();
         inputBindingResolver.Reset();
         inputBindings?.Release();
         inputBindings = null;

--- a/docs/commands-phase3-audit.md
+++ b/docs/commands-phase3-audit.md
@@ -1,0 +1,57 @@
+# Command routing audit — issue #56 Phase 3
+
+Baseline: `bf4b120a9fc3b98f7b1f2e075b68abab394b74eb` (Phase 2 merged).
+This audit precedes implementation. Phase 1/2 remain the canonical action and keyboard paths.
+
+| Area | Existing behavior | Needed for Phase 3 | Proposed reuse |
+| --- | --- | --- | --- |
+| Control tree | ControlCollection maintains Parent; parenting cycles are rejected. | A bounded route with deterministic order. | Snapshot the live Parent chain per invocation; no registry, graph cache or reflection. |
+| Windows | WindowBase is a Component, not a Control. Its ControlAdapter roots the tree; FindWindow follows Parent. | Window handlers and ownership boundary. | Include the existing adapter's window once; never follow Form.Owner or popup ownership. |
+| Focus | Native windows have adapter.SelectedControl. SkiaControlSurface observes Selected in its borrowed tree. No unambiguous application-wide active focus. | Target selection without crossing windows. | Keyboard entry points already supply focus/root/window. Button defaults to itself. |
+| Input/events | Window KeyDown preview, Phase 2 lookup, then selected-control dispatch. No general routed-event/tunnel infrastructure. | Command handler lookup independent of gesture lookup. | A separate synchronous target-to-root command traversal; retain all input ordering and consumption. |
+| Semantics | Canonical accessibility includes logical/non-Control item nodes and platform adapters. | Accessible activation of existing command sources. | Button Invoke still calls normal activation. Non-Control semantic nodes do not become route nodes. |
+| Action sources | CommandSource centralizes ICommand, parameters, weak subscriptions, Enabled, version guards and exceptions. | Target-aware evaluation for RoutedCommand only. | Extend this helper narrowly for Button; plain ICommand and NotifyIconMenuItem retain their paths. |
+| InputBindingResolver | Snapshots matching gesture registrations; validates versions/lifetimes; evaluates concrete ICommand. | Feed routed commands a target and consume the prepared evaluation. | A small RoutedCommand branch after gesture lookup; ordinary commands remain direct. |
+| Lifetime | Control disposal, actual window close and application shutdown already release input bindings. | Release handler ownership and observers. | Parallel command cleanup at those same lifetime points; cancelled close preserves bindings. |
+| Diagnostics | InputBindingCollection has opt-in diagnostic events. | Explain route traversal and outcomes. | Per-RoutedCommand opt-in diagnostics, separate from gesture diagnostics, no global subscribers. |
+| Designer | DesignerCommandService owns design/session operations; native command IDs have a separate legacy purpose. | Preserve tooling boundaries. | No reuse of Designer services/native command registry for runtime routing; hide runtime properties from serialization. |
+| TestHost | Real controls, immutable diagnostic tree snapshots, deterministic UI dispatcher. | Repeatable route/activation tests. | Existing control/window seams and host dispatcher; no alternate production tree or keyboard simulator. |
+
+## Selected contracts
+
+- A sealed `RoutedCommand : System.Windows.Input.ICommand` has immutable optional Name and
+  reference identity. Target overloads are canonical. Parameter-only calls have no context:
+  CanExecute returns false and Execute does nothing. Framework sources supply their context.
+  This avoids inventing a global focus singleton or guessing between windows.
+- `Control? CommandTarget` is additive on Button and InputBinding only, and ignored for ordinary
+  ICommand. Explicit invalid/detached/disposed/wrong-context targets fail closed without fallback.
+  Button: explicit target, otherwise source Button. Keyboard: explicit target, otherwise valid
+  focused control, binding control scope, then entry root. Focus from another tree is ignored.
+- A target must reach an existing native ControlAdapter or standalone surface root. Detached
+  trees are unavailable. The route uses controls, then window (if present), then application as
+  a terminal fallback. Popup ownership does not extend the route to the owner's window.
+- Immutable CommandBinding ties a RoutedCommand to synchronous Executed and optional CanExecute
+  delegates. An absent CanExecute delegate is unavailable. Collections have one-owner bindings,
+  insertion order and creating-UI-thread affinity. Commands are never disposed by a collection.
+- Query scans in order: true selects the first available binding; false/Unhandled continues;
+  false/Handled vetoes the remaining route. Execution starts at the selected binding and may
+  continue to later available bindings until Executed.Handled. Each later binding is queried
+  before execution. This gives local override and explicit event-style continuation without
+  accidentally executing a handler whose CanExecute was false.
+- Each invocation captures nodes and matching immutable registrations before application code.
+  Query and execution share that snapshot. Adds/removes/reparent/focus changes take effect at the
+  next invocation, without changing the current route. Disposed owners/targets and closed windows
+  are terminal safety boundaries, even for a captured route. Nested calls get separate contexts.
+- No preview/tunnel: existing window input preview remains sufficient for this phase. Routing
+  has no async state, cancellation, command registry, global reentrancy lock or service locator.
+- RoutedCommand.RaiseCanExecuteChanged uses Phase 1 subscription/dispatcher behavior. Collection
+  edits notify the affected commands; source attachment refreshes routed Button availability.
+  Application state changes require explicit requery; there is no global polling.
+- Diagnostics are public opt-in per command for app logging and future tools. Events identify
+  visited owners, bindings, query/execution/handled results and constant failure reasons. They
+  do not expose the route snapshot or parameter value, call ToString, or copy control text.
+  Handler exceptions propagate unchanged; diagnostic reporting must not replace an original
+  command exception. Observers should be fast and must not mutate UI state.
+
+Phase 4, async helpers, deeper action-control integration, Designer work, #61 UI, #85 and #97
+remain outside this implementation. Issue #56 stays OPEN. Work is committed locally only.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,4 +1,4 @@
-# Commands and input bindings (issue #56, Phases 1 and 2)
+# Commands, input bindings and routing (issue #56, Phases 1–3)
 
 Commands represent reusable application actions. `System.Windows.Input.ICommand` is the contract:
 existing application implementations can be assigned directly. `ModernFormsNext.DelegateCommand`
@@ -7,7 +7,8 @@ an application can use `button.Click` without creating any command.
 
 Phase 1 provides delegate commands, parameters, availability and two action sources: `Button`
 and `NotifyIconMenuItem`. Phase 2 adds keyboard gestures and scoped input bindings to concrete
-commands. Issue #56 remains open: routed commands, async helpers and Designer integration are
+commands. Phase 3 adds routed commands, control targets and hierarchical command handlers.
+Issue #56 remains open: Phase 4 async helpers and deeper control/Designer integration are
 **not implemented**.
 
 ## Define once, reuse with different parameters
@@ -224,7 +225,8 @@ Within a collection, the **first added available match** wins. Duplicates are al
 command, invalid gesture or `CanExecute == false` allows later registrations and outer scopes
 to provide a fallback. If nothing executes, a fresh key press remains available to normal input.
 This is binding lookup through control ancestry, **not hierarchical command routing**. Every
-binding directly names its ICommand; there is no CommandTarget, CommandBinding or handler route.
+binding directly names its ICommand. Phase 3 performs a separate handler-routing stage only when
+that command is a RoutedCommand; ordinary commands keep their direct execution behavior.
 
 ### Execution, consumption and mutation
 
@@ -309,12 +311,12 @@ starts without old registrations. Tests use the same internal cleanup path for i
 Subscribe optionally to a collection's `Diagnostic` event for InvalidBinding, DuplicateGesture,
 CommandUnavailable and Executed outcomes. Observations are synchronous, allocate event args only
 when subscribed, and do not format parameter contents. Observers must not mutate input state;
-their exceptions propagate. This is minimal binding diagnostics; command-route diagnostics remain
-Phase 3. Collection changes do not trigger layout/rendering by themselves. Public InputBindings
+their exceptions propagate. These binding diagnostics are separate from the Phase 3 route
+diagnostics below. InputBindings changes do not trigger layout/rendering by themselves. Public InputBindings
 properties are hidden from Designer browsing/serialization and remain runtime-only.
 This public observer API lets applications explain conflicting registrations and unavailable
 shortcuts using their own logging. It exposes the binding and outcome, not resolver snapshots,
-scope traversal state or future command-route details.
+scope traversal state or command-route details.
 
 The existing ControlGallery **Button** section now supports Ctrl+1 / Ctrl+2 with the same save
 command and parameters as its buttons. With focus in the section, the panel's Ctrl+1 saves first
@@ -324,9 +326,175 @@ first** affects that Button's local enabled intent; it does not change availabil
 command for another source. `KeyGestureTests`, `InputBindingTests` and `AndroidKeyboardBindingTests`
 cover matching, lookup, input integration, mutation, lifecycle and source classification.
 
+## Routed commands and command bindings (Phase 3)
+
+Use `RoutedCommand` when an action's implementation depends on the target's location in the UI.
+It implements `System.Windows.Input.ICommand`, has an immutable optional `Name`, and compares by
+reference identity. Two commands called `"Save"` are different actions. It captures no target,
+registers no global ID and introduces no dependency on WPF or a backend-specific type.
+
+`InputBinding` answers **which command this gesture selects**. `CommandBinding` answers **which
+handler on this target's route can execute that command**. A DelegateCommand or custom ICommand
+never enters the handler resolver, even when its source has a CommandTarget assigned.
+
+```csharp
+using ModernFormsNext;
+using ModernFormsNext.WindowKit.Input;
+
+var save = new RoutedCommand("Save");
+bool canSave = true;
+
+form.CommandBindings.Add(new CommandBinding(save,
+    executed: (_, e) => {
+        SaveDocument(e.Parameter);
+        e.Handled = true;
+    },
+    canExecute: (_, e) => e.CanExecute = canSave));
+
+var editor = form.Controls.Add(new TextBox());
+var saveButton = form.Controls.Add(new Button {
+    Text = "Save", Command = save, CommandTarget = editor, CommandParameter = document
+});
+form.InputBindings.Add(new KeyBinding(save, new KeyGesture(Keys.S, KeyModifiers.Control)) {
+    CommandTarget = editor, CommandParameter = document
+});
+
+canSave = false;
+save.RaiseCanExecuteChanged(); // Normal Button enabled/accessibility update.
+```
+
+CommandBinding's `Command`, `Executed` and optional `CanExecute` delegates are immutable. Replace
+the registration to change handlers. An absent CanExecute handler is **unavailable**, not an
+implicit permission to execute. All handlers are synchronous and receive the visited owner as
+sender. For the application terminal, sender is `typeof(Application)`.
+
+### Target resolution and boundaries
+
+| Entry | Target order | Boundary |
+| --- | --- | --- |
+| Button | Explicit CommandTarget, otherwise the source Button itself | Same window or standalone surface as the Button |
+| KeyBinding | Explicit CommandTarget, otherwise valid focus, binding control scope, then keyboard entry root | Existing input root; foreign/stale focus is ignored |
+| Direct target overload | Supplied Control | The target's own attached tree |
+| Parameter-only ICommand | No target/context; CanExecute false, Execute no-op | No global focus guessing |
+
+An invalid explicit target fails closed; it does not fall back to focus/source. Button target
+resolution deliberately does not follow focus: pointer activation can change focus, while a Save
+button often acts on a separate editor. Set CommandTarget explicitly for that editor. A Button's
+default route remains stable when some other control or window has focus.
+
+Use `save.CanExecute(parameter, target)` and `save.Execute(parameter, target)` for direct calls.
+The latter performs its own fresh query. `Control` is the target contract; there is no new public
+ICommandTarget abstraction. Targets must reach an existing native window adapter or standalone
+SkiaControlSurface root. Detached/disposed targets and closed windows are unavailable. A caller
+cannot use a detached Control merely to reach application fallback handlers.
+
+Routing itself resolves application availability; it does not select a control or synthesize input.
+Normal Button and keyboard-source input guards continue to enforce their effective enabled/input
+state. Direct programmatic target calls require an attached live target and use the handlers'
+CanExecute policy; they do not derive application permission from the target's cached command-enabled
+flag. This also allows a disabled command source to recover after a successful requery.
+
+The parent chain ends at its current window. Form.Owner and popup ownership do not cross that
+boundary. A standalone surface uses its borrowed root and has no WindowBase scope. Non-Control
+semantic accessibility nodes are not command targets or additional route nodes in this phase.
+
+### Route, CanExecute and Handled
+
+The resolver snapshots the current `target → Parent → ...` chain, followed by the owning window
+(if present) and `Application.CommandBindings` as a terminal fallback. The internal native root
+adapter is represented by the window; standalone surface infrastructure adds no handler scope.
+Every matching registration is captured in insertion order before invoking application code.
+No second tree, cached route graph, reflection lookup or static control dictionary is used.
+
+Only target-to-root traversal is implemented. There is no preview/tunnel command stage: the
+existing Window.KeyDown preview already gives input handlers first refusal, and Phase 3 does not
+introduce a general routed-event framework.
+
+Each binding gets fresh CanExecuteCommandEventArgs with Command, Parameter, Target, Source,
+CanExecute=false and Handled=false:
+
+| Query result | Effect |
+| --- | --- |
+| CanExecute=true | Select the first available binding |
+| CanExecute=false, Handled=false | Continue to the next registration/scope |
+| CanExecute=false, Handled=true | Veto the rest of this route |
+| No available registration | Command unavailable |
+
+Execution starts at that selected binding. ExecutedCommandEventArgs carries Command, Parameter,
+Target, Source and a fresh Handled=false. **Set Handled=true after handling an action** to stop.
+If left false, traversal continues; each later binding must pass its own CanExecute query before
+its execution handler runs. A query's Handled value does not implicitly handle execution. This
+permits duplicate registrations and explicit continuation without invoking unavailable handlers.
+
+```csharp
+editor.CommandBindings.Add(new CommandBinding(save,
+    (_, e) => { SaveEditorDocument(e.Parameter); e.Handled = true; },
+    (_, e) => e.CanExecute = editorHasDocument));
+// If editorHasDocument is false and the query is unhandled, the window handler can take over.
+```
+
+### Mutation, lifecycle, threading and exceptions
+
+Query and execution within one invocation share the captured nodes and registrations. Reparenting,
+removing a control, changing focus, adding/removing bindings or replacing a registration does not
+rebuild that route midway. Those changes affect the next invocation. Disposed owners/targets and
+closed windows stop the current traversal, including a close/dispose during CanExecute. Nested
+commands, including recursive calls to the same command, each own a separate invocation context.
+There is no shared mutable cursor or global reentrancy lock.
+
+Create RoutedCommand and CommandBinding on the UI thread. Route calls and collection mutations
+reject a different thread. RaiseCanExecuteChanged uses the existing Phase 1 notification policy:
+framework sources marshal background notifications through the application dispatcher. No new
+synchronization or scheduler is added. Predicates should be fast and free of side effects.
+Requery caused by collection mutation inside the same source's query does not recursively replace
+its in-progress snapshot; application state changes should be followed by explicit requery.
+
+Adding/removing/replacing/clearing CommandBindings requeries affected commands. Attaching or
+reparenting a source subtree refreshes routed Button availability. Other application state changes
+require `RaiseCanExecuteChanged`; there is no focus polling or command registry. Ordinary ICommand
+evaluation counts, Button Click ordering, local Enabled intent and NotifyIconMenuItem behavior
+remain unchanged. Button accessibility Invoke follows normal Button activation and command execution;
+CanExecute=false updates effective Enabled and accessibility availability through that same source.
+
+A CommandBinding has at most one collection owner. Removal releases ownership and permits re-add
+or transfer. Clearing collections does not dispose commands/delegate captures. Control disposal,
+actual window close/disposal and application shutdown release registrations; cancelled close
+preserves them. Application registrations retain captures until removed/shutdown: explicitly remove
+short-lived captures. Shutdown cleanup does not add support for a second Application.Run loop.
+
+Original CanExecute and Executed exceptions propagate unchanged. Each invocation's state is local,
+so an exception cannot corrupt a later route. Button retains Phase 1's fail-closed availability and
+recovery behavior. There are no async handlers, execution-state flags or cancellation helpers.
+
+### Opt-in route diagnostics
+
+Subscribe to `RoutedCommand.Diagnostic` to observe NodeVisited, BindingFound, CanExecuteEvaluated,
+Executed, Handled and Failed transitions. This per-command public event supports application logging
+and future tools without a Developer Tools UI. Owner identifies a Control, WindowBase or
+`typeof(Application)` terminal. Target and Binding are identities; CanExecute records query outcomes.
+FailureReason contains only framework-defined text. The internal route snapshot is not exposed.
+
+```csharp
+save.Diagnostic += (_, e) => {
+    // No parameter value or control text is formatted here.
+    Log($"{e.Kind}; owner type={e.Owner?.GetType().Name}; parameter type={e.ParameterType?.FullName}");
+};
+```
+
+Diagnostics never call parameter.ToString, copy control text/passwords, or include exception
+messages. ParameterType exposes only the CLR type. Do not retain owner/binding references longer
+than necessary. Without observers, no diagnostic event args are allocated. Observers execute
+synchronously on the UI thread and should not mutate UI state. Observer exceptions propagate,
+except that an original command-handler exception wins over a failure-reporting observer exception.
+
+The ControlGallery **Command routing** page shares one RoutedCommand between two Buttons and Ctrl+S.
+**Save locally** has a local override; **Save via window** reaches a real window CommandBinding.
+The status shows the executed owner and count. **Allow routed Save** updates both sources and
+keyboard availability. Unloading the page removes its window registration and short-lived captures.
+Runtime CommandBindings and Button.CommandTarget are hidden from Designer browsing/serialization.
+
 ## Deferred work
 
-- Phase 3: command targets, hierarchical routing, CommandBinding and diagnostics.
 - Phase 4: task-aware async helpers, deeper menu/toolbar/context-menu integration, Designer
   assignment/serialization, and expanded examples/documentation.
 
@@ -334,4 +502,5 @@ MenuItem ownership/lifecycle requires separate work before safe event subscripti
 across Menu, ToolBar, Ribbon and ContextMenu. Command properties on the Phase 1 sources are hidden
 from design-time browsing/serialization. There is no Designer Ctrl+S fix, BindingNavigator port,
 Developer Tools integration, automation bridge, release or version bump in this phase. See the
-[Phase 1 audit](commands-phase1-audit.md) and [Phase 2 keyboard audit](commands-phase2-audit.md).
+[Phase 1 audit](commands-phase1-audit.md), [Phase 2 keyboard audit](commands-phase2-audit.md) and
+[Phase 3 routing audit](commands-phase3-audit.md).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -377,7 +377,9 @@ sender. For the application terminal, sender is `typeof(Application)`.
 | Direct target overload | Supplied Control | The target's own attached tree |
 | Parameter-only ICommand | No target/context; CanExecute false, Execute no-op | No global focus guessing |
 
-An invalid explicit target fails closed; it does not fall back to focus/source. Button target
+An invalid explicit target fails closed; it does not fall back to focus/source. Keyboard fallback
+ignores disposed controls as implicit focus, even if native focus bookkeeping still retains their
+old Parent reference. Button target
 resolution deliberately does not follow focus: pointer activation can change focus, while a Save
 button often acts on a separate editor. Set CommandTarget explicitly for that editor. A Button's
 default route remains stable when some other control or window has focus.
@@ -437,8 +439,12 @@ editor.CommandBindings.Add(new CommandBinding(save,
 
 Query and execution within one invocation share the captured nodes and registrations. Reparenting,
 removing a control, changing focus, adding/removing bindings or replacing a registration does not
-rebuild that route midway. Those changes affect the next invocation. Disposed owners/targets and
-closed windows stop the current traversal, including a close/dispose during CanExecute. Nested
+rebuild that route midway. Those changes affect the next invocation. Disposal of the source, target
+or **any captured owner** stops the current traversal before another query/action callback, even
+when that owner was already visited or the live target has moved elsewhere. Closing the captured
+window or application shutdown also stops traversal. A close/dispose during CanExecute prevents
+the selected action from running; removing/reparenting alone does not. Diagnostic completion events
+may still describe the handler that just returned. Nested
 commands, including recursive calls to the same command, each own a separate invocation context.
 There is no shared mutable cursor or global reentrancy lock.
 
@@ -492,6 +498,12 @@ The ControlGallery **Command routing** page shares one RoutedCommand between two
 The status shows the executed owner and count. **Allow routed Save** updates both sources and
 keyboard availability. Unloading the page removes its window registration and short-lived captures.
 Runtime CommandBindings and Button.CommandTarget are hidden from Designer browsing/serialization.
+
+The routing regressions cover full owner traversal, lifetime aborts after reparenting, nested queries,
+recursive execution, diagnostic reentrancy and inner exceptions. Dedicated Windows UIA provider and
+Android accessibility session tests invoke a real routed Button through the canonical semantic path,
+verify query/Click/query/execution ordering, and reject activation after availability becomes false.
+These provider tests do not establish physical-device or screen-reader coverage.
 
 ## Deferred work
 

--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -21,6 +21,7 @@ namespace ControlGallery
 
             tree.Items.Add ("Accessibility", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Button", ImageLoader.Get ("button.png"));
+            tree.Items.Add ("Command routing", ImageLoader.Get ("button.png"));
             tree.Items.Add ("Animations", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Animated layout", ImageLoader.Get ("swatches.png"));
             tree.Items.Add ("Layout-aware visual states", ImageLoader.Get ("swatches.png"));
@@ -122,6 +123,8 @@ namespace ControlGallery
                     return new AnimationsAndInteractionEffectsPanel ();
                 case "Button":
                     return new ButtonPanel ();
+                case "Command routing":
+                    return new CommandRoutingPanel(this);
                 case "CheckBox":
                     return new CheckBoxPanel ();
                 case "CheckedListBox":

--- a/samples/ControlGallery/Panels/CommandRoutingPanel.cs
+++ b/samples/ControlGallery/Panels/CommandRoutingPanel.cs
@@ -1,0 +1,73 @@
+using ModernFormsNext;
+using ModernFormsNext.WindowKit.Input;
+
+namespace ControlGallery.Panels;
+
+/// <summary>Demonstrates one routed Save action shared by buttons and a keyboard binding.</summary>
+public sealed class CommandRoutingPanel : BasePanel
+{
+    private CommandBindingCollection? windowBindings;
+    private readonly CommandBinding windowBinding;
+
+    /// <summary>Creates a local override and a handler in the gallery's existing window scope.</summary>
+    /// <param name="window">The gallery window; its sample registration is removed when this page unloads.</param>
+    public CommandRoutingPanel(WindowBase window)
+    {
+        var command = new RoutedCommand("Gallery.Save");
+        int saves = 0;
+        Controls.Add(new Label {
+            Text = "Routed Save: one command, two handler locations", Left = 36, Top = 44, Width = 700, Height = 36
+        });
+        var allowed = Controls.Add(new CheckBox {
+            Text = "Allow routed Save", Checked = true, Left = 36, Top = 104, Width = 300
+        });
+        var status = Controls.Add(new Label {
+            Text = "Route owner: none", Left = 36, Top = 226, Width = 700, Height = 36
+        });
+        var local = Controls.Add(new Button {
+            Text = "Save locally", Left = 36, Top = 160, Width = 170,
+            Command = command, CommandParameter = "Document"
+        });
+        Controls.Add(new Button {
+            Text = "Save via window", Left = 230, Top = 160, Width = 190,
+            Command = command, CommandParameter = "Document"
+        });
+        local.CommandBindings.Add(new CommandBinding(command,
+            (_, e) => { status.Text = $"Route owner: local; saves: {++saves}"; e.Handled = true; },
+            (_, e) => e.CanExecute = allowed.Checked));
+        windowBinding = new CommandBinding(command,
+            (_, e) => { status.Text = $"Route owner: window; saves: {++saves}"; e.Handled = true; },
+            (_, e) => e.CanExecute = allowed.Checked);
+        windowBindings = window.CommandBindings;
+        windowBindings.Add(windowBinding);
+        // Gesture lookup remains on the page. Handler lookup starts at the selected control and
+        // either finds its local override or reaches the real WindowBase registration.
+        InputBindings.Add(new KeyBinding(command, new KeyGesture(Keys.S, KeyModifiers.Control)) {
+            CommandParameter = "Document"
+        });
+        allowed.CheckedChanged += (_, _) => command.RaiseCanExecuteChanged();
+        Controls.Add(new Label {
+            Text = "Click a Save button, or focus it and press Ctrl+S. Save locally handles first;\nSave via window falls back to the window. Uncheck Allow routed Save to disable both.",
+            Left = 36, Top = 288, Width = 740, Height = 72
+        });
+    }
+
+    /// <inheritdoc/>
+    public override void UnloadPanel() => ReleaseWindowBinding();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        // UI-thread unloading removes the short-lived capture. A closed window has already
+        // released the collection, whose Count is then zero. Finalization must not call UI code.
+        if (disposing) ReleaseWindowBinding();
+        base.Dispose(disposing);
+    }
+
+    private void ReleaseWindowBinding()
+    {
+        var bindings = windowBindings;
+        windowBindings = null;
+        if (bindings?.Contains(windowBinding) == true) bindings.Remove(windowBinding);
+    }
+}

--- a/samples/ControlGallery/Panels/CommandRoutingPanel.cs
+++ b/samples/ControlGallery/Panels/CommandRoutingPanel.cs
@@ -47,8 +47,8 @@ public sealed class CommandRoutingPanel : BasePanel
         });
         allowed.CheckedChanged += (_, _) => command.RaiseCanExecuteChanged();
         Controls.Add(new Label {
-            Text = "Click a Save button, or focus it and press Ctrl+S. Save locally handles first;\nSave via window falls back to the window. Uncheck Allow routed Save to disable both.",
-            Left = 36, Top = 288, Width = 740, Height = 72
+            Text = "Click either Save button, or focus it and press Ctrl+S.\nLocal overrides window. Uncheck Allow routed Save to disable both.",
+            Left = 36, Top = 288, Width = 740, Height = 72, Multiline = true
         });
     }
 


### PR DESCRIPTION
## Summary

Implements Phase 3 of #56 — routed commands, command targets, hierarchical command bindings and route diagnostics. A Button or keyboard gesture can invoke the same action while the target's location selects a local handler or a window/application fallback.

Final review also fixed two lifetime edges: disposal of an already visited ancestor after reparenting now terminates the captured route, and stale disposed focus falls back to the keyboard entry root.

## Architecture

The existing control tree is the route: Parent ancestors, the owning WindowBase, then Application. No second hierarchy, command registry, service locator or global current route is introduced. Gesture lookup remains in the Phase 2 input resolver; only RoutedCommand enters handler routing. Ordinary ICommand and DelegateCommand remain direct/non-routed.

## API

- Sealed RoutedCommand with reference identity and optional immutable diagnostic Name.
- Immutable CommandBinding and single-owner, ordered CommandBindingCollection on Control, WindowBase and Application.
- Additive Control-valued CommandTarget on Button and InputBinding.
- CanExecuteCommandEventArgs, ExecutedCommandEventArgs and opt-in CommandRoutingDiagnosticEventArgs / diagnostic kinds.
- UI-thread contracts, nullable parameters, lifecycle behavior and examples documented in XML and docs/commands.md; preimplementation audit in docs/commands-phase3-audit.md.

## Target resolution

- Button: explicit target, otherwise the source Button itself; focus does not retarget a Button action.
- Keyboard/InputBinding: explicit target, otherwise live valid focus, control binding scope, then entry root. Foreign/detached/stale disposed focus is ignored.
- Direct invocation: supplied attached target through the target overload. Parameter-only ICommand CanExecute returns false and Execute does nothing; there is no hidden global focus lookup.
- Explicit foreign, detached or disposed targets fail closed without fallback. Source routes stay in the same window/surface; Form.Owner is not traversed.

## Routing

The route is target → parent → window → application. Each invocation snapshots nodes and matching registrations before application callbacks; query and execution share that snapshot. Reparenting, removal, focus changes and binding edits affect the next invocation.

The first CanExecute=true binding is selected. False/unhandled continues; false/Handled vetoes the rest of the route. Execution continues only through later bindings that pass their own query, until Executed.Handled. Query Handled does not implicitly handle execution. Duplicate registrations use insertion order; separate binding instances can share the command.

Disposal of source, target or any captured owner, captured-window closure, or application shutdown stops further query/action callbacks, even after reparenting. Actual disposal/closure releases registrations; cancelled close preserves them. Commands are never disposed by collections. Explicit requery reuses existing weak source subscriptions and dispatcher behavior. Every nested query, execution and diagnostic-triggered query owns separate invocation state; original handler exceptions propagate unchanged.

## Diagnostics

Per-command diagnostics are synchronous and opt-in: visited owner/binding identities, query/execution/handled outcomes and framework-defined failure reasons. They do not expose the internal route snapshot, parameter values, control text/passwords or exception messages and never call parameter.ToString(). Original command exceptions take precedence over observers that throw while reporting that failure.

## Validation

Validated final head: `cfcf25985d53ffb358178ce5759213b9b5a69627`.

| Suite | Debug | Release |
| --- | ---: | ---: |
| Core | 1134/1134 | 1134/1134 |
| Designer | 622/622 | 622/622 |
| Testing | 55/55 | 55/55 |
| Windows backend | 67/67 | 67/67 |
| Android backend | 164/164 | 164/164 |
| Cross-platform | 16/16 | 16/16 |
| VSIX | 26/26 | 26/26 |
| Total | **2084/2084** | **2084/2084** |

Zero failures/skips. Included per configuration: **76 Phase 3 cases** (72 core, 2 host, 1 Windows UIA, 1 Android accessibility); Phase 1 **64**, Phase 2 **105**, semantic accessibility **32**, Windows UIA **55**, Android accessibility provider **32**.

- Full solution restore and Debug/Release builds pass, zero warnings/errors; Android and VSIX targets included.
- ApiCompat: **4/4** comparisons against verified Phase 2 baseline `bf4b120a9fc3b98f7b1f2e075b68abab394b74eb`, including attribute and parameter-name rules.
- Documentation script tests: **32 assertions**; DocFX: zero warnings/errors; **4/4** versioned documentation archives validated against this head.
- Package validation: **9 NuGet + 8 symbol packages**, unchanged version **1.10.0**, generated locally only.
- Native Windows ControlGallery UIA/SendInput smoke: **10/10**, covering routed Button and Ctrl+S, local/window handlers, disabled/recovery, ordinary DelegateCommand, and page unload/reload. Screenshot inspected; no clipping. Execution policy unchanged.
- Final diff check passes; 30 scoped files, no artifacts or local config in the PR.

Physical Android device/TalkBack, screen-reader, physical AltGr/dead-key layout and a full theme/DPI matrix were not executed. DemoApp/templates are unchanged; template smoke was not required.

## Phase 1/2 compatibility

DelegateCommand behavior, Button query/Click/query/Execute ordering, local Enabled intent and NotifyIconMenuItem remain unchanged. KeyGesture matching, InputBinding precedence, repeats/KeyUp consumption and AltGraph/text input safety keep their existing path. Windows UIA and Android accessibility regressions invoke a real routed Button through canonical semantic activation and verify disabled state and recovery.

## Deferred

Phase 4 remains unimplemented:
- AsyncCommand/helpers and execution/cancellation state.
- Deeper menu/toolbar/context-menu integration.
- Designer assignment/serialization support.
- Expanded diagnostics/examples.

No #85, #97 or #61 UI work; no release, tag or version bump.

## Issue state

Part of #56 — completes Phase 3 only.

**Issue #56 must remain OPEN for Phase 4.**
