### PR TITLE
Add Phase 1a semantic automation core

### DIFF
--- a/ModernFormsNext.Automation.Tests/ActionTests.cs
+++ b/ModernFormsNext.Automation.Tests/ActionTests.cs
@@ -1,0 +1,228 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Tests;
+
+[Trait("Category", "Actions")]
+public sealed class ActionTests
+{
+    [Fact]
+    public void InvokePreservesClickBeforeDelegateCommand()
+    {
+        using var f = new AutomationFixture();
+        var order = new List<string>();
+        var b = f.Add(new Button { Command = new DelegateCommand(() => order.Add("command")) });
+        b.Click += (_, _) => order.Add("click");
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(b, AccessibleActions.Invoke).Status);
+        Assert.Equal(new[] { "click", "command" }, order);
+    }
+
+    [Fact]
+    public void RoutedCommandUsesNormalSourceAndBindings()
+    {
+        using var f = new AutomationFixture();
+        var panel = f.Add(new Panel());
+        var command = new RoutedCommand("save");
+        int calls = 0;
+        panel.CommandBindings.Add(new(command, (_, e) => { calls++; e.Handled = true; }, (_, e) => e.CanExecute = true));
+        var button = panel.Controls.Add(new Button { Command = command });
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(button, AccessibleActions.Invoke).Status);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void AsyncCommandAcceptancePrecedesBusinessCompletion()
+    {
+        using var f = new AutomationFixture();
+        var pending = new TaskCompletionSource();
+        int started = 0;
+        var command = new AsyncCommand(() => { started++; return pending.Task; });
+        var button = f.Add(new Button { Command = command });
+        var result = f.Act(button, AccessibleActions.Invoke);
+        Assert.Equal(AutomationActionStatus.Accepted, result.Status);
+        Assert.True(command.IsExecuting);
+        Assert.Equal(1, started);
+        Assert.False(command.ExecutionTask!.IsCompleted);
+        CompletedTaskAssertions.Worker(pending.SetResult);
+        f.Host.Dispatcher.Drain();
+        Assert.True(pending.Task.IsCompletedSuccessfully);
+        Assert.True(command.ExecutionTask.IsCompletedSuccessfully);
+        Assert.False(command.IsExecuting);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DisabledOrCanExecuteFalseCannotExecute(bool commandDenied)
+    {
+        using var f = new AutomationFixture();
+        int calls = 0;
+        var b = f.Add(new Button { Command = new DelegateCommand(() => calls++, () => !commandDenied) });
+        if (!commandDenied) b.Enabled = false;
+        var result = f.Act(b, AccessibleActions.Invoke);
+        Assert.Equal(AutomationActionStatus.Rejected, result.Status);
+        Assert.Equal(AutomationErrorCode.ActionRejected, result.Error);
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public void ClickCanCancelCommandThroughNormalCanExecuteRecheck()
+    {
+        using var f = new AutomationFixture();
+        bool allowed = true; int calls = 0;
+        var b = f.Add(new Button { Command = new DelegateCommand(() => calls++, () => allowed) });
+        b.Click += (_, _) => allowed = false;
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(b, AccessibleActions.Invoke).Status);
+        Assert.Equal(0, calls); // Acceptance belongs to canonical activation, not command completion.
+    }
+
+    [Fact]
+    public void ToggleAndRadioSelectionChangeRealControlState()
+    {
+        using var f = new AutomationFixture();
+        var check = f.Add(new CheckBox());
+        var first = f.Add(new RadioButton { Checked = true });
+        var second = f.Add(new RadioButton());
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(check, AccessibleActions.Toggle).Status);
+        Assert.True(check.Checked);
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(second, AccessibleActions.Select).Status);
+        Assert.True(second.Checked);
+        Assert.False(first.Checked);
+    }
+
+    [Fact]
+    public void SetValueAndClearUseEditableTextBoxSemantics()
+    {
+        using var f = new AutomationFixture();
+        var text = f.Add(new TextBox());
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(text, AccessibleActions.SetValue, AutomationActionValue.FromText("changed")).Status);
+        Assert.Equal("changed", text.Text);
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(text, AccessibleActions.SetValue).Status);
+        Assert.Equal(string.Empty, text.Text);
+    }
+
+    [Fact]
+    public void FocusChangesRealControlFocus()
+    {
+        using var f = new AutomationFixture();
+        var text = f.Add(new TextBox());
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(text, AccessibleActions.Focus).Status);
+        Assert.True(text.Focused);
+        Assert.True((f.Inspect(text).Value!.States & AccessibleStates.Focused) != 0);
+    }
+
+    [Fact]
+    public void ListSelectionUsesLogicalPeer()
+    {
+        using var f = new AutomationFixture();
+        var list = f.Add(new ListBox()); list.Items.Add("one"); list.Items.Add("two");
+        var node = f.Session.FindOneAsync(f.Root.RootId, new() { Name = "two", ControlType = AccessibleControlType.ListItem }).Completed().Value!;
+        Assert.Equal(AutomationActionStatus.Accepted, f.Session.PerformActionAsync(f.Root.RootId, node.Handle, AccessibleActions.Select).Completed().Status);
+        Assert.Equal(1, list.SelectedIndex);
+    }
+
+    [Fact]
+    public void TreeExpansionAndCollapseUseLogicalPeer()
+    {
+        using var f = new AutomationFixture();
+        var tree = f.Add(new TreeView()); var branch = tree.Items.Add(new TreeViewItem("branch", new TreeViewItem("leaf")));
+        var handle = f.Handle(tree.AccessibilityObject.GetChild(0)!);
+        Assert.Equal(AutomationActionStatus.Accepted, f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Expand).Completed().Status);
+        Assert.True(branch.Expanded);
+        Assert.Equal(AutomationActionStatus.Accepted, f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Collapse).Completed().Status);
+        Assert.False(branch.Expanded);
+    }
+
+    [Fact]
+    public void NumericSetIncrementAndDecrementUseCanonicalRange()
+    {
+        using var f = new AutomationFixture();
+        var track = f.Add(new TrackBar { Minimum = 0, Maximum = 10, SmallChange = 2 });
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(track, AccessibleActions.SetValue, AutomationActionValue.FromNumber(4)).Status);
+        Assert.Equal(4, track.Value);
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(track, AccessibleActions.Increment).Status);
+        Assert.Equal(6, track.Value);
+        Assert.Equal(AutomationActionStatus.Accepted, f.Act(track, AccessibleActions.Decrement).Status);
+        Assert.Equal(4, track.Value);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(11)]
+    [InlineData(2.5)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void InvalidNumericValuesAreRejectedWithoutMutation(double number)
+    {
+        using var f = new AutomationFixture();
+        var track = f.Add(new TrackBar { Minimum = 0, Maximum = 10, Value = 3 });
+        Assert.Equal(AutomationErrorCode.InvalidArgument, f.Act(track, AccessibleActions.SetValue, AutomationActionValue.FromNumber(number)).Error);
+        Assert.Equal(3, track.Value);
+    }
+
+    [Theory]
+    [InlineData(AccessibleActions.None, AutomationErrorCode.InvalidArgument)]
+    [InlineData(AccessibleActions.Invoke | AccessibleActions.Focus, AutomationErrorCode.InvalidArgument)]
+    [InlineData(AccessibleActions.Scroll, AutomationErrorCode.ActionUnsupported)]
+    [InlineData(AccessibleActions.Toggle, AutomationErrorCode.ActionUnsupported)]
+    public void InvalidOrUnsupportedActionsAreExplicit(AccessibleActions action, AutomationErrorCode expected)
+    {
+        using var f = new AutomationFixture();
+        Assert.Equal(expected, f.Act(f.Add(new Button()), action).Error);
+    }
+
+    [Fact]
+    public void WrongValueTypesAndUnexpectedPayloadAreRejected()
+    {
+        using var f = new AutomationFixture();
+        Assert.Equal(AutomationErrorCode.InvalidArgument, f.Act(f.Add(new Button()), AccessibleActions.Invoke, AutomationActionValue.FromText("x")).Error);
+        Assert.Equal(AutomationErrorCode.InvalidArgument, f.Act(f.Add(new TextBox()), AccessibleActions.SetValue, AutomationActionValue.FromNumber(1)).Error);
+        Assert.Equal(AutomationErrorCode.InvalidArgument, f.Act(f.Add(new TrackBar()), AccessibleActions.SetValue, AutomationActionValue.FromText("1")).Error);
+    }
+
+    [Fact]
+    public void AdvertisedScrollIntoViewUsesCustomCanonicalAction()
+    {
+        using var f = new AutomationFixture();
+        var c = f.Add(new SemanticControl()); c.Child.Actions = AccessibleActions.ScrollIntoView;
+        AccessibleActions observed = AccessibleActions.None;
+        c.Child.Action = (a, value) => { Assert.Null(value); observed = a; return true; };
+        Assert.Equal(AutomationActionStatus.Accepted, f.Session.PerformActionAsync(f.Root.RootId, f.Handle(c.Child), AccessibleActions.ScrollIntoView).Completed().Status);
+        Assert.Equal(AccessibleActions.ScrollIntoView, observed);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CanonicalFalseAndExceptionsAreSafelyMapped(bool throws)
+    {
+        using var f = new AutomationFixture();
+        var c = f.Add(new SemanticControl());
+        c.Child.Action = (_, _) => throws ? throw new Exception("private action failure") : false;
+        var result = f.Session.PerformActionAsync(f.Root.RootId, f.Handle(c.Child), AccessibleActions.Invoke).Completed();
+        Assert.Equal(throws ? AutomationErrorCode.ApplicationError : AutomationErrorCode.ActionRejected, result.Error);
+        Assert.False(f.Session.IsStopped);
+    }
+
+    [Fact]
+    public void GetterDetachBetweenResolveAndActionIsRejected()
+    {
+        using var f = new AutomationFixture();
+        var c = f.Add(new SemanticControl()); int actions = 0;
+        c.Child.ActionsGetter = () => { f.Form.Controls.Remove(c); return AccessibleActions.Invoke; };
+        c.Child.Action = (_, _) => { actions++; return true; };
+        Assert.Equal(AutomationErrorCode.NodeUnavailable,
+            f.Session.PerformActionAsync(f.Root.RootId, f.Handle(c.Child), AccessibleActions.Invoke).Completed().Error);
+        Assert.Equal(0, actions);
+    }
+
+    [Fact]
+    public void CurrentReadOnlyAndChangedRangeOverrideEarlierSnapshot()
+    {
+        using var f = new AutomationFixture();
+        var text = f.Add(new TextBox()); _ = f.Inspect(text); text.ReadOnly = true;
+        Assert.NotEqual(AutomationActionStatus.Accepted, f.Act(text, AccessibleActions.SetValue, AutomationActionValue.FromText("x")).Status);
+        var track = f.Add(new TrackBar { Maximum = 10 }); _ = f.Inspect(track); track.Maximum = 5;
+        Assert.Equal(AutomationErrorCode.InvalidArgument, f.Act(track, AccessibleActions.SetValue, AutomationActionValue.FromNumber(8)).Error);
+    }
+}

--- a/ModernFormsNext.Automation.Tests/AutomationFixture.cs
+++ b/ModernFormsNext.Automation.Tests/AutomationFixture.cs
@@ -1,0 +1,101 @@
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.Testing;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace ModernFormsNext.Automation.Tests;
+
+internal sealed class AutomationFixture : IDisposable
+{
+    internal ModernFormsTestHost Host { get; } = ModernFormsTestHost.Create();
+    internal Form Form { get; } = new() { Text = "Automation test" };
+    internal AutomationSession Session { get; }
+    internal AutomationRootRegistration Root { get; }
+
+    internal AutomationFixture(AutomationQueryOptions? limits = null,
+        AutomationCapability capabilities = AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions)
+    {
+        Host.Show(Form);
+        Session = new(capabilities, limits);
+        Root = Session.RegisterRoot(Form);
+    }
+
+    internal T Add<T>(T control) where T : Control => Form.Controls.Add(control);
+    internal AutomationNodeHandle Handle(Control control) => new(Session.SessionId, control.AccessibilityObject.RuntimeId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    internal AutomationNodeHandle Handle(AccessibleObject peer) => new(Session.SessionId, peer.RuntimeId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    internal AutomationResult<AutomationNodeSnapshot> Inspect(Control control) => Session.InspectAsync(Root.RootId, Handle(control)).GetAwaiter().GetResult();
+    internal AutomationActionResult Act(Control control, AccessibleActions action, AutomationActionValue? value = null)
+        => Session.PerformActionAsync(Root.RootId, Handle(control), action, value).GetAwaiter().GetResult();
+    internal AutomationResult<System.Collections.Immutable.ImmutableArray<AutomationNodeSnapshot>> Find(AutomationQuery query)
+        => Session.FindAllAsync(Root.RootId, query).GetAwaiter().GetResult();
+    public void Dispose() { Session.Dispose(); Host.Dispose(); }
+}
+
+internal static class CompletedTaskAssertions
+{
+    // UI-thread calls complete inline. Assert that contract before observing the result so
+    // these synchronous, thread-affine TestHost tests can never block on a dispatcher job.
+    internal static T Completed<T>(this Task<T> task)
+    {
+        Assert.True(task.IsCompletedSuccessfully);
+        return task.GetAwaiter().GetResult();
+    }
+
+    internal static void Worker(Action action)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() => { try { action(); } catch (Exception error) { failure = error; } });
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)));
+        Assert.Null(failure);
+    }
+
+    internal static T Finish<T>(Task<T> task) => task.WaitAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+}
+
+// A deliberately raw custom child sequence lets the consumer test malformed canonical peers
+// without changing #59's peer model or bypassing it with a separate testing tree.
+internal sealed class SemanticControl : Control
+{
+    internal ScriptPeer Child { get; } = new();
+    protected override AccessibleObject CreateAccessibilityInstance() => new Peer(this);
+    private sealed class Peer : ControlAccessibleObject
+    {
+        private readonly SemanticControl owner;
+        internal Peer(SemanticControl owner) : base(owner) { this.owner = owner; owner.Child.ParentValue = this; }
+        public override int GetChildCount() => 1;
+        public override AccessibleObject? GetChild(int index) => index == 0 ? owner.Child : null;
+    }
+}
+
+internal sealed class ScriptPeer : AccessibleObject
+{
+    internal AccessibleObject? ParentValue { get; set; }
+    internal Func<AccessibleObject?>? ParentGetter { get; set; }
+    internal Func<string?>? NameGetter { get; set; }
+    internal Func<string?>? ValueGetter { get; set; }
+    internal Func<bool>? SensitiveGetter { get; set; }
+    internal Func<AccessibleStates>? StateGetter { get; set; }
+    internal Func<int>? CountGetter { get; set; }
+    internal Func<int, AccessibleObject?>? ChildGetter { get; set; }
+    internal Func<AccessibleActions>? ActionsGetter { get; set; }
+    internal Func<AccessibleActions, object?, bool>? Action { get; set; }
+    internal Func<AccessibleRangeValue?>? RangeGetter { get; set; }
+    internal List<AccessibleObject> Children { get; } = [];
+    internal AccessibleStates States { get; set; }
+    internal AccessibilityView Projection { get; set; } = AccessibilityView.Control;
+    internal AccessibleActions Actions { get; set; } = AccessibleActions.Invoke;
+    internal ScriptPeer Add(ScriptPeer child) { child.ParentValue = this; Children.Add(child); return child; }
+    public override AccessibleObject? Parent => ParentGetter is null ? ParentValue : ParentGetter();
+    public override string? Name { get => NameGetter is null ? base.Name : NameGetter(); set => base.Name = value; }
+    public override string? Value { get => ValueGetter is null ? base.Value : ValueGetter(); set => base.Value = value; }
+    public override bool IsSensitive => SensitiveGetter?.Invoke() ?? false;
+    public override AccessibleStates State => StateGetter?.Invoke() ?? States;
+    public override AccessibilityView View => Projection;
+    public override AccessibleActions SupportedActions => ActionsGetter?.Invoke() ?? Actions;
+    public override AccessibleRangeValue? RangeValue => RangeGetter?.Invoke();
+    public override int GetChildCount() => CountGetter?.Invoke() ?? Children.Count;
+    public override AccessibleObject? GetChild(int index) => ChildGetter is null ? Children.ElementAtOrDefault(index) : ChildGetter(index);
+    public override bool PerformAction(AccessibleActions action, object? parameter = null) => Action?.Invoke(action, parameter) ?? true;
+}

--- a/ModernFormsNext.Automation.Tests/IdentityTests.cs
+++ b/ModernFormsNext.Automation.Tests/IdentityTests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using System.Text.Json;
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Tests;
+
+[Trait("Category", "Identity")]
+public sealed class IdentityTests
+{
+    [Fact]
+    public void SameControlRemoveReinsertAndReorderRetainCanonicalHandle()
+    {
+        using var f = new AutomationFixture();
+        var first = f.Add(new Button { Name = "first" }); var second = f.Add(new Button { Name = "second" });
+        var handle = f.Handle(first);
+        f.Form.Controls.Remove(first);
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Session.InspectAsync(f.Root.RootId, handle).Completed().Error);
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Invoke).Completed().Error);
+        f.Form.Controls.Add(first);
+        Assert.Equal(AutomationErrorCode.None, f.Session.InspectAsync(f.Root.RootId, handle).Completed().Error);
+        Assert.Equal(handle, f.Handle(first));
+        Assert.NotEqual(handle, f.Handle(second));
+    }
+
+    [Fact]
+    public void RecreatedSameNameNeverRetargetsOldHandle()
+    {
+        using var f = new AutomationFixture();
+        var first = f.Add(new Button { Name = "same" }); var old = f.Handle(first); first.Dispose();
+        var replacement = f.Add(new Button { Name = "same" });
+        Assert.NotEqual(old, f.Handle(replacement));
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Session.InspectAsync(f.Root.RootId, old).Completed().Error);
+    }
+
+    [Fact]
+    public void DuplicateNamesHaveDistinctHandles()
+    {
+        using var f = new AutomationFixture();
+        f.Add(new Button { Name = "same" }); f.Add(new Button { Name = "same" });
+        var nodes = f.Find(new() { AutomationId = "same" }).Value;
+        Assert.Equal(2, nodes.Length);
+        Assert.NotEqual(nodes[0].Handle, nodes[1].Handle);
+    }
+
+    [Fact]
+    public void DuplicateListTextKeepsOccurrenceIdentityOnMove()
+    {
+        using var f = new AutomationFixture();
+        var list = f.Add(new ListBox()); list.Items.Add("same"); list.Items.Add("same");
+        var children = f.Session.GetChildrenAsync(f.Root.RootId, f.Handle(list)).Completed().Value;
+        Assert.NotEqual(children[0].Handle, children[1].Handle);
+        list.Items.Move(0, 1);
+        var moved = f.Session.GetChildrenAsync(f.Root.RootId, f.Handle(list)).Completed().Value;
+        Assert.Equal(children[0].Handle, moved[1].Handle);
+        Assert.Equal(children[1].Handle, moved[0].Handle);
+    }
+
+    [Fact]
+    public void ListRemoveAddCreatesNewOccurrenceWhileTreeReinsertKeepsCachedPeer()
+    {
+        using var f = new AutomationFixture();
+        var list = f.Add(new ListBox()); list.Items.Add("item");
+        var oldList = f.Handle(list.AccessibilityObject.GetChild(0)!);
+        list.Items.RemoveAt(0); _ = f.Find(new()); list.Items.Add("item");
+        Assert.NotEqual(oldList, f.Handle(list.AccessibilityObject.GetChild(0)!));
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Session.InspectAsync(f.Root.RootId, oldList).Completed().Error);
+        var tree = f.Add(new TreeView()); var item = tree.Items.Add(new TreeViewItem("item"));
+        var oldTree = f.Handle(tree.AccessibilityObject.GetChild(0)!);
+        tree.Items.Remove(item);
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Session.InspectAsync(f.Root.RootId, oldTree).Completed().Error);
+        tree.Items.Add(item);
+        Assert.Equal(AutomationErrorCode.None, f.Session.InspectAsync(f.Root.RootId, oldTree).Completed().Error);
+        Assert.Equal(oldTree, f.Handle(tree.AccessibilityObject.GetChild(0)!));
+    }
+
+    [Fact]
+    public void HiddenHandleBecomesResolvableWhenCanonicalPeerIsExposedAgain()
+    {
+        using var f = new AutomationFixture();
+        var b = f.Add(new Button()); var handle = f.Handle(b);
+        b.AccessibilityView = AccessibilityView.Hidden;
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Inspect(b).Error);
+        b.AccessibilityView = AccessibilityView.Control;
+        Assert.Equal(handle, f.Inspect(b).Value!.Handle);
+    }
+
+    [Fact]
+    public void SessionsRejectEachOthersHandlesEvenForSameRoot()
+    {
+        using var f = new AutomationFixture();
+        using var other = new AutomationSession(); using var root = other.RegisterRoot(f.Form);
+        var handle = f.Handle(f.Add(new Button()));
+        Assert.NotEqual(f.Session.SessionId, other.SessionId);
+        Assert.Equal(AutomationErrorCode.StaleNode, other.InspectAsync(root.RootId, handle).Completed().Error);
+        Assert.Equal(AutomationErrorCode.StaleNode, other.PerformActionAsync(root.RootId, handle, AccessibleActions.Invoke).Completed().Error);
+    }
+
+    [Fact]
+    public void ExplicitRootScopesQueriesAndRejectsCrossRootActions()
+    {
+        using var f = new AutomationFixture();
+        var a = f.Add(new Button { Name = "same" });
+        var formB = new Form(); var b = formB.Controls.Add(new Button { Name = "same" }); f.Host.Show(formB);
+        using var rootB = f.Session.RegisterRoot(formB);
+        Assert.Equal(f.Handle(a), f.Session.FindOneAsync(f.Root.RootId, new() { AutomationId = "same" }).Completed().Value!.Handle);
+        Assert.Equal(f.Handle(b), f.Session.FindOneAsync(rootB.RootId, new() { AutomationId = "same" }).Completed().Value!.Handle);
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Session.PerformActionAsync(rootB.RootId, f.Handle(a), AccessibleActions.Invoke).Completed().Error);
+    }
+
+    [Fact]
+    public void RuntimeIdBeyondJavaScriptSafeIntegerIsPreservedAsString()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        const long id = 9007199254740993;
+        typeof(AccessibleObject).GetField("runtime_id", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(c.Child, id);
+        var snapshot = f.Session.InspectAsync(f.Root.RootId, f.Handle(c.Child)).Completed().Value!;
+        Assert.Equal("9007199254740993", snapshot.RuntimeId);
+        Assert.Contains("\"RuntimeId\":\"9007199254740993\"", JsonSerializer.Serialize(snapshot));
+    }
+}

--- a/ModernFormsNext.Automation.Tests/LifecycleTests.cs
+++ b/ModernFormsNext.Automation.Tests/LifecycleTests.cs
@@ -1,0 +1,155 @@
+using System.Runtime.CompilerServices;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.Testing;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Tests;
+
+[Trait("Category", "Lifecycle")]
+public sealed class LifecycleTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StopAndDisposeInvalidateAllHandlesAndAreIdempotent(bool dispose)
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button()); var handle = f.Handle(b);
+        if (dispose) f.Session.Dispose(); else f.Session.Stop();
+        f.Session.Stop(); f.Session.Dispose();
+        Assert.True(f.Session.IsStopped); Assert.False(f.Root.IsRegistered);
+        Assert.Equal(AutomationErrorCode.SessionEnded, f.Session.GetRootsAsync().Completed().Error);
+        Assert.Equal(AutomationErrorCode.SessionEnded, f.Session.InspectAsync(f.Root.RootId, handle).Completed().Error);
+        Assert.Equal(AutomationErrorCode.SessionEnded, f.Session.FindOneAsync(f.Root.RootId, new()).Completed().Error);
+        Assert.Equal(AutomationErrorCode.SessionEnded, f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Invoke).Completed().Error);
+        Assert.Throws<ObjectDisposedException>(() => f.Session.RegisterRoot(new Form()));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClosingOneWindowUnregistersItAndPreservesAnother(bool dispose)
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button()); var handle = f.Handle(b);
+        var other = new Form(); f.Host.Show(other); using var otherRoot = f.Session.RegisterRoot(other);
+        if (dispose) f.Form.Dispose(); else f.Form.Close();
+        Assert.False(f.Root.IsRegistered); Assert.True(otherRoot.IsRegistered); Assert.False(f.Session.IsStopped);
+        Assert.Equal(otherRoot.RootId, Assert.Single(f.Session.GetRootsAsync().Completed().Value).RootId);
+        Assert.Equal(AutomationErrorCode.StaleNode, f.Session.InspectAsync(f.Root.RootId, handle).Completed().Error);
+        Assert.Throws<ObjectDisposedException>(() => f.Session.RegisterRoot(f.Form));
+    }
+
+    [Fact]
+    public void CancelledClosePreservesRoot()
+    {
+        using var f = new AutomationFixture();
+        f.Form.Closing += (_, e) => e.Cancel = true;
+        f.Form.Close();
+        Assert.True(f.Root.IsRegistered);
+        Assert.Single(f.Session.GetRootsAsync().Completed().Value);
+    }
+
+    [Fact]
+    public void ExplicitUnregisterAndReregisterHaveDistinctScopeIdentity()
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button()); var handle = f.Handle(b);
+        f.Root.Dispose(); f.Root.Dispose();
+        using var newRoot = f.Session.RegisterRoot(f.Form);
+        Assert.NotEqual(newRoot.RootId, f.Root.RootId);
+        Assert.Equal(AutomationErrorCode.StaleNode, f.Session.InspectAsync(f.Root.RootId, handle).Completed().Error);
+        Assert.Equal(AutomationErrorCode.None, f.Session.InspectAsync(newRoot.RootId, handle).Completed().Error);
+    }
+
+    [Fact]
+    public void NoRootEnumerationHappensWithoutExplicitRegistration()
+    {
+        using var host = ModernFormsTestHost.Create(); var form = new Form(); host.Show(form);
+        using var session = new AutomationSession();
+        Assert.Empty(session.GetRootsAsync().Completed().Value);
+        using var root = session.RegisterRoot(form);
+        Assert.Throws<InvalidOperationException>(() => session.RegisterRoot(form));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SurfaceDisposalOrControlDisposalInvalidatesRegistration(bool disposeControl)
+    {
+        using var host = ModernFormsTestHost.Create(); using var control = new Panel(); using var surface = new SkiaControlSurface(control);
+        surface.Resize(300, 200);
+        var text = control.Controls.Add(new TextBox { Name = "field" });
+        using var session = new AutomationSession(); using var root = session.RegisterRoot(surface);
+        var result = session.FindOneAsync(root.RootId, new() { AutomationId = "field" }).Completed();
+        Assert.Equal(AutomationErrorCode.None, result.Error);
+        Assert.Equal(AutomationCoordinateSpace.Surface, result.Value!.Bounds.CoordinateSpace);
+        Assert.Equal(AutomationActionStatus.Accepted, session.PerformActionAsync(root.RootId, result.Value.Handle,
+            AccessibleActions.SetValue, AutomationActionValue.FromText("surface text")).Completed().Status);
+        Assert.Equal("surface text", text.Text);
+        if (disposeControl) control.Dispose(); else surface.Dispose();
+        Assert.False(root.IsRegistered); Assert.Empty(session.GetRootsAsync().Completed().Value);
+        Assert.Equal(AutomationErrorCode.StaleNode, session.InspectAsync(root.RootId, result.Value.Handle).Completed().Error);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RegistrationsAndSnapshotsNeverRetainBorrowedControls(bool stop)
+    {
+        using var host = ModernFormsTestHost.Create(); using var session = new AutomationSession();
+        var weak = RegisterAndReleaseSurface(session);
+        if (stop) session.Stop();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        Assert.False(weak.Control.IsAlive); Assert.False(weak.Surface.IsAlive);
+        Assert.False(weak.Registration.IsRegistered);
+        GC.KeepAlive(weak.Snapshot); GC.KeepAlive(weak.Registration);
+    }
+
+    [Fact]
+    public void CapabilitiesAreIntersectedAndEnforcedIndependently()
+    {
+        using var f = new AutomationFixture(capabilities: AutomationCapability.Inspect | AutomationCapability.Query);
+        var b = f.Add(new Button());
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, f.Act(b, AccessibleActions.Invoke).Error);
+        using var onlyActions = new AutomationSession(AutomationCapability.Actions);
+        using var actionRoot = onlyActions.RegisterRoot(f.Form);
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, onlyActions.GetRootsAsync().Completed().Error);
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, onlyActions.FindAllAsync(actionRoot.RootId, new()).Completed().Error);
+        Assert.Equal(AutomationActionStatus.Accepted, onlyActions.PerformActionAsync(actionRoot.RootId,
+            new(onlyActions.SessionId, b.AccessibilityObject.RuntimeId.ToString()), AccessibleActions.Invoke).Completed().Status);
+        using var limited = new AutomationSession(); using var limitedRoot = limited.RegisterRoot(f.Form, AutomationCapability.Inspect);
+        Assert.Equal(AutomationCapability.Inspect, limitedRoot.Capabilities);
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, limited.FindAllAsync(limitedRoot.RootId, new()).Completed().Error);
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, limited.PerformActionAsync(limitedRoot.RootId,
+            new(limited.SessionId, b.AccessibilityObject.RuntimeId.ToString()), AccessibleActions.Invoke).Completed().Error);
+    }
+
+    [Fact]
+    public void InvalidSessionBudgetsAndCapabilitiesAreRejected()
+    {
+        using var host = ModernFormsTestHost.Create();
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AutomationSession((AutomationCapability)32));
+        foreach (var options in new[] { new AutomationQueryOptions { MaxNodes = 0 }, new() { MaxResults = 0 }, new() { MaxDepth = -1 }, new() { MaxDepth = 257 }, new() { MaxNodes = int.MaxValue } })
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AutomationSession(limits: options));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EndDuringSnapshotGetterDoesNotReturnLiveSuccess(bool stopSession)
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        c.Child.NameGetter = () => { if (stopSession) f.Session.Stop(); else f.Root.Dispose(); return "after end"; };
+        var result = f.Find(new());
+        Assert.Equal(stopSession ? AutomationErrorCode.SessionEnded : AutomationErrorCode.StaleNode, result.Error);
+        Assert.False(result.Value.IsDefault);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Control, WeakReference Surface, AutomationRootRegistration Registration, AutomationNodeSnapshot Snapshot) RegisterAndReleaseSurface(AutomationSession session)
+    {
+        var control = new Panel(); var surface = new SkiaControlSurface(control); surface.Resize(300, 200);
+        var registration = session.RegisterRoot(surface);
+        var root = session.GetRootsAsync().Completed().Value[0];
+        var snapshot = session.InspectAsync(root.RootId, root.Handle).Completed().Value!;
+        return (new(control), new(surface), registration, snapshot);
+    }
+}

--- a/ModernFormsNext.Automation.Tests/ModernFormsNext.Automation.Tests.csproj
+++ b/ModernFormsNext.Automation.Tests/ModernFormsNext.Automation.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <ProjectReference Include="..\ModernFormsNext.Automation\ModernFormsNext.Automation.csproj" />
+    <ProjectReference Include="..\ModernFormsNext.Testing\ModernFormsNext.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/ModernFormsNext.Automation.Tests/PrivacyTests.cs
+++ b/ModernFormsNext.Automation.Tests/PrivacyTests.cs
@@ -168,6 +168,25 @@ public sealed class PrivacyTests
     }
 
     private static void NoSecret<T>(T value) => Assert.DoesNotContain(Secret, JsonSerializer.Serialize(value), StringComparison.Ordinal);
+
+    [Fact]
+    public void PrivacyFailureStillRedactsWhenDiagnosticBudgetIsFull()
+    {
+        using var f = new AutomationFixture(new() { MaxNodes = 4 });
+        var c = f.Add(new SemanticControl());
+        int stateReads = 0;
+        c.Child.StateGetter = () => ++stateReads >= 3 ? throw new Exception(Secret) : AccessibleStates.None;
+        c.Child.AutomationId = Secret;
+        c.Child.NameGetter = () => throw new Exception(Secret);
+        c.Child.ValueGetter = () => throw new Exception(Secret);
+        c.Child.RangeGetter = () => throw new Exception(Secret);
+        c.Child.ActionsGetter = () => throw new Exception(Secret);
+        var result = f.Session.InspectAsync(f.Root.RootId, f.Handle(c.Child)).Completed();
+        Assert.Equal(4, result.Issues.Length);
+        Assert.True(result.Truncated);
+        Assert.True((result.Value!.Redaction & AutomationRedaction.PrivacyUnknown) != 0);
+        Assert.False(JsonSerializer.Serialize(result).Contains(Secret, StringComparison.Ordinal));
+    }
     private sealed class HostileParameter
     {
         internal int StringCalls;

--- a/ModernFormsNext.Automation.Tests/PrivacyTests.cs
+++ b/ModernFormsNext.Automation.Tests/PrivacyTests.cs
@@ -1,0 +1,187 @@
+using System.Reflection;
+using System.Text.Json;
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Tests;
+
+[Trait("Category", "Privacy")]
+public sealed class PrivacyTests
+{
+    private const string Secret = "AUTOMATION_PRIVATE_MARKER_97_6f893a";
+
+    [Fact]
+    public void PasswordSetValueHasNoReadbackLeak()
+    {
+        using var f = new AutomationFixture();
+        var password = f.Add(new TextBox { Name = "password", PasswordCharacter = '*', Text = Secret });
+        var before = f.Inspect(password);
+        Assert.Equal(AutomationErrorCode.None, before.Error);
+        Assert.Null(before.Value!.Value);
+        Assert.Null(before.Value.RangeValue);
+        Assert.NotEqual(AutomationRedaction.None, before.Value.Redaction);
+        NoSecret(before);
+        var result = f.Act(password, AccessibleActions.SetValue, AutomationActionValue.FromText(Secret + "updated"));
+        Assert.Equal(AutomationActionStatus.Accepted, result.Status);
+        Assert.EndsWith("updated", password.Text, StringComparison.Ordinal);
+        NoSecret(result); NoSecret(f.Inspect(password)); NoSecret(f.Find(new()));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SensitiveAndProtectedCustomPeersSuppressAllTextAndRangeGetters(bool protectedState)
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        c.Child.SensitiveGetter = () => !protectedState;
+        c.Child.States = protectedState ? AccessibleStates.Protected : AccessibleStates.None;
+        int payloadReads = 0;
+        c.Child.AutomationId = Secret;
+        c.Child.NameGetter = () => { payloadReads++; return Secret; };
+        c.Child.ValueGetter = () => { payloadReads++; return Secret; };
+        c.Child.RangeGetter = () => { payloadReads++; return new(1, 0, 5, 1, 1, false); };
+        var result = f.Find(new());
+        Assert.Equal(AutomationErrorCode.None, result.Error);
+        Assert.Equal(0, payloadReads);
+        NoSecret(result);
+        var snapshot = Assert.Single(result.Value, n => n.RuntimeId == c.Child.RuntimeId.ToString());
+        Assert.Null(snapshot.Name); Assert.Null(snapshot.AutomationId); Assert.Null(snapshot.Value); Assert.Null(snapshot.RangeValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PrivacyGetterFailureFailsClosedAndDoesNotEndSession(bool stateGetter)
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        if (stateGetter) c.Child.StateGetter = () => throw new Exception(Secret);
+        else c.Child.SensitiveGetter = () => throw new Exception(Secret);
+        c.Child.ValueGetter = () => throw new InvalidOperationException("Payload should never be read");
+        var result = f.Find(new());
+        Assert.Equal(AutomationErrorCode.GetterFault, result.Error);
+        Assert.Contains(result.Value, n => (n.Redaction & AutomationRedaction.PrivacyUnknown) != 0);
+        Assert.DoesNotContain(result.Issues, i => i.Property == AutomationProperty.Value);
+        Assert.False(f.Session.IsStopped);
+        NoSecret(result);
+    }
+
+    [Theory]
+    [InlineData("name")]
+    [InlineData("value")]
+    [InlineData("child")]
+    [InlineData("action")]
+    public void ExceptionMessagesAreNotExported(string field)
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        switch (field)
+        {
+            case "name": c.Child.NameGetter = () => throw new Exception(Secret); break;
+            case "value": c.Child.ValueGetter = () => throw new Exception(Secret); break;
+            case "child": c.Child.CountGetter = () => throw new Exception(Secret); break;
+            case "action": c.Child.Action = (_, _) => throw new Exception(Secret); break;
+        }
+        if (field == "action")
+        {
+            var result = f.Session.PerformActionAsync(f.Root.RootId, f.Handle(c.Child), AccessibleActions.Invoke).Completed();
+            Assert.Equal(AutomationErrorCode.ApplicationError, result.Error); NoSecret(result);
+        }
+        else
+        {
+            var result = f.Find(new());
+            Assert.Equal(AutomationErrorCode.GetterFault, result.Error); NoSecret(result);
+        }
+        Assert.Empty(f.Host.Dispatcher.UnhandledExceptions);
+    }
+
+    [Fact]
+    public void SensitiveAncestorRedactsUnmarkedCustomDescendants()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        c.Child.SensitiveGetter = () => true;
+        c.Child.Add(new ScriptPeer { Name = Secret, Value = Secret, AutomationId = Secret });
+        NoSecret(f.Find(new()));
+    }
+
+    [Fact]
+    public void EditableTextNeverFallsBackIntoNameQuery()
+    {
+        using var f = new AutomationFixture(); var text = f.Add(new TextBox { Name = "field", Text = Secret });
+        Assert.Empty(f.Find(new() { Name = Secret }).Value);
+        Assert.Equal("field", f.Inspect(text).Value!.Name);
+        // This is explicitly non-sensitive editable value, which remains valid semantic output.
+        Assert.True(f.Inspect(text).Value!.Value == Secret);
+    }
+
+    [Fact]
+    public void HostileCommandParameterToStringIsNeverCalled()
+    {
+        using var f = new AutomationFixture(); var parameter = new HostileParameter();
+        int called = 0;
+        var b = f.Add(new Button { CommandParameter = parameter, Command = new DelegateCommand(p => { Assert.Same(parameter, p); called++; }) });
+        var result = f.Act(b, AccessibleActions.Invoke);
+        Assert.Equal(AutomationActionStatus.Accepted, result.Status);
+        Assert.Equal(1, called); Assert.Equal(0, parameter.StringCalls);
+        NoSecret(result); NoSecret(f.Inspect(b));
+    }
+
+    [Fact]
+    public void ActionPayloadDiagnosticStringAndResultsOmitSecret()
+    {
+        using var f = new AutomationFixture(); var value = AutomationActionValue.FromText(Secret);
+        Assert.DoesNotContain(Secret, value.ToString());
+        NoSecret(f.Act(f.Add(new Button()), AccessibleActions.Invoke, value));
+        Assert.True(typeof(AutomationActionValue).IsSealed);
+        Assert.DoesNotContain(typeof(AutomationSession).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.DeclaringType == typeof(AutomationSession)).SelectMany(m => m.GetParameters()), p => p.ParameterType == typeof(object));
+    }
+
+    [Fact]
+    public void OversizedPayloadIsOmittedWithExplicitLimit()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        c.Child.Name = new string('x', 5000);
+        var result = f.Find(new());
+        Assert.True(result.Truncated); Assert.Equal(AutomationErrorCode.LimitExceeded, result.Error);
+        Assert.Null(Assert.Single(result.Value, n => n.RuntimeId == c.Child.RuntimeId.ToString()).Name);
+        Assert.Equal(AutomationErrorCode.InvalidArgument, f.Act(f.Add(new TextBox()), AccessibleActions.SetValue, AutomationActionValue.FromText(c.Child.Name)).Error);
+    }
+
+    [Fact]
+    public void CustomPasswordPeerCannotNegateKnownOwnerPrivacy()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new UnsafePassword { PasswordCharacter = '*', Text = Secret });
+        var snapshot = f.Inspect(c);
+        Assert.NotEqual(AutomationRedaction.None, snapshot.Value!.Redaction);
+        NoSecret(snapshot);
+    }
+
+    [Fact]
+    public void PrivacyEscalationDuringGetterDiscardsAlreadyCapturedPayload()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl()); bool sensitive = false;
+        c.Child.SensitiveGetter = () => sensitive;
+        c.Child.NameGetter = () => { sensitive = true; return Secret; };
+        c.Child.Value = Secret;
+        var result = f.Find(new());
+        NoSecret(result);
+        Assert.NotEqual(AutomationRedaction.None, Assert.Single(result.Value, n => n.RuntimeId == c.Child.RuntimeId.ToString()).Redaction);
+    }
+
+    private static void NoSecret<T>(T value) => Assert.DoesNotContain(Secret, JsonSerializer.Serialize(value), StringComparison.Ordinal);
+    private sealed class HostileParameter
+    {
+        internal int StringCalls;
+        public override string ToString() { StringCalls++; throw new Exception(Secret); }
+    }
+    private sealed class UnsafePassword : TextBox
+    {
+        protected override AccessibleObject CreateAccessibilityInstance() => new Peer(this);
+        private sealed class Peer(Control owner) : ControlAccessibleObject(owner)
+        {
+            public override bool IsSensitive => false;
+            public override AccessibleStates State => AccessibleStates.None;
+            public override string? Value { get => Secret; set { } }
+            public override string? Name { get => Secret; set { } }
+        }
+    }
+}

--- a/ModernFormsNext.Automation.Tests/QueryTests.cs
+++ b/ModernFormsNext.Automation.Tests/QueryTests.cs
@@ -260,4 +260,43 @@ public sealed class QueryTests
         Assert.Contains("\"Value\":[]", System.Text.Json.JsonSerializer.Serialize(roots));
     }
 
+    [Fact]
+    public void FormClientAreaIsValidatedButNeverProjected()
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button());
+        var canonicalParent = b.AccessibilityObject.Parent!;
+        Assert.NotSame(f.Form.AccessibilityObject, canonicalParent);
+        Assert.Same(f.Form.AccessibilityObject, canonicalParent.Parent);
+        var result = f.Find(new());
+        Assert.Equal(AutomationErrorCode.None, result.Error);
+        Assert.DoesNotContain(result.Value, n => n.RuntimeId == canonicalParent.RuntimeId.ToString());
+        Assert.Equal(f.Handle(f.Form.AccessibilityObject).RuntimeId,
+            Assert.Single(result.Value, n => n.Handle == f.Handle(b)).ParentRuntimeId);
+    }
+
+    [Theory]
+    [InlineData("detached", AutomationErrorCode.MalformedTree)]
+    [InlineData("cycle", AutomationErrorCode.CycleDetected)]
+    [InlineData("depth", AutomationErrorCode.LimitExceeded)]
+    public void OmittedParentChainsMustReachTraversedParentWithinBudget(string kind, AutomationErrorCode expected)
+    {
+        using var f = new AutomationFixture(new() { MaxDepth = 4 }); var c = f.Add(new SemanticControl());
+        _ = c.AccessibilityObject;
+        var omitted = new ScriptPeer(); c.Child.ParentValue = omitted;
+        if (kind == "cycle") omitted.ParentValue = c.Child;
+        if (kind == "depth")
+        {
+            var current = omitted;
+            for (int i = 0; i < 6; i++) { var next = new ScriptPeer(); current.ParentValue = next; current = next; }
+            current.ParentValue = c.AccessibilityObject;
+        }
+        var result = f.Find(new());
+        Assert.Contains(result.Issues, i => i.Code == expected && i.Property == AutomationProperty.Parent);
+        Assert.DoesNotContain(result.Value, n => n.Handle == f.Handle(c.Child));
+        int actions = 0; c.Child.Action = (_, _) => { actions++; return true; };
+        Assert.NotEqual(AutomationActionStatus.Accepted,
+            f.Session.PerformActionAsync(f.Root.RootId, f.Handle(c.Child), AccessibleActions.Invoke).Completed().Status);
+        Assert.Equal(0, actions);
+    }
+
 }

--- a/ModernFormsNext.Automation.Tests/QueryTests.cs
+++ b/ModernFormsNext.Automation.Tests/QueryTests.cs
@@ -1,0 +1,263 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Tests;
+
+[Trait("Category", "Query")]
+public sealed class QueryTests
+{
+    [Fact]
+    public void RootEnumerationAndInspectionUseCanonicalRoot()
+    {
+        using var f = new AutomationFixture();
+        var roots = f.Session.GetRootsAsync().Completed();
+        Assert.Equal(AutomationErrorCode.None, roots.Error);
+        var root = Assert.Single(roots.Value);
+        Assert.Equal(f.Root.RootId, root.RootId);
+        Assert.Equal(f.Form.AccessibilityObject.RuntimeId.ToString(), root.Handle.RuntimeId);
+        var snapshot = f.Session.InspectAsync(root.RootId, root.Handle).Completed();
+        Assert.Equal(AutomationErrorCode.None, snapshot.Error);
+        Assert.Equal(AccessibleControlType.Window, snapshot.Value!.ControlType);
+        Assert.Null(snapshot.Value.ParentRuntimeId);
+    }
+
+    [Fact]
+    public void ChildrenAreDirectCanonicalEdges()
+    {
+        using var f = new AutomationFixture();
+        var panel = f.Add(new Panel { Name = "panel" });
+        var first = panel.Controls.Add(new Button { Name = "a" });
+        var second = panel.Controls.Add(new TextBox { Name = "b" });
+        var result = f.Session.GetChildrenAsync(f.Root.RootId, f.Handle(panel)).Completed();
+        Assert.Equal(AutomationErrorCode.None, result.Error);
+        Assert.Equal(new[] { f.Handle(first).RuntimeId, f.Handle(second).RuntimeId }, result.Value.Select(n => n.RuntimeId));
+        Assert.All(result.Value, n => Assert.Equal(f.Handle(panel).RuntimeId, n.ParentRuntimeId));
+    }
+
+    [Theory]
+    [InlineData("id")]
+    [InlineData("name")]
+    [InlineData("type")]
+    [InlineData("state")]
+    public void FiltersReadSemanticMetadata(string filter)
+    {
+        using var f = new AutomationFixture();
+        var button = f.Add(new Button { Name = "fallback", Text = "Visible label", AccessibleName = "Semantic label", AccessibleAutomationId = "save", Enabled = false });
+        f.Add(new TextBox { Name = "other" });
+        var query = filter switch
+        {
+            "id" => new AutomationQuery { AutomationId = "save" },
+            "name" => new AutomationQuery { Name = "Semantic label" },
+            "type" => new AutomationQuery { ControlType = AccessibleControlType.Button },
+            _ => new AutomationQuery { RequiredStates = AccessibleStates.Unavailable, ExcludedStates = AccessibleStates.Checked }
+        };
+        var result = f.Session.FindOneAsync(f.Root.RootId, query).Completed();
+        Assert.Equal(AutomationErrorCode.None, result.Error);
+        Assert.Equal(f.Handle(button), result.Value!.Handle);
+    }
+
+    [Fact]
+    public void AutomationIdFallsBackToNameAndMatchingIsOrdinal()
+    {
+        using var f = new AutomationFixture();
+        f.Add(new Button { Name = "Save" });
+        Assert.Single(f.Find(new() { AutomationId = "Save" }).Value);
+        Assert.Empty(f.Find(new() { AutomationId = "save" }).Value);
+    }
+
+    [Theory]
+    [InlineData(0, AutomationErrorCode.NodeNotFound)]
+    [InlineData(1, AutomationErrorCode.None)]
+    [InlineData(2, AutomationErrorCode.AmbiguousMatch)]
+    public void FindOneDistinguishesZeroOneAndMultipleEvenWithOneResultBudget(int count, AutomationErrorCode expected)
+    {
+        using var f = new AutomationFixture(new() { MaxResults = 1 });
+        for (int i = 0; i < count; i++) f.Add(new Button { AccessibleAutomationId = "same" });
+        var result = f.Session.FindOneAsync(f.Root.RootId, new() { AutomationId = "same" }).Completed();
+        Assert.Equal(expected, result.Error);
+        Assert.Equal(expected == AutomationErrorCode.None, result.Value is not null);
+    }
+
+    [Fact]
+    public void TraversalIsDepthFirstAndFindAllReportsResultTruncation()
+    {
+        using var f = new AutomationFixture(new() { MaxResults = 2 });
+        var parent = f.Add(new Panel { AccessibleName = "match" });
+        var child = parent.Controls.Add(new Button { AccessibleName = "match" });
+        f.Add(new Button { AccessibleName = "match" });
+        var result = f.Find(new() { Name = "match" });
+        Assert.True(result.Truncated);
+        Assert.Equal(AutomationErrorCode.LimitExceeded, result.Error);
+        Assert.Equal(new[] { f.Handle(parent), f.Handle(child) }, result.Value.Select(n => n.Handle));
+    }
+
+    [Fact]
+    public void LogicalListAndTreeItemsAndCustomChildrenAreQueryable()
+    {
+        using var f = new AutomationFixture();
+        var list = f.Add(new ListBox()); list.Items.Add("list item");
+        var tree = f.Add(new TreeView()); tree.Items.Add(new TreeViewItem { Text = "tree item" });
+        var custom = f.Add(new SemanticControl()); custom.Child.Name = "custom item";
+        foreach (var name in new[] { "list item", "tree item", "custom item" })
+            Assert.Equal(AutomationErrorCode.None, f.Session.FindOneAsync(f.Root.RootId, new() { Name = name }).Completed().Error);
+        Assert.Single(f.Find(new() { ControlType = AccessibleControlType.ListItem }).Value);
+        Assert.Single(f.Find(new() { ControlType = AccessibleControlType.TreeItem }).Value);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void HiddenAndInvisibleControlsAreNotExposed(bool hiddenView)
+    {
+        using var f = new AutomationFixture();
+        var button = f.Add(new Button { Name = "hidden" });
+        bool disposed = false;
+        button.Disposed += (_, _) => disposed = true;
+        if (hiddenView) button.AccessibilityView = AccessibilityView.Hidden; else button.Visible = false;
+        Assert.Empty(f.Find(new() { AutomationId = "hidden" }).Value);
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, f.Inspect(button).Error);
+        Assert.False(disposed);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DepthAndNodeLimitsCannotCertifyAbsenceOrUniqueness(bool depth)
+    {
+        using var f = new AutomationFixture(depth ? new() { MaxDepth = 0 } : new() { MaxNodes = 1 });
+        f.Add(new Button { Name = "target" });
+        var result = f.Session.FindOneAsync(f.Root.RootId, new() { AutomationId = "target" }).Completed();
+        Assert.Equal(AutomationErrorCode.LimitExceeded, result.Error);
+        Assert.True(result.Truncated);
+        Assert.Null(result.Value);
+        var root = f.Session.GetRootsAsync().Completed().Value[0];
+        Assert.True(f.Session.InspectAsync(root.RootId, root.Handle).Completed().Value!.Truncated);
+    }
+
+    [Fact]
+    public void ChildCycleIsReportedWithoutRecursion()
+    {
+        using var f = new AutomationFixture();
+        var c = f.Add(new SemanticControl()); c.Child.Children.Add(c.Child);
+        var result = f.Find(new());
+        Assert.Contains(result.Issues, i => i.Code == AutomationErrorCode.CycleDetected);
+    }
+
+    [Fact]
+    public void ParentCycleIsReportedWithoutFollowingIt()
+    {
+        using var f = new AutomationFixture();
+        var c = f.Add(new SemanticControl()); _ = c.AccessibilityObject; c.Child.ParentValue = c.Child;
+        Assert.Contains(f.Find(new()).Issues, i => i.Code == AutomationErrorCode.CycleDetected);
+    }
+
+    [Theory]
+    [InlineData("count")]
+    [InlineData("null")]
+    [InlineData("parent")]
+    [InlineData("getter")]
+    public void MalformedPeersProduceStructuredErrorsAndSessionRemainsUsable(string kind)
+    {
+        using var f = new AutomationFixture();
+        var c = f.Add(new SemanticControl());
+        switch (kind)
+        {
+            case "count": c.Child.CountGetter = () => -1; break;
+            case "null": c.Child.CountGetter = () => 1; break;
+            case "parent": c.Child.Add(new ScriptPeer()).ParentValue = null; break;
+            case "getter": c.Child.NameGetter = () => throw new Exception("private"); break;
+        }
+        Assert.NotEqual(AutomationErrorCode.None, f.Find(new()).Error);
+        c.Dispose();
+        Assert.Equal(AutomationErrorCode.None, f.Find(new()).Error);
+        Assert.False(f.Session.IsStopped);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RepeatedObjectAndCorruptDuplicateRuntimeIdAreRejected(bool distinctObject)
+    {
+        using var f = new AutomationFixture();
+        var c = f.Add(new SemanticControl());
+        var child = c.Child.Add(new ScriptPeer());
+        var duplicate = distinctObject ? c.Child.Add(new ScriptPeer()) : child;
+        if (distinctObject)
+        {
+            // RuntimeId is nonvirtual and unique in normal #59 code. Corrupt only a test peer's
+            // private readonly field to prove the consumer fails closed on duplicate identity.
+            typeof(AccessibleObject).GetField("runtime_id", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(duplicate, child.RuntimeId);
+        }
+        else c.Child.Children.Add(duplicate);
+        Assert.Contains(f.Find(new()).Issues, i => i.Code == AutomationErrorCode.DuplicateRuntimeId);
+        Assert.NotEqual(AutomationActionStatus.Accepted, f.Session.PerformActionAsync(f.Root.RootId, f.Handle(child), AccessibleActions.Invoke).Completed().Status);
+    }
+
+    [Fact]
+    public void ExplodingChildCountIsBoundedEvenWhenEveryChildIsNull()
+    {
+        using var f = new AutomationFixture(new() { MaxNodes = 16 });
+        var c = f.Add(new SemanticControl());
+        int calls = 0;
+        c.Child.CountGetter = () => int.MaxValue;
+        c.Child.ChildGetter = _ => { calls++; return null; };
+        var result = f.Find(new());
+        Assert.True(result.Truncated);
+        Assert.InRange(calls, 1, 16);
+        Assert.InRange(result.Issues.Length, 1, 16);
+    }
+
+    [Fact]
+    public void SnapshotIsDetachedAndChildrenAreImmutable()
+    {
+        using var f = new AutomationFixture();
+        var b = f.Add(new Button { Text = "before" });
+        var first = f.Inspect(b).Value!;
+        b.Text = "after";
+        var second = f.Inspect(b).Value!;
+        Assert.Equal("before", first.Name);
+        Assert.Equal("after", second.Name);
+        Assert.NotEqual(first.CaptureId, second.CaptureId);
+        Assert.IsType<ImmutableArray<string>>(first.ChildRuntimeIds);
+        Assert.All(typeof(AutomationNodeSnapshot).GetProperties(), p => Assert.Null(p.SetMethod));
+    }
+
+    [Fact]
+    public void InvalidQueryAndHandlePayloadsAreStructured()
+    {
+        using var f = new AutomationFixture();
+        Assert.Equal(AutomationErrorCode.InvalidArgument,
+            f.Find(new() { RequiredStates = AccessibleStates.Checked, ExcludedStates = AccessibleStates.Checked }).Error);
+        Assert.Equal(AutomationErrorCode.InvalidArgument,
+            f.Session.InspectAsync(f.Root.RootId, new(f.Session.SessionId, "900719925474099300000")).Completed().Error);
+        Assert.Equal(AutomationErrorCode.InvalidArgument,
+            f.Session.InspectAsync(f.Root.RootId, new(f.Session.SessionId, "01")).Completed().Error);
+    }
+
+    [Fact]
+    public void RootResultLimitIsExplicit()
+    {
+        using var f = new AutomationFixture(new() { MaxResults = 1 });
+        var other = new Form(); f.Host.Show(other); using var root = f.Session.RegisterRoot(other);
+        var result = f.Session.GetRootsAsync().Completed();
+        Assert.Single(result.Value);
+        Assert.True(result.Truncated);
+        Assert.Equal(AutomationErrorCode.LimitExceeded, result.Error);
+    }
+
+    [Fact]
+    public void ErrorCollectionsAreInitializedAndSafeToSerialize()
+    {
+        using var f = new AutomationFixture(); var handle = f.Handle(f.Add(new Button()));
+        var children = f.Session.GetChildrenAsync("missing root", handle).Completed();
+        Assert.False(children.Value.IsDefault);
+        Assert.Contains("\"Value\":[]", System.Text.Json.JsonSerializer.Serialize(children));
+        f.Session.Stop();
+        var roots = f.Session.GetRootsAsync().Completed();
+        Assert.False(roots.Value.IsDefault);
+        Assert.Contains("\"Value\":[]", System.Text.Json.JsonSerializer.Serialize(roots));
+    }
+
+}

--- a/ModernFormsNext.Automation.Tests/ThreadingTests.cs
+++ b/ModernFormsNext.Automation.Tests/ThreadingTests.cs
@@ -1,0 +1,76 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Tests;
+
+[Trait("Category", "Threading")]
+public sealed class ThreadingTests
+{
+    [Fact]
+    public void BackgroundQueryReadsOnlyOnProductionDispatcher()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        int ui = Environment.CurrentManagedThreadId; var reads = new List<int>();
+        c.Child.NameGetter = () => { reads.Add(Environment.CurrentManagedThreadId); return "child"; };
+        Task<AutomationResult<AutomationNodeSnapshot>>? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.FindOneAsync(f.Root.RootId, new() { Name = "child" }));
+        Assert.Empty(reads); Assert.False(pending!.IsCompleted); Assert.True(f.Host.Dispatcher.PendingWorkCount > 0);
+        f.Host.Dispatcher.Drain();
+        Assert.Equal(AutomationErrorCode.None, CompletedTaskAssertions.Finish(pending).Error);
+        Assert.NotEmpty(reads); Assert.All(reads, thread => Assert.Equal(ui, thread));
+    }
+
+    [Fact]
+    public void BackgroundActionExecutesCanonicalPathOnlyOnUiThread()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        int ui = Environment.CurrentManagedThreadId, actionThread = 0;
+        c.Child.Action = (_, _) => { actionThread = Environment.CurrentManagedThreadId; return true; };
+        var handle = f.Handle(c.Child);
+        Task<AutomationActionResult>? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Invoke));
+        Assert.Equal(0, actionThread);
+        f.Host.Dispatcher.Drain();
+        Assert.Equal(AutomationActionStatus.Accepted, CompletedTaskAssertions.Finish(pending!).Status);
+        Assert.Equal(ui, actionThread);
+    }
+
+    [Fact]
+    public void StopBeforeQueuedActionRunsInvalidatesIt()
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button()); int clicks = 0; b.Click += (_, _) => clicks++;
+        var handle = f.Handle(b); Task<AutomationActionResult>? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Invoke));
+        f.Session.Stop(); f.Host.Dispatcher.Drain();
+        Assert.Equal(AutomationErrorCode.SessionEnded, CompletedTaskAssertions.Finish(pending!).Error);
+        Assert.Equal(0, clicks);
+    }
+
+    [Fact]
+    public void BackgroundStopAsyncRemovesRootsOnDispatcher()
+    {
+        using var f = new AutomationFixture(); Task? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.StopAsync());
+        Assert.False(f.Session.IsStopped); f.Host.Dispatcher.Drain();
+        Assert.True(pending!.IsCompletedSuccessfully); Assert.True(f.Session.IsStopped); Assert.False(f.Root.IsRegistered);
+    }
+
+    [Fact]
+    public void CancellationBeforeQueuedExecutionProducesNoMutation()
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button()); int clicks = 0; b.Click += (_, _) => clicks++;
+        using var cancellation = new CancellationTokenSource(); var handle = f.Handle(b);
+        Task<AutomationActionResult>? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Invoke, cancellationToken: cancellation.Token));
+        cancellation.Cancel(); f.Host.Dispatcher.Drain();
+        Assert.ThrowsAny<OperationCanceledException>(() => CompletedTaskAssertions.Finish(pending!)); Assert.Equal(0, clicks);
+    }
+
+    [Fact]
+    public void RegistrationRejectsNonUiCaller()
+    {
+        using var f = new AutomationFixture(); Exception? failure = null;
+        CompletedTaskAssertions.Worker(() => failure = Record.Exception(() => f.Session.RegisterRoot(f.Form)));
+        Assert.IsType<InvalidOperationException>(failure);
+    }
+}

--- a/ModernFormsNext.Automation.Tests/ThreadingTests.cs
+++ b/ModernFormsNext.Automation.Tests/ThreadingTests.cs
@@ -73,4 +73,86 @@ public sealed class ThreadingTests
         CompletedTaskAssertions.Worker(() => failure = Record.Exception(() => f.Session.RegisterRoot(f.Form)));
         Assert.IsType<InvalidOperationException>(failure);
     }
+
+    [Fact]
+    public void StopBeforeQueuedQueryPreventsSemanticReads()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        int reads = 0; c.Child.NameGetter = () => { reads++; return "child"; };
+        Task<AutomationResult<AutomationNodeSnapshot>>? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.FindOneAsync(f.Root.RootId, new()));
+        f.Session.Stop(); f.Host.Dispatcher.Drain();
+        Assert.Equal(AutomationErrorCode.SessionEnded, CompletedTaskAssertions.Finish(pending!).Error);
+        Assert.Equal(0, reads);
+    }
+
+    [Theory]
+    [InlineData("close")]
+    [InlineData("dispose")]
+    [InlineData("unregister")]
+    public void EndingRootBeforeQueuedActionPreventsMutation(string end)
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button());
+        int clicks = 0; b.Click += (_, _) => clicks++;
+        var handle = f.Handle(b); Task<AutomationActionResult>? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Invoke));
+        if (end == "close") f.Form.Close(); else if (end == "dispose") f.Form.Dispose(); else f.Root.Dispose();
+        f.Host.Dispatcher.Drain();
+        Assert.Equal(AutomationErrorCode.StaleNode, CompletedTaskAssertions.Finish(pending!).Error);
+        Assert.Equal(0, clicks);
+    }
+
+    [Fact]
+    public void BackgroundStopDuringGetterCompletesAfterCurrentDispatcherTurn()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        Task? stopped = null;
+        c.Child.NameGetter = () =>
+        {
+            CompletedTaskAssertions.Worker(() => stopped = f.Session.StopAsync());
+            Assert.False(stopped!.IsCompleted); Assert.False(f.Session.IsStopped);
+            return "child";
+        };
+        Assert.Equal(AutomationErrorCode.None, f.Session.FindOneAsync(f.Root.RootId, new() { Name = "child" }).Completed().Error);
+        f.Host.Dispatcher.Drain();
+        Assert.True(stopped!.IsCompletedSuccessfully); Assert.True(f.Session.IsStopped);
+        Assert.False(f.Root.IsRegistered);
+    }
+
+    [Fact]
+    public void CancellationAndStopBeforeQueuedActionNeverMutate()
+    {
+        using var f = new AutomationFixture(); var b = f.Add(new Button());
+        int clicks = 0; b.Click += (_, _) => clicks++;
+        using var cancellation = new CancellationTokenSource();
+        var handle = f.Handle(b); Task<AutomationActionResult>? pending = null;
+        CompletedTaskAssertions.Worker(() => pending = f.Session.PerformActionAsync(f.Root.RootId, handle, AccessibleActions.Invoke, cancellationToken: cancellation.Token));
+        cancellation.Cancel(); f.Session.Stop(); f.Session.Dispose(); f.Host.Dispatcher.Drain();
+        Assert.ThrowsAny<OperationCanceledException>(() => CompletedTaskAssertions.Finish(pending!));
+        Assert.Equal(0, clicks); Assert.True(f.Session.IsStopped);
+    }
+
+    [Fact]
+    public void CancellationDuringGetterStopsBeforeNextPayloadRead()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        using var cancellation = new CancellationTokenSource(); int valueReads = 0;
+        c.Child.NameGetter = () => { cancellation.Cancel(); return "child"; };
+        c.Child.ValueGetter = () => { valueReads++; return "value"; };
+        var pending = f.Session.InspectAsync(f.Root.RootId, f.Handle(c.Child), cancellation.Token);
+        Assert.ThrowsAny<OperationCanceledException>(() => CompletedTaskAssertions.Finish(pending));
+        Assert.Equal(0, valueReads);
+    }
+
+    [Fact]
+    public void CancellationDuringFinalActionGetterPreventsMutation()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        using var cancellation = new CancellationTokenSource(); int actions = 0, reads = 0;
+        c.Child.ActionsGetter = () => { if (++reads == 2) cancellation.Cancel(); return AccessibleActions.Invoke; };
+        c.Child.Action = (_, _) => { actions++; return true; };
+        var pending = f.Session.PerformActionAsync(f.Root.RootId, f.Handle(c.Child), AccessibleActions.Invoke, cancellationToken: cancellation.Token);
+        Assert.ThrowsAny<OperationCanceledException>(() => CompletedTaskAssertions.Finish(pending));
+        Assert.Equal(0, actions);
+    }
 }

--- a/ModernFormsNext.Automation/AutomationActionResult.cs
+++ b/ModernFormsNext.Automation/AutomationActionResult.cs
@@ -1,0 +1,49 @@
+namespace ModernFormsNext.Automation;
+
+/// <summary>Separates acceptance of a canonical action from later business-operation completion.</summary>
+public enum AutomationActionStatus
+{
+    /// <summary>PerformAction returned true. Async business work may still be running.</summary>
+    Accepted,
+    /// <summary>The current state, session policy, or canonical path rejected the request.</summary>
+    Rejected,
+    /// <summary>The action is outside this service's allowlist or is not currently advertised.</summary>
+    Unsupported,
+    /// <summary>The root/node is not reachable, the session ended, or reachability could not be validated.</summary>
+    NodeUnavailable,
+    /// <summary>The action flags or value payload are invalid.</summary>
+    InvalidArgument,
+    /// <summary>A canonical getter or action raised an application exception.</summary>
+    ApplicationError
+}
+
+/// <summary>Contains acceptance status and a safe reason; it never claims async business completion.</summary>
+/// <param name="Status">The request acceptance category.</param>
+/// <param name="Error">The specific semantic reason; None accompanies Accepted.</param>
+public sealed record AutomationActionResult(AutomationActionStatus Status, AutomationErrorCode Error);
+
+/// <summary>Contains one explicitly typed text or numeric action value, with no arbitrary CLR object payload.</summary>
+/// <remarks>Use null as the method argument to clear editable text. Never log or echo action values; ToString intentionally omits them.</remarks>
+public sealed class AutomationActionValue
+{
+    private AutomationActionValue(string? text, double? number) { Text = text; Number = number; }
+    /// <summary>Gets the text payload, or null for a numeric payload.</summary>
+    public string? Text { get; }
+    /// <summary>Gets the numeric payload, or null for a text payload.</summary>
+    public double? Number { get; }
+    /// <summary>Creates a text payload. Length is checked by the action service.</summary>
+    /// <param name="text">The requested text, which may be sensitive.</param>
+    /// <returns>The typed text value.</returns>
+    public static AutomationActionValue FromText(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return new(text, null);
+    }
+    /// <summary>Creates a numeric payload. Finiteness and range are checked by the action service.</summary>
+    /// <param name="number">The requested numeric value.</param>
+    /// <returns>The typed numeric value.</returns>
+    public static AutomationActionValue FromNumber(double number) => new(null, number);
+    /// <summary>Returns a fixed diagnostic label without revealing the payload.</summary>
+    /// <returns>A safe label.</returns>
+    public override string ToString() => nameof(AutomationActionValue);
+}

--- a/ModernFormsNext.Automation/AutomationCapability.cs
+++ b/ModernFormsNext.Automation/AutomationCapability.cs
@@ -1,0 +1,16 @@
+namespace ModernFormsNext.Automation;
+
+/// <summary>Specifies the operations explicitly allowed by a semantic session or root.</summary>
+/// <remarks>Root capabilities are intersected with session capabilities. There is no transport or authentication in this package.</remarks>
+[Flags]
+public enum AutomationCapability
+{
+    /// <summary>No operations are allowed.</summary>
+    None = 0,
+    /// <summary>Root enumeration and inspection of known handles are allowed.</summary>
+    Inspect = 1,
+    /// <summary>Child enumeration and semantic searches are allowed.</summary>
+    Query = 2,
+    /// <summary>Advertised canonical semantic actions are allowed.</summary>
+    Actions = 4
+}

--- a/ModernFormsNext.Automation/AutomationErrorCode.cs
+++ b/ModernFormsNext.Automation/AutomationErrorCode.cs
@@ -19,7 +19,7 @@ public enum AutomationErrorCode
     ActionRejected,
     /// <summary>The request has an invalid type, value, range, scope, or flag combination.</summary>
     InvalidArgument,
-    /// <summary>A canonical action threw; its private exception data is not returned.</summary>
+    /// <summary>A live operation or dispatcher call failed; private exception data is not returned.</summary>
     ApplicationError,
     /// <summary>The semantic session has stopped.</summary>
     SessionEnded,
@@ -31,7 +31,7 @@ public enum AutomationErrorCode
     GetterFault,
     /// <summary>A child, parent edge, or child count violates the canonical tree contract.</summary>
     MalformedTree,
-    /// <summary>A child edge points back to an ancestor.</summary>
+    /// <summary>A child edge or parent chain contains a cycle.</summary>
     CycleDetected,
     /// <summary>A runtime ID or canonical object occurs more than once in a root traversal.</summary>
     DuplicateRuntimeId

--- a/ModernFormsNext.Automation/AutomationErrorCode.cs
+++ b/ModernFormsNext.Automation/AutomationErrorCode.cs
@@ -1,0 +1,77 @@
+namespace ModernFormsNext.Automation;
+
+/// <summary>Identifies a safe, structured semantic outcome without exporting application exception text.</summary>
+public enum AutomationErrorCode
+{
+    /// <summary>The query completed without an error.</summary>
+    None,
+    /// <summary>A complete search found no matching node.</summary>
+    NodeNotFound,
+    /// <summary>At least two nodes match a request requiring exactly one.</summary>
+    AmbiguousMatch,
+    /// <summary>The handle belongs to another session or an ended root registration.</summary>
+    StaleNode,
+    /// <summary>The node is not currently exposed by the requested root; this does not imply disposal.</summary>
+    NodeUnavailable,
+    /// <summary>The action is not advertised or is outside the supported Phase 1a action set.</summary>
+    ActionUnsupported,
+    /// <summary>The current state or canonical action path rejected the request.</summary>
+    ActionRejected,
+    /// <summary>The request has an invalid type, value, range, scope, or flag combination.</summary>
+    InvalidArgument,
+    /// <summary>A canonical action threw; its private exception data is not returned.</summary>
+    ApplicationError,
+    /// <summary>The semantic session has stopped.</summary>
+    SessionEnded,
+    /// <summary>The session or root does not allow this operation.</summary>
+    CapabilityDenied,
+    /// <summary>A traversal, result, or text budget prevented complete capture.</summary>
+    LimitExceeded,
+    /// <summary>A custom semantic getter threw; its private exception data is not returned.</summary>
+    GetterFault,
+    /// <summary>A child, parent edge, or child count violates the canonical tree contract.</summary>
+    MalformedTree,
+    /// <summary>A child edge points back to an ancestor.</summary>
+    CycleDetected,
+    /// <summary>A runtime ID or canonical object occurs more than once in a root traversal.</summary>
+    DuplicateRuntimeId
+}
+
+/// <summary>Identifies the semantic field associated with a safe capture diagnostic.</summary>
+public enum AutomationProperty
+{
+    /// <summary>The diagnostic concerns an entire node or traversal.</summary>
+    Node,
+    /// <summary>The privacy marker could not be read.</summary>
+    IsSensitive,
+    /// <summary>The state flags could not be read.</summary>
+    States,
+    /// <summary>The active projection could not be read.</summary>
+    View,
+    /// <summary>The parent edge is invalid or unavailable.</summary>
+    Parent,
+    /// <summary>The child sequence is invalid or unavailable.</summary>
+    Children,
+    /// <summary>The locator could not be safely captured.</summary>
+    AutomationId,
+    /// <summary>The semantic name could not be safely captured.</summary>
+    Name,
+    /// <summary>The role could not be read.</summary>
+    Role,
+    /// <summary>The normalized control type could not be read.</summary>
+    ControlType,
+    /// <summary>The advertised actions could not be read.</summary>
+    SupportedActions,
+    /// <summary>The value could not be safely captured.</summary>
+    Value,
+    /// <summary>The numeric range could not be safely captured.</summary>
+    RangeValue,
+    /// <summary>The bounds could not be read.</summary>
+    Bounds
+}
+
+/// <summary>Contains only controlled diagnostic metadata; it never contains an exception or application message.</summary>
+/// <param name="Code">The failure category.</param>
+/// <param name="RuntimeId">The affected canonical ID as an invariant decimal string, when known.</param>
+/// <param name="Property">The affected field.</param>
+public sealed record AutomationIssue(AutomationErrorCode Code, string? RuntimeId, AutomationProperty Property);

--- a/ModernFormsNext.Automation/AutomationNodeHandle.cs
+++ b/ModernFormsNext.Automation/AutomationNodeHandle.cs
@@ -1,0 +1,7 @@
+namespace ModernFormsNext.Automation;
+
+/// <summary>Identifies a canonical peer within one semantic session, independently of its name or position.</summary>
+/// <param name="SessionId">The session's random nonce; this is not a PID or authentication credential.</param>
+/// <param name="RuntimeId">The positive canonical Int64 ID written as an invariant decimal string.</param>
+/// <remarks>Every live operation also requires an explicit root registration ID and revalidates reachability.</remarks>
+public readonly record struct AutomationNodeHandle(string SessionId, string RuntimeId);

--- a/ModernFormsNext.Automation/AutomationNodeSnapshot.cs
+++ b/ModernFormsNext.Automation/AutomationNodeSnapshot.cs
@@ -1,0 +1,90 @@
+using System.Collections.Immutable;
+using ModernFormsNext.Accessibility;
+
+namespace ModernFormsNext.Automation;
+
+/// <summary>Specifies the canonical coordinate reference for bounds; no clipping or occlusion guarantee is implied.</summary>
+public enum AutomationCoordinateSpace
+{
+    /// <summary>Canonical screen coordinates from a window peer.</summary>
+    Screen,
+    /// <summary>Canonical coordinates relative to a windowless Skia surface.</summary>
+    Surface
+}
+
+/// <summary>Contains detached canonical bounds in logical pixels.</summary>
+/// <param name="X">The left coordinate.</param>
+/// <param name="Y">The top coordinate.</param>
+/// <param name="Width">The width.</param>
+/// <param name="Height">The height.</param>
+/// <param name="CoordinateSpace">The coordinate reference supplied by the registered host.</param>
+public readonly record struct AutomationBounds(int X, int Y, int Width, int Height, AutomationCoordinateSpace CoordinateSpace);
+
+/// <summary>Describes why string/value/range metadata was omitted.</summary>
+[Flags]
+public enum AutomationRedaction
+{
+    /// <summary>No privacy redaction was required.</summary>
+    None = 0,
+    /// <summary>This node or an ancestor was marked sensitive or protected.</summary>
+    Sensitive = 1,
+    /// <summary>Privacy could not be established because a privacy/state getter failed.</summary>
+    PrivacyUnknown = 2
+}
+
+/// <summary>Contains immutable semantic data captured on the UI thread, with no live framework references.</summary>
+/// <remarks>
+/// Text fields are omitted for sensitive/protected subtrees. Child IDs describe captured active edges;
+/// Truncated means the child sequence or payload is incomplete. Inspect the result's Issues as well.
+/// CaptureId groups one UI operation, not a business transaction or semantic revision.
+/// </remarks>
+public sealed class AutomationNodeSnapshot
+{
+    internal AutomationNodeSnapshot(AutomationNodeHandle handle, string rootId, string? automationId,
+        string? name, AccessibleRole role, AccessibleControlType controlType, AccessibleStates states,
+        AccessibleActions actions, string? value, AccessibleRangeValue? range, AutomationBounds bounds,
+        string? parentId, ImmutableArray<string> children, AutomationRedaction redaction, string captureId, bool truncated)
+    {
+        Handle = handle; RootId = rootId; AutomationId = automationId; Name = name; Role = role;
+        ControlType = controlType; States = states; SupportedActions = actions; Value = value;
+        RangeValue = range; Bounds = bounds; ParentRuntimeId = parentId; ChildRuntimeIds = children;
+        Redaction = redaction; CaptureId = captureId; Truncated = truncated;
+    }
+
+    /// <summary>Gets the session-scoped canonical handle.</summary>
+    public AutomationNodeHandle Handle { get; }
+    /// <summary>Gets the semantic session nonce.</summary>
+    public string SessionId => Handle.SessionId;
+    /// <summary>Gets the root registration ID, required when resolving this handle.</summary>
+    public string RootId { get; }
+    /// <summary>Gets the canonical Int64 runtime ID as a precision-preserving decimal string.</summary>
+    public string RuntimeId => Handle.RuntimeId;
+    /// <summary>Gets the potentially nonunique locator, or null when absent/redacted/unavailable.</summary>
+    public string? AutomationId { get; }
+    /// <summary>Gets the canonical name, or null when absent/redacted/unavailable.</summary>
+    public string? Name { get; }
+    /// <summary>Gets the canonical role.</summary>
+    public AccessibleRole Role { get; }
+    /// <summary>Gets the canonical normalized control type.</summary>
+    public AccessibleControlType ControlType { get; }
+    /// <summary>Gets captured canonical state flags.</summary>
+    public AccessibleStates States { get; }
+    /// <summary>Gets captured advertised actions; actions must recheck the live peer.</summary>
+    public AccessibleActions SupportedActions { get; }
+    /// <summary>Gets the safe semantic value, or null when absent/redacted/unavailable.</summary>
+    public string? Value { get; }
+    /// <summary>Gets safe immutable numeric metadata, or null when absent/redacted/unavailable.</summary>
+    public AccessibleRangeValue? RangeValue { get; }
+    /// <summary>Gets canonical bounds without additional clipping/occlusion inference.</summary>
+    public AutomationBounds Bounds { get; }
+    /// <summary>Gets the captured parent ID within this root; null for the registered root.</summary>
+    public string? ParentRuntimeId { get; }
+    /// <summary>Gets the immutable sequence of captured active child IDs in canonical order.</summary>
+    public ImmutableArray<string> ChildRuntimeIds { get; }
+    /// <summary>Gets privacy redaction reasons.</summary>
+    public AutomationRedaction Redaction { get; }
+    /// <summary>Gets the opaque identity of the capturing operation.</summary>
+    public string CaptureId { get; }
+    /// <summary>Gets whether limits prevented complete capture of this node's fields or children.</summary>
+    public bool Truncated { get; }
+}

--- a/ModernFormsNext.Automation/AutomationQuery.cs
+++ b/ModernFormsNext.Automation/AutomationQuery.cs
@@ -1,0 +1,51 @@
+using ModernFormsNext.Accessibility;
+
+namespace ModernFormsNext.Automation;
+
+/// <summary>Combines exact ordinal semantic filters with all-required and all-excluded state predicates.</summary>
+/// <remarks>Null filters are ignored; an empty string matches only an empty string. Filters see redacted snapshots, never private values.</remarks>
+public sealed record AutomationQuery
+{
+    /// <summary>Gets the optional, potentially nonunique semantic locator.</summary>
+    public string? AutomationId { get; init; }
+    /// <summary>Gets the optional accessible name; this is not arbitrary Control.Text.</summary>
+    public string? Name { get; init; }
+    /// <summary>Gets the optional normalized semantic type.</summary>
+    public AccessibleControlType? ControlType { get; init; }
+    /// <summary>Gets flags that must all be present.</summary>
+    public AccessibleStates RequiredStates { get; init; }
+    /// <summary>Gets flags that must all be absent.</summary>
+    public AccessibleStates ExcludedStates { get; init; }
+
+    internal bool Matches(AutomationNodeSnapshot node)
+        => (AutomationId is null || string.Equals(AutomationId, node.AutomationId, StringComparison.Ordinal))
+        && (Name is null || string.Equals(Name, node.Name, StringComparison.Ordinal))
+        && (ControlType is null || ControlType == node.ControlType)
+        && (node.States & RequiredStates) == RequiredStates
+        && (node.States & ExcludedStates) == 0;
+}
+
+/// <summary>Bounds every live traversal in a session. Options are immutable after initialization.</summary>
+/// <remarks>
+/// Root depth is zero. Child attempts, including malformed or hidden children, consume the node budget.
+/// Limits never interrupt an individual application getter: custom peers must return promptly.
+/// </remarks>
+public sealed record AutomationQueryOptions
+{
+    /// <summary>Gets the maximum depth, from 0 to 256; the default is 64.</summary>
+    public int MaxDepth { get; init; } = 64;
+    /// <summary>Gets the maximum node/edge attempts, from 1 to 100000; the default is 4096.</summary>
+    public int MaxNodes { get; init; } = 4096;
+    /// <summary>Gets the maximum returned roots or nodes, from 1 to 100000; the default is 1024.</summary>
+    public int MaxResults { get; init; } = 1024;
+
+    internal void Validate()
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaxDepth, 0);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(MaxDepth, 256);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaxNodes, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(MaxNodes, 100000);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaxResults, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(MaxResults, 100000);
+    }
+}

--- a/ModernFormsNext.Automation/AutomationResult.cs
+++ b/ModernFormsNext.Automation/AutomationResult.cs
@@ -1,0 +1,34 @@
+using System.Collections.Immutable;
+
+namespace ModernFormsNext.Automation;
+
+/// <summary>Contains a detached query result and safe information about incomplete or failed capture.</summary>
+/// <typeparam name="T">The immutable DTO or immutable DTO array returned by the operation.</typeparam>
+/// <remarks>A nonempty partial Value does not certify completeness. Check Error, Truncated and Issues before drawing conclusions.</remarks>
+public sealed class AutomationResult<T>
+{
+    internal AutomationResult(T? value, AutomationErrorCode error, string captureId,
+        bool truncated = false, ImmutableArray<AutomationIssue> issues = default)
+    {
+        Value = value; Error = error; CaptureId = captureId; Truncated = truncated;
+        Issues = issues.IsDefault ? [] : issues;
+    }
+    /// <summary>Gets detached captured data; absent when an operation could not produce a value.</summary>
+    public T? Value { get; }
+    /// <summary>Gets the primary result code; None means complete capture without faults.</summary>
+    public AutomationErrorCode Error { get; }
+    /// <summary>Gets whether a budget prevented a complete result.</summary>
+    public bool Truncated { get; }
+    /// <summary>Gets safe structured diagnostics with no exception messages or request values.</summary>
+    public ImmutableArray<AutomationIssue> Issues { get; }
+    /// <summary>Gets the opaque capture operation identity.</summary>
+    public string CaptureId { get; }
+}
+
+/// <summary>Contains detached metadata for an explicitly registered root.</summary>
+/// <param name="RootId">The unique registration identity.</param>
+/// <param name="Handle">The root's canonical handle.</param>
+/// <param name="Capabilities">The effective allowed operations.</param>
+/// <param name="CoordinateSpace">The reference frame for canonical bounds.</param>
+public sealed record AutomationRootInfo(string RootId, AutomationNodeHandle Handle,
+    AutomationCapability Capabilities, AutomationCoordinateSpace CoordinateSpace);

--- a/ModernFormsNext.Automation/AutomationResult.cs
+++ b/ModernFormsNext.Automation/AutomationResult.cs
@@ -13,7 +13,7 @@ public sealed class AutomationResult<T>
         Value = value; Error = error; CaptureId = captureId; Truncated = truncated;
         Issues = issues.IsDefault ? [] : issues;
     }
-    /// <summary>Gets detached captured data; absent when an operation could not produce a value.</summary>
+    /// <summary>Gets detached captured data; failures without data return null for a single DTO or an initialized empty immutable array.</summary>
     public T? Value { get; }
     /// <summary>Gets the primary result code; None means complete capture without faults.</summary>
     public AutomationErrorCode Error { get; }

--- a/ModernFormsNext.Automation/AutomationRootRegistration.cs
+++ b/ModernFormsNext.Automation/AutomationRootRegistration.cs
@@ -1,0 +1,93 @@
+namespace ModernFormsNext.Automation;
+
+/// <summary>Owns an opt-in registration, while borrowing its window/surface through weak references.</summary>
+/// <remarks>
+/// Dispose on the session UI thread to unregister without closing the application root.
+/// Window close/disposal unregisters immediately. Surface disposal or collection is also observed
+/// by IsRegistered and the next live operation. Keeping this token never keeps the root alive.
+/// </remarks>
+public sealed class AutomationRootRegistration : IDisposable
+{
+    private readonly WeakReference<AutomationSession> session;
+    private readonly WeakReference<WindowBase>? window;
+    private readonly WeakReference<SkiaControlSurface>? surface;
+    private readonly WeakReference<Control>? surfaceControl;
+    private bool removed;
+
+    internal AutomationRootRegistration(AutomationSession owner, WindowBase root, AutomationCapability capabilities)
+    {
+        session = new(owner); window = new(root); Capabilities = capabilities;
+        CoordinateSpace = AutomationCoordinateSpace.Screen;
+        root.Closed += OnEnded;
+        root.Disposed += OnEnded;
+    }
+
+    internal AutomationRootRegistration(AutomationSession owner, SkiaControlSurface root, AutomationCapability capabilities)
+    {
+        session = new(owner); surface = new(root); surfaceControl = new(root.Root); Capabilities = capabilities;
+        CoordinateSpace = AutomationCoordinateSpace.Surface;
+        root.Root.Disposed += OnEnded;
+    }
+
+    /// <summary>Gets the unique registration identity; unregistering and registering again produces a new ID.</summary>
+    public string RootId { get; } = Guid.NewGuid().ToString("N");
+    /// <summary>Gets the intersection of the requested root policy and session policy.</summary>
+    public AutomationCapability Capabilities { get; }
+    /// <summary>Gets the coordinate reference for this root's canonical bounds.</summary>
+    public AutomationCoordinateSpace CoordinateSpace { get; }
+    /// <summary>Gets whether the root remains registered. Read on the owning UI thread.</summary>
+    public bool IsRegistered
+    {
+        get
+        {
+            if (!session.TryGetTarget(out var owner)) return false;
+            owner.VerifyAccess();
+            return !owner.IsStopped && !removed && owner.IsLive(this);
+        }
+    }
+
+    internal bool Represents(object candidate)
+        => (window?.TryGetTarget(out var w) == true && ReferenceEquals(w, candidate))
+        || (surface?.TryGetTarget(out var s) == true && ReferenceEquals(s, candidate));
+
+    internal bool TryGetPeer(out Accessibility.AccessibleObject? peer)
+    {
+        peer = null;
+        if (removed) return false;
+        if (window?.TryGetTarget(out var w) == true)
+        {
+            // This existing flag is set on actual close/disposal, but not a cancelled close.
+            // Component does not expose IsDisposed; using this seam avoids agent API on WindowBase.
+            if (w.InputBindingsClosed) return false;
+            peer = w.AccessibilityObject;
+        }
+        else if (surface?.TryGetTarget(out var s) == true && !s.IsDisposed && !s.Root.IsDisposed)
+            peer = s.Root.AccessibilityObject;
+        return peer is not null;
+    }
+
+    /// <summary>Unregisters and removes lifetime subscriptions on the owning UI thread. Repeated calls are safe.</summary>
+    public void Dispose()
+    {
+        if (session.TryGetTarget(out var owner))
+        {
+            owner.VerifyAccess();
+            owner.Remove(this);
+        }
+        else Detach();
+    }
+
+    internal void Detach()
+    {
+        if (removed) return;
+        removed = true;
+        if (window?.TryGetTarget(out var w) == true)
+        {
+            w.Closed -= OnEnded;
+            w.Disposed -= OnEnded;
+        }
+        if (surfaceControl?.TryGetTarget(out var c) == true) c.Disposed -= OnEnded;
+    }
+
+    private void OnEnded(object? sender, EventArgs args) => Dispose();
+}

--- a/ModernFormsNext.Automation/AutomationRootRegistration.cs
+++ b/ModernFormsNext.Automation/AutomationRootRegistration.cs
@@ -53,7 +53,7 @@ public sealed class AutomationRootRegistration : IDisposable
     internal bool TryGetPeer(out Accessibility.AccessibleObject? peer)
     {
         peer = null;
-        if (removed) return false;
+        if (!IsAlive) return false;
         if (window?.TryGetTarget(out var w) == true)
         {
             // This existing flag is set on actual close/disposal, but not a cancelled close.
@@ -65,6 +65,11 @@ public sealed class AutomationRootRegistration : IDisposable
             peer = s.Root.AccessibilityObject;
         return peer is not null;
     }
+
+    // Lifetime observation must not invoke an application's custom peer factory/getters.
+    internal bool IsAlive => !removed &&
+        ((window?.TryGetTarget(out var w) == true && !w.InputBindingsClosed)
+        || (surface?.TryGetTarget(out var s) == true && !s.IsDisposed && !s.Root.IsDisposed));
 
     /// <summary>Unregisters and removes lifetime subscriptions on the owning UI thread. Repeated calls are safe.</summary>
     public void Dispose()

--- a/ModernFormsNext.Automation/AutomationSession.Actions.cs
+++ b/ModernFormsNext.Automation/AutomationSession.Actions.cs
@@ -101,6 +101,8 @@ public sealed partial class AutomationSession
         if ((peer.SupportedActions & action) == 0) return ActionResult(AutomationErrorCode.ActionUnsupported);
         if (stopped) return ActionResult(AutomationErrorCode.SessionEnded);
         if (!root!.IsRegistered) return ActionResult(AutomationErrorCode.StaleNode);
+        // The last state/action getter may itself request cancellation.
+        token.ThrowIfCancellationRequested();
         return peer.PerformAction(action, parameter)
             ? new(AutomationActionStatus.Accepted, AutomationErrorCode.None)
             : ActionResult(AutomationErrorCode.ActionRejected);

--- a/ModernFormsNext.Automation/AutomationSession.Actions.cs
+++ b/ModernFormsNext.Automation/AutomationSession.Actions.cs
@@ -30,7 +30,9 @@ public sealed partial class AutomationSession
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (dispatcher.CheckAccess()) return PerformCore(rootId, handle, action, value, cancellationToken);
+            // Invoke's same-thread path also installs the production dispatcher context. Async
+            // commands must capture that context, including when invoked from a TestHost caller.
+            if (dispatcher.CheckAccess()) return dispatcher.Invoke(() => PerformCore(rootId, handle, action, value, cancellationToken));
             return await dispatcher.InvokeAsync(() => PerformCore(rootId, handle, action, value, cancellationToken),
                 DispatcherPriority.Default, cancellationToken).GetTask().ConfigureAwait(false);
         }

--- a/ModernFormsNext.Automation/AutomationSession.Actions.cs
+++ b/ModernFormsNext.Automation/AutomationSession.Actions.cs
@@ -1,0 +1,115 @@
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.WindowKit.Threading;
+
+namespace ModernFormsNext.Automation;
+
+public sealed partial class AutomationSession
+{
+    private const AccessibleActions AllowedActions = AccessibleActions.Invoke | AccessibleActions.Focus
+        | AccessibleActions.SetValue | AccessibleActions.Select | AccessibleActions.Toggle
+        | AccessibleActions.Expand | AccessibleActions.Collapse | AccessibleActions.Increment
+        | AccessibleActions.Decrement | AccessibleActions.ScrollIntoView;
+
+    /// <summary>Requests one currently advertised canonical action on the UI dispatcher.</summary>
+    /// <param name="rootId">The exact allowed root registration identity.</param>
+    /// <param name="handle">The session and canonical runtime identity, re-resolved before execution.</param>
+    /// <param name="action">Exactly one advertised action from the Phase 1a allowlist.</param>
+    /// <param name="value">Only SetValue accepts a payload: text, a finite numeric range value, or null to clear text.</param>
+    /// <param name="cancellationToken">Cancels before execution or between reachability reads; it cannot undo an accepted action.</param>
+    /// <returns>Accepted when PerformAction returns true, independently of future async work.</returns>
+    /// <remarks>
+    /// This calls AccessibleObject.PerformAction only. Button Invoke follows ordinary activation,
+    /// Click and command routing; no command is executed directly. Numeric range limits are
+    /// checked before dispatch; the canonical peer retains final validation of units and step rules.
+    /// A throwing application action may already have produced effects: do not automatically retry.
+    /// </remarks>
+    public async Task<AutomationActionResult> PerformActionAsync(string rootId, AutomationNodeHandle handle,
+        AccessibleActions action, AutomationActionValue? value = null, CancellationToken cancellationToken = default)
+    {
+        if (stopped) return ActionResult(AutomationErrorCode.SessionEnded);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (dispatcher.CheckAccess()) return PerformCore(rootId, handle, action, value, cancellationToken);
+            return await dispatcher.InvokeAsync(() => PerformCore(rootId, handle, action, value, cancellationToken),
+                DispatcherPriority.Default, cancellationToken).GetTask().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (Exception) { return ActionResult(AutomationErrorCode.ApplicationError); }
+    }
+
+    private AutomationActionResult PerformCore(string rootId, AutomationNodeHandle handle,
+        AccessibleActions action, AutomationActionValue? value, CancellationToken token)
+    {
+        var error = ValidateHandle(handle);
+        if (error != AutomationErrorCode.None) return ActionResult(error);
+        int flag = (int)action;
+        if (flag <= 0 || (flag & (flag - 1)) != 0) return ActionResult(AutomationErrorCode.InvalidArgument);
+        if ((AllowedActions & action) == 0) return ActionResult(AutomationErrorCode.ActionUnsupported);
+        if (action != AccessibleActions.SetValue && value is not null) return ActionResult(AutomationErrorCode.InvalidArgument);
+        if (value?.Text is { Length: > SemanticTraversal.MaxTextLength } || value?.Number is double number && !double.IsFinite(number))
+            return ActionResult(AutomationErrorCode.InvalidArgument);
+
+        error = Begin(rootId, AutomationCapability.Actions, token, out var root, out var traversal);
+        if (error != AutomationErrorCode.None) return ActionResult(error);
+        if (traversal!.Error != AutomationErrorCode.None) return ActionResult(traversal.Error);
+        var entry = traversal.Find(handle.RuntimeId);
+        if (entry is null) return ActionResult(AutomationErrorCode.NodeUnavailable);
+        var peer = entry.Peer;
+
+        // All validation and the final canonical call share one dispatcher turn. No stale
+        // snapshot supplies availability, capabilities, range values or the target reference.
+        var state = peer.State;
+        if ((state & (AccessibleStates.Unavailable | AccessibleStates.Invisible)) != 0)
+            return ActionResult(AutomationErrorCode.ActionRejected);
+        if ((peer.SupportedActions & action) == 0) return ActionResult(AutomationErrorCode.ActionUnsupported);
+        object? parameter = null;
+        if (action == AccessibleActions.SetValue)
+        {
+            if ((state & AccessibleStates.ReadOnly) != 0) return ActionResult(AutomationErrorCode.ActionRejected);
+            var range = peer.RangeValue;
+            if (range is { } r)
+            {
+                if (r.IsReadOnly) return ActionResult(AutomationErrorCode.ActionRejected);
+                if (value?.Number is not double numeric || numeric < r.Minimum || numeric > r.Maximum)
+                    return ActionResult(AutomationErrorCode.InvalidArgument);
+                // TrackBar's canonical natural type is an integral range. Other custom ranges
+                // can use fractional values; never infer the type from a CLR control name.
+                if (peer is Control.ControlAccessibleObject { Owner: TrackBar } && numeric != Math.Truncate(numeric))
+                    return ActionResult(AutomationErrorCode.InvalidArgument);
+                parameter = numeric;
+            }
+            else
+            {
+                if (value?.Number is not null) return ActionResult(AutomationErrorCode.InvalidArgument);
+                parameter = value?.Text;
+            }
+        }
+
+        // Custom getter callbacks can reenter application code and detach/close a target. A
+        // second bounded structural pass after parameter reads rejects those stale references.
+        error = Begin(rootId, AutomationCapability.Actions, token, out root, out var current);
+        if (error != AutomationErrorCode.None) return ActionResult(error);
+        if (current!.Error != AutomationErrorCode.None) return ActionResult(current.Error);
+        var live = current.Find(handle.RuntimeId);
+        if (live is null || !ReferenceEquals(live.Peer, peer)) return ActionResult(AutomationErrorCode.NodeUnavailable);
+        token.ThrowIfCancellationRequested();
+        if ((peer.State & (AccessibleStates.Unavailable | AccessibleStates.Invisible)) != 0)
+            return ActionResult(AutomationErrorCode.ActionRejected);
+        if ((peer.SupportedActions & action) == 0) return ActionResult(AutomationErrorCode.ActionUnsupported);
+        if (stopped) return ActionResult(AutomationErrorCode.SessionEnded);
+        if (!root!.IsRegistered) return ActionResult(AutomationErrorCode.StaleNode);
+        return peer.PerformAction(action, parameter)
+            ? new(AutomationActionStatus.Accepted, AutomationErrorCode.None)
+            : ActionResult(AutomationErrorCode.ActionRejected);
+    }
+
+    private static AutomationActionResult ActionResult(AutomationErrorCode error) => new(error switch
+    {
+        AutomationErrorCode.ActionUnsupported => AutomationActionStatus.Unsupported,
+        AutomationErrorCode.InvalidArgument => AutomationActionStatus.InvalidArgument,
+        AutomationErrorCode.GetterFault or AutomationErrorCode.ApplicationError => AutomationActionStatus.ApplicationError,
+        AutomationErrorCode.ActionRejected or AutomationErrorCode.CapabilityDenied => AutomationActionStatus.Rejected,
+        _ => AutomationActionStatus.NodeUnavailable
+    }, error);
+}

--- a/ModernFormsNext.Automation/AutomationSession.Queries.cs
+++ b/ModernFormsNext.Automation/AutomationSession.Queries.cs
@@ -10,21 +10,29 @@ public sealed partial class AutomationSession
     public Task<AutomationResult<ImmutableArray<AutomationRootInfo>>> GetRootsAsync(CancellationToken cancellationToken = default)
         => Dispatch(captureId =>
         {
-            if (stopped) return new AutomationResult<ImmutableArray<AutomationRootInfo>>(default, AutomationErrorCode.SessionEnded, captureId);
+            if (stopped) return new AutomationResult<ImmutableArray<AutomationRootInfo>>([], AutomationErrorCode.SessionEnded, captureId);
             if ((Capabilities & AutomationCapability.Inspect) == 0)
-                return new(default, AutomationErrorCode.CapabilityDenied, captureId);
+                return new([], AutomationErrorCode.CapabilityDenied, captureId);
             PruneRoots();
             var result = ImmutableArray.CreateBuilder<AutomationRootInfo>();
+            var issues = ImmutableArray.CreateBuilder<AutomationIssue>();
             bool truncated = false;
-            foreach (var root in roots)
+            foreach (var root in roots.ToArray())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if ((root.Capabilities & AutomationCapability.Inspect) == 0 || !root.TryGetPeer(out var peer)) continue;
+                if ((root.Capabilities & AutomationCapability.Inspect) == 0) continue;
                 if (result.Count == Limits.MaxResults) { truncated = true; break; }
-                result.Add(new(root.RootId, new(SessionId, Id(peer!.RuntimeId)), root.Capabilities, root.CoordinateSpace));
+                try
+                {
+                    if (root.TryGetPeer(out var peer))
+                        result.Add(new(root.RootId, new(SessionId, Id(peer!.RuntimeId)), root.Capabilities, root.CoordinateSpace));
+                }
+                catch (Exception) { issues.Add(new(AutomationErrorCode.GetterFault, null, AutomationProperty.Node)); }
             }
-            return new(result.ToImmutable(), truncated ? AutomationErrorCode.LimitExceeded : AutomationErrorCode.None, captureId, truncated);
-        }, cancellationToken);
+            if (stopped) return new([], AutomationErrorCode.SessionEnded, captureId);
+            return new(result.ToImmutable(), issues.Count > 0 ? AutomationErrorCode.GetterFault
+                : truncated ? AutomationErrorCode.LimitExceeded : AutomationErrorCode.None, captureId, truncated, issues.ToImmutable());
+        }, cancellationToken, ImmutableArray<AutomationRootInfo>.Empty);
 
     /// <summary>Captures a handle currently reachable from the specified registered root.</summary>
     /// <param name="rootId">The exact root registration identity; no cross-root fallback occurs.</param>
@@ -46,19 +54,19 @@ public sealed partial class AutomationSession
         {
             var error = ValidateHandle(handle);
             if (error != AutomationErrorCode.None)
-                return new AutomationResult<ImmutableArray<AutomationNodeSnapshot>>(default, error, captureId);
+                return new AutomationResult<ImmutableArray<AutomationNodeSnapshot>>([], error, captureId);
             error = Begin(rootId, AutomationCapability.Query, cancellationToken, out var root, out var traversal);
-            if (error != AutomationErrorCode.None) return new(default, error, captureId);
+            if (error != AutomationErrorCode.None) return new([], error, captureId);
             var entry = traversal!.Find(handle.RuntimeId);
-            if (entry is null) return new(default, Missing(traversal), captureId, traversal.Truncated, traversal.Issues);
+            if (entry is null) return new([], Missing(traversal), captureId, traversal.Truncated, traversal.Issues);
             var result = ImmutableArray.CreateBuilder<AutomationNodeSnapshot>();
             foreach (var child in entry.Children)
             {
                 if (result.Count == Limits.MaxResults) { traversal.Limit(); break; }
                 result.Add(traversal.Capture(child, SessionId, rootId, root!.CoordinateSpace, captureId));
             }
-            return Result(result.ToImmutable(), traversal, captureId);
-        }, cancellationToken);
+            return Result(result.ToImmutable(), traversal, rootId, captureId, ImmutableArray<AutomationNodeSnapshot>.Empty);
+        }, cancellationToken, ImmutableArray<AutomationNodeSnapshot>.Empty);
 
     /// <summary>Finds matches by depth-first preorder within one root, including the root itself.</summary>
     /// <param name="rootId">The exact allowed root registration identity.</param>
@@ -67,7 +75,7 @@ public sealed partial class AutomationSession
     /// <returns>Up to MaxResults matches. Limits/faults explicitly prevent a completeness guarantee.</returns>
     public Task<AutomationResult<ImmutableArray<AutomationNodeSnapshot>>> FindAllAsync(string rootId, AutomationQuery query,
         CancellationToken cancellationToken = default)
-        => Dispatch(captureId => FindCore(rootId, query, false, captureId, cancellationToken), cancellationToken);
+        => Dispatch(captureId => FindCore(rootId, query, false, captureId, cancellationToken), cancellationToken, ImmutableArray<AutomationNodeSnapshot>.Empty);
 
     /// <summary>Requires exactly one match in a complete root traversal; never guesses among duplicate locators.</summary>
     /// <param name="rootId">The exact allowed root registration identity.</param>
@@ -95,7 +103,7 @@ public sealed partial class AutomationSession
         var entry = traversal!.Find(handle.RuntimeId);
         if (entry is null) return new(null, Missing(traversal), captureId, traversal.Truncated, traversal.Issues);
         var snapshot = traversal.Capture(entry, SessionId, rootId, root!.CoordinateSpace, captureId);
-        return Result(snapshot, traversal, captureId);
+        return Result(snapshot, traversal, rootId, captureId);
     }
 
     private AutomationResult<ImmutableArray<AutomationNodeSnapshot>> FindCore(string rootId, AutomationQuery query,
@@ -117,7 +125,7 @@ public sealed partial class AutomationSession
             if (result.Count == Limits.MaxResults) { traversal.Limit(); break; }
             result.Add(snapshot);
         }
-        return Result(result.ToImmutable(), traversal, captureId);
+        return Result(result.ToImmutable(), traversal, rootId, captureId, ImmutableArray<AutomationNodeSnapshot>.Empty);
     }
 
     private AutomationErrorCode Begin(string rootId, AutomationCapability capability, CancellationToken token,
@@ -126,7 +134,9 @@ public sealed partial class AutomationSession
         traversal = null;
         var error = ResolveRoot(rootId, capability, out root);
         if (error != AutomationErrorCode.None) return error;
-        if (!root!.TryGetPeer(out var peer)) return AutomationErrorCode.NodeUnavailable;
+        Accessibility.AccessibleObject? peer;
+        try { if (!root!.TryGetPeer(out peer)) return AutomationErrorCode.NodeUnavailable; }
+        catch (Exception) { return AutomationErrorCode.GetterFault; }
         traversal = new(Limits, token);
         traversal.Walk(peer!);
         if (stopped) return AutomationErrorCode.SessionEnded;
@@ -137,7 +147,8 @@ public sealed partial class AutomationSession
     private static AutomationErrorCode Missing(SemanticTraversal traversal)
         => traversal.Error == AutomationErrorCode.None ? AutomationErrorCode.NodeUnavailable : traversal.Error;
 
-    private AutomationResult<T> Result<T>(T value, SemanticTraversal traversal, string captureId)
-        => stopped ? new(default, AutomationErrorCode.SessionEnded, captureId)
+    private AutomationResult<T> Result<T>(T value, SemanticTraversal traversal, string rootId, string captureId, T? empty = default)
+        => stopped ? new(empty, AutomationErrorCode.SessionEnded, captureId)
+        : !roots.Any(r => r.RootId == rootId && r.IsAlive) ? new(empty, AutomationErrorCode.StaleNode, captureId)
         : new(value, traversal.Error, captureId, traversal.Truncated, traversal.Issues);
 }

--- a/ModernFormsNext.Automation/AutomationSession.Queries.cs
+++ b/ModernFormsNext.Automation/AutomationSession.Queries.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+
+namespace ModernFormsNext.Automation;
+
+public sealed partial class AutomationSession
+{
+    /// <summary>Enumerates explicitly registered live roots in registration order, subject to MaxResults.</summary>
+    /// <param name="cancellationToken">Cancels queued work or traversal between semantic getter calls.</param>
+    /// <returns>Detached root descriptors. Only roots allowing Inspect are listed.</returns>
+    public Task<AutomationResult<ImmutableArray<AutomationRootInfo>>> GetRootsAsync(CancellationToken cancellationToken = default)
+        => Dispatch(captureId =>
+        {
+            if (stopped) return new AutomationResult<ImmutableArray<AutomationRootInfo>>(default, AutomationErrorCode.SessionEnded, captureId);
+            if ((Capabilities & AutomationCapability.Inspect) == 0)
+                return new(default, AutomationErrorCode.CapabilityDenied, captureId);
+            PruneRoots();
+            var result = ImmutableArray.CreateBuilder<AutomationRootInfo>();
+            bool truncated = false;
+            foreach (var root in roots)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if ((root.Capabilities & AutomationCapability.Inspect) == 0 || !root.TryGetPeer(out var peer)) continue;
+                if (result.Count == Limits.MaxResults) { truncated = true; break; }
+                result.Add(new(root.RootId, new(SessionId, Id(peer!.RuntimeId)), root.Capabilities, root.CoordinateSpace));
+            }
+            return new(result.ToImmutable(), truncated ? AutomationErrorCode.LimitExceeded : AutomationErrorCode.None, captureId, truncated);
+        }, cancellationToken);
+
+    /// <summary>Captures a handle currently reachable from the specified registered root.</summary>
+    /// <param name="rootId">The exact root registration identity; no cross-root fallback occurs.</param>
+    /// <param name="handle">The session and canonical runtime identity.</param>
+    /// <param name="cancellationToken">Cancels queued work or traversal between getters.</param>
+    /// <returns>A detached snapshot, or a structured stale/unavailable/fault/limit result.</returns>
+    public Task<AutomationResult<AutomationNodeSnapshot>> InspectAsync(string rootId, AutomationNodeHandle handle,
+        CancellationToken cancellationToken = default)
+        => Dispatch(captureId => InspectCore(rootId, handle, captureId, cancellationToken), cancellationToken);
+
+    /// <summary>Captures direct active semantic children in ascending canonical child-index order.</summary>
+    /// <param name="rootId">The exact allowed root registration identity.</param>
+    /// <param name="handle">The currently reachable parent handle.</param>
+    /// <param name="cancellationToken">Cancels queued work or traversal between getters.</param>
+    /// <returns>Immutable child snapshots with explicit incomplete-capture diagnostics.</returns>
+    public Task<AutomationResult<ImmutableArray<AutomationNodeSnapshot>>> GetChildrenAsync(string rootId, AutomationNodeHandle handle,
+        CancellationToken cancellationToken = default)
+        => Dispatch(captureId =>
+        {
+            var error = ValidateHandle(handle);
+            if (error != AutomationErrorCode.None)
+                return new AutomationResult<ImmutableArray<AutomationNodeSnapshot>>(default, error, captureId);
+            error = Begin(rootId, AutomationCapability.Query, cancellationToken, out var root, out var traversal);
+            if (error != AutomationErrorCode.None) return new(default, error, captureId);
+            var entry = traversal!.Find(handle.RuntimeId);
+            if (entry is null) return new(default, Missing(traversal), captureId, traversal.Truncated, traversal.Issues);
+            var result = ImmutableArray.CreateBuilder<AutomationNodeSnapshot>();
+            foreach (var child in entry.Children)
+            {
+                if (result.Count == Limits.MaxResults) { traversal.Limit(); break; }
+                result.Add(traversal.Capture(child, SessionId, rootId, root!.CoordinateSpace, captureId));
+            }
+            return Result(result.ToImmutable(), traversal, captureId);
+        }, cancellationToken);
+
+    /// <summary>Finds matches by depth-first preorder within one root, including the root itself.</summary>
+    /// <param name="rootId">The exact allowed root registration identity.</param>
+    /// <param name="query">Exact ordinal filters combined with AND; no selector language is parsed.</param>
+    /// <param name="cancellationToken">Cancels queued work or traversal between getters.</param>
+    /// <returns>Up to MaxResults matches. Limits/faults explicitly prevent a completeness guarantee.</returns>
+    public Task<AutomationResult<ImmutableArray<AutomationNodeSnapshot>>> FindAllAsync(string rootId, AutomationQuery query,
+        CancellationToken cancellationToken = default)
+        => Dispatch(captureId => FindCore(rootId, query, false, captureId, cancellationToken), cancellationToken);
+
+    /// <summary>Requires exactly one match in a complete root traversal; never guesses among duplicate locators.</summary>
+    /// <param name="rootId">The exact allowed root registration identity.</param>
+    /// <param name="query">The exact semantic filters.</param>
+    /// <param name="cancellationToken">Cancels queued work or traversal between getters.</param>
+    /// <returns>NodeNotFound for zero, a snapshot for one, or AmbiguousMatch for at least two. Incomplete searches cannot certify uniqueness.</returns>
+    public Task<AutomationResult<AutomationNodeSnapshot>> FindOneAsync(string rootId, AutomationQuery query,
+        CancellationToken cancellationToken = default)
+        => Dispatch(captureId =>
+        {
+            var found = FindCore(rootId, query, true, captureId, cancellationToken);
+            var error = found.Error;
+            if (found.Value.Length > 1) error = AutomationErrorCode.AmbiguousMatch;
+            else if (error == AutomationErrorCode.None && found.Value.Length == 0) error = AutomationErrorCode.NodeNotFound;
+            return new AutomationResult<AutomationNodeSnapshot>(error == AutomationErrorCode.None ? found.Value[0] : null,
+                error, captureId, found.Truncated, found.Issues);
+        }, cancellationToken);
+
+    private AutomationResult<AutomationNodeSnapshot> InspectCore(string rootId, AutomationNodeHandle handle, string captureId, CancellationToken token)
+    {
+        var error = ValidateHandle(handle);
+        if (error != AutomationErrorCode.None) return new(null, error, captureId);
+        error = Begin(rootId, AutomationCapability.Inspect, token, out var root, out var traversal);
+        if (error != AutomationErrorCode.None) return new(null, error, captureId);
+        var entry = traversal!.Find(handle.RuntimeId);
+        if (entry is null) return new(null, Missing(traversal), captureId, traversal.Truncated, traversal.Issues);
+        var snapshot = traversal.Capture(entry, SessionId, rootId, root!.CoordinateSpace, captureId);
+        return Result(snapshot, traversal, captureId);
+    }
+
+    private AutomationResult<ImmutableArray<AutomationNodeSnapshot>> FindCore(string rootId, AutomationQuery query,
+        bool unique, string captureId, CancellationToken token)
+    {
+        if (query is null || (query.RequiredStates & query.ExcludedStates) != 0
+            || query.Name is { Length: > SemanticTraversal.MaxTextLength } || query.AutomationId is { Length: > SemanticTraversal.MaxTextLength })
+            return new([], AutomationErrorCode.InvalidArgument, captureId);
+        var error = Begin(rootId, AutomationCapability.Query, token, out var root, out var traversal);
+        if (error != AutomationErrorCode.None) return new([], error, captureId);
+        var result = ImmutableArray.CreateBuilder<AutomationNodeSnapshot>();
+        foreach (var entry in traversal!.Entries)
+        {
+            var snapshot = traversal.Capture(entry, SessionId, rootId, root!.CoordinateSpace, captureId);
+            if (!query.Matches(snapshot)) continue;
+            // FindOne must detect a second match even when MaxResults is one. Only its single
+            // final snapshot can escape; this second candidate is solely an ambiguity witness.
+            if (unique && result.Count == 1) { result.Add(snapshot); break; }
+            if (result.Count == Limits.MaxResults) { traversal.Limit(); break; }
+            result.Add(snapshot);
+        }
+        return Result(result.ToImmutable(), traversal, captureId);
+    }
+
+    private AutomationErrorCode Begin(string rootId, AutomationCapability capability, CancellationToken token,
+        out AutomationRootRegistration? root, out SemanticTraversal? traversal)
+    {
+        traversal = null;
+        var error = ResolveRoot(rootId, capability, out root);
+        if (error != AutomationErrorCode.None) return error;
+        if (!root!.TryGetPeer(out var peer)) return AutomationErrorCode.NodeUnavailable;
+        traversal = new(Limits, token);
+        traversal.Walk(peer!);
+        if (stopped) return AutomationErrorCode.SessionEnded;
+        if (!root.IsRegistered) return AutomationErrorCode.StaleNode;
+        return AutomationErrorCode.None;
+    }
+
+    private static AutomationErrorCode Missing(SemanticTraversal traversal)
+        => traversal.Error == AutomationErrorCode.None ? AutomationErrorCode.NodeUnavailable : traversal.Error;
+
+    private AutomationResult<T> Result<T>(T value, SemanticTraversal traversal, string captureId)
+        => stopped ? new(default, AutomationErrorCode.SessionEnded, captureId)
+        : new(value, traversal.Error, captureId, traversal.Truncated, traversal.Issues);
+}

--- a/ModernFormsNext.Automation/AutomationSession.cs
+++ b/ModernFormsNext.Automation/AutomationSession.cs
@@ -11,6 +11,8 @@ namespace ModernFormsNext.Automation;
 /// captured production dispatcher. Await them; do not block the UI thread on queued operations.
 /// This package starts no listener and provides no transport authentication. Omit it from applications
 /// that do not need development automation. Dispose the session before shutting down its dispatcher.
+/// The application must initialize that dispatcher before construction; VerifyAccess checks thread
+/// access, not backend readiness. All roots in a session must belong to that same dispatcher.
 /// </remarks>
 /// <example><code>
 /// using var automation = new AutomationSession();
@@ -29,7 +31,7 @@ public sealed partial class AutomationSession : IDisposable
     /// <summary>Creates a new session on the current production UI dispatcher.</summary>
     /// <param name="capabilities">Explicitly allowed operations; unknown flags are rejected.</param>
     /// <param name="limits">Immutable limits applying to every traversal; null selects bounded defaults.</param>
-    /// <exception cref="InvalidOperationException">The caller is not on the initialized UI dispatcher.</exception>
+    /// <exception cref="InvalidOperationException">The caller is not on the captured UI dispatcher.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Capabilities or limits are invalid.</exception>
     public AutomationSession(AutomationCapability capabilities = AllCapabilities, AutomationQueryOptions? limits = null)
     {
@@ -54,6 +56,8 @@ public sealed partial class AutomationSession : IDisposable
     /// <param name="root">The live window explicitly allowed for automation; it may be registered before Show.</param>
     /// <param name="capabilities">The requested root policy, intersected with session capabilities.</param>
     /// <returns>A disposable registration that never owns or closes the window.</returns>
+    /// <exception cref="ArgumentNullException">The root is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Capabilities contain unknown flags.</exception>
     /// <exception cref="ObjectDisposedException">The session or window has ended.</exception>
     /// <exception cref="InvalidOperationException">The root is already registered or the caller is not on the UI thread.</exception>
     public AutomationRootRegistration RegisterRoot(WindowBase root, AutomationCapability capabilities = AllCapabilities)
@@ -69,6 +73,8 @@ public sealed partial class AutomationSession : IDisposable
     /// <param name="root">The live surface. Its canonical Root remains the only semantic source.</param>
     /// <param name="capabilities">The requested root policy, intersected with session capabilities.</param>
     /// <returns>A disposable registration; surface/root disposal is checked on each live operation.</returns>
+    /// <exception cref="ArgumentNullException">The root is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Capabilities contain unknown flags.</exception>
     /// <exception cref="ObjectDisposedException">The session, surface or root has ended.</exception>
     /// <exception cref="InvalidOperationException">The surface is already registered or the caller is not on the UI thread.</exception>
     public AutomationRootRegistration RegisterRoot(SkiaControlSurface root, AutomationCapability capabilities = AllCapabilities)
@@ -92,6 +98,7 @@ public sealed partial class AutomationSession : IDisposable
 
     /// <summary>Marshals session cleanup to its production UI dispatcher.</summary>
     /// <returns>A task completed after subscriptions are removed and every handle is invalidated.</returns>
+    /// <remarks>A background request is queued. It does not preempt a running getter or action; session end occurs when cleanup executes.</remarks>
     public Task StopAsync()
     {
         if (stopped) return Task.CompletedTask;

--- a/ModernFormsNext.Automation/AutomationSession.cs
+++ b/ModernFormsNext.Automation/AutomationSession.cs
@@ -106,7 +106,7 @@ public sealed partial class AutomationSession : IDisposable
     internal void Remove(AutomationRootRegistration root) { root.Detach(); roots.Remove(root); }
     internal bool IsLive(AutomationRootRegistration root)
     {
-        if (root.TryGetPeer(out _)) return true;
+        if (root.IsAlive) return true;
         Remove(root);
         return false;
     }
@@ -130,7 +130,7 @@ public sealed partial class AutomationSession : IDisposable
     private void PruneRoots()
     {
         for (int index = roots.Count - 1; index >= 0; index--)
-            if (!roots[index].TryGetPeer(out _)) Remove(roots[index]);
+            if (!roots[index].IsAlive) Remove(roots[index]);
     }
 
     private AutomationErrorCode ResolveRoot(string rootId, AutomationCapability capability, out AutomationRootRegistration? root)
@@ -156,21 +156,21 @@ public sealed partial class AutomationSession : IDisposable
 
     private static string Id(long value) => value.ToString(CultureInfo.InvariantCulture);
 
-    private async Task<AutomationResult<T>> Dispatch<T>(Func<string, AutomationResult<T>> action, CancellationToken token)
+    private async Task<AutomationResult<T>> Dispatch<T>(Func<string, AutomationResult<T>> action, CancellationToken token, T? empty = default)
     {
         string captureId = Guid.NewGuid().ToString("N");
-        if (stopped) return new(default, AutomationErrorCode.SessionEnded, captureId);
+        if (stopped) return new(empty, AutomationErrorCode.SessionEnded, captureId);
         try
         {
             token.ThrowIfCancellationRequested();
-            if (dispatcher.CheckAccess()) return action(captureId);
+            if (dispatcher.CheckAccess()) return dispatcher.Invoke(() => action(captureId));
             return await dispatcher.InvokeAsync(() => action(captureId), DispatcherPriority.Default, token).GetTask().ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested) { throw; }
         catch (Exception)
         {
             // Never forward arbitrary application exception messages, inner exceptions or ToString.
-            return new(default, stopped ? AutomationErrorCode.SessionEnded : AutomationErrorCode.ApplicationError, captureId);
+            return new(empty, stopped ? AutomationErrorCode.SessionEnded : AutomationErrorCode.ApplicationError, captureId);
         }
     }
 }

--- a/ModernFormsNext.Automation/AutomationSession.cs
+++ b/ModernFormsNext.Automation/AutomationSession.cs
@@ -1,0 +1,176 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using ModernFormsNext.WindowKit.Threading;
+
+namespace ModernFormsNext.Automation;
+
+/// <summary>Owns an explicit development-time in-process semantic session over registered canonical roots.</summary>
+/// <remarks>
+/// Construct, register roots and dispose on the application's initialized UI dispatcher. Async
+/// query/action methods may be called from any thread and marshal all live reads through that
+/// captured production dispatcher. Await them; do not block the UI thread on queued operations.
+/// This package starts no listener and provides no transport authentication. Omit it from applications
+/// that do not need development automation. Dispose the session before shutting down its dispatcher.
+/// </remarks>
+/// <example><code>
+/// using var automation = new AutomationSession();
+/// using var root = automation.RegisterRoot(form);
+/// var found = await automation.FindOneAsync(root.RootId, new AutomationQuery { AutomationId = "save" });
+/// if (found.Error == AutomationErrorCode.None)
+///     await automation.PerformActionAsync(root.RootId, found.Value!.Handle, AccessibleActions.Invoke);
+/// </code></example>
+public sealed partial class AutomationSession : IDisposable
+{
+    private const AutomationCapability AllCapabilities = AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions;
+    private readonly Dispatcher dispatcher;
+    private readonly List<AutomationRootRegistration> roots = [];
+    private volatile bool stopped;
+
+    /// <summary>Creates a new session on the current production UI dispatcher.</summary>
+    /// <param name="capabilities">Explicitly allowed operations; unknown flags are rejected.</param>
+    /// <param name="limits">Immutable limits applying to every traversal; null selects bounded defaults.</param>
+    /// <exception cref="InvalidOperationException">The caller is not on the initialized UI dispatcher.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Capabilities or limits are invalid.</exception>
+    public AutomationSession(AutomationCapability capabilities = AllCapabilities, AutomationQueryOptions? limits = null)
+    {
+        dispatcher = Dispatcher.UIThread;
+        dispatcher.VerifyAccess();
+        ValidateCapabilities(capabilities);
+        Limits = limits ?? new();
+        Limits.Validate();
+        Capabilities = capabilities;
+    }
+
+    /// <summary>Gets a unique random nonce for this session, independent of process IDs and root names.</summary>
+    public string SessionId { get; } = Guid.NewGuid().ToString("N");
+    /// <summary>Gets the session's immutable capability policy.</summary>
+    public AutomationCapability Capabilities { get; }
+    /// <summary>Gets immutable budgets used by all traversals in this session.</summary>
+    public AutomationQueryOptions Limits { get; }
+    /// <summary>Gets whether Stop or Dispose has ended this session; safe to read from any thread.</summary>
+    public bool IsStopped => stopped;
+
+    /// <summary>Registers a borrowed Form or other WindowBase on its UI thread.</summary>
+    /// <param name="root">The live window explicitly allowed for automation; it may be registered before Show.</param>
+    /// <param name="capabilities">The requested root policy, intersected with session capabilities.</param>
+    /// <returns>A disposable registration that never owns or closes the window.</returns>
+    /// <exception cref="ObjectDisposedException">The session or window has ended.</exception>
+    /// <exception cref="InvalidOperationException">The root is already registered or the caller is not on the UI thread.</exception>
+    public AutomationRootRegistration RegisterRoot(WindowBase root, AutomationCapability capabilities = AllCapabilities)
+    {
+        VerifyRegistration(root, capabilities);
+        ObjectDisposedException.ThrowIf(root.InputBindingsClosed, nameof(root));
+        var registration = new AutomationRootRegistration(this, root, Capabilities & capabilities);
+        roots.Add(registration);
+        return registration;
+    }
+
+    /// <summary>Registers a borrowed windowless Skia surface on its UI thread.</summary>
+    /// <param name="root">The live surface. Its canonical Root remains the only semantic source.</param>
+    /// <param name="capabilities">The requested root policy, intersected with session capabilities.</param>
+    /// <returns>A disposable registration; surface/root disposal is checked on each live operation.</returns>
+    /// <exception cref="ObjectDisposedException">The session, surface or root has ended.</exception>
+    /// <exception cref="InvalidOperationException">The surface is already registered or the caller is not on the UI thread.</exception>
+    public AutomationRootRegistration RegisterRoot(SkiaControlSurface root, AutomationCapability capabilities = AllCapabilities)
+    {
+        VerifyRegistration(root, capabilities);
+        ObjectDisposedException.ThrowIf(root.IsDisposed || root.Root.IsDisposed, nameof(root));
+        var registration = new AutomationRootRegistration(this, root, Capabilities & capabilities);
+        roots.Add(registration);
+        return registration;
+    }
+
+    /// <summary>Ends the session on the UI thread, unregistering all roots without closing them. Repeated calls are safe.</summary>
+    public void Stop()
+    {
+        VerifyAccess();
+        if (stopped) return;
+        stopped = true;
+        foreach (var root in roots) root.Detach();
+        roots.Clear();
+    }
+
+    /// <summary>Marshals session cleanup to its production UI dispatcher.</summary>
+    /// <returns>A task completed after subscriptions are removed and every handle is invalidated.</returns>
+    public Task StopAsync()
+    {
+        if (stopped) return Task.CompletedTask;
+        if (dispatcher.CheckAccess()) { Stop(); return Task.CompletedTask; }
+        return dispatcher.InvokeAsync(Stop).GetTask();
+    }
+
+    /// <summary>Ends the session on its UI thread, without disposing application windows or controls.</summary>
+    public void Dispose() => Stop();
+
+    internal void VerifyAccess() => dispatcher.VerifyAccess();
+    internal void Remove(AutomationRootRegistration root) { root.Detach(); roots.Remove(root); }
+    internal bool IsLive(AutomationRootRegistration root)
+    {
+        if (root.TryGetPeer(out _)) return true;
+        Remove(root);
+        return false;
+    }
+
+    private void VerifyRegistration(object root, AutomationCapability capabilities)
+    {
+        VerifyAccess();
+        ArgumentNullException.ThrowIfNull(root);
+        ObjectDisposedException.ThrowIf(stopped, this);
+        ValidateCapabilities(capabilities);
+        PruneRoots();
+        if (roots.Any(r => r.Represents(root))) throw new InvalidOperationException("The root is already registered.");
+        if (roots.Count >= Limits.MaxNodes) throw new InvalidOperationException("The root registration budget is exhausted.");
+    }
+
+    private static void ValidateCapabilities(AutomationCapability capabilities)
+    {
+        if ((capabilities & ~AllCapabilities) != 0) throw new ArgumentOutOfRangeException(nameof(capabilities));
+    }
+
+    private void PruneRoots()
+    {
+        for (int index = roots.Count - 1; index >= 0; index--)
+            if (!roots[index].TryGetPeer(out _)) Remove(roots[index]);
+    }
+
+    private AutomationErrorCode ResolveRoot(string rootId, AutomationCapability capability, out AutomationRootRegistration? root)
+    {
+        root = null;
+        if (stopped) return AutomationErrorCode.SessionEnded;
+        if ((Capabilities & capability) != capability) return AutomationErrorCode.CapabilityDenied;
+        if (string.IsNullOrEmpty(rootId)) return AutomationErrorCode.InvalidArgument;
+        PruneRoots();
+        root = roots.Find(r => string.Equals(r.RootId, rootId, StringComparison.Ordinal));
+        if (root is null) return AutomationErrorCode.StaleNode;
+        return (root.Capabilities & capability) == capability ? AutomationErrorCode.None : AutomationErrorCode.CapabilityDenied;
+    }
+
+    private AutomationErrorCode ValidateHandle(AutomationNodeHandle handle)
+    {
+        if (stopped) return AutomationErrorCode.SessionEnded;
+        if (!string.Equals(handle.SessionId, SessionId, StringComparison.Ordinal)) return AutomationErrorCode.StaleNode;
+        if (!long.TryParse(handle.RuntimeId, NumberStyles.None, CultureInfo.InvariantCulture, out long id)
+            || id <= 0 || !string.Equals(Id(id), handle.RuntimeId, StringComparison.Ordinal)) return AutomationErrorCode.InvalidArgument;
+        return AutomationErrorCode.None;
+    }
+
+    private static string Id(long value) => value.ToString(CultureInfo.InvariantCulture);
+
+    private async Task<AutomationResult<T>> Dispatch<T>(Func<string, AutomationResult<T>> action, CancellationToken token)
+    {
+        string captureId = Guid.NewGuid().ToString("N");
+        if (stopped) return new(default, AutomationErrorCode.SessionEnded, captureId);
+        try
+        {
+            token.ThrowIfCancellationRequested();
+            if (dispatcher.CheckAccess()) return action(captureId);
+            return await dispatcher.InvokeAsync(() => action(captureId), DispatcherPriority.Default, token).GetTask().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested) { throw; }
+        catch (Exception)
+        {
+            // Never forward arbitrary application exception messages, inner exceptions or ToString.
+            return new(default, stopped ? AutomationErrorCode.SessionEnded : AutomationErrorCode.ApplicationError, captureId);
+        }
+    }
+}

--- a/ModernFormsNext.Automation/ModernFormsNext.Automation.csproj
+++ b/ModernFormsNext.Automation/ModernFormsNext.Automation.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>ModernFormsNext.Automation</PackageId>
+    <Title>ModernFormsNext Automation</Title>
+    <Version>$(ModernFormsNextPackageVersion)</Version>
+    <Product>ModernFormsNext.Automation</Product>
+    <Description>Optional in-process semantic inspection and canonical actions for development-time ModernFormsNext automation.</Description>
+    <PackageTags>ui;automation;accessibility;development;forms;framework;modernforms</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\icon.png" Pack="true" PackagePath="\" Link="icon.png" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <ProjectReference Include="..\ModernFormsNext\ModernFormsNext.csproj" />
+  </ItemGroup>
+</Project>

--- a/ModernFormsNext.Automation/README.md
+++ b/ModernFormsNext.Automation/README.md
@@ -1,0 +1,12 @@
+# ModernFormsNext.Automation
+
+Optional development-time **in-process semantic core**, issue #97 Phase 1a. It consumes the
+canonical `AccessibleObject` tree and production UI dispatcher. No Testing dependency, listener,
+IPC, discovery, authentication, MCP, screenshot, input simulation, or wait service is included.
+
+Create a session on the initialized application UI thread, explicitly register allowed windows or
+Skia surfaces, and await its semantic query/action methods. Dispose registrations/session before
+the UI dispatcher stops. The session borrows roots; it does not close application windows.
+
+See [the semantic core guide](https://github.com/ProGraMajster/ModernFormsNext/blob/master/docs/automation.md)
+for lifetime, privacy, query completeness, action acceptance and Phase 1b boundaries.

--- a/ModernFormsNext.Automation/SemanticTraversal.cs
+++ b/ModernFormsNext.Automation/SemanticTraversal.cs
@@ -81,6 +81,9 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
         // getters are never called for a sensitive node or an unknown privacy classification.
         int before = issues.Count;
         bool sensitive = Read(entry, AutomationProperty.IsSensitive, () => peer.IsSensitive, true);
+        // A custom ControlAccessibleObject must not be able to negate its known password owner
+        // merely by overriding IsSensitive/State. Unknown custom owners still use the canonical markers.
+        sensitive |= peer is Control.ControlAccessibleObject { Owner: TextBox { PasswordCharacter: not null } };
         entry.States = Read(entry, AutomationProperty.States, () => peer.State, AccessibleStates.Unavailable);
         entry.Redaction = parent?.Redaction ?? AutomationRedaction.None;
         if (issues.Count != before) entry.Redaction |= AutomationRedaction.PrivacyUnknown;
@@ -91,16 +94,33 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
         before = issues.Count;
         entry.ActualParent = Read(entry, AutomationProperty.Parent, () => peer.Parent, null);
         if (issues.Count != before) return null;
-        if (parent is not null && !ReferenceEquals(entry.ActualParent, parent.Peer))
-        {
-            Add(ReferenceEquals(entry.ActualParent, peer) ? AutomationErrorCode.CycleDetected : AutomationErrorCode.MalformedTree,
-                entry, AutomationProperty.Parent);
-            return null;
-        }
+        if (parent is not null && !ValidateParent(entry, parent)) return null;
         byId.Add(peer.RuntimeId, entry);
         Entries.Add(entry);
         parent?.Children.Add(entry);
         return entry;
+    }
+
+    private bool ValidateParent(Entry entry, Entry expected)
+    {
+        // Canonical Form children intentionally omit FormClientArea although their Parent points
+        // through that implementation peer. Validate the bounded canonical parent chain without
+        // projecting these omitted peers or enumerating a second control/visual tree.
+        var parents = new HashSet<AccessibleObject>(ReferenceEqualityComparer.Instance) { entry.Peer };
+        var current = entry.ActualParent;
+        int depth = 0;
+        while (current is not null)
+        {
+            if (!parents.Add(current)) { Add(AutomationErrorCode.CycleDetected, entry, AutomationProperty.Parent); return false; }
+            if (ReferenceEquals(current, expected.Peer)) return true;
+            if (++depth > limits.MaxDepth || attempts >= limits.MaxNodes) { Limit(entry, AutomationProperty.Parent); return false; }
+            attempts++;
+            token.ThrowIfCancellationRequested();
+            var next = current;
+            current = Read(entry, AutomationProperty.Parent, () => next.Parent, null);
+        }
+        Add(AutomationErrorCode.MalformedTree, entry, AutomationProperty.Parent);
+        return false;
     }
 
     private void Push(Entry entry, Stack<Frame> stack)
@@ -117,6 +137,7 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
     {
         token.ThrowIfCancellationRequested();
         var peer = entry.Peer;
+        RefreshPrivacy(entry);
         string? automationId = null, name = null, value = null;
         AccessibleRangeValue? range = null;
         if (entry.Redaction == AutomationRedaction.None)
@@ -130,9 +151,25 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
         var type = Read(entry, AutomationProperty.ControlType, () => peer.ControlType, AccessibleControlType.Custom);
         var actions = Read(entry, AutomationProperty.SupportedActions, () => peer.SupportedActions, AccessibleActions.None);
         var bounds = Read(entry, AutomationProperty.Bounds, () => peer.Bounds, System.Drawing.Rectangle.Empty);
+        // A getter can reenter application code. Discard captured payload if privacy became
+        // sensitive/unknown during capture instead of returning a value classified earlier.
+        RefreshPrivacy(entry);
+        if (entry.Redaction != AutomationRedaction.None) { automationId = null; name = null; value = null; range = null; }
         return new(new(sessionId, entry.Id), rootId, automationId, name, role, type, entry.States,
             actions, value, range, new(bounds.X, bounds.Y, bounds.Width, bounds.Height, coordinates),
             entry.Parent?.Id, entry.Children.Select(child => child.Id).ToImmutableArray(), entry.Redaction, captureId, entry.Truncated);
+    }
+
+    private void RefreshPrivacy(Entry entry)
+    {
+        int before = issues.Count;
+        bool sensitive = Read(entry, AutomationProperty.IsSensitive, () => entry.Peer.IsSensitive, true);
+        var state = Read(entry, AutomationProperty.States, () => entry.Peer.State, AccessibleStates.Unavailable);
+        entry.Redaction |= entry.Parent?.Redaction ?? AutomationRedaction.None;
+        if (issues.Count != before) entry.Redaction |= AutomationRedaction.PrivacyUnknown;
+        if (sensitive || (state & AccessibleStates.Protected) != 0
+            || entry.Peer is Control.ControlAccessibleObject { Owner: TextBox { PasswordCharacter: not null } })
+            entry.Redaction |= AutomationRedaction.Sensitive;
     }
 
     private string? Text(Entry entry, AutomationProperty property, Func<string?> getter)

--- a/ModernFormsNext.Automation/SemanticTraversal.cs
+++ b/ModernFormsNext.Automation/SemanticTraversal.cs
@@ -12,6 +12,7 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
     private readonly HashSet<AccessibleObject> seen = new(ReferenceEqualityComparer.Instance);
     private readonly List<AutomationIssue> issues = [];
     private int attempts;
+    private long getterFaults;
     internal List<Entry> Entries { get; } = [];
     internal bool Truncated { get; private set; }
     internal AutomationErrorCode Error => issues.Count > 0 ? issues[0].Code
@@ -79,21 +80,21 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
 
         // Read privacy first, fail closed, and propagate it to custom descendants. Payload
         // getters are never called for a sensitive node or an unknown privacy classification.
-        int before = issues.Count;
+        long before = getterFaults;
         bool sensitive = Read(entry, AutomationProperty.IsSensitive, () => peer.IsSensitive, true);
         // A custom ControlAccessibleObject must not be able to negate its known password owner
         // merely by overriding IsSensitive/State. Unknown custom owners still use the canonical markers.
         sensitive |= peer is Control.ControlAccessibleObject { Owner: TextBox { PasswordCharacter: not null } };
         entry.States = Read(entry, AutomationProperty.States, () => peer.State, AccessibleStates.Unavailable);
         entry.Redaction = parent?.Redaction ?? AutomationRedaction.None;
-        if (issues.Count != before) entry.Redaction |= AutomationRedaction.PrivacyUnknown;
+        if (getterFaults != before) entry.Redaction |= AutomationRedaction.PrivacyUnknown;
         if (sensitive || (entry.States & AccessibleStates.Protected) != 0) entry.Redaction |= AutomationRedaction.Sensitive;
         var view = Read(entry, AutomationProperty.View, () => peer.View, AccessibilityView.Hidden);
         if (view == AccessibilityView.Hidden || (entry.States & AccessibleStates.Invisible) != 0) return null;
 
-        before = issues.Count;
+        before = getterFaults;
         entry.ActualParent = Read(entry, AutomationProperty.Parent, () => peer.Parent, null);
-        if (issues.Count != before) return null;
+        if (getterFaults != before) return null;
         if (parent is not null && !ValidateParent(entry, parent)) return null;
         byId.Add(peer.RuntimeId, entry);
         Entries.Add(entry);
@@ -162,11 +163,11 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
 
     private void RefreshPrivacy(Entry entry)
     {
-        int before = issues.Count;
+        long before = getterFaults;
         bool sensitive = Read(entry, AutomationProperty.IsSensitive, () => entry.Peer.IsSensitive, true);
         var state = Read(entry, AutomationProperty.States, () => entry.Peer.State, AccessibleStates.Unavailable);
         entry.Redaction |= entry.Parent?.Redaction ?? AutomationRedaction.None;
-        if (issues.Count != before) entry.Redaction |= AutomationRedaction.PrivacyUnknown;
+        if (getterFaults != before) entry.Redaction |= AutomationRedaction.PrivacyUnknown;
         if (sensitive || (state & AccessibleStates.Protected) != 0
             || entry.Peer is Control.ControlAccessibleObject { Owner: TextBox { PasswordCharacter: not null } })
             entry.Redaction |= AutomationRedaction.Sensitive;
@@ -181,12 +182,21 @@ internal sealed class SemanticTraversal(AutomationQueryOptions limits, Cancellat
 
     internal T Read<T>(Entry entry, AutomationProperty property, Func<T> getter, T fallback)
     {
-        try { return getter(); }
+        token.ThrowIfCancellationRequested();
+        T value;
+        try { value = getter(); }
         catch (Exception)
         {
+            // Fault detection must survive a full diagnostic budget, especially for privacy.
+            // The bounded exported issue collection cannot serve as a success/failure counter.
+            getterFaults++;
             Add(AutomationErrorCode.GetterFault, entry, property);
-            return fallback;
+            value = fallback;
         }
+        // Cancellation is cooperative: observe it after a returning getter, outside the catch
+        // that sanitizes application failures, before invoking another application callback.
+        token.ThrowIfCancellationRequested();
+        return value;
     }
 
     internal void Limit(Entry? entry = null, AutomationProperty property = AutomationProperty.Node)

--- a/ModernFormsNext.Automation/SemanticTraversal.cs
+++ b/ModernFormsNext.Automation/SemanticTraversal.cs
@@ -1,0 +1,188 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using ModernFormsNext.Accessibility;
+
+namespace ModernFormsNext.Automation;
+
+/// <summary>One bounded UI-thread capture. No peer references escape this operation.</summary>
+internal sealed class SemanticTraversal(AutomationQueryOptions limits, CancellationToken token)
+{
+    internal const int MaxTextLength = 4096;
+    private readonly Dictionary<long, Entry> byId = [];
+    private readonly HashSet<AccessibleObject> seen = new(ReferenceEqualityComparer.Instance);
+    private readonly List<AutomationIssue> issues = [];
+    private int attempts;
+    internal List<Entry> Entries { get; } = [];
+    internal bool Truncated { get; private set; }
+    internal AutomationErrorCode Error => issues.Count > 0 ? issues[0].Code
+        : Truncated ? AutomationErrorCode.LimitExceeded : AutomationErrorCode.None;
+    internal ImmutableArray<AutomationIssue> Issues => issues.ToImmutableArray();
+
+    internal Entry? Find(string runtimeId)
+        => long.TryParse(runtimeId, NumberStyles.None, CultureInfo.InvariantCulture, out long id)
+            && byId.TryGetValue(id, out var entry) ? entry : null;
+
+    internal void Walk(AccessibleObject root)
+    {
+        var first = Visit(root, null, 0);
+        if (first is null) return;
+        var stack = new Stack<Frame>();
+        Push(first, stack);
+        while (stack.TryPeek(out var frame))
+        {
+            token.ThrowIfCancellationRequested();
+            if (frame.Next >= frame.Count) { stack.Pop(); continue; }
+            if (attempts >= limits.MaxNodes)
+            {
+                foreach (var pending in stack) pending.Entry.Truncated = true;
+                Limit(frame.Entry, AutomationProperty.Children);
+                break;
+            }
+            int index = frame.Next++;
+            // Count every attempted edge, even null/throwing/repeated/hidden children.
+            // GetChildCount can report Int32.MaxValue without causing proportional allocation.
+            attempts++;
+            AccessibleObject? child = Read(frame.Entry, AutomationProperty.Children, () => frame.Entry.Peer.GetChild(index), null);
+            if (child is null)
+            {
+                Add(AutomationErrorCode.MalformedTree, frame.Entry, AutomationProperty.Children);
+                continue;
+            }
+            var visited = Visit(child, frame.Entry, frame.Entry.Depth + 1);
+            if (visited is not null) Push(visited, stack);
+        }
+
+        // A scoped surface root may have an external semantic parent. A parent pointing back
+        // inside its own captured subtree, however, is a parent cycle; never follow that chain.
+        if (first.ActualParent is { } parent && seen.Contains(parent))
+            Add(AutomationErrorCode.CycleDetected, first, AutomationProperty.Parent);
+    }
+
+    private Entry? Visit(AccessibleObject peer, Entry? parent, int depth)
+    {
+        token.ThrowIfCancellationRequested();
+        if (parent is null) attempts++;
+        var entry = new Entry(peer, parent, depth);
+        if (!seen.Add(peer) || byId.ContainsKey(peer.RuntimeId))
+        {
+            bool cycle = false;
+            for (var ancestor = parent; ancestor is not null; ancestor = ancestor.Parent)
+                if (ReferenceEquals(ancestor.Peer, peer)) { cycle = true; break; }
+            Add(cycle ? AutomationErrorCode.CycleDetected : AutomationErrorCode.DuplicateRuntimeId, entry, AutomationProperty.Node);
+            return null;
+        }
+        if (peer.RuntimeId <= 0)
+        {
+            Add(AutomationErrorCode.MalformedTree, entry, AutomationProperty.Node);
+            return null;
+        }
+
+        // Read privacy first, fail closed, and propagate it to custom descendants. Payload
+        // getters are never called for a sensitive node or an unknown privacy classification.
+        int before = issues.Count;
+        bool sensitive = Read(entry, AutomationProperty.IsSensitive, () => peer.IsSensitive, true);
+        entry.States = Read(entry, AutomationProperty.States, () => peer.State, AccessibleStates.Unavailable);
+        entry.Redaction = parent?.Redaction ?? AutomationRedaction.None;
+        if (issues.Count != before) entry.Redaction |= AutomationRedaction.PrivacyUnknown;
+        if (sensitive || (entry.States & AccessibleStates.Protected) != 0) entry.Redaction |= AutomationRedaction.Sensitive;
+        var view = Read(entry, AutomationProperty.View, () => peer.View, AccessibilityView.Hidden);
+        if (view == AccessibilityView.Hidden || (entry.States & AccessibleStates.Invisible) != 0) return null;
+
+        before = issues.Count;
+        entry.ActualParent = Read(entry, AutomationProperty.Parent, () => peer.Parent, null);
+        if (issues.Count != before) return null;
+        if (parent is not null && !ReferenceEquals(entry.ActualParent, parent.Peer))
+        {
+            Add(ReferenceEquals(entry.ActualParent, peer) ? AutomationErrorCode.CycleDetected : AutomationErrorCode.MalformedTree,
+                entry, AutomationProperty.Parent);
+            return null;
+        }
+        byId.Add(peer.RuntimeId, entry);
+        Entries.Add(entry);
+        parent?.Children.Add(entry);
+        return entry;
+    }
+
+    private void Push(Entry entry, Stack<Frame> stack)
+    {
+        int count = Read(entry, AutomationProperty.Children, entry.Peer.GetChildCount, 0);
+        if (count < 0) { Add(AutomationErrorCode.MalformedTree, entry, AutomationProperty.Children); return; }
+        if (count == 0) return;
+        if (entry.Depth >= limits.MaxDepth) { Limit(entry, AutomationProperty.Children); return; }
+        stack.Push(new(entry, count));
+    }
+
+    internal AutomationNodeSnapshot Capture(Entry entry, string sessionId, string rootId,
+        AutomationCoordinateSpace coordinates, string captureId)
+    {
+        token.ThrowIfCancellationRequested();
+        var peer = entry.Peer;
+        string? automationId = null, name = null, value = null;
+        AccessibleRangeValue? range = null;
+        if (entry.Redaction == AutomationRedaction.None)
+        {
+            automationId = Text(entry, AutomationProperty.AutomationId, () => peer.AutomationId);
+            name = Text(entry, AutomationProperty.Name, () => peer.Name);
+            value = Text(entry, AutomationProperty.Value, () => peer.Value);
+            range = Read(entry, AutomationProperty.RangeValue, () => peer.RangeValue, null);
+        }
+        var role = Read(entry, AutomationProperty.Role, () => peer.Role, AccessibleRole.Default);
+        var type = Read(entry, AutomationProperty.ControlType, () => peer.ControlType, AccessibleControlType.Custom);
+        var actions = Read(entry, AutomationProperty.SupportedActions, () => peer.SupportedActions, AccessibleActions.None);
+        var bounds = Read(entry, AutomationProperty.Bounds, () => peer.Bounds, System.Drawing.Rectangle.Empty);
+        return new(new(sessionId, entry.Id), rootId, automationId, name, role, type, entry.States,
+            actions, value, range, new(bounds.X, bounds.Y, bounds.Width, bounds.Height, coordinates),
+            entry.Parent?.Id, entry.Children.Select(child => child.Id).ToImmutableArray(), entry.Redaction, captureId, entry.Truncated);
+    }
+
+    private string? Text(Entry entry, AutomationProperty property, Func<string?> getter)
+    {
+        string? value = Read(entry, property, getter, null);
+        if (value is { Length: > MaxTextLength }) { Limit(entry, property); return null; }
+        return value;
+    }
+
+    internal T Read<T>(Entry entry, AutomationProperty property, Func<T> getter, T fallback)
+    {
+        try { return getter(); }
+        catch (Exception)
+        {
+            Add(AutomationErrorCode.GetterFault, entry, property);
+            return fallback;
+        }
+    }
+
+    internal void Limit(Entry? entry = null, AutomationProperty property = AutomationProperty.Node)
+    {
+        Truncated = true;
+        if (entry is not null) entry.Truncated = true;
+        Add(AutomationErrorCode.LimitExceeded, entry, property);
+    }
+
+    private void Add(AutomationErrorCode code, Entry? entry, AutomationProperty property)
+    {
+        // Diagnostics must be bounded too, including multiple faults per hostile peer.
+        if (issues.Count < limits.MaxNodes) issues.Add(new(code, entry?.Id, property));
+        else Truncated = true;
+    }
+
+    internal sealed class Entry(AccessibleObject peer, Entry? parent, int depth)
+    {
+        internal AccessibleObject Peer { get; } = peer;
+        internal string Id { get; } = peer.RuntimeId.ToString(CultureInfo.InvariantCulture);
+        internal Entry? Parent { get; } = parent;
+        internal AccessibleObject? ActualParent { get; set; }
+        internal int Depth { get; } = depth;
+        internal AccessibleStates States { get; set; }
+        internal AutomationRedaction Redaction { get; set; }
+        internal bool Truncated { get; set; }
+        internal List<Entry> Children { get; } = [];
+    }
+
+    private sealed class Frame(Entry entry, int count)
+    {
+        internal Entry Entry { get; } = entry;
+        internal int Count { get; } = count;
+        internal int Next { get; set; }
+    }
+}

--- a/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
+++ b/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
@@ -10,6 +10,7 @@ public sealed class ReleaseVersionConsistencyTests
     private static readonly string[] PackableProjects =
     [
         "ModernFormsNext/ModernFormsNext.csproj",
+        "ModernFormsNext.Automation/ModernFormsNext.Automation.csproj",
         "ModernFormsNext.CodeGeneration/ModernFormsNext.CodeGeneration.csproj",
         "ModernFormsNext.Designer/ModernFormsNext.Designer.csproj",
         "ModernFormsNext.Designing/ModernFormsNext.Designing.csproj",

--- a/ModernFormsNext.slnx
+++ b/ModernFormsNext.slnx
@@ -13,6 +13,7 @@
     <Project Path="samples/Outlaw/Outlaw.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="ModernFormsNext.Automation.Tests/ModernFormsNext.Automation.Tests.csproj" />
     <Project Path="ModernFormsNext.CrossPlatform.Sample.Tests/ModernFormsNext.CrossPlatform.Sample.Tests.csproj" />
     <Project Path="ModernFormsNext.Designer.Tests/ModernFormsNext.Designer.Tests.csproj" />
     <Project Path="ModernFormsNext.Testing.Tests/ModernFormsNext.Testing.Tests.csproj" />
@@ -24,6 +25,7 @@
     <Project Path="ModernFormsNext.Tests/ModernFormsNext.Tests.csproj" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="ModernFormsNext.Automation/ModernFormsNext.Automation.csproj" />
     <Project Path="ModernFormsNext.CodeGeneration/ModernFormsNext.CodeGeneration.csproj" />
     <Project Path="ModernFormsNext.Designer/ModernFormsNext.Designer.csproj" />
     <Project Path="ModernFormsNext.Designing/ModernFormsNext.Designing.csproj" />

--- a/ModernFormsNext/Properties/AssemblyInfo.cs
+++ b/ModernFormsNext/Properties/AssemblyInfo.cs
@@ -4,4 +4,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ModernFormsNext.WindowKit.Backend.Android.Tests")]
 [assembly: InternalsVisibleTo("ModernFormsNext.Designer")]
 [assembly: InternalsVisibleTo("ModernFormsNext.Testing")]
+[assembly: InternalsVisibleTo("ModernFormsNext.Automation")]
 [assembly: InternalsVisibleTo("ModernFormsNext.VisualStudioDesignerHost")]

--- a/ModernFormsNext/SkiaControlSurface.cs
+++ b/ModernFormsNext/SkiaControlSurface.cs
@@ -52,6 +52,10 @@ public sealed class SkiaControlSurface : IDisposable, IPlatformAccessibilityHost
     /// <summary>Gets the borrowed root control.</summary>
     public Control Root { get; }
 
+    // Borrowing semantic services must observe surface disposal without retaining the surface or
+    // consulting a platform accessibility adapter. This is a lifetime seam, not another tree.
+    internal bool IsDisposed => disposed;
+
     // The Android host borrows this existing adapter. Surface coordinates are logical pixels
     // relative to the native surface, since this control tree has no WindowBase screen origin.
     IPlatformAccessibleObject? IPlatformAccessibilityHost.AccessibilityRoot

--- a/docs-site/toc.yml
+++ b/docs-site/toc.yml
@@ -20,6 +20,8 @@
   href: content/docs/testing/testhost.md
 - name: Commands and action sources
   href: content/docs/commands.md
+- name: In-process semantic automation
+  href: content/docs/automation.md
 - name: Accessibility semantic model
   href: content/docs/accessibility/semantic-model.md
 - name: Android accessibility backend

--- a/docs/automation-phase1a-audit.md
+++ b/docs/automation-phase1a-audit.md
@@ -47,7 +47,8 @@ canonical children and discards temporary peer references before returning immut
 
 Traversal is depth-first preorder, child indices ascending, roots in registration order. Every
 visit/child attempt counts against a budget; a huge child count never allocates a matching array.
-Parent pointers are validated against the traversed edge, never recursively followed. Duplicate
+Parent pointers are validated against the traversed edge with bounded canonical parent-chain
+hops for omitted implementation peers (FormClientArea), never projected as additional nodes. Duplicate
 RuntimeId and repeated references are errors (RuntimeId is nonvirtual, so genuine duplicates
 require corrupt peers; tests may simulate corruption). Incomplete queries cannot certify unique
 matches or absence. Actions fail closed when reachability cannot be fully validated.

--- a/docs/automation-phase1a-audit.md
+++ b/docs/automation-phase1a-audit.md
@@ -68,3 +68,71 @@ Future transport adapters call the same async semantic methods. No Stream, Socke
 protocol version, discovery, auth/token handshake, IPC, CLI, MCP, timers, event stream, screenshots
 or raw input belongs in this delivery. No #64 Phase 2, #61/#62/#63/#72/#108/#109 implementation.
 Issue #97 stays OPEN; only a local amendment proposal will be prepared after implementation.
+
+## Final public API review
+
+Phase 1a has 18 exported types before and after review. No type exists solely for tests. The
+following contracts remain public because callers need them to invoke the service, own an opt-in
+registration, express a request, or interpret returned data. Internal traversal/entry/frame types,
+redaction logic, dispatcher plumbing and lifetime accessors remain internal. No existing framework
+public API or enum value changes.
+
+| Type | Why public | Stable for Phase 1b? | Verdict |
+| --- | --- | --- | --- |
+| AutomationSession | In-process service and explicit session lifetime | Yes; adapters call its async methods | Keep |
+| AutomationRootRegistration | Disposable borrowed-root scope and effective policy | Yes; token remains in process | Keep |
+| AutomationNodeHandle | Request identity: session plus canonical decimal RuntimeId | Yes; root scope remains required separately | Keep |
+| AutomationNodeSnapshot | Detached semantic output used by clients and predicates | Yes; not a wire schema or revision | Keep |
+| AutomationRootInfo | Detached registered-root description | Yes; no live registration reference | Keep |
+| AutomationQuery | Simple immutable AND filters | Yes; additive filters need no selector language | Keep |
+| AutomationQueryOptions | Caller-selected immutable traversal budgets | Yes; independent of transport limits | Keep |
+| AutomationResult&lt;T&gt; | Typed query data, completeness and safe diagnostics | Yes; no protocol/exception payload | Keep |
+| AutomationIssue | Bounded diagnostic record clients must interpret | Yes; controlled metadata only | Keep |
+| AutomationActionValue | Explicit string/number input without object payloads | Yes; adapters use factories after wire validation | Keep |
+| AutomationActionResult | Action acceptance and semantic error | Yes; business completion stays separate | Keep |
+| AutomationBounds | Immutable canonical geometry with explicit reference frame | Yes; no native handle or clipping claim | Keep |
+| AutomationCapability | Session/root Inspect, Query and Actions policy | Yes; no speculative flags | Keep |
+| AutomationErrorCode | Machine-readable semantic outcomes | Yes; existing values must remain stable | Keep |
+| AutomationProperty | Safe diagnostic field identity | Yes; avoids arbitrary property-name strings | Keep |
+| AutomationActionStatus | Acceptance categories distinct from completion | Yes; no generic Success promise | Keep |
+| AutomationRedaction | Explains omitted private/unknown payload | Yes; bounded diagnostics do not disable privacy | Keep |
+| AutomationCoordinateSpace | Distinguishes window screen and surface geometry | Yes; no backend-specific types | Keep |
+
+The session and registration are live service/lifetime types, not DTOs to serialize. Requests and
+output use strings, numbers, enums, immutable records/arrays and existing immutable range metadata.
+Output getters support serialization; output-only internal constructors intentionally do not promise
+JSON deserialization. A transport must define and validate its own wire envelopes. Public signatures
+contain no JSON dependency. Nullable metadata means absent, redacted or unavailable; result codes
+and diagnostics disambiguate failures. A failed collection request returns an initialized empty array.
+
+Each snapshot field supplies current Phase 1a inspection, identity, query, action discovery, hierarchy,
+privacy, geometry or completeness information. SessionId/RuntimeId are convenience projections of
+Handle, not extra stored identities. CaptureId correlates a returned result and its snapshots today;
+later waits can identify the observation that satisfied a predicate. It does not order captures or
+claim atomicity, a semantic revision, render completion, idle, or business completion.
+
+One captured production UI dispatcher matches current Windows WindowBase and SkiaControlSurface
+ownership. A future server can schedule from I/O threads through the existing async API. Creating
+another dispatcher per root would conflict with current framework ownership. Backend initialization
+is the application's precondition. Android's separate IPlatformDispatcher is not automatically wired
+to this contract; Android bridge scheduling and activity/surface recreation remain future validation,
+not promised parity. Session/registration lifetimes must end before their dispatcher shuts down.
+
+Friend access is granted only to ModernFormsNext.Automation. Its consumed core internals are exactly
+WindowBase.InputBindingsClosed, Control.IsDisposed and SkiaControlSurface.IsDisposed. These are
+read-only lifetime observations; command collections, root adapters and private setters are not used.
+Removing the friend seam would require a larger public core lifetime API or duplicate lifecycle state.
+
+Final review added regressions for a full diagnostic budget followed by a privacy fault, cancellation
+during a getter and final action validation, queued query/action versus session/root termination,
+background StopAsync during a getter, cancellation plus Stop/Dispose, FormClientArea omission, and
+detached/cyclic/over-budget parent chains. Three regression cases failed before the fixes. Fault
+tracking now remains independent of exported diagnostic capacity, and cooperative cancellation is
+checked at returning capture getter boundaries and immediately before the canonical action call.
+
+The default depth64/nodes4096/results1024 budgets stay unchanged. Hard limits bound structural
+storage, result storage, diagnostics and parent hops; huge declared child counts never preallocate
+matching storage. Raising all limits and retaining maximum-length text can still consume substantial
+memory, so defaults are recommended. Synchronous application callbacks must return promptly and
+honor canonical semantics. Reentrant application mutation is not an atomic transaction or a sandbox;
+the canonical action remains the final authority. No polling, timeout or thread-abort feature was added.

--- a/docs/automation-phase1a-audit.md
+++ b/docs/automation-phase1a-audit.md
@@ -1,0 +1,69 @@
+# Issue #97 Phase 1a: semantic core audit
+
+Baseline: `master == origin/master`, `6e3a7cfd148915f51b305aa17296d41fbd9222c1`, divergence 0/0.
+Read the complete current [issue #97](https://github.com/ProGraMajster/ModernFormsNext/issues/97)
+(OPEN, no comments), its acceptance direction, and the local dependency audit and body proposal.
+The issue still describes the complete external bridge. This delivery implements only its
+in-process semantic foundation; it does not meet the external-client acceptance of all Phase 1.
+
+## Capability audit before API design
+
+| Capability | Existing source | How #97 will reuse it | Gap |
+| --- | --- | --- | --- |
+| Canonical peers | `Accessibility/AccessibleObject.cs`, `Control.Accessibility.cs` | Read the actual cached accessibility objects | Defensive snapshot projection |
+| Runtime identity | `AccessibleObject.RuntimeId` | Nonvirtual, immutable, atomically assigned positive Int64 | Session nonce and decimal-string handles |
+| Locator | `Control.ControlAccessibleObject.AutomationId` | Exact ordinal match; fallback to Control.Name is canonical | Zero/one/multiple result contract |
+| Role/type/state | `AccessibleRole`, `AccessibleControlType`, `AccessibleStates` | Copy canonical values | Immutable bounded result |
+| Logical/custom children | `Control.ControlAccessibleObject.LogicalChildren.cs`, `GetAccessibilityChildren` | Traverse GetChildCount/GetChild in index order | Cycle, duplicate, parent consistency, count and getter fault protection |
+| Active projection | `EnumerateActiveChildren`, peer View/State | Respect Hidden/Invisible and logical expansion | Absence must not imply disposal |
+| Item lifetime | Occurrence identity for ListBox; ConditionalWeakTable for TreeView | Re-resolve each live operation | Tests must distinguish occurrence replacement from cached peer reinsertion |
+| Privacy | IsSensitive, Protected, TextBox password semantics | Central conservative redaction before reading payload fields | Custom getters and exception text are untrusted |
+| Range | AccessibleRangeValue, TrackBar/ProgressBar peers | Copy immutable range; validate finite values and bounds | No arbitrary parameter object in DTO |
+| Actions/focus | SupportedActions/PerformAction; Control.Select | Advertised canonical operations only | Validate current state and return accepted/rejected status |
+| Commands | Button.PerformClick, CommandSource, Delegate/Routed/AsyncCommand | Invoke through canonical activation, preserving Click and CanExecute | No command catalog; accepted is not async completion |
+| UI thread | WindowKit.Threading.Dispatcher.UIThread/InvokeAsync | Capture production dispatcher at session creation | Async entry from background callers |
+| Window roots | WindowBase.AccessibilityObject, Closed/Disposed | Explicit borrowed root registration, weak ownership | Already-ended check uses existing internal InputBindingsClosed lifetime flag |
+| Surface roots | SkiaControlSurface.Root and Dispose | Register root peer with surface coordinates | Minimal internal disposed-state accessor; no public agent APIs |
+| Notifications | AccessibleObject.ClientNotification | Reserve for later waits design | Not a complete tree event stream; no subscriptions/polling now |
+| Tests | ModernFormsTestHost, UiTestDispatcher, TestWindowHost | Real Form/controls and production dispatcher in tests | New Automation.Tests references both packages |
+
+## Design decisions
+
+Use a separate optional `ModernFormsNext.Automation` package targeting `net10.0`, depending only
+on the neutral ModernFormsNext target. It follows existing package metadata/readme/XML conventions.
+Do not change versions or add third-party dependencies. Testing and platform backends are not core
+dependencies. Core never references Automation.
+
+Sessions are explicit and created on the existing UI dispatcher. Roots are borrowed, weakly held,
+and individually disposable; window close/disposal removes registration without stopping other
+roots. Surface disposal is checked when registration state or a live operation is observed.
+The only framework seam is friend access for existing window lifetime state and a read-only
+internal surface disposed accessor. No new public Control/Application/Form API is needed.
+
+Handles contain session nonce plus canonical runtime ID, both strings. Root scope is a separate
+registration ID, required on every node query/action. Re-registration gets a new root ID.
+There is no persistent peer index or second tree: each bounded UI operation traverses allowed
+canonical children and discards temporary peer references before returning immutable DTOs.
+
+Traversal is depth-first preorder, child indices ascending, roots in registration order. Every
+visit/child attempt counts against a budget; a huge child count never allocates a matching array.
+Parent pointers are validated against the traversed edge, never recursively followed. Duplicate
+RuntimeId and repeated references are errors (RuntimeId is nonvirtual, so genuine duplicates
+require corrupt peers; tests may simulate corruption). Incomplete queries cannot certify unique
+matches or absence. Actions fail closed when reachability cannot be fully validated.
+
+Public errors contain only codes and fixed enum metadata, never arbitrary exception messages,
+ToString output or request parameters. Sensitive/protected peers redact value/range and textual
+metadata conservatively; privacy propagates to descendants. Getter faults do not terminate a
+session. Snapshots and queries report structured faults and explicit truncation.
+
+## Deferred contracts
+
+Waits will consume query predicates, immutable state, capture IDs, scoped handles, completeness
+and error codes. Do not publish speculative WaitCondition APIs: Phase 1b must design notification
+registration/reconciliation, cancellation, monotonic deadlines and narrow idle checkpoints.
+
+Future transport adapters call the same async semantic methods. No Stream, Socket, JSON attributes,
+protocol version, discovery, auth/token handshake, IPC, CLI, MCP, timers, event stream, screenshots
+or raw input belongs in this delivery. No #64 Phase 2, #61/#62/#63/#72/#108/#109 implementation.
+Issue #97 stays OPEN; only a local amendment proposal will be prepared after implementation.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -64,6 +64,23 @@ on unregister/stop. There are no semantic-change subscriptions in Phase 1a. Stop
 invalidates every handle. `Stop`, `Dispose`, `RegisterRoot`, and registration `IsRegistered`/`Dispose`
 are UI-thread-affine. `StopAsync` marshals cleanup for a background caller.
 
+One session captures one `WindowKit.Threading.Dispatcher.UIThread` for its entire lifetime.
+Current Windows windows and windowless surfaces use that application dispatcher, so multiple roots
+do not require multiple dispatchers. Initialization is an application precondition: `VerifyAccess`
+checks thread access, not whether a real backend was initialized. Do not construct the session
+before platform startup or carry it across replacement/shutdown of its dispatcher. A future live
+server can call the async methods from its own I/O threads without owning a UI dispatcher.
+
+The Android backend also has a separate `IPlatformDispatcher` service. Phase 1a does not adapt that
+service or claim Android-host automation parity. A future Android bridge must verify scheduling
+and activity/surface lifetime explicitly; registering a surface alone is not proof of that integration.
+No speculative dispatcher-injection or multiple-dispatcher API is introduced here.
+
+A background `StopAsync` request takes effect when its queued cleanup executes. It cannot interrupt
+the current synchronous getter or action. Once cleanup has executed, queued operations cannot act.
+Cancellation is checked before/after returning capture getters and immediately before dispatching
+an action. A cancellation request does not undo already executed application work.
+
 ## Identity, scope and lifetime
 
 Every session gets a random nonce independent of PID. An `AutomationNodeHandle` contains exactly
@@ -75,6 +92,12 @@ Each operation also requires the root registration ID. There is no cross-root or
 fallback. Re-registering the same window produces a new root ID, while its canonical peer may keep
 the same runtime ID. `AutomationId` is an exact ordinal locator, may fall back to Control.Name,
 may be null for logical items, and may match multiple nodes.
+
+The pair `root.RootId` and `snapshot.Handle` is the required operation scope. The snapshot/root
+descriptor already carries both, so clients need not infer IDs. Keeping registration scope separate
+from canonical identity lets the same peer participate in independently permitted registrations;
+neither a composite handle nor a second identity counter is needed. Transport adapters may wrap
+these existing values in a request envelope without changing semantic identity.
 
 Every query/action re-traverses the allowed active canonical tree. Temporary peer/edge maps exist
 only during that UI operation. They are discarded before DTOs leave the dispatcher; there is no
@@ -168,6 +191,10 @@ It suppresses Value, RangeValue, Name and AutomationId for sensitive nodes and t
 including untrusted custom peers. Payload getters are skipped when privacy is already sensitive
 or unknown. Failed privacy/state getters cause conservative redaction. Privacy is rechecked during
 capture; an escalation discards already captured payload.
+
+`PrivacyUnknown` specifically means a failing privacy/state getter. An ordinary custom
+`AccessibleObject` inherits `IsSensitive == false` and remains queryable without an extra marker.
+Fault tracking remains effective even after the bounded diagnostic collection fills up.
 
 This conservative policy intentionally omits even labels/locators on a password node. An application
 can address such a node by a known runtime handle or an unambiguous type/state query, for example

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,242 @@
+# In-process semantic automation
+
+`ModernFormsNext.Automation` is the optional development-time semantic core from **issue #97
+Phase 1a**. It reads the existing `AccessibleObject` hierarchy and executes existing semantic
+actions. It can be used in an initialized live application or in `ModernFormsNext.Testing` tests.
+The runtime package depends only on the platform-neutral ModernFormsNext target, never Testing,
+Windows/Android backends or MCP. Existing application startup and accessibility behavior remain
+unchanged when this package is omitted.
+
+This is an in-process API. It opens no endpoint, enumerates no processes, and implements no
+discovery, authentication, IPC, CLI, event stream, wait service or MCP adapter. The whole #97
+issue remains open. A session ID identifies a semantic lifetime; it is **not an authentication
+token** or a security boundary against application code already running in the same process.
+
+## Opt-in and ownership
+
+Create the session on the application's initialized production UI dispatcher. Register only the
+windows or surfaces that the developer explicitly permits. Registrations may precede window
+Show; they do not implicitly register other open windows.
+
+```csharp
+using ModernFormsNext;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.Automation;
+
+// On the application's UI thread, after normal platform startup:
+var form = new Form { Text = "Orders" };
+var save = form.Controls.Add(new Button
+{
+    Name = "saveOrder",
+    Text = "Save",
+    Command = new DelegateCommand(() => SaveOrder())
+});
+
+#if DEBUG
+using var automation = new AutomationSession(
+    AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions);
+using var root = automation.RegisterRoot(form);
+
+var found = await automation.FindOneAsync(root.RootId,
+    new AutomationQuery { AutomationId = "saveOrder" });
+if (found.Error == AutomationErrorCode.None)
+{
+    var action = await automation.PerformActionAsync(root.RootId,
+        found.Value!.Handle, AccessibleActions.Invoke);
+    // Accepted means canonical activation accepted the request. SaveOrder may still be running.
+}
+#endif
+```
+
+`SaveOrder` represents application-owned behavior. Keep the session/registration alive for the
+intended development scope; dispose them before the owning dispatcher shuts down. An application
+may also explicitly opt into testing its Release build, or omit the package and activation code
+entirely. Merely referencing the assembly starts nothing.
+
+`RegisterRoot(WindowBase)` covers Form and other existing windows. `RegisterRoot(SkiaControlSurface)`
+borrows `surface.Root`; it does not create a new host. Window close/disposal immediately unregisters
+that window. A cancelled close preserves registration. Surface disposal, root disposal and garbage
+collection invalidate registration; surface disposal/collection is pruned when registration state
+or a live operation is observed. Unregistering never disposes the application root.
+
+The session and registration tokens hold roots weakly. Window lifetime subscriptions are removed
+on unregister/stop. There are no semantic-change subscriptions in Phase 1a. Stop is idempotent and
+invalidates every handle. `Stop`, `Dispose`, `RegisterRoot`, and registration `IsRegistered`/`Dispose`
+are UI-thread-affine. `StopAsync` marshals cleanup for a background caller.
+
+## Identity, scope and lifetime
+
+Every session gets a random nonce independent of PID. An `AutomationNodeHandle` contains exactly
+the session nonce and `AccessibleObject.RuntimeId` as an invariant positive decimal **string**.
+This preserves every Int64 bit when a later JavaScript client reads the DTO. No replacement
+global node counter or control-name identity is introduced.
+
+Each operation also requires the root registration ID. There is no cross-root or cross-session
+fallback. Re-registering the same window produces a new root ID, while its canonical peer may keep
+the same runtime ID. `AutomationId` is an exact ordinal locator, may fall back to Control.Name,
+may be null for logical items, and may match multiple nodes.
+
+Every query/action re-traverses the allowed active canonical tree. Temporary peer/edge maps exist
+only during that UI operation. They are discarded before DTOs leave the dispatcher; there is no
+persistent peer cache or second semantic tree.
+
+| Change | Handle behavior |
+| --- | --- |
+| Same control reordered | Same canonical peer and handle |
+| Removed/detached or Hidden/Invisible | Currently unavailable; this is not proof of disposal |
+| Same cached control/TreeView peer reinserted | Resolvable again if #59 preserves its RuntimeId |
+| ListBox occurrence removed and added again | New occurrence identity, as defined by #59 |
+| New control with the same name | New RuntimeId; old handle never retargets |
+| Wrong root | NodeUnavailable; no fallback to another root |
+| Other session or ended root registration | StaleNode |
+| Stopped session | SessionEnded |
+
+## Queries and immutable snapshots
+
+The async methods are `GetRootsAsync`, `InspectAsync`, `GetChildrenAsync`, `FindOneAsync` and
+`FindAllAsync`. Find filters combine AutomationId, accessible Name, normalized ControlType,
+all-required States and all-excluded States with AND. Null filters are ignored. Empty strings
+match only empty strings. There is no XPath/CSS language or reflection query.
+
+```csharp
+var selectedItems = await automation.FindAllAsync(root.RootId, new AutomationQuery
+{
+    ControlType = AccessibleControlType.ListItem,
+    RequiredStates = AccessibleStates.Selected,
+    ExcludedStates = AccessibleStates.Unavailable
+});
+if (selectedItems.Error != AutomationErrorCode.None || selectedItems.Truncated)
+{
+    // Inspect the safe Issues; do not infer that the returned list is complete.
+}
+```
+
+Traversal is depth-first preorder, including the registered root, with canonical child indices
+ascending. Root descriptors preserve registration order. Child queries return direct projected
+children. Snapshot parent IDs describe these traversed edges within the registered scope. Form's
+canonical child enumeration skips its internal FormClientArea although Parent pointers pass
+through that peer; bounded parent-chain validation accepts this existing projection without
+adding the omitted peer to query results. Outside-scope parents are not exported.
+
+`FindOne` returns NodeNotFound for zero complete matches, a snapshot for exactly one complete
+match, and AmbiguousMatch when at least two match. A limit or getter fault cannot certify uniqueness
+or absence. A second candidate is checked even when MaxResults is one; no `FindFirst` behavior is
+silently substituted.
+
+Snapshots contain session/root/runtime IDs, locator/name, canonical role/type/states/actions,
+safe value/range, bounds, projected parent/child IDs, redaction reasons, truncation and capture ID.
+They contain no Control, AccessibleObject, object payload, delegate, CLR Type, native handle or
+exception. Child IDs and result/diagnostic collections are immutable. Error collection results
+use initialized empty arrays and can be inspected/serialized safely.
+
+CaptureId identifies one UI operation, not a semantic revision, a completed render, a transaction
+across async work, or an assertion that state is still current. Window bounds preserve canonical
+screen coordinates; windowless bounds preserve surface coordinates, in logical pixels. Bounds do
+not claim complete clipping, occlusion or native accessibility parity.
+
+## Limits and faulty custom peers
+
+Session `AutomationQueryOptions` is immutable:
+
+| Option | Default | Accepted range |
+| --- | --- | --- |
+| MaxDepth | 64 | 0–256; root depth is zero |
+| MaxNodes | 4096 | 1–100000 |
+| MaxResults | 1024 | 1–100000 |
+
+MaxNodes counts node/child attempts, including malformed or hidden children, plus parent-chain
+hops through omitted peers. MaxResults also bounds root descriptors. The registration count is
+bounded by MaxNodes. Each exported/input text field is limited to 4096 UTF-16 code units; oversized
+output is omitted and reported as LimitExceeded. Action/query inputs exceeding that limit return
+InvalidArgument. Diagnostics are bounded by MaxNodes too.
+
+Cycles, repeated references, duplicate RuntimeId, invalid/null child entries, negative child count
+and inconsistent parent chains return structured issues. A huge reported count never causes an
+equally huge preallocation or unbounded child loop. Getter exceptions are caught without ending
+the session and appear as GetterFault. Incomplete data has explicit Error/Issues/Truncated metadata;
+check all three. Actions fail closed when traversal cannot establish valid reachability.
+
+These are cooperative in-process bounds. They cannot preempt a single synchronous getter that
+blocks forever or enumerates infinitely inside its own implementation. Custom peers must return
+promptly and obey their semantic contract. This layer is not a sandbox for hostile application
+code or a hard real-time deadline service. The framework model is unchanged.
+
+## Privacy and errors
+
+One central capture layer classifies IsSensitive, Protected and known password TextBox owners.
+It suppresses Value, RangeValue, Name and AutomationId for sensitive nodes and their descendants,
+including untrusted custom peers. Payload getters are skipped when privacy is already sensitive
+or unknown. Failed privacy/state getters cause conservative redaction. Privacy is rechecked during
+capture; an escalation discards already captured payload.
+
+This conservative policy intentionally omits even labels/locators on a password node. An application
+can address such a node by a known runtime handle or an unambiguous type/state query, for example
+ControlType.Edit with RequiredStates.Protected. There is no filtering by a redacted value. Ordinary
+editable TextBox.Name follows #59 semantics and never falls back to the user's Text.
+
+Password SetValue is allowed when Actions and the canonical peer permit it, with no value readback
+in the action result. The caller owns any secret in `AutomationActionValue`; do not log/echo or
+serialize it as diagnostics. Its ToString returns only a fixed label. The action service accepts
+no arbitrary object parameter. Existing application CommandParameter objects remain inside the
+normal command path and are never formatted by Automation.
+
+Client-facing failures contain only controlled codes and property/ID metadata. They never include
+Exception.Message, Exception.ToString, control text, action values or arbitrary parameter.ToString.
+No exception/log/diagnostic event stream is exposed. An unmarked custom peer can still deliberately
+misrepresent private data as ordinary semantic metadata; application code must honor the canonical
+privacy markers. Phase 1a cannot infer secrets from arbitrary strings.
+
+## Actions and dispatcher
+
+`PerformActionAsync` supports Invoke, Focus, SetValue, Select, Toggle, Expand, Collapse, Increment,
+Decrement and ScrollIntoView **only when currently advertised**. Scroll has no Phase 1a parameter
+contract and returns Unsupported. Exactly one flag is required. Only SetValue accepts a typed text
+or finite numeric value; null clears text. Range minimum/maximum/read-only semantics are checked,
+and TrackBar's integral natural value is enforced. Other peer-specific rules remain canonical.
+
+All live reads, range validation, state rechecks and PerformAction run on the captured production
+Dispatcher. Same-thread calls use Dispatcher.Invoke's existing context; background calls use its
+InvokeAsync queue. No additional SynchronizationContext, worker UI thread or dispatcher is created.
+Cancellation stops queued work or traversal between getters, and never rolls back an action.
+Do not synchronously wait on an unfinished operation from the UI thread.
+
+Reachability is checked again after getter-based action validation, since custom callbacks can
+detach/close a node. The canonical implementation remains the final authority on state/action
+acceptance. The service does not execute ICommand directly, invoke private event handlers, set
+AccessibleObject.Value directly, or use reflection. Button activation preserves Click ordering,
+CommandSource, CanExecute and Delegate/Routed/AsyncCommand behavior.
+
+| Action status | Meaning |
+| --- | --- |
+| Accepted | PerformAction returned true; business work may still be running |
+| Rejected | Canonical false, unavailable state or capability denial; see Error |
+| Unsupported | Not advertised or outside the Phase 1a allowlist |
+| NodeUnavailable | Stale/ended scope, no active node, or invalid/incomplete reachability |
+| InvalidArgument | Invalid action flags or typed value |
+| ApplicationError | Getter or action threw; no private exception detail is exported |
+
+A throwing action may already have changed application state. Do not automatically retry a
+mutation after ApplicationError. An accepted AsyncCommand can remain IsExecuting until its
+application-owned Task finishes. Acceptance does not prove command execution after a Click handler
+changed CanExecute, or business success after later async completion.
+
+## TestHost integration and future seams
+
+Only `ModernFormsNext.Automation.Tests` references both Automation and Testing. It creates real
+Forms, buttons with Delegate/Routed/AsyncCommand, TextBox/password, CheckBox, RadioButton, ListBox,
+TreeView and custom semantic children. It verifies actual state changes, canonical identity,
+bounded malformed peers, privacy, root/session lifetime and background dispatch with explicit
+dispatcher drains and controlled task completion.
+
+No public WaitCondition is published speculatively. Phase 1b can use existing immutable filters,
+states, capture metadata, root-scoped handles, safe errors and completeness flags. It must separately
+design condition evaluation, notification subscription/reconciliation, cancellation/deadlines and
+narrow idle checkpoints. ClientNotification is not assumed to cover all custom changes.
+
+Future named-pipe/other transport adapters call these same async methods. No Stream/Socket, JSON
+attribute, wire protocol version, auth handshake or MCP type is present in the core contract.
+Phase 1b still needs Windows IPC, discovery/authentication, live waits and a minimal client; actual
+external-client acceptance follows separately. Events, screenshots, MCP and broader diagnostics
+remain their later scope. No #64 Phase 2 or #61/#62/#63/#72/#108/#109 work is part of this package.
+
+See the [pre-implementation audit](automation-phase1a-audit.md) for the source capability matrix.

--- a/scripts/Build-ReleaseDocumentation.ps1
+++ b/scripts/Build-ReleaseDocumentation.ps1
@@ -317,6 +317,7 @@ if (Test-Path -LiteralPath $workingRoot) {
 try {
     $apiAssemblies = @(
         [pscustomobject]@{ Id = 'ModernFormsNext'; Tfm = 'net10.0' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.Automation'; Tfm = 'net10.0' },
         [pscustomobject]@{ Id = 'ModernFormsNext.CodeGeneration'; Tfm = 'net10.0' },
         [pscustomobject]@{ Id = 'ModernFormsNext.Designer'; Tfm = 'net10.0-windows' },
         [pscustomobject]@{ Id = 'ModernFormsNext.Designing'; Tfm = 'net10.0' },

--- a/scripts/Validate-ReleasePackages.ps1
+++ b/scripts/Validate-ReleasePackages.ps1
@@ -22,6 +22,7 @@ if ([string]::IsNullOrWhiteSpace($ExpectedVersion)) {
 
 $packageSpecs = @(
     [pscustomobject]@{ Id = "ModernFormsNext"; Frameworks = @("net10.0", "net10.0-windows"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.Automation"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
     [pscustomobject]@{ Id = "ModernFormsNext.CodeGeneration"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
     [pscustomobject]@{ Id = "ModernFormsNext.Designer"; Frameworks = @("net10.0-windows"); Symbols = $true; Template = $false },
     [pscustomobject]@{ Id = "ModernFormsNext.Designing"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
@@ -169,6 +170,9 @@ function Assert-PackageArchive {
         foreach ($dependency in @($nuspec.Metadata.SelectNodes(".//*[local-name()='dependency']"))) {
             $dependencyId = $dependency.GetAttribute('id')
             $dependencyVersion = $dependency.GetAttribute('version')
+            if ($Spec.Id -ceq 'ModernFormsNext.Automation' -and $dependencyId -cne 'ModernFormsNext') {
+                throw "Automation must depend only on the neutral ModernFormsNext core; found '$dependencyId'."
+            }
             if ($dependencyId -ceq 'Microsoft.VisualStudio.SDK' -or ($dependencyId -ceq 'MessagePack' -and $dependencyVersion -match '2\.5\.192')) {
                 throw "Package '$Path' contains forbidden dependency '$dependencyId' version '$dependencyVersion'."
             }


### PR DESCRIPTION
## Summary

Introduces the opt-in, in-process semantic foundation for #97. Development tools can register application roots, inspect immutable semantic state, find nodes without guessing among duplicate locators, and request normal control actions.

## Automation core

- Separate `ModernFormsNext.Automation` package targeting `net10.0`, with only ModernFormsNext as its direct dependency.
- `AutomationSession`, explicit borrowed window/surface roots, immutable snapshots, bounded queries and canonical actions on the production UI dispatcher.
- Independent Inspect/Query/Actions capability policies, structured errors, weak root ownership and stop/disposal handling.
- Final review retained 18 documented public types. Three reproduced regressions were fixed: privacy fault detection after diagnostic capacity is exhausted, cancellation between capture getters, and cancellation during final action validation. Added parent-chain and queued lifetime regressions.

## Canonical reuse

Every operation traverses the existing active `AccessibleObject` hierarchy and discards temporary peer references before returning. There is no second semantic tree. Actions call `AccessibleObject.PerformAction`, preserving normal control activation, Click ordering, current CanExecute and Delegate/Routed/AsyncCommand routing. No reflection or direct command execution is added.

Core changes are limited to friend access and an internal surface disposal accessor; no existing public framework API changes.

## Identity

Handles combine a session nonce with the canonical RuntimeId encoded as an invariant decimal string, preserving Int64 precision. Every node operation also requires the exact root registration ID. AutomationId is a nonunique locator. Reordering preserves identity, replacement never retargets an old handle, and reinsertion follows canonical peer lifetime. Hidden/detached means currently unavailable, not necessarily disposed.

## Privacy

Sensitive/protected/password nodes and descendants omit textual metadata, value and range. Failed privacy/state getters fail closed, including after diagnostics fill their budget; ordinary unmarked custom peers remain queryable. Errors contain controlled codes/property/ID metadata, never exception messages or arbitrary ToString output. Action payloads are explicitly typed and never echoed in results.

## Async semantics

Accepted means the canonical action returned true; it does not mean async business work completed. CaptureId identifies an observation, not a revision, atomic transaction or idle checkpoint. StopAsync from a worker queues cleanup; synchronous getters cannot be preempted. One initialized production dispatcher owns the session. Android's separate dispatcher service is not automatically integrated by registering a surface.

## Scope boundary

Not implemented: IPC, discovery, authentication, live waits, CLI, MCP, event stream, screenshots or raw input. Android-host bridge scheduling remains future work. No release, tag, version bump or package publication is included.

## Validation

Final pre-push commit: `76c472f68ff1fc4577e675c785ba137e7d874e79`.

- Restore; Debug/Release solution and explicit VSIX builds: pass, zero warnings/errors.
- Full tests: 2281/2281 in each configuration, zero failures/skips. Automation: 115/115 each (query33, identity9, actions27, privacy17, threading14, lifecycle15).
- Other full suites each: core1149, Designer640, Testing104, cross-platform16, VSIX26, Android164, Windows67.
- Regressions each: canonical accessibility32, Windows UIA55 including real HWND/client, Android accessibility84 (mapper52/provider32), and the TRX test-name command subset408 across the full solution. Additional filtered runs explicitly selected accessibility, command methods, Testing, Designer, cross-platform and VSIX.
- ApiCompat: nine existing package assembly/TFM pairs against master `6e3a7cf`, in both configurations. Automation is additive.
- Documentation script tests32; DocFX with warnings as errors; four documentation archives validated for this commit.
- Ten local NuGet packages and nine symbol packages validated. Fresh package-only consumer: surface registration, query, Button Invoke → DelegateCommand, TextBox SetValue and actual state; no Testing or platform backend dependency.
- Final diff and privacy-marker output scan pass.

Manual visual, Android emulator/device and TalkBack checks: not executed. Templates/startup are unchanged and template verification was not required.

## Issue state

Progresses #97 — Phase 1a only. **#97 remains OPEN.** Phase 1b remains Windows IPC, discovery/authentication, bounded live waits and a minimal CLI; MCP remains a later separate adapter. The issue-body amendment proposal remains local and unpublished.
