### PR TITLE
Add Phase 1b Windows live automation bridge

### DIFF
--- a/ModernFormsNext.Automation.Cli/ModernFormsNext.Automation.Cli.csproj
+++ b/ModernFormsNext.Automation.Cli/ModernFormsNext.Automation.Cli.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ModernFormsNext.Automation.Windows\ModernFormsNext.Automation.Windows.csproj" />
+  </ItemGroup>
+</Project>

--- a/ModernFormsNext.Automation.Cli/Program.cs
+++ b/ModernFormsNext.Automation.Cli/Program.cs
@@ -92,6 +92,7 @@ internal static class Cli
                 return SemanticExit(captured.Error);
             }
             AutomationNodeHandle? handle = Get("--node") is { } runtime && Get("--session") is { } session ? new(session, runtime) : null;
+            if ((Get("--node") is null) != (Get("--session") is null)) return Error("FullHandleRequired", 2);
             if (command == "inspect")
             {
                 if (handle is null) return Error("FullHandleRequired", 2);

--- a/ModernFormsNext.Automation.Cli/Program.cs
+++ b/ModernFormsNext.Automation.Cli/Program.cs
@@ -1,0 +1,158 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.Automation;
+using ModernFormsNext.Automation.Windows;
+
+return await Cli.Run(args);
+
+// A small nonpackable diagnostic executable. All transport and semantics use the public client.
+// No pipe handle, credential, control, reflection dispatch, UIA or input simulation is used here.
+internal static class Cli
+{
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
+    private static readonly HashSet<string> ValueOptions = ["--instance", "--pid", "--root", "--session", "--node",
+        "--automation-id", "--name", "--action", "--condition", "--equals", "--states", "--timeout-ms", "--depth", "--number"];
+
+    internal static async Task<int> Run(string[] args)
+    {
+        var options = new Dictionary<string, string?>(StringComparer.Ordinal); bool json = args.Contains("--json");
+        using var cancelled = new CancellationTokenSource();
+        Console.CancelKeyPress += OnCancel;
+        void OnCancel(object? sender, ConsoleCancelEventArgs e) { e.Cancel = true; cancelled.Cancel(); }
+        try
+        {
+            if (args.Length == 0 || args[0] == "help")
+            {
+                Console.WriteLine("mfn-automation list|info|connect|roots|tree|find|inspect|action|wait --instance ID|--pid PID [--root ID] [--json]");
+                Console.WriteLine("find: --automation-id ID|--name NAME; inspect/action: --session ID --node ID; action: --action Invoke|SetValue [--value-stdin|--number N]");
+                Console.WriteLine("wait: --condition KIND [--automation-id ID|--session ID --node ID] [--equals TEXT|--value-stdin] [--timeout-ms 10000]; tree: --depth 3");
+                return args.Length == 0 ? 2 : 0;
+            }
+            string command = args[0];
+            if (command is not ("list" or "connect" or "info" or "roots" or "tree" or "find" or "inspect" or "action" or "wait")) return Error("Usage", 2);
+            for (int index = 1; index < args.Length; index++)
+            {
+                string key = args[index];
+                if (options.ContainsKey(key)) return Error("Usage", 2);
+                if (key is "--json" or "--value-stdin") options.Add(key, null);
+                else if (ValueOptions.Contains(key) && index + 1 < args.Length) options.Add(key, args[++index]);
+                else return Error("Usage", 2);
+            }
+            var applications = await AutomationDiscovery.DiscoverAsync(cancelled.Token);
+            if (command == "list")
+            {
+                if (json) Print(applications);
+                else foreach (var app in applications) Console.WriteLine($"{app.ApplicationName}\t{app.ProcessId}\t{app.InstanceId}\t{app.Capabilities}");
+                return 0;
+            }
+            string? instance = Get("--instance"), pidText = Get("--pid");
+            if ((instance is null) == (pidText is null)) return Error("InstanceOrPidRequired", 2);
+            int pid = 0;
+            if (pidText is not null && (!int.TryParse(pidText, NumberStyles.None, CultureInfo.InvariantCulture, out pid) || pid <= 0)) return Error("Usage", 2);
+            var matches = applications.Where(app => instance is not null ? app.InstanceId == instance : app.ProcessId == pid).ToArray();
+            if (matches.Length != 1) return Error(matches.Length == 0 ? "ApplicationUnavailable" : "AmbiguousInstance", 4);
+            await using var client = await WindowsAutomationClient.ConnectAsync(matches[0], cancellationToken: cancelled.Token);
+            if (command is "connect" or "info") { Print(await client.GetSessionInfoAsync(cancelled.Token)); return 0; }
+            if (command == "roots") { var roots = await client.GetRootsAsync(cancelled.Token); Print(roots); return SemanticExit(roots.Error); }
+            string? rootId = Get("--root");
+            if (rootId is null)
+            {
+                var roots = await client.GetRootsAsync(cancelled.Token);
+                if (roots.Error != AutomationErrorCode.None || roots.Value.Length != 1) return Error("RootRequired", 2);
+                rootId = roots.Value[0].RootId;
+            }
+            var query = new AutomationQuery { AutomationId = Get("--automation-id"), Name = Get("--name") };
+            if (command == "find") { var found = await client.FindOneAsync(rootId, query, cancelled.Token); Print(found); return SemanticExit(found.Error); }
+            if (command == "tree")
+            {
+                int depthLimit = Integer("--depth", 3, 0, 32);
+                var captured = await client.FindAllAsync(rootId, new(), cancelled.Token);
+                var depths = new Dictionary<string, int>(StringComparer.Ordinal); var rows = new List<TreeRow>();
+                foreach (var node in captured.Value)
+                {
+                    // This indexes only detached output indentation, never live peers or a
+                    // second semantic identity. Core preorder and parent IDs remain authoritative.
+                    int depth = node.ParentRuntimeId is { } parent && depths.TryGetValue(parent, out int parentDepth) ? parentDepth + 1 : 0;
+                    depths[node.RuntimeId] = depth;
+                    if (depth <= depthLimit) rows.Add(new(depth, node));
+                }
+                if (json) Print(new { captured.Error, captured.Truncated, captured.Issues, Nodes = rows });
+                else
+                {
+                    foreach (var row in rows) Console.WriteLine($"{new string(' ', row.Depth * 2)}{row.Node.RuntimeId} {row.Node.ControlType} {SafeText(row.Node.AutomationId)} {SafeText(row.Node.Name)}");
+                    if (captured.Error != AutomationErrorCode.None) Console.WriteLine($"Error: {captured.Error}");
+                }
+                return SemanticExit(captured.Error);
+            }
+            AutomationNodeHandle? handle = Get("--node") is { } runtime && Get("--session") is { } session ? new(session, runtime) : null;
+            if (command == "inspect")
+            {
+                if (handle is null) return Error("FullHandleRequired", 2);
+                var inspected = await client.InspectAsync(rootId, handle.Value, cancelled.Token); Print(inspected); return SemanticExit(inspected.Error);
+            }
+            if (command == "action")
+            {
+                if (handle is null || !Enum.TryParse<AccessibleActions>(Get("--action"), false, out var action)) return Error("Usage", 2);
+                if (options.ContainsKey("--value-stdin") && options.ContainsKey("--number")) return Error("Usage", 2);
+                AutomationActionValue? value = options.ContainsKey("--value-stdin") ? AutomationActionValue.FromText(await ReadValue(cancelled.Token)) : null;
+                if (Get("--number") is { } number)
+                {
+                    if (!double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double numeric) || !double.IsFinite(numeric)) return Error("Usage", 2);
+                    value = AutomationActionValue.FromNumber(numeric);
+                }
+                var result = await client.PerformActionAsync(rootId, handle.Value, action, value, cancelled.Token);
+                Print(result); return SemanticExit(result.Error);
+            }
+            if (!Enum.TryParse<AutomationWaitKind>(Get("--condition"), false, out var kind) || !Enum.IsDefined(kind)) return Error("Usage", 2);
+            if (options.ContainsKey("--value-stdin") && options.ContainsKey("--equals")) return Error("Usage", 2);
+            AccessibleStates states = AccessibleStates.None;
+            if (Get("--states") is { } stateText && !Enum.TryParse(stateText, false, out states)) return Error("Usage", 2);
+            var condition = new AutomationWaitCondition
+            {
+                Kind = kind, Handle = handle, Query = kind == AutomationWaitKind.RootEnded || handle is not null ? null : query,
+                Value = options.ContainsKey("--value-stdin") ? await ReadValue(cancelled.Token) : Get("--equals"), States = states
+            };
+            var waited = await client.WaitForConditionAsync(rootId, condition,
+                new() { Timeout = TimeSpan.FromMilliseconds(Integer("--timeout-ms", 10000, 0, 60000)) }, cancelled.Token);
+            Print(waited);
+            return waited.Status == AutomationWaitStatus.Satisfied ? 0 : waited.Status == AutomationWaitStatus.Cancelled ? 130 : 3;
+        }
+        catch (AutomationTransportException error) { return Error(error.Error.ToString(), error.Error == AutomationTransportError.OutcomeUnknown ? 5 : error.Error == AutomationTransportError.Cancelled ? 130 : 4); }
+        catch (OperationCanceledException) { return Error("Cancelled", 130); }
+        catch (ArgumentException) { return Error("Usage", 2); }
+        catch (Exception) { return Error("ApplicationUnavailable", 4); }
+        finally { Console.CancelKeyPress -= OnCancel; }
+
+        string? Get(string key) => options.GetValueOrDefault(key);
+        int Integer(string key, int fallback, int minimum, int maximum)
+        {
+            if (Get(key) is not { } text) return fallback;
+            if (!int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out int value) || value < minimum || value > maximum) throw new ArgumentException();
+            return value;
+        }
+        void Print<T>(T value) => Console.WriteLine(JsonSerializer.Serialize(value, Json));
+        int Error(string code, int exit) { if (json) Print(new { Error = code }); else Console.Error.WriteLine(code); return exit; }
+    }
+
+    private static int SemanticExit(AutomationErrorCode error) => error == AutomationErrorCode.None ? 0 : 3;
+    private static string SafeText(string? text) => text is null ? "" : JsonSerializer.Serialize(text);
+    private static async Task<string> ReadValue(CancellationToken token)
+    {
+        char[] buffer = new char[4097]; int length = 0;
+        while (length < buffer.Length)
+        {
+            int count = await Console.In.ReadAsync(buffer.AsMemory(length), token);
+            if (count == 0) return new string(buffer, 0, length);
+            length += count;
+        }
+        throw new ArgumentException();
+    }
+    private sealed record TreeRow(int Depth, AutomationNodeSnapshot Node);
+}

--- a/ModernFormsNext.Automation.Tests/WaitTests.cs
+++ b/ModernFormsNext.Automation.Tests/WaitTests.cs
@@ -1,0 +1,176 @@
+using System.Diagnostics;
+using System.Reflection;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.WindowKit.Threading;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Tests;
+
+[Trait("Category", "Wait")]
+public sealed class WaitTests
+{
+    [Theory]
+    [InlineData(AutomationWaitKind.NodeExists)]
+    [InlineData(AutomationWaitKind.Exposed)]
+    [InlineData(AutomationWaitKind.Enabled)]
+    [InlineData(AutomationWaitKind.Focused)]
+    [InlineData(AutomationWaitKind.Selected)]
+    [InlineData(AutomationWaitKind.StateContains)]
+    [InlineData(AutomationWaitKind.ValueEquals)]
+    public void AlreadySatisfiedCompletesWithoutQueuedWork(AutomationWaitKind kind)
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        c.Child.States = AccessibleStates.Focused | AccessibleStates.Selected; c.Child.Value = "Done";
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Kind = kind, Handle = f.Handle(c.Child), Value = "Done", States = AccessibleStates.Selected },
+            new() { Timeout = TimeSpan.Zero }).Completed();
+        Assert.Equal(AutomationWaitStatus.Satisfied, result.Status);
+        AssertNoObservation(f, c.Child);
+    }
+
+    [Fact]
+    public void ChangeBetweenInitialReadAndSubscriptionIsRereadWithoutWaiting()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl()); int reads = 0;
+        c.Child.ValueGetter = () => ++reads == 1 ? "Pending" : "Done";
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Kind = AutomationWaitKind.ValueEquals, Handle = f.Handle(c.Child), Value = "Done" },
+            new() { ReconciliationInterval = TimeSpan.FromSeconds(1) }).Completed();
+        Assert.Equal(AutomationWaitStatus.Satisfied, result.Status); Assert.Equal(2, reads);
+        AssertNoObservation(f, c.Child);
+    }
+
+    [Fact]
+    public void NotificationWakesAndRereadsActualValue()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl()); c.Child.Value = "Pending";
+        var pending = WaitValue(f, c, interval: TimeSpan.FromSeconds(1));
+        Assert.False(pending.IsCompleted);
+        c.Child.Value = "Done"; c.Child.NotifyClients(AccessibleEvents.ValueChange);
+        Assert.Equal(AutomationWaitStatus.Satisfied, Pump(f, pending).Status);
+        AssertNoObservation(f, c.Child);
+    }
+
+    [Fact]
+    public void MissingNotificationUsesBoundedReconciliation()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl()); c.Child.Value = "Pending";
+        var pending = WaitValue(f, c); c.Child.Value = "Done";
+        Assert.Equal(AutomationWaitStatus.Satisfied, Pump(f, pending).Status); AssertNoObservation(f, c.Child);
+    }
+
+    [Theory]
+    [InlineData("cancel", AutomationWaitStatus.Cancelled)]
+    [InlineData("timeout", AutomationWaitStatus.TimedOut)]
+    [InlineData("root", AutomationWaitStatus.RootEnded)]
+    [InlineData("session", AutomationWaitStatus.SessionEnded)]
+    public void EveryUnsuccessfulEndDetachesObservers(string end, AutomationWaitStatus expected)
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl());
+        using var cancellation = new CancellationTokenSource();
+        var pending = WaitValue(f, c, cancellation.Token, timeout: end == "timeout" ? TimeSpan.FromMilliseconds(80) : null);
+        if (end == "cancel") cancellation.Cancel();
+        if (end == "root") f.Root.Dispose();
+        if (end == "session") f.Session.Stop();
+        Assert.Equal(expected, Pump(f, pending).Status); AssertNoObservation(f, c.Child);
+    }
+
+    [Fact]
+    public void RootEndedWaitObservesUnregistration()
+    {
+        using var f = new AutomationFixture();
+        var pending = f.Session.WaitForConditionAsync(f.Root.RootId, new() { Kind = AutomationWaitKind.RootEnded });
+        f.Root.Dispose(); Assert.Equal(AutomationWaitStatus.Satisfied, Pump(f, pending).Status);
+    }
+
+    [Fact]
+    public void CompleteAbsenceSatisfiesNodeNotExposed()
+    {
+        using var f = new AutomationFixture();
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Kind = AutomationWaitKind.NodeNotExposed, Query = new() { AutomationId = "absent" } }).Completed();
+        Assert.Equal(AutomationWaitStatus.Satisfied, result.Status); Assert.Null(result.Snapshot);
+    }
+
+    [Fact]
+    public void IncompleteTraversalCannotCertifyAbsence()
+    {
+        using var f = new AutomationFixture(new() { MaxNodes = 1 }); f.Add(new Button());
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Kind = AutomationWaitKind.NodeNotExposed, Query = new() { AutomationId = "absent" } }).Completed();
+        Assert.Equal(AutomationWaitStatus.Failed, result.Status); Assert.Equal(AutomationErrorCode.LimitExceeded, result.Error);
+    }
+
+    [Fact]
+    public void RedactedValueCannotBeUsedAsAnEqualityOracle()
+    {
+        using var f = new AutomationFixture(); var c = f.Add(new SemanticControl()); int reads = 0;
+        c.Child.SensitiveGetter = () => true; c.Child.ValueGetter = () => { reads++; return "secret"; };
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Kind = AutomationWaitKind.ValueEquals, Handle = f.Handle(c.Child), Value = "secret" }).Completed();
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, result.Error); Assert.Equal(0, reads); AssertNoObservation(f, c.Child);
+    }
+
+    [Fact]
+    public void StaleSessionHandleIsNotRootClosure()
+    {
+        using var f = new AutomationFixture();
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Handle = new("another-session", "1") }).Completed();
+        Assert.Equal(AutomationWaitStatus.Failed, result.Status); Assert.Equal(AutomationErrorCode.StaleNode, result.Error);
+    }
+
+    [Fact]
+    public void QueryRequiresQueryCapability()
+    {
+        using var f = new AutomationFixture(capabilities: AutomationCapability.Inspect);
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId, new() { Query = new() }).Completed();
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, result.Error);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(60001)]
+    public void InvalidTimeoutIsSafeFailure(int milliseconds)
+    {
+        using var f = new AutomationFixture();
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId, new() { Query = new() },
+            new() { Timeout = TimeSpan.FromMilliseconds(milliseconds) }).Completed();
+        Assert.Equal(AutomationErrorCode.InvalidArgument, result.Error);
+    }
+
+    [Fact]
+    public void CheckpointAlwaysQueuesAndPreservesEarlierNormalPriorityWork()
+    {
+        using var f = new AutomationFixture(); bool earlierRan = false;
+        f.Host.Dispatcher.Post(() => earlierRan = true);
+        var checkpoint = f.Session.CheckpointAsync(); Assert.False(checkpoint.IsCompleted);
+        Assert.Equal(AutomationErrorCode.None, Pump(f, checkpoint)); Assert.True(earlierRan);
+    }
+
+    private static Task<AutomationWaitResult> WaitValue(AutomationFixture f, SemanticControl c, CancellationToken token = default,
+        TimeSpan? interval = null, TimeSpan? timeout = null)
+        => f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Kind = AutomationWaitKind.ValueEquals, Handle = f.Handle(c.Child), Value = "Done" },
+            new() { Timeout = timeout ?? TimeSpan.FromSeconds(5), ReconciliationInterval = interval ?? TimeSpan.FromMilliseconds(20) }, token);
+
+    private static T Pump<T>(AutomationFixture f, Task<T> task)
+    {
+        // TestHost has a manually pumped dispatcher; bounded yielding drives asynchronous wakeups
+        // without blocking that dispatcher or adding sleeps to the condition protocol.
+        var timer = Stopwatch.StartNew();
+        // Drain asserts global queue emptiness, which is intentionally not guaranteed while a
+        // background continuation posts more work. Use its existing one-job test seam instead.
+        var runOne = typeof(Dispatcher).GetMethod("RunOneJobForTesting", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Func<bool>>(Dispatcher.UIThread);
+        while (!task.IsCompleted && timer.Elapsed < TimeSpan.FromSeconds(10)) { runOne(); Thread.Yield(); }
+        Assert.True(task.IsCompleted); return task.GetAwaiter().GetResult();
+    }
+
+    private static void AssertNoObservation(AutomationFixture f, ScriptPeer peer)
+    {
+        // Test-only inspection verifies cleanup of the actual event subscriptions, not a surrogate counter.
+        Assert.Null(typeof(AccessibleObject).GetField("ClientNotification", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(peer));
+        Assert.Null(typeof(AutomationSession).GetField("lifetimeChanged", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(f.Session));
+    }
+}

--- a/ModernFormsNext.Automation.Tests/WaitTests.cs
+++ b/ModernFormsNext.Automation.Tests/WaitTests.cs
@@ -128,6 +128,31 @@ public sealed class WaitTests
         Assert.Equal(AutomationErrorCode.CapabilityDenied, result.Error);
     }
 
+    [Fact]
+    public void AmbiguousQueryFailsWithoutChoosingATargetOrSubscribing()
+    {
+        using var f = new AutomationFixture();
+        f.Add(new Button { AccessibleAutomationId = "duplicate" });
+        f.Add(new Button { AccessibleAutomationId = "duplicate" });
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Query = new() { AutomationId = "duplicate" } }).Completed();
+        Assert.Equal(AutomationWaitStatus.Failed, result.Status);
+        Assert.Equal(AutomationErrorCode.AmbiguousMatch, result.Error);
+        Assert.Null(result.Snapshot);
+        Assert.Null(typeof(AutomationSession).GetField("lifetimeChanged", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(f.Session));
+    }
+
+    [Fact]
+    public void ZeroTimeoutStillChecksAbsenceWithoutSubscribing()
+    {
+        using var f = new AutomationFixture();
+        var result = f.Session.WaitForConditionAsync(f.Root.RootId,
+            new() { Query = new() { AutomationId = "absent" } }, new() { Timeout = TimeSpan.Zero }).Completed();
+        Assert.Equal(AutomationWaitStatus.TimedOut, result.Status);
+        Assert.Equal(AutomationErrorCode.None, result.Error);
+        Assert.Null(typeof(AutomationSession).GetField("lifetimeChanged", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(f.Session));
+    }
+
     [Theory]
     [InlineData(-1)]
     [InlineData(60001)]

--- a/ModernFormsNext.Automation.Windows.TestHost/ModernFormsNext.Automation.Windows.TestHost.csproj
+++ b/ModernFormsNext.Automation.Windows.TestHost/ModernFormsNext.Automation.Windows.TestHost.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ModernFormsNext.Automation.Windows\ModernFormsNext.Automation.Windows.csproj" />
+    <ProjectReference Include="..\ModernFormsNext\ModernFormsNext.csproj" />
+  </ItemGroup>
+</Project>

--- a/ModernFormsNext.Automation.Windows.TestHost/Program.cs
+++ b/ModernFormsNext.Automation.Windows.TestHost/Program.cs
@@ -30,6 +30,7 @@ if (args.Contains("--privacy"))
     form.Controls.Add(new PrivateControl());
     form.Controls.Add(new FaultControl());
 }
+if (args.Contains("--crash-setvalue")) form.Controls.Add(new CrashValueControl());
 AutomationSession? semantic = null; AutomationRootRegistration? root = null; AutomationRootRegistration? otherRoot = null;
 WindowsAutomationServer? server = null;
 form.Shown += (_, _) =>
@@ -120,5 +121,19 @@ internal sealed class FaultControl : Control
         public override AccessibleActions SupportedActions => AccessibleActions.SetValue;
         public override bool PerformAction(AccessibleActions action, object? parameter = null)
             => throw new InvalidOperationException("ACTION-MARKER-97:" + parameter);
+    }
+}
+
+// Proves a canonical SetValue can enter application code and lose its response without
+// exposing its parameter or relying on transport-specific failure injection.
+internal sealed class CrashValueControl : Control
+{
+    protected override AccessibleObject CreateAccessibilityInstance() => new Peer(this);
+    private sealed class Peer(Control owner) : ControlAccessibleObject(owner)
+    {
+        public override string? AutomationId => "crash-value";
+        public override AccessibleActions SupportedActions => AccessibleActions.SetValue;
+        public override bool PerformAction(AccessibleActions action, object? parameter = null)
+        { Console.WriteLine("ACTION-ENTERED"); Environment.Exit(97); return true; }
     }
 }

--- a/ModernFormsNext.Automation.Windows.TestHost/Program.cs
+++ b/ModernFormsNext.Automation.Windows.TestHost/Program.cs
@@ -36,16 +36,27 @@ form.Shown += (_, _) =>
 {
     try
     {
-        semantic = new(); root = semantic.RegisterRoot(form);
+        semantic = args.Contains("--inspect-session") ? new(AutomationCapability.Inspect) : new();
+        root = semantic.RegisterRoot(form, args.Contains("--inspect-root") ? AutomationCapability.Inspect
+            : AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions);
         secondary.Show(); otherRoot = semantic.RegisterRoot(secondary);
         if (!args.Contains("--no-server")) server = WindowsAutomationServer.Start(semantic, new()
         {
             ApplicationName = "ModernFormsNext bridge test host",
+            Capabilities = args.Contains("--inspect-server") ? AutomationCapability.Inspect
+                : AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions,
             MaxResponseBytes = args.Contains("--small-response") ? 4096 : 4 * 1024 * 1024
         });
+        bool duplicateRejected = false;
+        if (args.Contains("--double-start"))
+        {
+            try { _ = WindowsAutomationServer.Start(semantic); }
+            catch (AutomationTransportException error) when (error.Error == AutomationTransportError.Busy) { duplicateRejected = true; }
+        }
         Console.WriteLine("READY:" + JsonSerializer.Serialize(new
         {
             ProcessId = Environment.ProcessId, Application = server?.Application,
+            DuplicateRejected = duplicateRejected,
             RootId = root.RootId, OtherRootId = otherRoot.RootId,
             Password = new AutomationNodeHandle(semantic.SessionId, password.AccessibilityObject.RuntimeId.ToString())
         }));

--- a/ModernFormsNext.Automation.Windows.TestHost/Program.cs
+++ b/ModernFormsNext.Automation.Windows.TestHost/Program.cs
@@ -20,6 +20,8 @@ var invoke = new Button { AccessibleAutomationId = "invoke", Text = "Invoke", Bo
 var asyncButton = new Button { AccessibleAutomationId = "async", Text = "Async", Bounds = new(190, 105, 150, 36),
     Command = new AsyncCommand(async () => { status.Text = "Pending"; await gate.Task; status.Text = "Completed"; }) };
 form.Controls.Add(status); form.Controls.Add(input); form.Controls.Add(password); form.Controls.Add(invoke); form.Controls.Add(asyncButton);
+form.Controls.Add(new Button { AccessibleAutomationId = "crash-action", Text = "Crash action", Bounds = new(360, 105, 150, 36),
+    Command = new DelegateCommand(() => { Console.WriteLine("ACTION-ENTERED"); Environment.Exit(97); }) });
 form.Controls.Add(new CheckBox { AccessibleAutomationId = "check", Text = "Check", Bounds = new(20, 155, 150, 32) });
 var list = new ListBox { AccessibleAutomationId = "list", Bounds = new(20, 200, 250, 150) }; list.Items.Add("One"); list.Items.Add("Two"); form.Controls.Add(list);
 var tree = new TreeView { AccessibleAutomationId = "tree", Bounds = new(290, 200, 250, 150) }; tree.Items.Add(new TreeViewItem("Parent", new TreeViewItem("Child"))); form.Controls.Add(tree);

--- a/ModernFormsNext.Automation.Windows.TestHost/Program.cs
+++ b/ModernFormsNext.Automation.Windows.TestHost/Program.cs
@@ -1,0 +1,111 @@
+using System.Drawing;
+using System.Text.Json;
+using ModernFormsNext;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.Automation;
+using ModernFormsNext.Automation.Windows;
+using ModernFormsNext.WindowKit.Threading;
+
+// Dedicated real native fixture. Stdin is a test-only application control plane, never part of
+// the bridge protocol. It releases deterministic async gates and controls process/root lifetime.
+using var form = new Form { Text = "ModernFormsNext live bridge fixture", ClientSize = new Size(620, 500) };
+using var secondary = new Form { Text = "Closable bridge root", ClientSize = new Size(220, 140) };
+var status = new TextBox { AccessibleAutomationId = "status", Text = "Ready", ReadOnly = true, Bounds = new(20, 20, 500, 32) };
+var input = new TextBox { AccessibleAutomationId = "input", Text = "Initial", Bounds = new(20, 60, 250, 32) };
+var password = new TextBox { AccessibleAutomationId = "password-secret", Text = "PASSWORD-MARKER-97", PasswordCharacter = '*', Bounds = new(290, 60, 250, 32) };
+var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+int invocations = 0;
+var invoke = new Button { AccessibleAutomationId = "invoke", Text = "Invoke", Bounds = new(20, 105, 150, 36),
+    Command = new DelegateCommand(() => status.Text = "Invoked:" + ++invocations) };
+var asyncButton = new Button { AccessibleAutomationId = "async", Text = "Async", Bounds = new(190, 105, 150, 36),
+    Command = new AsyncCommand(async () => { status.Text = "Pending"; await gate.Task; status.Text = "Completed"; }) };
+form.Controls.Add(status); form.Controls.Add(input); form.Controls.Add(password); form.Controls.Add(invoke); form.Controls.Add(asyncButton);
+form.Controls.Add(new CheckBox { AccessibleAutomationId = "check", Text = "Check", Bounds = new(20, 155, 150, 32) });
+var list = new ListBox { AccessibleAutomationId = "list", Bounds = new(20, 200, 250, 150) }; list.Items.Add("One"); list.Items.Add("Two"); form.Controls.Add(list);
+var tree = new TreeView { AccessibleAutomationId = "tree", Bounds = new(290, 200, 250, 150) }; tree.Items.Add(new TreeViewItem("Parent", new TreeViewItem("Child"))); form.Controls.Add(tree);
+if (args.Contains("--privacy"))
+{
+    form.Controls.Add(new PrivateControl());
+    form.Controls.Add(new FaultControl());
+}
+AutomationSession? semantic = null; AutomationRootRegistration? root = null; AutomationRootRegistration? otherRoot = null;
+WindowsAutomationServer? server = null;
+form.Shown += (_, _) =>
+{
+    try
+    {
+        semantic = new(); root = semantic.RegisterRoot(form);
+        secondary.Show(); otherRoot = semantic.RegisterRoot(secondary);
+        if (!args.Contains("--no-server")) server = WindowsAutomationServer.Start(semantic, new()
+        {
+            ApplicationName = "ModernFormsNext bridge test host",
+            MaxResponseBytes = args.Contains("--small-response") ? 4096 : 4 * 1024 * 1024
+        });
+        Console.WriteLine("READY:" + JsonSerializer.Serialize(new
+        {
+            ProcessId = Environment.ProcessId, Application = server?.Application,
+            RootId = root.RootId, OtherRootId = otherRoot.RootId,
+            Password = new AutomationNodeHandle(semantic.SessionId, password.AccessibilityObject.RuntimeId.ToString())
+        }));
+        // Console's synchronized reader can block even through ReadLineAsync. Isolate this
+        // fixture-only stdin loop from the UI thread, then dispatch each application command.
+        _ = Task.Run(ReadCommands);
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine("START-ERROR:" + (error is AutomationTransportException transport ? transport.Error.ToString() : error.GetType().Name));
+        form.Close();
+    }
+};
+
+async Task ReadCommands()
+{
+    while (await Console.In.ReadLineAsync() is { } command)
+    {
+        // All actual UI changes use the production dispatcher; this is application fixture code,
+        // not an alternative automation action implementation.
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (command == "complete") gate.TrySetResult();
+            else if (command == "close-root") secondary.Close();
+            else if (command == "remove-input") form.Controls.Remove(input);
+            else if (command == "crash") Environment.Exit(97);
+            else if (command == "stop-server") _ = StopServer();
+            else if (command == "quit") _ = Quit();
+        }).GetTask().ConfigureAwait(false);
+    }
+}
+async Task StopServer()
+{
+    if (server is not null) await server.StopAsync();
+    Console.WriteLine("SERVER-STOPPED:" + (semantic?.IsStopped == false));
+}
+async Task Quit()
+{
+    if (server is not null) await server.StopAsync();
+    root?.Dispose(); otherRoot?.Dispose(); semantic?.Dispose(); secondary.Close(); form.Close();
+}
+Application.Run(form);
+
+internal sealed class PrivateControl : Control
+{
+    protected override AccessibleObject CreateAccessibilityInstance() => new Peer(this);
+    private sealed class Peer(Control owner) : ControlAccessibleObject(owner)
+    {
+        public override bool IsSensitive => true;
+        public override string? Name { get => "CUSTOM-GETTER-MARKER-97"; set { } }
+        public override string? Value { get => "SENSITIVE-MARKER-97"; set { } }
+    }
+}
+internal sealed class FaultControl : Control
+{
+    protected override AccessibleObject CreateAccessibilityInstance() => new Peer(this);
+    private sealed class Peer(Control owner) : ControlAccessibleObject(owner)
+    {
+        public override string? AutomationId => "fault";
+        public override string? Name { get => throw new InvalidOperationException("EXCEPTION-MARKER-97"); set { } }
+        public override AccessibleActions SupportedActions => AccessibleActions.SetValue;
+        public override bool PerformAction(AccessibleActions action, object? parameter = null)
+            => throw new InvalidOperationException("ACTION-MARKER-97:" + parameter);
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/CliTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/CliTests.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Cli")]
+[Trait("Category", "Process")]
+public sealed class CliTests
+{
+    [Fact]
+    public async Task CliSmokeUsesSeparateProcessesForListRootsFindActionWaitAndInspect()
+    {
+        await using var host = await ProcessFixture.Start();
+        var list = await Run(null, "list", "--json"); Assert.Equal(0, list.Exit); Assert.Contains(host.Application!.InstanceId, list.Output);
+        var roots = await Target(host, "roots"); Assert.Equal(0, roots.Exit);
+        var find = await Target(host, "find", "--automation-id", "invoke"); Assert.Equal(0, find.Exit);
+        var handle = Handle(find.Output);
+        var action = await Target(host, "action", "--session", handle.SessionId, "--node", handle.RuntimeId, "--action", "Invoke");
+        Assert.Equal(0, action.Exit); Assert.Contains("Accepted", action.Output);
+        var wait = await Target(host, "wait", "--condition", "ValueEquals", "--automation-id", "status", "--equals", "Invoked:1");
+        Assert.Equal(0, wait.Exit); Assert.Contains("Satisfied", wait.Output);
+        var status = await Target(host, "find", "--automation-id", "status"); var statusHandle = Handle(status.Output);
+        var inspect = await Target(host, "inspect", "--session", statusHandle.SessionId, "--node", statusHandle.RuntimeId);
+        Assert.Equal(0, inspect.Exit); Assert.Contains("Invoked:1", inspect.Output);
+        SaveSmoke("cli-smoke", new[] { list, roots, find, action, wait, inspect });
+    }
+
+    [Fact]
+    public async Task CliTreeHasBoundedDepthAndReadableText()
+    {
+        await using var host = await ProcessFixture.Start();
+        var tree = await Target(host, "tree", "--depth", "0"); Assert.Equal(0, tree.Exit);
+        using var json = JsonDocument.Parse(tree.Output); Assert.Single(json.RootElement.GetProperty("nodes").EnumerateArray());
+        var text = await Run(null, "tree", "--instance", host.Application!.InstanceId, "--root", host.RootId, "--depth", "1");
+        Assert.Equal(0, text.Exit); Assert.Contains("invoke", text.Output); Assert.DoesNotContain("PASSWORD-MARKER-97", text.Output);
+    }
+
+    [Fact]
+    public async Task CliSetValueUsesStdinAndNeverEchoesTheProtectedParameter()
+    {
+        await using var host = await ProcessFixture.Start(); const string secret = "CLI-ACTION-PARAMETER-MARKER-97";
+        var action = await Run(secret, "action", "--instance", host.Application!.InstanceId, "--root", host.RootId,
+            "--session", host.Password.SessionId, "--node", host.Password.RuntimeId, "--action", "SetValue", "--value-stdin", "--json");
+        Assert.Equal(0, action.Exit);
+        var inspected = await Target(host, "inspect", "--session", host.Password.SessionId, "--node", host.Password.RuntimeId);
+        Assert.Equal(0, inspected.Exit); Assert.DoesNotContain(secret, action.Output + action.Error + inspected.Output + string.Join("", host.Output));
+    }
+
+    [Fact]
+    public async Task CliPrivacyOutputDoesNotExposeCustomGettersOrExceptions()
+    {
+        await using var host = await ProcessFixture.Start("--privacy");
+        var tree = await Target(host, "tree"); Assert.Equal(3, tree.Exit);
+        foreach (string marker in new[] { "PASSWORD-MARKER-97", "CUSTOM-GETTER-MARKER-97", "SENSITIVE-MARKER-97", "EXCEPTION-MARKER-97" })
+            Assert.DoesNotContain(marker, tree.Output + tree.Error);
+    }
+
+    [Fact]
+    public async Task CliAsyncWaitObservesCompletedWithoutClientSleep()
+    {
+        await using var host = await ProcessFixture.Start();
+        var found = await Target(host, "find", "--automation-id", "async"); var handle = Handle(found.Output);
+        var accepted = await Target(host, "action", "--session", handle.SessionId, "--node", handle.RuntimeId, "--action", "Invoke");
+        Assert.Contains("Accepted", accepted.Output);
+        var before = await Target(host, "find", "--automation-id", "status"); Assert.Contains("Pending", before.Output);
+        var pending = Target(host, "wait", "--condition", "ValueEquals", "--automation-id", "status", "--equals", "Completed");
+        Assert.False(pending.IsCompleted); await host.Send("complete");
+        var done = await pending; Assert.Equal(0, done.Exit); Assert.Contains("Completed", done.Output);
+        SaveSmoke("cli-async", new[] { accepted, before, done });
+    }
+
+    [Fact]
+    public async Task CliRequiresExplicitIdentityAndSupportsPidSelection()
+    {
+        await using var first = await ProcessFixture.Start(); await using var second = await ProcessFixture.Start();
+        var ambiguous = await Run(null, "info", "--json"); Assert.Equal(2, ambiguous.Exit); Assert.Contains("InstanceOrPidRequired", ambiguous.Output);
+        var selected = await Run(null, "info", "--pid", second.Process.Id.ToString(), "--json");
+        Assert.Equal(0, selected.Exit); Assert.Contains(second.Application!.InstanceId, selected.Output); Assert.DoesNotContain(first.Application!.InstanceId, selected.Output);
+    }
+
+    [Fact]
+    public async Task CliUnknownMutationHasDistinctExitCode()
+    {
+        await using var host = await ProcessFixture.Start();
+        var found = await Target(host, "find", "--automation-id", "crash-action"); var handle = Handle(found.Output);
+        var action = await Target(host, "action", "--session", handle.SessionId, "--node", handle.RuntimeId, "--action", "Invoke");
+        Assert.Equal(5, action.Exit); Assert.Contains("OutcomeUnknown", action.Output);
+        await host.Process.WaitForExitAsync(); await AutomationDiscovery.DiscoverAsync();
+    }
+
+    [Fact]
+    public async Task OversizedStdinFailsBeforeChangingTheTarget()
+    {
+        await using var host = await ProcessFixture.Start();
+        var found = await Target(host, "find", "--automation-id", "input"); var handle = Handle(found.Output);
+        var action = await Run(new string('x', 4097), "action", "--instance", host.Application!.InstanceId, "--root", host.RootId,
+            "--session", handle.SessionId, "--node", handle.RuntimeId, "--action", "SetValue", "--value-stdin", "--json");
+        Assert.Equal(2, action.Exit); Assert.DoesNotContain(new string('x', 100), action.Output + action.Error);
+        Assert.Contains("Initial", (await Target(host, "inspect", "--session", handle.SessionId, "--node", handle.RuntimeId)).Output);
+    }
+
+    private static AutomationNodeHandle Handle(string output)
+    {
+        using var json = JsonDocument.Parse(output);
+        var handle = json.RootElement.GetProperty("value").GetProperty("handle");
+        return new(handle.GetProperty("sessionId").GetString()!, handle.GetProperty("runtimeId").GetString()!);
+    }
+    private static Task<CliResult> Target(ProcessFixture host, string command, params string[] arguments)
+        => Run(null, [command, "--instance", host.Application!.InstanceId, "--root", host.RootId, "--json", .. arguments]);
+
+    private static async Task<CliResult> Run(string? input, params string[] arguments)
+    {
+        using var process = new Process { StartInfo = new ProcessStartInfo(ProcessFixture.Executable("ModernFormsNext.Automation.Cli"))
+        { UseShellExecute = false, CreateNoWindow = true, RedirectStandardInput = true, RedirectStandardOutput = true, RedirectStandardError = true } };
+        foreach (string argument in arguments) process.StartInfo.ArgumentList.Add(argument);
+        process.Start(); var stdout = process.StandardOutput.ReadToEndAsync(); var stderr = process.StandardError.ReadToEndAsync();
+        if (input is not null) await process.StandardInput.WriteAsync(input);
+        process.StandardInput.Close();
+        try { await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(20)); }
+        catch { if (!process.HasExited) process.Kill(true); throw; }
+        return new(process.ExitCode, await stdout, await stderr);
+    }
+
+    private static void SaveSmoke(string name, IEnumerable<CliResult> results)
+    {
+        var root = new DirectoryInfo(AppContext.BaseDirectory);
+        while (root is not null && !File.Exists(System.IO.Path.Combine(root.FullName, "ModernFormsNext.slnx"))) root = root.Parent;
+        Assert.NotNull(root);
+#if DEBUG
+        const string configuration = "Debug";
+#else
+        const string configuration = "Release";
+#endif
+        string directory = System.IO.Path.Combine(root.FullName, "artifacts", "issue-97-phase1b", "cli", configuration);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(System.IO.Path.Combine(directory, name + ".txt"), string.Join("\n", results.Select(result => $"Exit: {result.Exit}\n{result.Output}\n{result.Error}")));
+    }
+    private sealed record CliResult(int Exit, string Output, string Error);
+}

--- a/ModernFormsNext.Automation.Windows.Tests/FramingTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/FramingTests.cs
@@ -1,0 +1,62 @@
+using System.Buffers.Binary;
+using System.Text;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Framing")]
+public sealed class FramingTests
+{
+    [Fact]
+    public async Task PrefixAndBodyMayArriveOneByteAtATime()
+    {
+        byte[] body = Encoding.UTF8.GetBytes("{\"value\":\"line\\nvalue\"}");
+        using var frame = new MemoryStream(); await Protocol.WriteFrame(frame, body, default);
+        using var fragmented = new FragmentedStream(frame.ToArray());
+        Assert.Equal(body, await Protocol.ReadFrame(fragmented, 4096, default));
+        Assert.Null(await Protocol.ReadFrame(fragmented, 4096, default));
+    }
+
+    [Theory]
+    [InlineData(0, AutomationTransportError.InvalidRequest)]
+    [InlineData(-1, AutomationTransportError.InvalidRequest)]
+    [InlineData(int.MaxValue, AutomationTransportError.PayloadTooLarge)]
+    public async Task InvalidLengthRejectedBeforeReadingOrAllocatingBody(int length, AutomationTransportError expected)
+    {
+        byte[] prefix = new byte[4]; BinaryPrimitives.WriteInt32LittleEndian(prefix, length);
+        using var stream = new MemoryStream(prefix);
+        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => Protocol.ReadFrame(stream, 4096, default));
+        Assert.Equal(expected, error.Error); Assert.Equal(4, stream.Position);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(7)]
+    public async Task TruncatedPrefixOrBodyIsEof(int bytes)
+    {
+        byte[] frame = new byte[8]; BinaryPrimitives.WriteInt32LittleEndian(frame, 4);
+        using var stream = new MemoryStream(frame[..bytes]);
+        await Assert.ThrowsAsync<EndOfStreamException>(() => Protocol.ReadFrame(stream, 4096, default));
+    }
+
+    [Fact]
+    public void ResponseBudgetRejectsDuringSerialization()
+    {
+        var error = Assert.Throws<AutomationTransportException>(() => Protocol.Encode(new { Value = new string('x', 100000) }, 4096));
+        Assert.Equal(AutomationTransportError.PayloadTooLarge, error.Error);
+    }
+
+    [Fact]
+    public void DuplicateEnvelopeFieldsAreRejected()
+    {
+        var bytes = Encoding.UTF8.GetBytes("{\"version\":1,\"id\":1,\"id\":2,\"kind\":0,\"deadlineMilliseconds\":1000,\"payload\":{}}");
+        Assert.Equal(AutomationTransportError.InvalidRequest, Assert.Throws<AutomationTransportException>(() => Protocol.DecodeRequest(bytes)).Error);
+    }
+
+    private sealed class FragmentedStream(byte[] bytes) : MemoryStream(bytes)
+    {
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => base.ReadAsync(buffer[..Math.Min(1, buffer.Length)], cancellationToken);
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/LifetimeTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/LifetimeTests.cs
@@ -1,0 +1,119 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Process")]
+[Trait("Category", "Lifetime")]
+public sealed class LifetimeTests
+{
+    [Fact]
+    public async Task TwoProcessesWithTheSameNameHaveDistinctDiscoverableIdentity()
+    {
+        await using var first = await ProcessFixture.Start(); await using var second = await ProcessFixture.Start();
+        Assert.Equal(first.Application!.ApplicationName, second.Application!.ApplicationName);
+        Assert.NotEqual(first.Application.InstanceId, second.Application.InstanceId); Assert.NotEqual(first.Process.Id, second.Process.Id);
+        var discovered = await AutomationDiscovery.DiscoverAsync();
+        Assert.Contains(first.Application, discovered); Assert.Contains(second.Application, discovered);
+        await using var a = await first.Connect(); await using var b = await second.Connect();
+        Assert.NotEqual(a.Info.SessionId, b.Info.SessionId);
+    }
+
+    [Fact]
+    public async Task CanonicalStaleAndUnsupportedErrorsSurviveTransport()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var input = (await client.FindOneAsync(host.RootId, new() { AutomationId = "input" })).Value!;
+        Assert.Equal(AutomationErrorCode.StaleNode, (await client.InspectAsync(host.RootId, input.Handle with { SessionId = "stale" })).Error);
+        Assert.Equal(AutomationErrorCode.ActionUnsupported, (await client.PerformActionAsync(host.RootId, input.Handle, AccessibleActions.Invoke)).Error);
+        await host.Send("remove-input");
+        var gone = await client.WaitForConditionAsync(host.RootId, new() { Kind = AutomationWaitKind.NodeNotExposed, Handle = input.Handle });
+        Assert.Equal(AutomationWaitStatus.Satisfied, gone.Status);
+        Assert.Equal(AutomationErrorCode.NodeUnavailable, (await client.InspectAsync(host.RootId, input.Handle)).Error);
+    }
+
+    [Fact]
+    public async Task RealWindowCloseSatisfiesRootEnded()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var wait = client.WaitForConditionAsync(host.OtherRootId, new() { Kind = AutomationWaitKind.RootEnded });
+        await host.Send("close-root"); Assert.Equal(AutomationWaitStatus.Satisfied, (await wait).Status);
+        Assert.DoesNotContain((await client.GetRootsAsync()).Value, root => root.RootId == host.OtherRootId);
+    }
+
+    [Fact]
+    public async Task TimeoutAndCancellationHaveStructuredWaitResultsAndReleaseRequestSlot()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var condition = new AutomationWaitCondition { Query = new() { AutomationId = "not-yet" } };
+        Assert.Equal(AutomationWaitStatus.TimedOut,
+            (await client.WaitForConditionAsync(host.RootId, condition, new() { Timeout = TimeSpan.FromMilliseconds(50) })).Status);
+        using var cancellation = new CancellationTokenSource();
+        var pending = client.WaitForConditionAsync(host.RootId, condition, cancellationToken: cancellation.Token);
+        cancellation.Cancel();
+        try { Assert.Equal(AutomationWaitStatus.Cancelled, (await pending).Status); }
+        catch (AutomationTransportException error) { Assert.Equal(AutomationTransportError.Cancelled, error.Error); }
+        Assert.Equal(AutomationErrorCode.None, (await client.GetRootsAsync()).Error);
+    }
+
+    [Fact]
+    public async Task DisconnectEndsWaitButServerAndBorrowedSessionRemainAlive()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var pending = client.WaitForConditionAsync(host.RootId, new() { Query = new() { AutomationId = "absent" } });
+        await client.DisconnectAsync();
+        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => pending);
+        Assert.Contains(error.Error, new[] { AutomationTransportError.SessionEnded, AutomationTransportError.ApplicationUnavailable });
+        await using var next = await Reconnect(host);
+        Assert.Equal(AutomationErrorCode.None, (await next.GetRootsAsync()).Error);
+    }
+
+    [Fact]
+    public async Task ServerStopEndsWaitRemovesFilesAndPreservesBorrowedCore()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var pending = client.WaitForConditionAsync(host.RootId, new() { Query = new() { AutomationId = "absent" } });
+        await host.StopServer();
+        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => pending);
+        Assert.Contains(error.Error, new[] { AutomationTransportError.SessionEnded, AutomationTransportError.ApplicationUnavailable });
+        Assert.False(File.Exists(AutomationDiscovery.DescriptorPath(host.Application!.InstanceId)));
+        Assert.False(File.Exists(AutomationDiscovery.AuthPath(host.Application.InstanceId)));
+        Assert.Contains("SERVER-STOPPED:True", host.Output);
+        Assert.Equal(AutomationTransportError.ApplicationUnavailable, (await Assert.ThrowsAsync<AutomationTransportException>(() => host.Connect())).Error);
+    }
+
+    [Fact]
+    public async Task ProcessKillEndsWaitAndNextDiscoveryRemovesStaleRecords()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var pending = client.WaitForConditionAsync(host.RootId, new() { Query = new() { AutomationId = "absent" } });
+        host.Process.Kill(true); await host.Process.WaitForExitAsync();
+        Assert.Equal(AutomationTransportError.ApplicationUnavailable, (await Assert.ThrowsAsync<AutomationTransportException>(() => pending)).Error);
+        Assert.DoesNotContain(await AutomationDiscovery.DiscoverAsync(), x => x.InstanceId == host.Application!.InstanceId);
+        Assert.False(File.Exists(AutomationDiscovery.DescriptorPath(host.Application!.InstanceId)));
+    }
+
+    [Fact]
+    public async Task ActionWhichKillsProcessHasUnknownOutcomeAndIsNeverRetried()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var button = (await client.FindOneAsync(host.RootId, new() { AutomationId = "crash-action" })).Value!;
+        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => client.PerformActionAsync(host.RootId, button.Handle, AccessibleActions.Invoke));
+        Assert.Equal(AutomationTransportError.OutcomeUnknown, error.Error);
+        await host.Process.WaitForExitAsync(); Assert.Single(host.Output, x => x == "ACTION-ENTERED");
+        await AutomationDiscovery.DiscoverAsync();
+    }
+
+    private static async Task<WindowsAutomationClient> Reconnect(ProcessFixture host)
+    {
+        // EOF cancels the old server wait asynchronously. Retry only connection acquisition,
+        // bounded by monotonic time; never retry an action or introduce a fixed sleep.
+        long start = System.Diagnostics.Stopwatch.GetTimestamp();
+        while (true)
+        {
+            try { return await host.Connect(); }
+            catch (AutomationTransportException error) when (error.Error == AutomationTransportError.Busy
+                && System.Diagnostics.Stopwatch.GetElapsedTime(start) < TimeSpan.FromSeconds(5)) { await Task.Yield(); }
+        }
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/LifetimeTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/LifetimeTests.cs
@@ -64,7 +64,11 @@ public sealed class LifetimeTests
         await client.DisconnectAsync();
         var error = await Assert.ThrowsAsync<AutomationTransportException>(() => pending);
         Assert.Contains(error.Error, new[] { AutomationTransportError.SessionEnded, AutomationTransportError.ApplicationUnavailable });
+        await client.DisposeAsync(); await client.DisconnectAsync();
+        Assert.Equal(AutomationTransportError.SessionEnded,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => client.GetRootsAsync())).Error);
         await using var next = await Reconnect(host);
+        Assert.Equal(client.Info.SessionId, next.Info.SessionId);
         Assert.Equal(AutomationErrorCode.None, (await next.GetRootsAsync()).Error);
     }
 
@@ -93,14 +97,21 @@ public sealed class LifetimeTests
         Assert.False(File.Exists(AutomationDiscovery.DescriptorPath(host.Application!.InstanceId)));
     }
 
-    [Fact]
-    public async Task ActionWhichKillsProcessHasUnknownOutcomeAndIsNeverRetried()
+    [Theory]
+    [InlineData(AccessibleActions.Invoke)]
+    [InlineData(AccessibleActions.SetValue)]
+    public async Task ActionWhichKillsProcessHasUnknownOutcomeAndIsNeverRetried(AccessibleActions action)
     {
-        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
-        var button = (await client.FindOneAsync(host.RootId, new() { AutomationId = "crash-action" })).Value!;
-        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => client.PerformActionAsync(host.RootId, button.Handle, AccessibleActions.Invoke));
+        await using var host = await ProcessFixture.Start("--crash-setvalue"); await using var client = await host.Connect();
+        var target = (await client.FindOneAsync(host.RootId, new()
+        { AutomationId = action == AccessibleActions.Invoke ? "crash-action" : "crash-value" })).Value!;
+        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => client.PerformActionAsync(host.RootId, target.Handle, action,
+            action == AccessibleActions.SetValue ? AutomationActionValue.FromText("UNKNOWN-OUTCOME-PRIVATE-97") : null));
         Assert.Equal(AutomationTransportError.OutcomeUnknown, error.Error);
         await host.Process.WaitForExitAsync(); Assert.Single(host.Output, x => x == "ACTION-ENTERED");
+        Assert.DoesNotContain("UNKNOWN-OUTCOME-PRIVATE-97", string.Join("", host.Output));
+        Assert.Equal(AutomationTransportError.SessionEnded,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => client.GetRootsAsync())).Error);
         await AutomationDiscovery.DiscoverAsync();
     }
 

--- a/ModernFormsNext.Automation.Windows.Tests/LiveProcessTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/LiveProcessTests.cs
@@ -1,0 +1,49 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Process")]
+public sealed class LiveProcessTests
+{
+    [Fact]
+    public async Task RealWindowDiscoveryAuthQueryInvokeWaitInspectAndDisconnect()
+    {
+        await using var host = await ProcessFixture.Start();
+        Assert.Contains(await AutomationDiscovery.DiscoverAsync(), x => x.InstanceId == host.Application!.InstanceId);
+        await using var client = await host.Connect();
+        var roots = await client.GetRootsAsync(); Assert.Equal(AutomationErrorCode.None, roots.Error); Assert.Equal(2, roots.Value.Length);
+        var tree = await client.GetChildrenAsync(host.RootId, roots.Value[0].Handle); Assert.NotEmpty(tree.Value);
+        var button = await client.FindOneAsync(host.RootId, new() { AutomationId = "invoke" }); Assert.Equal(AutomationErrorCode.None, button.Error);
+        var action = await client.PerformActionAsync(host.RootId, button.Value!.Handle, AccessibleActions.Invoke);
+        Assert.Equal(AutomationActionStatus.Accepted, action.Status);
+        var wait = await client.WaitForConditionAsync(host.RootId, new()
+        { Kind = AutomationWaitKind.ValueEquals, Query = new() { AutomationId = "status" }, Value = "Invoked:1" });
+        Assert.Equal(AutomationWaitStatus.Satisfied, wait.Status);
+        Assert.Equal("Invoked:1", (await client.InspectAsync(host.RootId, wait.Snapshot!.Handle)).Value!.Value);
+        Assert.Equal(AutomationErrorCode.None, await client.CheckpointAsync());
+        await client.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task AsyncAcceptedRemainsPendingUntilObservablePostcondition()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var button = await client.FindOneAsync(host.RootId, new() { AutomationId = "async" });
+        Assert.Equal(AutomationActionStatus.Accepted, (await client.PerformActionAsync(host.RootId, button.Value!.Handle, AccessibleActions.Invoke)).Status);
+        Assert.Equal("Pending", (await client.FindOneAsync(host.RootId, new() { AutomationId = "status" })).Value!.Value);
+        var wait = client.WaitForConditionAsync(host.RootId, new()
+        { Kind = AutomationWaitKind.ValueEquals, Query = new() { AutomationId = "status" }, Value = "Completed" });
+        Assert.False(wait.IsCompleted); await host.Send("complete");
+        var done = await wait; Assert.Equal(AutomationWaitStatus.Satisfied, done.Status);
+        Assert.Equal("Completed", (await client.InspectAsync(host.RootId, done.Snapshot!.Handle)).Value!.Value);
+    }
+
+    [Fact]
+    public async Task ReferenceWithoutStartHasNoDiscoveryEvenInRelease()
+    {
+        await using var host = await ProcessFixture.Start("--no-server");
+        Assert.Null(host.Application);
+        Assert.DoesNotContain(await AutomationDiscovery.DiscoverAsync(), x => x.ProcessId == host.Process.Id);
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/ModernFormsNext.Automation.Windows.Tests.csproj
+++ b/ModernFormsNext.Automation.Windows.Tests/ModernFormsNext.Automation.Windows.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"><PrivateAssets>all</PrivateAssets></PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0"><PrivateAssets>all</PrivateAssets></PackageReference>
+    <ProjectReference Include="..\ModernFormsNext.Automation.Windows\ModernFormsNext.Automation.Windows.csproj" />
+    <ProjectReference Include="..\ModernFormsNext.Automation.Windows.TestHost\ModernFormsNext.Automation.Windows.TestHost.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>

--- a/ModernFormsNext.Automation.Windows.Tests/ModernFormsNext.Automation.Windows.Tests.csproj
+++ b/ModernFormsNext.Automation.Windows.Tests/ModernFormsNext.Automation.Windows.Tests.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0"><PrivateAssets>all</PrivateAssets></PackageReference>
     <ProjectReference Include="..\ModernFormsNext.Automation.Windows\ModernFormsNext.Automation.Windows.csproj" />
     <ProjectReference Include="..\ModernFormsNext.Automation.Windows.TestHost\ModernFormsNext.Automation.Windows.TestHost.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ModernFormsNext.Automation.Cli\ModernFormsNext.Automation.Cli.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/ModernFormsNext.Automation.Windows.Tests/ProcessFixture.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/ProcessFixture.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+internal sealed class ProcessFixture : IAsyncDisposable
+{
+    internal Process Process { get; }
+    internal AutomationApplicationInfo? Application { get; private set; }
+    internal string RootId { get; private set; } = "";
+    internal string OtherRootId { get; private set; } = "";
+    internal AutomationNodeHandle Password { get; private set; }
+    internal List<string> Output { get; } = [];
+    private readonly TaskCompletionSource ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource stopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private ProcessFixture(string[] arguments)
+    {
+        Process = new() { StartInfo = new ProcessStartInfo(Executable("ModernFormsNext.Automation.Windows.TestHost"))
+        { UseShellExecute = false, CreateNoWindow = true, RedirectStandardInput = true, RedirectStandardOutput = true, RedirectStandardError = true } };
+        foreach (string argument in arguments) Process.StartInfo.ArgumentList.Add(argument);
+        Process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null) return;
+            lock (Output) Output.Add(e.Data);
+            if (e.Data.StartsWith("READY:", StringComparison.Ordinal))
+            {
+                using var json = JsonDocument.Parse(e.Data[6..]); var root = json.RootElement;
+                Application = root.GetProperty("Application").Deserialize<AutomationApplicationInfo>();
+                RootId = root.GetProperty("RootId").GetString()!; OtherRootId = root.GetProperty("OtherRootId").GetString()!;
+                Password = root.GetProperty("Password").Deserialize<AutomationNodeHandle>(); ready.TrySetResult();
+            }
+            if (e.Data.StartsWith("START-ERROR:", StringComparison.Ordinal)) ready.TrySetException(new Exception(e.Data));
+            if (e.Data.StartsWith("SERVER-STOPPED:", StringComparison.Ordinal)) stopped.TrySetResult();
+        };
+        Process.ErrorDataReceived += (_, e) => { if (e.Data is not null) lock (Output) Output.Add(e.Data); };
+        Process.Start(); Process.BeginOutputReadLine(); Process.BeginErrorReadLine();
+    }
+
+    internal static async Task<ProcessFixture> Start(params string[] arguments)
+    {
+        var host = new ProcessFixture(arguments);
+        try { await host.ready.Task.WaitAsync(TimeSpan.FromSeconds(20)); return host; }
+        catch { await host.DisposeAsync(); throw; }
+    }
+    internal async Task Send(string command) { await Process.StandardInput.WriteLineAsync(command); await Process.StandardInput.FlushAsync(); }
+    internal async Task StopServer() { await Send("stop-server"); await stopped.Task.WaitAsync(TimeSpan.FromSeconds(10)); }
+    internal Task<WindowsAutomationClient> Connect(AutomationCapability capabilities = AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions)
+        => WindowsAutomationClient.ConnectAsync(Application!, capabilities);
+
+    internal static string Executable(string project)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(System.IO.Path.Combine(directory.FullName, "ModernFormsNext.slnx"))) directory = directory.Parent;
+        Assert.NotNull(directory);
+#if DEBUG
+        const string configuration = "Debug";
+#else
+        const string configuration = "Release";
+#endif
+        return System.IO.Path.Combine(directory.FullName, project, "bin", configuration, "net10.0-windows", project + ".exe");
+    }
+    public async ValueTask DisposeAsync()
+    {
+        if (!Process.HasExited)
+        {
+            try { await Send("quit"); await Process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(10)); }
+            catch { if (!Process.HasExited) Process.Kill(true); await Process.WaitForExitAsync(); }
+        }
+        Process.Dispose();
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/ProtocolPolicyTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/ProtocolPolicyTests.cs
@@ -61,6 +61,20 @@ public sealed class ProtocolPolicyTests
     }
 
     [Fact]
+    public async Task CompletedRepliesPermitImmediateSequentialRequests()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        await raw.Handshake(host.Application!);
+        // Responses exceed the native pipe buffer, exercising asynchronous writer completion
+        // while the client immediately begins the next request. No delay masks the handoff.
+        for (long id = 2; id <= 251; id++)
+        {
+            var reply = await raw.Request(id, RequestKind.FindAll, new Operation { RootId = host.RootId, Query = new() });
+            Assert.Equal(id, reply.Id); Assert.Equal(AutomationTransportError.None, reply.Error);
+        }
+    }
+
+    [Fact]
     public async Task ReplayingCompletedRequestIdIsRejected()
     {
         await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);

--- a/ModernFormsNext.Automation.Windows.Tests/ProtocolPolicyTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/ProtocolPolicyTests.cs
@@ -7,6 +7,21 @@ namespace ModernFormsNext.Automation.Windows.Tests;
 public sealed class ProtocolPolicyTests
 {
     [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public async Task NonFiniteActionNumberFailsLocallyWithoutLosingTheConnection(double number)
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect();
+        var input = (await client.FindOneAsync(host.RootId, new() { AutomationId = "input" })).Value!;
+        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => client.PerformActionAsync(host.RootId,
+            input.Handle, AccessibleActions.SetValue, AutomationActionValue.FromNumber(number)));
+        Assert.Equal(AutomationTransportError.InvalidRequest, error.Error);
+        Assert.Equal(AutomationErrorCode.None, (await client.GetRootsAsync()).Error);
+        Assert.Equal("Initial", (await client.InspectAsync(host.RootId, input.Handle)).Value!.Value);
+    }
+
+    [Theory]
     [InlineData("--inspect-session")]
     [InlineData("--inspect-server")]
     public async Task ServerAndSessionPoliciesRestrictNegotiation(string policy)

--- a/ModernFormsNext.Automation.Windows.Tests/ProtocolPolicyTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/ProtocolPolicyTests.cs
@@ -1,0 +1,70 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Security")]
+public sealed class ProtocolPolicyTests
+{
+    [Theory]
+    [InlineData("--inspect-session")]
+    [InlineData("--inspect-server")]
+    public async Task ServerAndSessionPoliciesRestrictNegotiation(string policy)
+    {
+        await using var host = await ProcessFixture.Start(policy); await using var client = await host.Connect();
+        Assert.Equal(AutomationCapability.Inspect, client.Info.Capabilities);
+        Assert.Equal(AutomationTransportError.CapabilityDenied,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => client.FindAllAsync(host.RootId, new()))).Error);
+    }
+
+    [Fact]
+    public async Task RootPolicyRemainsCanonicalAfterTransportNegotiation()
+    {
+        await using var host = await ProcessFixture.Start("--inspect-root"); await using var client = await host.Connect();
+        var root = Assert.Single((await client.GetRootsAsync()).Value, root => root.RootId == host.RootId);
+        Assert.Equal(AutomationCapability.Inspect, root.Capabilities);
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, (await client.FindAllAsync(host.RootId, new())).Error);
+        Assert.Equal(AutomationErrorCode.CapabilityDenied, (await client.PerformActionAsync(host.RootId, root.Handle, AccessibleActions.Invoke)).Error);
+    }
+
+    [Fact]
+    public async Task DuplicateStartDoesNotCreateAnotherEndpointForTheSameSession()
+    {
+        await using var host = await ProcessFixture.Start("--double-start");
+        Assert.Contains(host.Output, text => text.Contains("\"DuplicateRejected\":true", StringComparison.Ordinal));
+        Assert.Single(await AutomationDiscovery.DiscoverAsync(), app => app.ProcessId == host.Process.Id);
+    }
+
+    [Fact]
+    public async Task OnlyOneOutstandingRequestAndCancelDoesNotNeedItsOwnSlot()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        await raw.Handshake(host.Application!);
+        await raw.Send(2, RequestKind.WaitForCondition, new Operation { RootId = host.RootId,
+            Condition = new() { Query = new() { AutomationId = "absent" } } });
+        var busy = await raw.Request(3, RequestKind.GetRoots, new { }); Assert.Equal(AutomationTransportError.Busy, busy.Error); Assert.Equal(3, busy.Id);
+        await raw.Send(2, RequestKind.Cancel, new { });
+        var cancelled = await raw.Read(); Assert.Equal(2, cancelled.Id);
+        Assert.Equal(AutomationWaitStatus.Cancelled, Protocol.Read<AutomationWaitResult>(cancelled.Result!.Value).Status);
+        Assert.Equal(AutomationTransportError.None, (await raw.Request(4, RequestKind.GetRoots, new { })).Error);
+    }
+
+    [Fact]
+    public async Task RequestDeadlineIsDistinctFromCallerCancellation()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        await raw.Handshake(host.Application!);
+        var result = await raw.Request(2, RequestKind.WaitForCondition, new Operation { RootId = host.RootId,
+            Condition = new() { Query = new() { AutomationId = "absent" } } }, milliseconds: 50);
+        Assert.Equal(AutomationTransportError.DeadlineExceeded, result.Error);
+        Assert.Equal(AutomationTransportError.None, (await raw.Request(3, RequestKind.GetRoots, new { })).Error);
+    }
+
+    [Fact]
+    public async Task ReplayingCompletedRequestIdIsRejected()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        await raw.Handshake(host.Application!); await raw.Request(2, RequestKind.GetRoots, new { });
+        Assert.Equal(AutomationTransportError.InvalidRequest, (await raw.Request(2, RequestKind.GetRoots, new { })).Error);
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/RawClient.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/RawClient.cs
@@ -1,0 +1,43 @@
+using System.IO.Pipes;
+using System.Security.Principal;
+using System.Text.Json;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+// Test-only raw wire access exercises failures that the public client deliberately cannot create.
+internal sealed class RawClient : IAsyncDisposable
+{
+    internal NamedPipeClientStream Pipe { get; }
+    internal List<string> Responses { get; } = [];
+    private readonly CancellationTokenSource deadline = new(TimeSpan.FromSeconds(10));
+    internal CancellationToken Token => deadline.Token;
+    private RawClient(string endpoint) => Pipe = new(".", endpoint, PipeDirection.InOut, PipeOptions.Asynchronous,
+        TokenImpersonationLevel.Identification, HandleInheritability.None);
+    internal static async Task<RawClient> Connect(AutomationApplicationInfo application)
+    {
+        var client = new RawClient(application.EndpointName);
+        try { await client.Pipe.ConnectAsync(client.Token); return client; }
+        catch { await client.DisposeAsync(); throw; }
+    }
+    internal Task<Response> Handshake(AutomationApplicationInfo application, string? secret = null, bool omitSecret = false,
+        int version = 1, string? instance = null, AutomationCapability capabilities = AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions)
+        => Request(1, RequestKind.Handshake, new Handshake
+        {
+            InstanceId = instance ?? application.InstanceId, Secret = omitSecret ? null : secret ?? Convert.ToBase64String(AutomationDiscovery.ReadSecret(application)),
+            Capabilities = capabilities
+        }, version);
+
+    internal async Task<Response> Request(long id, RequestKind kind, object payload, int version = 1, int milliseconds = 60000)
+    {
+        await Send(id, kind, payload, version, milliseconds); return await Read();
+    }
+    internal Task Send(long id, RequestKind kind, object payload, int version = 1, int milliseconds = 60000)
+        => Protocol.WriteFrame(Pipe, Protocol.Encode(new { Version = version, Id = id, Kind = kind, DeadlineMilliseconds = milliseconds, Payload = payload }, 1048576), Token);
+    internal async Task<Response> Read()
+    {
+        byte[] bytes = await Protocol.ReadFrame(Pipe, 16777216, Token) ?? throw new EndOfStreamException();
+        Responses.Add(System.Text.Encoding.UTF8.GetString(bytes));
+        return JsonSerializer.Deserialize<Response>(bytes, Protocol.Json)!;
+    }
+    public async ValueTask DisposeAsync() { deadline.Cancel(); await Pipe.DisposeAsync(); deadline.Dispose(); }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/SecurityTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/SecurityTests.cs
@@ -1,0 +1,145 @@
+using System.Buffers.Binary;
+using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Text;
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Security")]
+public sealed class SecurityTests
+{
+    [Theory]
+    [InlineData("bad")]
+    [InlineData("missing")]
+    [InlineData("instance")]
+    public async Task InvalidAuthenticationCannotQuery(string failure)
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        var response = await raw.Handshake(host.Application!, failure == "bad" ? Convert.ToBase64String(new byte[32]) : null,
+            omitSecret: failure == "missing", instance: failure == "instance" ? Guid.NewGuid().ToString("N") : null);
+        Assert.Equal(AutomationTransportError.AuthenticationFailed, response.Error); Assert.Null(response.Result);
+    }
+
+    [Fact]
+    public async Task SemanticRequestBeforeHandshakeIsRejected()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        Assert.Equal(AutomationTransportError.AuthenticationFailed, (await raw.Request(1, RequestKind.GetRoots, new { })).Error);
+    }
+
+    [Fact]
+    public async Task IncompatibleProtocolIsExplicit()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        Assert.Equal(AutomationTransportError.ProtocolMismatch, (await raw.Handshake(host.Application!, version: 2)).Error);
+    }
+
+    [Fact]
+    public async Task OnlyOneAuthenticatedClientOwnsTheServer()
+    {
+        await using var host = await ProcessFixture.Start(); await using var first = await host.Connect();
+        var error = await Assert.ThrowsAsync<AutomationTransportException>(() => host.Connect());
+        Assert.Equal(AutomationTransportError.Busy, error.Error);
+        Assert.Equal(AutomationErrorCode.None, (await first.GetRootsAsync()).Error);
+    }
+
+    [Fact]
+    public async Task NegotiationCannotGrantOrExecuteUnrequestedCapabilities()
+    {
+        await using var host = await ProcessFixture.Start(); await using var client = await host.Connect(AutomationCapability.Inspect);
+        Assert.Equal(AutomationCapability.Inspect, client.Info.Capabilities);
+        var roots = await client.GetRootsAsync();
+        Assert.Equal(AutomationTransportError.CapabilityDenied,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => client.PerformActionAsync(host.RootId, roots.Value[0].Handle, AccessibleActions.Invoke))).Error);
+        Assert.Equal(AutomationTransportError.CapabilityDenied,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => client.FindAllAsync(host.RootId, new()))).Error);
+    }
+
+    [Theory]
+    [InlineData(0, AutomationTransportError.InvalidRequest)]
+    [InlineData(-1, AutomationTransportError.InvalidRequest)]
+    [InlineData(int.MaxValue, AutomationTransportError.PayloadTooLarge)]
+    public async Task RealPipeRejectsInvalidFrameLength(int length, AutomationTransportError expected)
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        byte[] header = new byte[4]; BinaryPrimitives.WriteInt32LittleEndian(header, length);
+        await raw.Pipe.WriteAsync(header, raw.Token);
+        Assert.Equal(expected, (await raw.Read()).Error);
+    }
+
+    [Fact]
+    public async Task RealPipeRejectsMalformedJsonWithoutEchoingInput()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        await Protocol.WriteFrame(raw.Pipe, Encoding.UTF8.GetBytes("{SECRET-MALFORMED-MARKER"), raw.Token);
+        Assert.Equal(AutomationTransportError.InvalidRequest, (await raw.Read()).Error);
+        Assert.DoesNotContain("SECRET-MALFORMED-MARKER", string.Join("", raw.Responses));
+    }
+
+    [Fact]
+    public async Task SeparateStringBudgetRejectsOversizedActionValue()
+    {
+        await using var host = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(host.Application!);
+        await raw.Handshake(host.Application!);
+        var response = await raw.Request(2, RequestKind.PerformAction, new Operation { RootId = host.RootId, Text = new string('s', 4097) });
+        Assert.Equal(AutomationTransportError.PayloadTooLarge, response.Error);
+        Assert.DoesNotContain(new string('s', 100), string.Join("", raw.Responses));
+    }
+
+    [Fact]
+    public async Task ResponseBudgetHasStructuredFailureAndConnectionRemainsUsable()
+    {
+        await using var host = await ProcessFixture.Start("--small-response"); await using var client = await host.Connect();
+        Assert.Equal(AutomationTransportError.PayloadTooLarge,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => client.FindAllAsync(host.RootId, new()))).Error);
+        Assert.Equal(AutomationErrorCode.None, (await client.GetRootsAsync()).Error);
+    }
+
+    [Fact]
+    public async Task DiscoveryAndSecretsHaveProtectedCurrentUserOnlyAcl()
+    {
+        await using var host = await ProcessFixture.Start(); var user = PipeSecurityPolicy.CurrentUser();
+        AutomationDiscovery.ValidateDirectory(user);
+        AutomationDiscovery.ValidateFile(AutomationDiscovery.DescriptorPath(host.Application!.InstanceId), user);
+        AutomationDiscovery.ValidateFile(AutomationDiscovery.AuthPath(host.Application.InstanceId), user);
+        string token = Convert.ToBase64String(AutomationDiscovery.ReadSecret(host.Application));
+        Assert.DoesNotContain(token, await File.ReadAllTextAsync(AutomationDiscovery.DescriptorPath(host.Application.InstanceId)));
+        Assert.DoesNotContain(token, string.Join("", host.Output));
+        await using var raw = await RawClient.Connect(host.Application); await raw.Handshake(host.Application);
+        var acl = raw.Pipe.GetAccessControl();
+        Assert.Equal(user, acl.GetOwner(typeof(System.Security.Principal.SecurityIdentifier)));
+        Assert.True(acl.AreAccessRulesProtected);
+        var rules = acl.GetAccessRules(true, true, typeof(System.Security.Principal.SecurityIdentifier));
+        Assert.Single(rules.Cast<PipeAccessRule>()); Assert.Equal(user, Assert.IsType<PipeAccessRule>(rules[0]).IdentityReference);
+        Assert.DoesNotContain(token, string.Join("", raw.Responses));
+    }
+
+    [Fact]
+    public async Task StoppedLifetimeSecretCannotAuthenticateAnotherInstance()
+    {
+        await using var old = await ProcessFixture.Start();
+        string oldToken = Convert.ToBase64String(AutomationDiscovery.ReadSecret(old.Application!));
+        await old.StopServer();
+        Assert.False(File.Exists(AutomationDiscovery.AuthPath(old.Application!.InstanceId)));
+        await using var next = await ProcessFixture.Start(); await using var raw = await RawClient.Connect(next.Application!);
+        Assert.Equal(AutomationTransportError.AuthenticationFailed, (await raw.Handshake(next.Application!, oldToken)).Error);
+        Assert.Equal(AutomationTransportError.ApplicationUnavailable,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => old.Connect())).Error);
+    }
+
+    [Fact]
+    public async Task SamePidWithWrongProcessStartIsStaleAndRemoved()
+    {
+        await using var host = await ProcessFixture.Start();
+        string staleNonce = Guid.NewGuid().ToString("N");
+        var stale = host.Application! with { InstanceId = staleNonce, ProcessStartUtcTicks = "1",
+            EndpointName = AutomationDiscovery.Endpoint(host.Process.Id, staleNonce) };
+        AutomationDiscovery.Publish(stale, new byte[32], PipeSecurityPolicy.CurrentUser());
+        Assert.DoesNotContain(await AutomationDiscovery.DiscoverAsync(), item => item.InstanceId == staleNonce);
+        Assert.False(File.Exists(AutomationDiscovery.DescriptorPath(staleNonce))); Assert.False(File.Exists(AutomationDiscovery.AuthPath(staleNonce)));
+        Assert.Equal(AutomationTransportError.ApplicationUnavailable,
+            (await Assert.ThrowsAsync<AutomationTransportException>(() => WindowsAutomationClient.ConnectAsync(stale))).Error);
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/SecurityTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/SecurityTests.cs
@@ -142,4 +142,33 @@ public sealed class SecurityTests
         Assert.Equal(AutomationTransportError.ApplicationUnavailable,
             (await Assert.ThrowsAsync<AutomationTransportException>(() => WindowsAutomationClient.ConnectAsync(stale))).Error);
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task MalformedDiscoveryCannotRedirectCleanupToAnotherFile(bool absolutePath)
+    {
+        await using var host = await ProcessFixture.Start();
+        string nonce = Guid.NewGuid().ToString("N");
+        var user = PipeSecurityPolicy.CurrentUser();
+        var counterfeit = host.Application! with { InstanceId = nonce, ProcessStartUtcTicks = "1",
+            EndpointName = AutomationDiscovery.Endpoint(host.Process.Id, nonce) };
+        AutomationDiscovery.Publish(counterfeit, new byte[32], user);
+        string target = AutomationDiscovery.DescriptorPath(host.Application.InstanceId);
+        string before = await File.ReadAllTextAsync(target);
+        try
+        {
+            string injected = absolutePath ? target : "../v1/" + host.Application.InstanceId;
+            await File.WriteAllTextAsync(AutomationDiscovery.DescriptorPath(nonce),
+                System.Text.Json.JsonSerializer.Serialize(counterfeit with { InstanceId = injected, EndpointName = target }, Protocol.Json));
+            Assert.DoesNotContain(await AutomationDiscovery.DiscoverAsync(), app => app.InstanceId == nonce);
+            AutomationDiscovery.Remove(injected);
+            Assert.Equal(before, await File.ReadAllTextAsync(target));
+            Assert.True(File.Exists(AutomationDiscovery.AuthPath(host.Application.InstanceId)));
+            Assert.True(File.Exists(AutomationDiscovery.DescriptorPath(nonce)));
+            await using var client = await host.Connect();
+            Assert.Equal(AutomationErrorCode.None, (await client.GetRootsAsync()).Error);
+        }
+        finally { AutomationDiscovery.Remove(nonce); }
+    }
 }

--- a/ModernFormsNext.Automation.Windows.Tests/TransportPrivacyTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/TransportPrivacyTests.cs
@@ -1,0 +1,36 @@
+using ModernFormsNext.Accessibility;
+using Xunit;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Privacy")]
+[Trait("Category", "Process")]
+public sealed class TransportPrivacyTests
+{
+    [Fact]
+    public async Task RealWireNeverContainsProtectedGettersExceptionsOrActionParameters()
+    {
+        await using var host = await ProcessFixture.Start("--privacy"); await using var raw = await RawClient.Connect(host.Application!);
+        await raw.Handshake(host.Application!);
+        var passwordResponse = await raw.Request(2, RequestKind.Inspect, new Operation { RootId = host.RootId, Handle = host.Password });
+        var password = Protocol.ReadResult<AutomationNodeSnapshot>(passwordResponse.Result!.Value).Value!;
+        Assert.Null(password.Value); Assert.Null(password.Name); Assert.Null(password.AutomationId);
+        Assert.NotEqual(AutomationRedaction.None, password.Redaction);
+        var found = await raw.Request(3, RequestKind.FindAll, new Operation { RootId = host.RootId, Query = new() });
+        var nodes = Protocol.ReadResult<System.Collections.Immutable.ImmutableArray<AutomationNodeSnapshot>>(found.Result!.Value);
+        Assert.Equal(AutomationErrorCode.GetterFault, nodes.Error);
+        Assert.Contains(nodes.Value, node => node.Redaction != AutomationRedaction.None && node.Handle != host.Password);
+        var fault = Assert.Single(nodes.Value.Where(node => node.AutomationId == "fault"));
+        var action = await raw.Request(4, RequestKind.PerformAction, new Operation
+        { RootId = host.RootId, Handle = fault.Handle, Action = AccessibleActions.SetValue, Text = "ACTION-PARAMETER-SECRET-97" });
+        Assert.Equal(AutomationErrorCode.ApplicationError, Protocol.Read<AutomationActionResult>(action.Result!.Value).Error);
+        var wait = await raw.Request(5, RequestKind.WaitForCondition, new Operation
+        { RootId = host.RootId, Condition = new() { Kind = AutomationWaitKind.ValueEquals, Handle = host.Password, Value = "PASSWORD-MARKER-97" } });
+        // An unrelated custom getter may make the root capture incomplete; either safe refusal
+        // preserves privacy. Equality can never report secret satisfaction.
+        Assert.NotEqual(AutomationWaitStatus.Satisfied, Protocol.Read<AutomationWaitResult>(wait.Result!.Value).Status);
+        string output = string.Join("\n", raw.Responses.Concat(host.Output));
+        foreach (string marker in new[] { "PASSWORD-MARKER-97", "CUSTOM-GETTER-MARKER-97", "SENSITIVE-MARKER-97",
+            "EXCEPTION-MARKER-97", "ACTION-MARKER-97", "ACTION-PARAMETER-SECRET-97", "password-secret" }) Assert.DoesNotContain(marker, output);
+    }
+}

--- a/ModernFormsNext.Automation.Windows.Tests/WindowsSecurityEvidenceTests.cs
+++ b/ModernFormsNext.Automation.Windows.Tests/WindowsSecurityEvidenceTests.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ModernFormsNext.Automation.Windows.Tests;
+
+[Trait("Category", "Security")]
+public sealed class WindowsSecurityEvidenceTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task RestrictedTokenIsDeniedByRealPipeAndSecretFileAcl()
+    {
+        await using var host = await ProcessFixture.Start();
+        // A restricting SID requires a second OS access check. This proves real ACL denial,
+        // without creating an account, changing ACLs or pretending this is a cross-user login.
+        using var identity = WindowsIdentity.GetCurrent(TokenAccessLevels.Duplicate | TokenAccessLevels.Query);
+        var world = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+        byte[] bytes = new byte[world.BinaryLength]; world.GetBinaryForm(bytes, 0);
+        var pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+        try
+        {
+            var sid = new SidAndAttributes { Sid = pin.AddrOfPinnedObject() };
+            Assert.True(CreateRestrictedToken(identity.AccessToken, 1, 0, IntPtr.Zero, 0, IntPtr.Zero, 1, ref sid, out var restricted),
+                new Win32Exception(Marshal.GetLastWin32Error()).Message);
+            using (restricted)
+            {
+                WindowsIdentity.RunImpersonated(restricted, () =>
+                {
+                    AssertDenied(@"\\.\pipe\" + host.Application!.EndpointName);
+                    AssertDenied(AutomationDiscovery.AuthPath(host.Application.InstanceId));
+                    AssertDenied(AutomationDiscovery.DescriptorPath(host.Application.InstanceId));
+                });
+            }
+        }
+        finally { pin.Free(); }
+        await using var client = await host.Connect(); Assert.Equal(AutomationErrorCode.None, (await client.GetRootsAsync()).Error);
+        output.WriteLine("PASS: actual Windows access denied (5) for restricted token: pipe, secret, descriptor. Ordinary current-user authentication succeeds. Different logged-on user: NOT EXECUTED.");
+    }
+
+    [Fact]
+    public async Task RemotePathProbeRequiresWorkingSmbControlBeforeClaimingRejection()
+    {
+        await using var host = await ProcessFixture.Start();
+        string name = "mfn-remote-control-" + Guid.NewGuid().ToString("N");
+        using var controlServer = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+        using var control = new NamedPipeClientStream(Environment.MachineName, name, PipeDirection.InOut, PipeOptions.Asynchronous);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var accepted = controlServer.WaitForConnectionAsync(timeout.Token);
+        try
+        {
+            await control.ConnectAsync(timeout.Token); await accepted;
+        }
+        catch (Exception error) when (error is IOException or OperationCanceledException or UnauthorizedAccessException)
+        {
+            timeout.Cancel(); try { await accepted; } catch (Exception) { }
+            output.WriteLine("NOT EXECUTED: remote-path rejection could not be distinguished from unavailable SMB/current-user loopback. Positive control failed. Local native PIPE_REJECT_REMOTE_CLIENTS creation and current-user auth are exercised separately.");
+            return;
+        }
+        using var remote = new NamedPipeClientStream(Environment.MachineName, host.Application!.EndpointName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        using var rejectionDeadline = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var failure = await Record.ExceptionAsync(() => remote.ConnectAsync(rejectionDeadline.Token));
+        Assert.NotNull(failure); Assert.False(remote.IsConnected);
+        output.WriteLine("PASS: SMB loopback positive control connected; the bridge remote path was rejected. A second physical machine was NOT EXECUTED.");
+    }
+
+    private static void AssertDenied(string path)
+    {
+        using var handle = CreateFileW(path, 0x80000000, 3, IntPtr.Zero, 3, 0, IntPtr.Zero);
+        int error = Marshal.GetLastWin32Error(); Assert.True(handle.IsInvalid); Assert.Equal(5, error);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SidAndAttributes { internal IntPtr Sid; internal uint Attributes; }
+    [DllImport("advapi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateRestrictedToken(SafeAccessTokenHandle existing, uint flags, uint disabledCount, IntPtr disabled,
+        uint privilegeCount, IntPtr privileges, uint restrictedCount, ref SidAndAttributes restricting, out SafeAccessTokenHandle token);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateFileW(string path, uint access, uint share, IntPtr security, uint creation, uint flags, IntPtr template);
+}

--- a/ModernFormsNext.Automation.Windows/AutomationDiscovery.cs
+++ b/ModernFormsNext.Automation.Windows/AutomationDiscovery.cs
@@ -146,6 +146,7 @@ public static class AutomationDiscovery
     internal static void ValidateFile(string path, SecurityIdentifier user)
     {
         var file = new FileInfo(path);
+        if (!file.Exists) throw new FileNotFoundException();
         if ((file.Attributes & FileAttributes.ReparsePoint) != 0) throw new AutomationTransportException(AutomationTransportError.UnsafeDiscovery);
         ValidateAcl(file.GetAccessControl(AccessControlSections.Access | AccessControlSections.Owner), user);
     }

--- a/ModernFormsNext.Automation.Windows/AutomationDiscovery.cs
+++ b/ModernFormsNext.Automation.Windows/AutomationDiscovery.cs
@@ -1,0 +1,178 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text.Json;
+using IOPath = System.IO.Path;
+
+namespace ModernFormsNext.Automation.Windows;
+
+/// <summary>Discovers explicitly enabled local bridges from restricted per-user metadata, without scanning named pipes.</summary>
+public static class AutomationDiscovery
+{
+    /// <summary>Gets the deterministic per-user descriptor directory. Reading this property creates nothing.</summary>
+    public static string DirectoryPath => IOPath.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "ModernFormsNext", "Automation", "v1");
+
+    /// <summary>Reads live descriptors and removes safely identified stale/orphan records.</summary>
+    /// <param name="cancellationToken">Cancels between bounded file/process checks.</param>
+    /// <returns>At most 1024 live instances, sorted by instance ID. An absent directory returns an empty array.</returns>
+    /// <remarks>May run on any thread. Throws a safe UnsafeDiscovery error for an unsafe directory. Malformed files are ignored; no arbitrary paths are deleted.</remarks>
+    public static Task<ImmutableArray<AutomationApplicationInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+        => Task.Run(() => Discover(cancellationToken), cancellationToken);
+
+    private static ImmutableArray<AutomationApplicationInfo> Discover(CancellationToken token)
+    {
+        if (!Directory.Exists(DirectoryPath)) return [];
+        var user = PipeSecurityPolicy.CurrentUser(); ValidateDirectory(user);
+        var result = ImmutableArray.CreateBuilder<AutomationApplicationInfo>();
+        foreach (string path in Directory.EnumerateFiles(DirectoryPath, "*.json").Take(1024))
+        {
+            token.ThrowIfCancellationRequested();
+            string instance = IOPath.GetFileNameWithoutExtension(path);
+            if (!ValidInstance(instance)) continue;
+            try
+            {
+                var descriptor = ReadDescriptor(instance, user);
+                if (descriptor is null) continue;
+                if (!IsLive(descriptor)) { Remove(instance); continue; }
+                if (!File.Exists(AuthPath(instance))) continue;
+                ValidateFile(AuthPath(instance), user);
+                result.Add(descriptor);
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException or JsonException or AutomationTransportException) { }
+        }
+        // Orphan secrets can result from a crash during publication. Do not remove a freshly
+        // publishing server's file; the age guard is for orphan cleanup, not process identity.
+        foreach (string path in Directory.EnumerateFiles(DirectoryPath, "*.auth").Take(1024))
+        {
+            token.ThrowIfCancellationRequested();
+            string instance = IOPath.GetFileNameWithoutExtension(path);
+            if (!ValidInstance(instance) || File.Exists(DescriptorPath(instance))) continue;
+            try
+            {
+                ValidateFile(path, user);
+                if (File.GetLastWriteTimeUtc(path) < DateTime.UtcNow.AddMinutes(-2)) File.Delete(path);
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException or AutomationTransportException) { }
+        }
+        return result.OrderBy(x => x.InstanceId, StringComparer.Ordinal).ToImmutableArray();
+    }
+
+    internal static void Publish(AutomationApplicationInfo info, byte[] secret, SecurityIdentifier user)
+    {
+        EnsureDirectory(user);
+        WriteRestricted(AuthPath(info.InstanceId), secret, user);
+        try { WriteRestricted(DescriptorPath(info.InstanceId), JsonSerializer.SerializeToUtf8Bytes(info, Protocol.Json), user); }
+        catch { Remove(info.InstanceId); throw; }
+    }
+
+    internal static AutomationApplicationInfo? ReadDescriptor(string instance, SecurityIdentifier user)
+    {
+        if (!ValidInstance(instance)) return null;
+        string path = DescriptorPath(instance); ValidateFile(path, user);
+        using var stream = File.OpenRead(path);
+        if (stream.Length is <= 0 or > 4096) return null;
+        var info = JsonSerializer.Deserialize<AutomationApplicationInfo>(stream, Protocol.Json);
+        return info is not null && info.InstanceId == instance && ValidInstance(info.InstanceId)
+            && info.ProcessId > 0 && info.EndpointName == Endpoint(info.ProcessId, instance)
+            && info.ApplicationName is { Length: > 0 and <= 128 } && !info.ApplicationName.Any(char.IsControl)
+            && Protocol.ValidCapabilities(info.Capabilities)
+            && long.TryParse(info.ProcessStartUtcTicks, NumberStyles.None, CultureInfo.InvariantCulture, out long ticks) && ticks > 0
+            ? info : null;
+    }
+
+    internal static byte[] ReadSecret(AutomationApplicationInfo info)
+    {
+        var user = PipeSecurityPolicy.CurrentUser(); ValidateDirectory(user);
+        if (ReadDescriptor(info.InstanceId, user) != info || !IsLive(info))
+            throw new AutomationTransportException(AutomationTransportError.ApplicationUnavailable);
+        string path = AuthPath(info.InstanceId); ValidateFile(path, user);
+        using var stream = File.OpenRead(path);
+        if (stream.Length != 32) throw new AutomationTransportException(AutomationTransportError.AuthenticationFailed);
+        byte[] secret = new byte[32]; stream.ReadExactly(secret); return secret;
+    }
+
+    internal static bool IsLive(AutomationApplicationInfo info)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(info.ProcessId);
+            return !process.HasExited && ProcessStart(process) == info.ProcessStartUtcTicks;
+        }
+        catch (Exception) { return false; }
+    }
+
+    internal static string ProcessStart(Process process) => process.StartTime.ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture);
+    internal static string Endpoint(int pid, string instance) => $"mfn-automation-{pid}-{instance}";
+    internal static bool ValidInstance(string instance) => Guid.TryParseExact(instance, "N", out var id) && id.ToString("N") == instance;
+    internal static string DescriptorPath(string instance) => IOPath.Combine(DirectoryPath, instance + ".json");
+    internal static string AuthPath(string instance) => IOPath.Combine(DirectoryPath, instance + ".auth");
+
+    internal static void Remove(string instance)
+    {
+        if (!ValidInstance(instance)) return;
+        var user = PipeSecurityPolicy.CurrentUser();
+        foreach (string path in new[] { DescriptorPath(instance), AuthPath(instance) })
+        {
+            try { ValidateDirectory(user); if (File.Exists(path)) { ValidateFile(path, user); File.Delete(path); } }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException or AutomationTransportException) { }
+        }
+    }
+
+    private static void EnsureDirectory(SecurityIdentifier user)
+    {
+        var directory = new DirectoryInfo(DirectoryPath);
+        RejectReparseAncestors(directory);
+        if (!directory.Exists)
+        {
+            Directory.CreateDirectory(directory.Parent!.FullName);
+            RejectReparseAncestors(directory);
+            var security = new DirectorySecurity(); security.SetOwner(user); security.SetAccessRuleProtection(true, false);
+            security.AddAccessRule(new FileSystemAccessRule(user, FileSystemRights.FullControl,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit, PropagationFlags.None, AccessControlType.Allow));
+            directory.Create(security);
+        }
+        ValidateDirectory(user);
+    }
+
+    internal static void ValidateDirectory(SecurityIdentifier user)
+    {
+        var directory = new DirectoryInfo(DirectoryPath); RejectReparseAncestors(directory);
+        ValidateAcl(directory.GetAccessControl(AccessControlSections.Access | AccessControlSections.Owner), user);
+    }
+
+    internal static void ValidateFile(string path, SecurityIdentifier user)
+    {
+        var file = new FileInfo(path);
+        if ((file.Attributes & FileAttributes.ReparsePoint) != 0) throw new AutomationTransportException(AutomationTransportError.UnsafeDiscovery);
+        ValidateAcl(file.GetAccessControl(AccessControlSections.Access | AccessControlSections.Owner), user);
+    }
+
+    private static void RejectReparseAncestors(DirectoryInfo? directory)
+    {
+        for (; directory is not null; directory = directory.Parent)
+            if (directory.Exists && (directory.Attributes & FileAttributes.ReparsePoint) != 0)
+                throw new AutomationTransportException(AutomationTransportError.UnsafeDiscovery);
+    }
+
+    private static void ValidateAcl(FileSystemSecurity security, SecurityIdentifier user)
+    {
+        var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
+        if (!security.AreAccessRulesProtected || security.GetOwner(typeof(SecurityIdentifier)) != user || rules.Count != 1
+            || rules[0] is not FileSystemAccessRule rule || rule.IdentityReference != user
+            || rule.AccessControlType != AccessControlType.Allow || rule.FileSystemRights != FileSystemRights.FullControl
+            || rule.IsInherited || rule.PropagationFlags != PropagationFlags.None)
+            throw new AutomationTransportException(AutomationTransportError.UnsafeDiscovery);
+    }
+
+    private static void WriteRestricted(string path, byte[] data, SecurityIdentifier user)
+    {
+        var security = new FileSecurity(); security.SetOwner(user); security.SetAccessRuleProtection(true, false);
+        security.AddAccessRule(new FileSystemAccessRule(user, FileSystemRights.FullControl, AccessControlType.Allow));
+        using var stream = new FileInfo(path).Create(FileMode.CreateNew, FileSystemRights.FullControl, FileShare.None,
+            4096, FileOptions.None, security);
+        stream.Write(data); stream.Flush(true);
+    }
+}

--- a/ModernFormsNext.Automation.Windows/AutomationTransportError.cs
+++ b/ModernFormsNext.Automation.Windows/AutomationTransportError.cs
@@ -40,6 +40,8 @@ public sealed class AutomationTransportException : Exception
     /// <summary>Constructs a safe transport exception with no inner application exception.</summary>
     /// <param name="error">The controlled failure code.</param>
     public AutomationTransportException(AutomationTransportError error) : base($"Automation transport: {error}.") => Error = error;
+    internal AutomationTransportException(AutomationTransportError error, bool serverResponse) : this(error) => IsServerResponse = serverResponse;
+    internal bool IsServerResponse { get; }
     /// <summary>Gets the structured transport failure.</summary>
     public AutomationTransportError Error { get; }
 }

--- a/ModernFormsNext.Automation.Windows/AutomationTransportError.cs
+++ b/ModernFormsNext.Automation.Windows/AutomationTransportError.cs
@@ -1,0 +1,45 @@
+namespace ModernFormsNext.Automation.Windows;
+
+/// <summary>Contains safe transport failures independent of canonical semantic result codes.</summary>
+public enum AutomationTransportError
+{
+    /// <summary>No transport error.</summary>
+    None,
+    /// <summary>The frame or request shape is invalid.</summary>
+    InvalidRequest,
+    /// <summary>The protocol version is incompatible.</summary>
+    ProtocolMismatch,
+    /// <summary>Peer identity, instance or secret authentication failed.</summary>
+    AuthenticationFailed,
+    /// <summary>Another authenticated client or request owns the available slot.</summary>
+    Busy,
+    /// <summary>The operation was not granted by transport capability negotiation.</summary>
+    CapabilityDenied,
+    /// <summary>A byte or string payload exceeded its explicit budget.</summary>
+    PayloadTooLarge,
+    /// <summary>The request deadline elapsed.</summary>
+    DeadlineExceeded,
+    /// <summary>The request was cancelled before an outcome became ambiguous.</summary>
+    Cancelled,
+    /// <summary>The server or connection session ended.</summary>
+    SessionEnded,
+    /// <summary>The process, endpoint or connection is unavailable.</summary>
+    ApplicationUnavailable,
+    /// <summary>A mutation may have executed but its response was lost. Never automatically retry it.</summary>
+    OutcomeUnknown,
+    /// <summary>A failure occurred without exposing arbitrary application details.</summary>
+    ApplicationError,
+    /// <summary>The discovery directory or file did not satisfy the restrictive local ACL/path policy.</summary>
+    UnsafeDiscovery
+}
+
+/// <summary>Reports a controlled transport failure without application messages, credentials or request values.</summary>
+/// <remarks>Semantic failures remain in AutomationResult/AutomationActionResult. This exception describes only the connection/protocol layer.</remarks>
+public sealed class AutomationTransportException : Exception
+{
+    /// <summary>Constructs a safe transport exception with no inner application exception.</summary>
+    /// <param name="error">The controlled failure code.</param>
+    public AutomationTransportException(AutomationTransportError error) : base($"Automation transport: {error}.") => Error = error;
+    /// <summary>Gets the structured transport failure.</summary>
+    public AutomationTransportError Error { get; }
+}

--- a/ModernFormsNext.Automation.Windows/ModernFormsNext.Automation.Windows.csproj
+++ b/ModernFormsNext.Automation.Windows/ModernFormsNext.Automation.Windows.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>ModernFormsNext.Automation.Windows</PackageId>
+    <Title>ModernFormsNext Windows Automation</Title>
+    <Version>$(ModernFormsNextPackageVersion)</Version>
+    <Product>ModernFormsNext.Automation.Windows</Product>
+    <Description>Explicitly enabled local Windows development automation over the canonical ModernFormsNext semantic core.</Description>
+    <PackageTags>ui;automation;windows;named-pipes;development;modernforms</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\icon.png" Pack="true" PackagePath="\" Link="icon.png" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <ProjectReference Include="..\ModernFormsNext.Automation\ModernFormsNext.Automation.csproj" />
+    <InternalsVisibleTo Include="ModernFormsNext.Automation.Windows.Tests" />
+  </ItemGroup>
+</Project>

--- a/ModernFormsNext.Automation.Windows/PipeSecurityPolicy.cs
+++ b/ModernFormsNext.Automation.Windows/PipeSecurityPolicy.cs
@@ -1,0 +1,79 @@
+using System.ComponentModel;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Microsoft.Win32.SafeHandles;
+
+namespace ModernFormsNext.Automation.Windows;
+
+// All platform interop lives in this Windows adapter. In particular CurrentUserOnly alone
+// does not set PIPE_REJECT_REMOTE_CLIENTS. ACL ownership uses User, not the token's Owner group.
+internal static class PipeSecurityPolicy
+{
+    internal static SecurityIdentifier CurrentUser()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        return identity.User ?? throw new AutomationTransportException(AutomationTransportError.AuthenticationFailed);
+    }
+
+    internal static NamedPipeServerStream Create(string endpoint, SecurityIdentifier user, bool first)
+    {
+        var security = new PipeSecurity();
+        security.SetOwner(user); security.SetAccessRuleProtection(true, false);
+        security.AddAccessRule(new PipeAccessRule(user, PipeAccessRights.FullControl, AccessControlType.Allow));
+        byte[] descriptor = security.GetSecurityDescriptorBinaryForm();
+        var pinned = GCHandle.Alloc(descriptor, GCHandleType.Pinned);
+        try
+        {
+            var attributes = new SecurityAttributes
+            {
+                Length = Marshal.SizeOf<SecurityAttributes>(), SecurityDescriptor = pinned.AddrOfPinnedObject()
+            };
+            // PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | optional FILE_FLAG_FIRST_PIPE_INSTANCE.
+            var handle = CreateNamedPipeW(@"\\.\pipe\" + endpoint,
+                3u | 0x40000000u | (first ? 0x00080000u : 0u), 0x00000008u,
+                8, 4096, 4096, 0, ref attributes);
+            if (handle.IsInvalid) { handle.Dispose(); throw new Win32Exception(Marshal.GetLastWin32Error()); }
+            try { return new NamedPipeServerStream(PipeDirection.InOut, true, false, handle); }
+            catch { handle.Dispose(); throw; }
+        }
+        finally { pinned.Free(); }
+    }
+
+    internal static bool IsSameUser(NamedPipeServerStream pipe, SecurityIdentifier user)
+    {
+        bool matches = false;
+        try
+        {
+            // Windows requires a preceding client write. Identification-level impersonation
+            // permits checking identity without giving the server delegation authority.
+            pipe.RunAsClient(() =>
+            {
+                using var identity = WindowsIdentity.GetCurrent(true);
+                matches = identity?.User == user;
+            });
+        }
+        catch (Exception) { return false; }
+        return matches;
+    }
+
+    internal static bool HasServerProcess(NamedPipeClientStream pipe, int processId)
+        => GetNamedPipeServerProcessId(pipe.SafePipeHandle, out uint actual) && actual == processId;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SecurityAttributes
+    {
+        internal int Length;
+        internal IntPtr SecurityDescriptor;
+        internal int InheritHandle;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafePipeHandle CreateNamedPipeW(string name, uint openMode, uint pipeMode,
+        uint maxInstances, uint outBufferSize, uint inBufferSize, uint defaultTimeout, ref SecurityAttributes securityAttributes);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetNamedPipeServerProcessId(SafePipeHandle pipe, out uint serverProcessId);
+}

--- a/ModernFormsNext.Automation.Windows/Protocol.cs
+++ b/ModernFormsNext.Automation.Windows/Protocol.cs
@@ -1,0 +1,158 @@
+using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModernFormsNext.Accessibility;
+
+namespace ModernFormsNext.Automation.Windows;
+
+internal enum RequestKind { Handshake, SessionInfo, GetRoots, Inspect, GetChildren, FindOne, FindAll, PerformAction, WaitForCondition, Checkpoint, Cancel, Disconnect }
+internal sealed record Request(int Version, long Id, RequestKind Kind, int DeadlineMilliseconds, JsonElement Payload);
+internal sealed record Response(int Version, long Id, AutomationTransportError Error, JsonElement? Result);
+internal sealed class Handshake
+{
+    public string? InstanceId { get; init; }
+    public string? Secret { get; init; }
+    public AutomationCapability Capabilities { get; init; }
+    public int MaxResponseBytes { get; init; } = 4 * 1024 * 1024;
+}
+internal sealed class Operation
+{
+    public string? RootId { get; init; }
+    public AutomationNodeHandle? Handle { get; init; }
+    public AutomationQuery? Query { get; init; }
+    public AccessibleActions Action { get; init; }
+    public string? Text { get; init; }
+    public double? Number { get; init; }
+    public AutomationWaitCondition? Condition { get; init; }
+    public AutomationWaitOptions? WaitOptions { get; init; }
+}
+
+internal static class Protocol
+{
+    internal const int Version = 1;
+    internal const int HandshakeLimit = 4096;
+    internal static readonly JsonSerializerOptions Json = CreateJson();
+    private static JsonSerializerOptions CreateJson()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase, MaxDepth = 32,
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow
+        };
+        options.Converters.Add(new SnapshotConverter());
+        return options;
+    }
+    internal static bool ValidCapabilities(AutomationCapability value)
+        => (value & ~(AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions)) == 0;
+    internal static JsonElement Element<T>(T value) => JsonSerializer.SerializeToElement(value, Json);
+    internal static T Read<T>(JsonElement element) => element.Deserialize<T>(Json)
+        ?? throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+
+    internal static async Task<byte[]?> ReadFrame(Stream stream, int limit, CancellationToken token)
+    {
+        byte[] header = new byte[4];
+        int first = await stream.ReadAsync(header.AsMemory(0, 4), token).ConfigureAwait(false);
+        if (first == 0) return null;
+        await stream.ReadExactlyAsync(header.AsMemory(first), token).ConfigureAwait(false);
+        int length = BinaryPrimitives.ReadInt32LittleEndian(header);
+        if (length <= 0) throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+        if (length > limit) throw new AutomationTransportException(AutomationTransportError.PayloadTooLarge);
+        byte[] bytes = new byte[length];
+        await stream.ReadExactlyAsync(bytes, token).ConfigureAwait(false);
+        return bytes;
+    }
+
+    internal static byte[] Encode<T>(T value, int limit)
+    {
+        using var stream = new BoundedBuffer(limit);
+        JsonSerializer.Serialize(stream, value, Json);
+        return stream.ToArray();
+    }
+
+    internal static async Task WriteFrame(Stream stream, byte[] bytes, CancellationToken token)
+    {
+        byte[] prefix = new byte[4]; BinaryPrimitives.WriteInt32LittleEndian(prefix, bytes.Length);
+        await stream.WriteAsync(prefix, token).ConfigureAwait(false);
+        await stream.WriteAsync(bytes, token).ConfigureAwait(false);
+        await stream.FlushAsync(token).ConfigureAwait(false);
+    }
+
+    internal static Request DecodeRequest(byte[] bytes)
+    {
+        using var document = JsonDocument.Parse(bytes, new() { MaxDepth = 32 });
+        CheckStrings(document.RootElement);
+        var request = Read<Request>(document.RootElement);
+        if (request.Id <= 0 || !Enum.IsDefined(request.Kind)) throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+        return request;
+    }
+
+    private static void CheckStrings(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.String && element.GetString()!.Length > 4096)
+            throw new AutomationTransportException(AutomationTransportError.PayloadTooLarge);
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var property in element.EnumerateObject())
+            {
+                if (!names.Add(property.Name)) throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+                CheckStrings(property.Value);
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+            foreach (var item in element.EnumerateArray()) CheckStrings(item);
+    }
+
+    internal static AutomationResult<T> ReadResult<T>(JsonElement element)
+    {
+        var value = element.GetProperty("value");
+        return new(value.ValueKind == JsonValueKind.Null ? default : Read<T>(value),
+            Read<AutomationErrorCode>(element.GetProperty("error")), element.GetProperty("captureId").GetString()!,
+            element.GetProperty("truncated").GetBoolean(), Read<ImmutableArray<AutomationIssue>>(element.GetProperty("issues")));
+    }
+
+    // Capped growth checks before allocation, including serializer flushes. No complete unbounded
+    // JSON element is constructed for responses; the core's already-detached DTO streams here.
+    private sealed class BoundedBuffer(int limit) : MemoryStream
+    {
+        private void Reserve(int count)
+        {
+            if (count > limit - Position) throw new AutomationTransportException(AutomationTransportError.PayloadTooLarge);
+            if (Position + count > Capacity) Capacity = Math.Min(limit, Math.Max((int)Position + count, Math.Max(256, Capacity * 2)));
+        }
+        public override void Write(byte[] buffer, int offset, int count) { Reserve(count); base.Write(buffer, offset, count); }
+        public override void Write(ReadOnlySpan<byte> buffer) { Reserve(buffer.Length); base.Write(buffer); }
+    }
+
+    private sealed class SnapshotConverter : JsonConverter<AutomationNodeSnapshot>
+    {
+        public override AutomationNodeSnapshot Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var document = JsonDocument.ParseValue(ref reader); var e = document.RootElement;
+            T Field<T>(string name) => e.GetProperty(name).Deserialize<T>(options)!;
+            var range = e.GetProperty("rangeValue");
+            AccessibleRangeValue? rangeValue = range.ValueKind == JsonValueKind.Null ? null : new(
+                range.GetProperty("value").GetDouble(), range.GetProperty("minimum").GetDouble(), range.GetProperty("maximum").GetDouble(),
+                range.GetProperty("smallChange").GetDouble(), range.GetProperty("largeChange").GetDouble(), range.GetProperty("isReadOnly").GetBoolean());
+            return new(Field<AutomationNodeHandle>("handle"), Field<string>("rootId"), Field<string?>("automationId"),
+                Field<string?>("name"), Field<AccessibleRole>("role"), Field<AccessibleControlType>("controlType"),
+                Field<AccessibleStates>("states"), Field<AccessibleActions>("supportedActions"), Field<string?>("value"),
+                rangeValue, Field<AutomationBounds>("bounds"), Field<string?>("parentRuntimeId"),
+                Field<ImmutableArray<string>>("childRuntimeIds"), Field<AutomationRedaction>("redaction"),
+                Field<string>("captureId"), Field<bool>("truncated"));
+        }
+
+        public override void Write(Utf8JsonWriter writer, AutomationNodeSnapshot value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            void Field<T>(string name, T data) { writer.WritePropertyName(name); JsonSerializer.Serialize(writer, data, options); }
+            Field("handle", value.Handle); Field("rootId", value.RootId); Field("automationId", value.AutomationId);
+            Field("name", value.Name); Field("role", value.Role); Field("controlType", value.ControlType);
+            Field("states", value.States); Field("supportedActions", value.SupportedActions); Field("value", value.Value);
+            Field("rangeValue", value.RangeValue); Field("bounds", value.Bounds); Field("parentRuntimeId", value.ParentRuntimeId);
+            Field("childRuntimeIds", value.ChildRuntimeIds); Field("redaction", value.Redaction);
+            Field("captureId", value.CaptureId); Field("truncated", value.Truncated); writer.WriteEndObject();
+        }
+    }
+}

--- a/ModernFormsNext.Automation.Windows/README.md
+++ b/ModernFormsNext.Automation.Windows/README.md
@@ -1,0 +1,12 @@
+# ModernFormsNext.Automation.Windows
+
+Optional Windows development bridge over `ModernFormsNext.Automation`. Explicit server startup
+enables local authenticated Named Pipes, per-user discovery and one active client. Merely referencing
+this package creates no listener, file or credential, in either Debug or Release.
+
+The bridge borrows an application's initialized semantic session. All live reads and actions remain
+in that neutral core. No Testing runtime dependency, MCP, TCP, Android transport or private control
+access is included. Same-user ACLs and tokens are not a sandbox against the same user or an administrator.
+
+See [the live bridge guide](https://github.com/ProGraMajster/ModernFormsNext/blob/master/docs/automation-live-bridge.md)
+for startup, security, client/CLI usage, bounded waits and limitations.

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
@@ -1,0 +1,221 @@
+using System.Collections.Immutable;
+using System.IO.Pipes;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text.Json;
+using ModernFormsNext.Accessibility;
+
+namespace ModernFormsNext.Automation.Windows;
+
+/// <summary>Provides authenticated Windows IPC access to an application's existing semantic automation session.</summary>
+/// <remarks>
+/// Safe to call asynchronously from any thread. Concurrent ordinary calls fail with Busy; no unbounded
+/// queue is retained. Cancellation is sent as a separate control frame. A mutation whose response is
+/// lost returns OutcomeUnknown through AutomationTransportException and is never retried automatically.
+/// Dispose/disconnect ends only this client; the server and its borrowed semantic session remain alive.
+/// </remarks>
+public sealed class WindowsAutomationClient : IAsyncDisposable
+{
+    private readonly NamedPipeClientStream pipe;
+    private readonly SemaphoreSlim operation = new(1, 1);
+    private readonly CancellationTokenSource disconnected = new();
+    private long nextId = 1;
+
+    private WindowsAutomationClient(NamedPipeClientStream pipe, AutomationConnectionInfo info)
+    { this.pipe = pipe; Info = info; }
+
+    /// <summary>Gets the immutable negotiated connection policy; SessionId scopes handles and is not a credential.</summary>
+    public AutomationConnectionInfo Info { get; }
+
+    /// <summary>Connects to a specific live descriptor and authenticates using its separate protected secret file.</summary>
+    /// <param name="application">An unambiguous instance returned by AutomationDiscovery.</param>
+    /// <param name="capabilities">Requested operations; the server grants their policy intersection.</param>
+    /// <param name="cancellationToken">Cancels connection/authentication; both are also bounded by five seconds.</param>
+    /// <returns>An authenticated client. No semantic operation is sent before authentication succeeds.</returns>
+    /// <exception cref="AutomationTransportException">A safe discovery, connection, authentication, version or Busy error.</exception>
+    public static async Task<WindowsAutomationClient> ConnectAsync(AutomationApplicationInfo application,
+        AutomationCapability capabilities = AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        if (!Protocol.ValidCapabilities(capabilities)) throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+        NamedPipeClientStream? stream = null; byte[]? secret = null;
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadline.CancelAfter(TimeSpan.FromSeconds(5));
+        try
+        {
+            if (application.ProtocolVersion != Protocol.Version) throw new AutomationTransportException(AutomationTransportError.ProtocolMismatch);
+            secret = AutomationDiscovery.ReadSecret(application);
+            stream = new NamedPipeClientStream(".", application.EndpointName, PipeDirection.InOut,
+                PipeOptions.Asynchronous, TokenImpersonationLevel.Identification, HandleInheritability.None);
+            await stream.ConnectAsync(deadline.Token).ConfigureAwait(false);
+            if (!PipeSecurityPolicy.HasServerProcess(stream, application.ProcessId) || !AutomationDiscovery.IsLive(application))
+                throw new AutomationTransportException(AutomationTransportError.AuthenticationFailed);
+            byte[] bytes = Protocol.Encode(new
+            {
+                Version = Protocol.Version, Id = 1L, Kind = RequestKind.Handshake, DeadlineMilliseconds = 5000,
+                Payload = new Handshake { InstanceId = application.InstanceId, Secret = Convert.ToBase64String(secret), Capabilities = capabilities }
+            }, Protocol.HandshakeLimit);
+            try { await Protocol.WriteFrame(stream, bytes, deadline.Token).ConfigureAwait(false); }
+            finally { CryptographicOperations.ZeroMemory(bytes); }
+            var result = await ReadResponse(stream, 1, Protocol.HandshakeLimit, deadline.Token).ConfigureAwait(false);
+            var info = Protocol.Read<AutomationConnectionInfo>(result);
+            if (info.InstanceId != application.InstanceId || (info.Capabilities & ~capabilities) != 0
+                || info.MaxRequestBytes is < 4096 or > 1048576 || info.MaxResponseBytes is < 4096 or > 16777216
+                || info.MaxDeadlineMilliseconds is < 1 or > 60000)
+                throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+            var client = new WindowsAutomationClient(stream, info); stream = null; return client;
+        }
+        catch (AutomationTransportException) { throw; }
+        catch (OperationCanceledException) { throw new AutomationTransportException(cancellationToken.IsCancellationRequested
+            ? AutomationTransportError.Cancelled : AutomationTransportError.DeadlineExceeded); }
+        catch (Exception) { throw new AutomationTransportException(AutomationTransportError.ApplicationUnavailable); }
+        finally { stream?.Dispose(); if (secret is not null) CryptographicOperations.ZeroMemory(secret); }
+    }
+
+    /// <summary>Reads current negotiated session metadata.</summary>
+    /// <param name="cancellationToken">Cancels this request.</param>
+    /// <returns>Detached connection information.</returns>
+    public async Task<AutomationConnectionInfo> GetSessionInfoAsync(CancellationToken cancellationToken = default)
+        => Protocol.Read<AutomationConnectionInfo>(await Call(RequestKind.SessionInfo, new(), cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Lists the application's explicitly registered inspectable roots.</summary>
+    /// <param name="cancellationToken">Cancels this request.</param>
+    /// <returns>The canonical detached root result, including completeness diagnostics.</returns>
+    public async Task<AutomationResult<ImmutableArray<AutomationRootInfo>>> GetRootsAsync(CancellationToken cancellationToken = default)
+        => Protocol.ReadResult<ImmutableArray<AutomationRootInfo>>(await Call(RequestKind.GetRoots, new(), cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Captures a currently reachable node in one exact root.</summary>
+    /// <param name="rootId">The registration scope.</param>
+    /// <param name="handle">The full session/runtime handle.</param>
+    /// <param name="cancellationToken">Cancels this request.</param>
+    /// <returns>The canonical detached snapshot result.</returns>
+    public async Task<AutomationResult<AutomationNodeSnapshot>> InspectAsync(string rootId, AutomationNodeHandle handle, CancellationToken cancellationToken = default)
+        => Protocol.ReadResult<AutomationNodeSnapshot>(await Call(RequestKind.Inspect, new() { RootId = rootId, Handle = handle }, cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Captures direct canonical semantic children.</summary>
+    /// <param name="rootId">The registration scope.</param>
+    /// <param name="handle">The full parent handle.</param>
+    /// <param name="cancellationToken">Cancels this request.</param>
+    /// <returns>The immutable canonical child result.</returns>
+    public async Task<AutomationResult<ImmutableArray<AutomationNodeSnapshot>>> GetChildrenAsync(string rootId, AutomationNodeHandle handle, CancellationToken cancellationToken = default)
+        => Protocol.ReadResult<ImmutableArray<AutomationNodeSnapshot>>(await Call(RequestKind.GetChildren, new() { RootId = rootId, Handle = handle }, cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Resolves exactly one canonical query match without guessing among duplicates.</summary>
+    /// <param name="rootId">The registration scope.</param>
+    /// <param name="query">Existing exact semantic filters.</param>
+    /// <param name="cancellationToken">Cancels this request.</param>
+    /// <returns>The canonical unique-match result.</returns>
+    public async Task<AutomationResult<AutomationNodeSnapshot>> FindOneAsync(string rootId, AutomationQuery query, CancellationToken cancellationToken = default)
+        => Protocol.ReadResult<AutomationNodeSnapshot>(await Call(RequestKind.FindOne, new() { RootId = rootId, Query = query }, cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Queries bounded current canonical matches.</summary>
+    /// <param name="rootId">The registration scope.</param>
+    /// <param name="query">Existing exact semantic filters.</param>
+    /// <param name="cancellationToken">Cancels this request.</param>
+    /// <returns>The immutable canonical match result and completeness diagnostics.</returns>
+    public async Task<AutomationResult<ImmutableArray<AutomationNodeSnapshot>>> FindAllAsync(string rootId, AutomationQuery query, CancellationToken cancellationToken = default)
+        => Protocol.ReadResult<ImmutableArray<AutomationNodeSnapshot>>(await Call(RequestKind.FindAll, new() { RootId = rootId, Query = query }, cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Requests a capability-checked canonical action; Accepted does not mean asynchronous business completion.</summary>
+    /// <param name="rootId">The registration scope.</param>
+    /// <param name="handle">The full target handle.</param>
+    /// <param name="action">One advertised canonical action.</param>
+    /// <param name="value">Optional bounded text or numeric action value; never logged.</param>
+    /// <param name="cancellationToken">Cancels work; an ambiguous mutation produces OutcomeUnknown.</param>
+    /// <returns>The canonical action acceptance result.</returns>
+    public async Task<AutomationActionResult> PerformActionAsync(string rootId, AutomationNodeHandle handle, AccessibleActions action,
+        AutomationActionValue? value = null, CancellationToken cancellationToken = default)
+        => Protocol.Read<AutomationActionResult>(await Call(RequestKind.PerformAction,
+            new() { RootId = rootId, Handle = handle, Action = action, Text = value?.Text, Number = value?.Number }, cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Waits on a canonical predicate in the application, using notifications and bounded reconciliation.</summary>
+    /// <param name="rootId">The registration scope.</param>
+    /// <param name="condition">A supported neutral core predicate.</param>
+    /// <param name="options">Bounded monotonic timeout and reconciliation interval.</param>
+    /// <param name="cancellationToken">Cancels the live wait and its UI observation.</param>
+    /// <returns>The core's detached wait evidence and status.</returns>
+    public async Task<AutomationWaitResult> WaitForConditionAsync(string rootId, AutomationWaitCondition condition,
+        AutomationWaitOptions? options = null, CancellationToken cancellationToken = default)
+        => Protocol.Read<AutomationWaitResult>(await Call(RequestKind.WaitForCondition,
+            new() { RootId = rootId, Condition = condition, WaitOptions = options }, cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Awaits a normal-priority dispatcher checkpoint; does not promise global idle or command completion.</summary>
+    /// <param name="cancellationToken">Cancels the queued checkpoint.</param>
+    /// <returns>The semantic session status at that checkpoint.</returns>
+    public async Task<AutomationErrorCode> CheckpointAsync(CancellationToken cancellationToken = default)
+        => Protocol.Read<AutomationErrorCode>(await Call(RequestKind.Checkpoint, new(), cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Closes this connection and cancels its outstanding work without stopping the application server.</summary>
+    /// <returns>A task completed after the local stream closes; server-side wait cleanup follows EOF on its dispatcher.</returns>
+    public async Task DisconnectAsync()
+    {
+        disconnected.Cancel();
+        await pipe.DisposeAsync().ConfigureAwait(false);
+    }
+    /// <summary>Disconnects this client. Repeated calls are safe.</summary>
+    public ValueTask DisposeAsync() => new(DisconnectAsync());
+
+    private async Task<JsonElement> Call(RequestKind kind, Operation payload, CancellationToken token)
+    {
+        if (disconnected.IsCancellationRequested) throw new AutomationTransportException(AutomationTransportError.SessionEnded);
+        if (!await operation.WaitAsync(0).ConfigureAwait(false)) throw new AutomationTransportException(AutomationTransportError.Busy);
+        bool writeStarted = false;
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(disconnected.Token);
+        // The client allows a small bounded cleanup/response grace after the server's deadline.
+        deadline.CancelAfter(TimeSpan.FromMilliseconds(Info.MaxDeadlineMilliseconds + 2000));
+        byte[]? bytes = null;
+        try
+        {
+            token.ThrowIfCancellationRequested();
+            long id = Interlocked.Increment(ref nextId);
+            bytes = Protocol.Encode(new { Version = Protocol.Version, Id = id, Kind = kind,
+                DeadlineMilliseconds = Info.MaxDeadlineMilliseconds, Payload = payload }, Info.MaxRequestBytes);
+            // Decode locally for bounded strings/duplicate contract checks before sending any mutation.
+            Protocol.DecodeRequest(bytes);
+            writeStarted = true;
+            await Protocol.WriteFrame(pipe, bytes, deadline.Token).ConfigureAwait(false);
+            var response = ReadResponse(pipe, id, Info.MaxResponseBytes, deadline.Token);
+            using var cancelSignal = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var cancellation = Task.Delay(Timeout.InfiniteTimeSpan, cancelSignal.Token);
+            if (await Task.WhenAny(response, cancellation).ConfigureAwait(false) == cancellation)
+            {
+                using var grace = CancellationTokenSource.CreateLinkedTokenSource(deadline.Token);
+                grace.CancelAfter(TimeSpan.FromSeconds(2));
+                await Protocol.WriteFrame(pipe, Protocol.Encode(new { Version = Protocol.Version, Id = id, Kind = RequestKind.Cancel,
+                    DeadlineMilliseconds = 0, Payload = new { } }, Protocol.HandshakeLimit), grace.Token).ConfigureAwait(false);
+                try { return await response.WaitAsync(grace.Token).ConfigureAwait(false); }
+                catch { await DisconnectAsync().ConfigureAwait(false); throw; }
+            }
+            cancelSignal.Cancel();
+            return await response.ConfigureAwait(false);
+        }
+        catch (AutomationTransportException) { throw; }
+        catch (OperationCanceledException)
+        {
+            if (writeStarted) await DisconnectAsync().ConfigureAwait(false);
+            throw new AutomationTransportException(writeStarted && kind == RequestKind.PerformAction ? AutomationTransportError.OutcomeUnknown
+                : token.IsCancellationRequested ? AutomationTransportError.Cancelled
+                : disconnected.IsCancellationRequested ? AutomationTransportError.SessionEnded : AutomationTransportError.DeadlineExceeded);
+        }
+        catch (Exception)
+        {
+            await DisconnectAsync().ConfigureAwait(false);
+            throw new AutomationTransportException(writeStarted && kind == RequestKind.PerformAction ? AutomationTransportError.OutcomeUnknown
+                : AutomationTransportError.ApplicationUnavailable);
+        }
+        finally { if (bytes is not null) CryptographicOperations.ZeroMemory(bytes); operation.Release(); }
+    }
+
+    private static async Task<JsonElement> ReadResponse(Stream stream, long id, int limit, CancellationToken token)
+    {
+        var bytes = await Protocol.ReadFrame(stream, limit, token).ConfigureAwait(false)
+            ?? throw new EndOfStreamException();
+        var response = JsonSerializer.Deserialize<Response>(bytes, Protocol.Json)
+            ?? throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+        if (response.Version != Protocol.Version) throw new AutomationTransportException(AutomationTransportError.ProtocolMismatch);
+        if (response.Id != id || !Enum.IsDefined(response.Error)) throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+        if (response.Error != AutomationTransportError.None) throw new AutomationTransportException(response.Error);
+        return response.Result ?? throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+    }
+}

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
@@ -125,9 +125,10 @@ public sealed class WindowsAutomationClient : IAsyncDisposable
     /// <param name="rootId">The registration scope.</param>
     /// <param name="handle">The full target handle.</param>
     /// <param name="action">One advertised canonical action.</param>
-    /// <param name="value">Optional bounded text or numeric action value; never logged.</param>
+    /// <param name="value">Optional bounded text or finite numeric action value; never logged.</param>
     /// <param name="cancellationToken">Cancels work; an ambiguous mutation produces OutcomeUnknown.</param>
     /// <returns>The canonical action acceptance result.</returns>
+    /// <exception cref="AutomationTransportException">InvalidRequest for a non-finite number, rejected before sending without closing the connection; other safe transport failures may also occur.</exception>
     public async Task<AutomationActionResult> PerformActionAsync(string rootId, AutomationNodeHandle handle, AccessibleActions action,
         AutomationActionValue? value = null, CancellationToken cancellationToken = default)
         => Protocol.Read<AutomationActionResult>(await Call(RequestKind.PerformAction,
@@ -173,6 +174,10 @@ public sealed class WindowsAutomationClient : IAsyncDisposable
         try
         {
             token.ThrowIfCancellationRequested();
+            // Protocol JSON has no NaN/infinity representation. Reject these caller values
+            // before encoding/writing instead of misclassifying a serializer failure as EOF.
+            if (payload.Number is double number && !double.IsFinite(number))
+                throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
             long id = Interlocked.Increment(ref nextId);
             bytes = Protocol.Encode(new { Version = Protocol.Version, Id = id, Kind = kind,
                 DeadlineMilliseconds = Info.MaxDeadlineMilliseconds, Payload = payload }, Info.MaxRequestBytes);

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
@@ -190,13 +190,22 @@ public sealed class WindowsAutomationClient : IAsyncDisposable
             cancelSignal.Cancel();
             return await response.ConfigureAwait(false);
         }
-        catch (AutomationTransportException) { throw; }
+        catch (AutomationTransportException error)
+        {
+            if (writeStarted && !error.IsServerResponse)
+            {
+                await DisconnectAsync().ConfigureAwait(false);
+                if (kind == RequestKind.PerformAction) throw new AutomationTransportException(AutomationTransportError.OutcomeUnknown);
+            }
+            throw;
+        }
         catch (OperationCanceledException)
         {
+            bool wasDisconnected = disconnected.IsCancellationRequested;
             if (writeStarted) await DisconnectAsync().ConfigureAwait(false);
             throw new AutomationTransportException(writeStarted && kind == RequestKind.PerformAction ? AutomationTransportError.OutcomeUnknown
                 : token.IsCancellationRequested ? AutomationTransportError.Cancelled
-                : disconnected.IsCancellationRequested ? AutomationTransportError.SessionEnded : AutomationTransportError.DeadlineExceeded);
+                : wasDisconnected ? AutomationTransportError.SessionEnded : AutomationTransportError.DeadlineExceeded);
         }
         catch (Exception)
         {
@@ -215,7 +224,7 @@ public sealed class WindowsAutomationClient : IAsyncDisposable
             ?? throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
         if (response.Version != Protocol.Version) throw new AutomationTransportException(AutomationTransportError.ProtocolMismatch);
         if (response.Id != id || !Enum.IsDefined(response.Error)) throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
-        if (response.Error != AutomationTransportError.None) throw new AutomationTransportException(response.Error);
+        if (response.Error != AutomationTransportError.None) throw new AutomationTransportException(response.Error, true);
         return response.Result ?? throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
     }
 }

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationClient.cs
@@ -13,6 +13,10 @@ namespace ModernFormsNext.Automation.Windows;
 /// queue is retained. Cancellation is sent as a separate control frame. A mutation whose response is
 /// lost returns OutcomeUnknown through AutomationTransportException and is never retried automatically.
 /// Dispose/disconnect ends only this client; the server and its borrowed semantic session remain alive.
+/// The caller owns the returned client and should await DisposeAsync. Disconnect is permanent for
+/// this object: later requests report SessionEnded. ConnectAsync always returns a new client.
+/// Connection loss closes this client. A server-reported OutcomeUnknown may leave it connected;
+/// either way, reconcile observed application state and never automatically replay the mutation.
 /// </remarks>
 public sealed class WindowsAutomationClient : IAsyncDisposable
 {
@@ -147,6 +151,7 @@ public sealed class WindowsAutomationClient : IAsyncDisposable
         => Protocol.Read<AutomationErrorCode>(await Call(RequestKind.Checkpoint, new(), cancellationToken).ConfigureAwait(false));
 
     /// <summary>Closes this connection and cancels its outstanding work without stopping the application server.</summary>
+    /// <remarks>Repeated calls are safe. This object cannot reconnect; use ConnectAsync to obtain a new client.</remarks>
     /// <returns>A task completed after the local stream closes; server-side wait cleanup follows EOF on its dispatcher.</returns>
     public async Task DisconnectAsync()
     {

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationOptions.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationOptions.cs
@@ -1,0 +1,46 @@
+namespace ModernFormsNext.Automation.Windows;
+
+/// <summary>Configures an explicitly started Windows development bridge; immutable after initialization.</summary>
+public sealed record WindowsAutomationOptions
+{
+    /// <summary>Gets a public discovery label (1–128 characters), not an identity or control-derived value.</summary>
+    public string ApplicationName { get; init; } = AppDomain.CurrentDomain.FriendlyName;
+    /// <summary>Gets the transport policy, intersected with the borrowed semantic session.</summary>
+    public AutomationCapability Capabilities { get; init; } = AutomationCapability.Inspect | AutomationCapability.Query | AutomationCapability.Actions;
+    /// <summary>Gets the request byte budget (4096–1048576); default 65536, excluding the four-byte prefix.</summary>
+    public int MaxRequestBytes { get; init; } = 64 * 1024;
+    /// <summary>Gets the response byte budget (4096–16777216); default 4194304, excluding the prefix.</summary>
+    public int MaxResponseBytes { get; init; } = 4 * 1024 * 1024;
+    /// <summary>Gets the maximum request/wait deadline (1–60000 milliseconds); default 60000.</summary>
+    public int MaxDeadlineMilliseconds { get; init; } = 60000;
+
+    internal void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(ApplicationName) || ApplicationName.Length > 128 || ApplicationName.Any(char.IsControl)
+            || !Protocol.ValidCapabilities(Capabilities) || MaxRequestBytes is < 4096 or > 1048576
+            || MaxResponseBytes is < 4096 or > 16777216 || MaxDeadlineMilliseconds is < 1 or > 60000)
+            throw new ArgumentException("Invalid automation server options.");
+    }
+}
+
+/// <summary>Contains public discovery metadata; no credential or semantic root data is included.</summary>
+/// <param name="InstanceId">Random bridge lifetime nonce, independent of process ID and semantic SessionId.</param>
+/// <param name="ApplicationName">The application's public discovery label.</param>
+/// <param name="ProcessId">The owning process.</param>
+/// <param name="ProcessStartUtcTicks">Process creation identity as a precision-preserving decimal string.</param>
+/// <param name="EndpointName">Local named-pipe endpoint, derived from process ID and instance nonce.</param>
+/// <param name="ProtocolVersion">Wire protocol integer version.</param>
+/// <param name="Capabilities">The server/session intersection, before client negotiation.</param>
+/// <param name="CreatedUtc">Descriptor publication time; never used for elapsed deadlines.</param>
+public sealed record AutomationApplicationInfo(string InstanceId, string ApplicationName, int ProcessId,
+    string ProcessStartUtcTicks, string EndpointName, int ProtocolVersion, AutomationCapability Capabilities, DateTimeOffset CreatedUtc);
+
+/// <summary>Contains negotiated connection metadata, detached from the server.</summary>
+/// <param name="InstanceId">The authenticated bridge nonce.</param>
+/// <param name="SessionId">Semantic handle scope, never an authentication credential.</param>
+/// <param name="Capabilities">The granted server/session/client capability intersection.</param>
+/// <param name="MaxRequestBytes">Effective request frame budget.</param>
+/// <param name="MaxResponseBytes">Effective response frame budget.</param>
+/// <param name="MaxDeadlineMilliseconds">Maximum per-request deadline.</param>
+public sealed record AutomationConnectionInfo(string InstanceId, string SessionId, AutomationCapability Capabilities,
+    int MaxRequestBytes, int MaxResponseBytes, int MaxDeadlineMilliseconds);

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
@@ -147,7 +147,7 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
         {
             bool ownsClient = false; long lastId = 0, activeRequestId = 0;
             Task? pending = null; CancellationTokenSource? requestCancellation = null;
-            int responseLimit = options.MaxResponseBytes;
+            int responseLimit = options.MaxResponseBytes, responseStarted = 0;
             async Task Reply(long id, AutomationTransportError error, object? result = null)
             {
                 // Serialize the detached result directly into a capped buffer, without a second
@@ -155,9 +155,20 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
                 byte[] bytes;
                 try { bytes = Protocol.Encode(new { Version = Protocol.Version, Id = id, Error = error, Result = result }, responseLimit); }
                 catch (AutomationTransportException) { bytes = Protocol.Encode(new Response(Protocol.Version, id, AutomationTransportError.PayloadTooLarge, null), responseLimit); }
-                await writeLock.WaitAsync(disconnected.Token).ConfigureAwait(false);
-                try { await Protocol.WriteFrame(pipe, bytes, disconnected.Token).ConfigureAwait(false); }
-                finally { writeLock.Release(); }
+                using var writeDeadline = CancellationTokenSource.CreateLinkedTokenSource(disconnected.Token);
+                writeDeadline.CancelAfter(TimeSpan.FromSeconds(5));
+                try
+                {
+                    await writeLock.WaitAsync(writeDeadline.Token).ConfigureAwait(false);
+                    try { await Protocol.WriteFrame(pipe, bytes, writeDeadline.Token).ConfigureAwait(false); }
+                    finally { writeLock.Release(); }
+                }
+                catch
+                {
+                    // A partial frame cannot be repaired by appending another error response.
+                    // Close this connection instead; mutating clients retain OutcomeUnknown.
+                    disconnected.Cancel(); throw;
+                }
             }
             try
             {
@@ -197,12 +208,20 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
                     if (request.Id <= lastId) { await Reply(request.Id, AutomationTransportError.InvalidRequest); break; }
                     lastId = request.Id;
                     if (request.Kind == RequestKind.Disconnect) break;
-                    if (pending is { IsCompleted: false }) { await Reply(request.Id, AutomationTransportError.Busy); continue; }
+                    if (pending is { IsCompleted: false })
+                    {
+                        if (Volatile.Read(ref responseStarted) == 0) { await Reply(request.Id, AutomationTransportError.Busy); continue; }
+                        // The peer can consume the reply before the writer's async continuation
+                        // completes. Finish that bounded write before admitting its next request;
+                        // semantic work is already done, so this is not a second operation slot.
+                        await pending.ConfigureAwait(false);
+                    }
                     if (request.DeadlineMilliseconds < 1 || request.DeadlineMilliseconds > options.MaxDeadlineMilliseconds)
                     { await Reply(lastId, AutomationTransportError.InvalidRequest); continue; }
                     requestCancellation?.Dispose();
                     requestCancellation = CancellationTokenSource.CreateLinkedTokenSource(disconnected.Token);
                     activeRequestId = request.Id;
+                    Volatile.Write(ref responseStarted, 0);
                     pending = Execute(request, info, requestCancellation.Token);
                 }
 
@@ -212,23 +231,28 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
                     using var combined = CancellationTokenSource.CreateLinkedTokenSource(manualCancellation, requestDeadline.Token);
                     var token = combined.Token;
                     bool Expired() => requestDeadline.IsCancellationRequested;
+                    Task Outcome(AutomationTransportError error, object? value = null)
+                    {
+                        Volatile.Write(ref responseStarted, 1);
+                        return Reply(operation.Id, error, value);
+                    }
                     try
                     {
                         object result = await Dispatch(operation, connection, token).ConfigureAwait(false);
                         if (result is AutomationWaitResult { Status: AutomationWaitStatus.Cancelled } && Expired())
-                            await Reply(operation.Id, AutomationTransportError.DeadlineExceeded).ConfigureAwait(false);
-                        else await Reply(operation.Id, AutomationTransportError.None, result).ConfigureAwait(false);
+                            await Outcome(AutomationTransportError.DeadlineExceeded).ConfigureAwait(false);
+                        else await Outcome(AutomationTransportError.None, result).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException) when (token.IsCancellationRequested)
                     {
                         // A cancelled action response cannot certify whether canonical mutation was
                         // already entered. Conservatively preserve ambiguity at this boundary.
-                        await Reply(operation.Id, operation.Kind == RequestKind.PerformAction ? AutomationTransportError.OutcomeUnknown
+                        await Outcome(operation.Kind == RequestKind.PerformAction ? AutomationTransportError.OutcomeUnknown
                             : disconnected.IsCancellationRequested ? AutomationTransportError.SessionEnded
                             : Expired() ? AutomationTransportError.DeadlineExceeded : AutomationTransportError.Cancelled).ConfigureAwait(false);
                     }
-                    catch (AutomationTransportException error) { await Reply(operation.Id, error.Error).ConfigureAwait(false); }
-                    catch (Exception) { await Reply(operation.Id, AutomationTransportError.ApplicationError).ConfigureAwait(false); }
+                    catch (AutomationTransportException error) { await Outcome(error.Error).ConfigureAwait(false); }
+                    catch (Exception) { await Outcome(AutomationTransportError.ApplicationError).ConfigureAwait(false); }
                 }
             }
             // An invalid frame has no validated correlation ID; zero explicitly denotes an

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
@@ -1,0 +1,247 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text.Json;
+
+namespace ModernFormsNext.Automation.Windows;
+
+/// <summary>Owns an explicitly enabled, local Windows Named Pipe endpoint over a borrowed semantic session.</summary>
+/// <remarks>
+/// Start only for application-authorized development/testing. No static initializer starts a server.
+/// One authenticated client is allowed, with one outstanding semantic operation. Stop/DisposeAsync
+/// cancel connections and waits without stopping the borrowed AutomationSession. Await shutdown while
+/// its UI dispatcher remains alive; never synchronously block that dispatcher on bridge operations.
+/// The current User SID is allowed across elevation levels; this is not an elevation boundary.
+/// </remarks>
+public sealed class WindowsAutomationServer : IAsyncDisposable
+{
+    private readonly AutomationSession session;
+    private readonly WindowsAutomationOptions options;
+    private readonly SecurityIdentifier user;
+    private readonly byte[] secret = RandomNumberGenerator.GetBytes(32);
+    private readonly CancellationTokenSource shutdown = new();
+    private readonly ConcurrentDictionary<int, Task> connections = new();
+    private readonly Task listenerTask;
+    private readonly object stopLock = new();
+    private Task? stopTask;
+    private int activeClient;
+    private int nextConnection;
+
+    private WindowsAutomationServer(AutomationSession session, WindowsAutomationOptions options)
+    {
+        this.session = session; this.options = options; user = PipeSecurityPolicy.CurrentUser();
+        using var process = Process.GetCurrentProcess(); string nonce = Guid.NewGuid().ToString("N");
+        Application = new(nonce, options.ApplicationName, process.Id, AutomationDiscovery.ProcessStart(process),
+            AutomationDiscovery.Endpoint(process.Id, nonce), Protocol.Version, options.Capabilities & session.Capabilities, DateTimeOffset.UtcNow);
+        var first = PipeSecurityPolicy.Create(Application.EndpointName, user, true);
+        try { AutomationDiscovery.Publish(Application, secret, user); }
+        catch { first.Dispose(); CryptographicOperations.ZeroMemory(secret); shutdown.Dispose(); throw; }
+        listenerTask = Listen(first);
+    }
+
+    /// <summary>Gets detached public metadata for this server instance; contains no token.</summary>
+    public AutomationApplicationInfo Application { get; }
+    /// <summary>Gets whether server shutdown has begun; safe to read on any thread.</summary>
+    public bool IsStopped => shutdown.IsCancellationRequested;
+
+    /// <summary>Creates a listener, restrictive discovery files and a fresh cryptographic credential.</summary>
+    /// <param name="session">The application's existing initialized semantic session, borrowed until shutdown.</param>
+    /// <param name="options">Explicit immutable application policy; null selects bounded defaults.</param>
+    /// <returns>The started server, which the application must stop before its dispatcher shuts down.</returns>
+    /// <remarks>May be called on any thread after session initialization. Every call creates a distinct instance, never restarts an ended server.</remarks>
+    /// <exception cref="AutomationTransportException">Secure discovery or endpoint startup failed.</exception>
+    /// <example><code>
+    /// using var semantic = new AutomationSession();
+    /// using var root = semantic.RegisterRoot(form);
+    /// await using var server = WindowsAutomationServer.Start(semantic, new() { ApplicationName = "My development app" });
+    /// </code></example>
+    public static WindowsAutomationServer Start(AutomationSession session, WindowsAutomationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(session); options ??= new(); options.Validate();
+        if (session.IsStopped) throw new AutomationTransportException(AutomationTransportError.SessionEnded);
+        try { return new(session, options); }
+        catch (AutomationTransportException) { throw; }
+        catch (Exception) { throw new AutomationTransportException(AutomationTransportError.ApplicationUnavailable); }
+    }
+
+    /// <summary>Cancels listeners/requests/waits and removes this instance's descriptor and secret. Repeated calls share completion.</summary>
+    /// <returns>A task completed after connection work and canonical wait cleanup finish.</returns>
+    public Task StopAsync()
+    {
+        lock (stopLock) return stopTask ??= StopCore();
+    }
+
+    /// <summary>Awaits server shutdown without disposing the borrowed semantic session or application roots.</summary>
+    public ValueTask DisposeAsync() => new(StopAsync());
+
+    private async Task StopCore()
+    {
+        shutdown.Cancel(); AutomationDiscovery.Remove(Application.InstanceId);
+        await listenerTask.ConfigureAwait(false);
+        await Task.WhenAll(connections.Values).ConfigureAwait(false);
+        CryptographicOperations.ZeroMemory(secret);
+        // Keep the cancelled CTS readable for idempotent IsStopped/StopAsync after disposal.
+    }
+
+    private async Task Listen(NamedPipeServerStream first)
+    {
+        NamedPipeServerStream? listener = first;
+        using var slots = new SemaphoreSlim(7, 7);
+        try
+        {
+            while (!shutdown.IsCancellationRequested)
+            {
+                await slots.WaitAsync(shutdown.Token).ConfigureAwait(false);
+                try { await listener.WaitForConnectionAsync(shutdown.Token).ConfigureAwait(false); }
+                catch { slots.Release(); throw; }
+                var connected = listener; listener = null;
+                // Keep the namespace occupied by the connected handle while creating the next
+                // listener. First-instance protection applies only to initial namespace creation.
+                try { listener = PipeSecurityPolicy.Create(Application.EndpointName, user, false); }
+                catch { connected.Dispose(); slots.Release(); throw; }
+                int id = Interlocked.Increment(ref nextConnection);
+                var task = Serve(connected); connections[id] = task;
+                _ = task.ContinueWith(_ => { connections.TryRemove(id, out var ignored); slots.Release(); },
+                    CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }
+        }
+        catch (Exception) { shutdown.Cancel(); }
+        finally
+        {
+            listener?.Dispose();
+            await Task.WhenAll(connections.Values).ConfigureAwait(false);
+            AutomationDiscovery.Remove(Application.InstanceId);
+        }
+    }
+
+    private async Task Serve(NamedPipeServerStream pipe)
+    {
+        using (pipe)
+        using (var disconnected = CancellationTokenSource.CreateLinkedTokenSource(shutdown.Token))
+        using (var writeLock = new SemaphoreSlim(1, 1))
+        {
+            bool ownsClient = false; long lastId = 0;
+            Task? pending = null; CancellationTokenSource? requestCancellation = null;
+            int responseLimit = options.MaxResponseBytes;
+            async Task Reply(long id, AutomationTransportError error, object? result = null)
+            {
+                // Serialize the detached result directly into a capped buffer, without a second
+                // unbounded JsonElement. Fallback contains only a fixed safe error.
+                byte[] bytes;
+                try { bytes = Protocol.Encode(new { Version = Protocol.Version, Id = id, Error = error, Result = result }, responseLimit); }
+                catch (AutomationTransportException) { bytes = Protocol.Encode(new Response(Protocol.Version, id, AutomationTransportError.PayloadTooLarge, null), responseLimit); }
+                await writeLock.WaitAsync(disconnected.Token).ConfigureAwait(false);
+                try { await Protocol.WriteFrame(pipe, bytes, disconnected.Token).ConfigureAwait(false); }
+                finally { writeLock.Release(); }
+            }
+            try
+            {
+                using var handshakeDeadline = CancellationTokenSource.CreateLinkedTokenSource(disconnected.Token);
+                handshakeDeadline.CancelAfter(TimeSpan.FromSeconds(5));
+                byte[]? bytes = await Protocol.ReadFrame(pipe, Protocol.HandshakeLimit, handshakeDeadline.Token).ConfigureAwait(false);
+                if (bytes is null) return;
+                var request = Protocol.DecodeRequest(bytes); lastId = request.Id;
+                if (request.Version != Protocol.Version) { await Reply(lastId, AutomationTransportError.ProtocolMismatch); return; }
+                if (request.Kind != RequestKind.Handshake || !PipeSecurityPolicy.IsSameUser(pipe, user))
+                { await Reply(lastId, AutomationTransportError.AuthenticationFailed); return; }
+                var auth = Protocol.Read<Handshake>(request.Payload);
+                byte[] candidate = new byte[32];
+                bool valid = auth.InstanceId == Application.InstanceId && auth.Secret is not null
+                    && Convert.TryFromBase64String(auth.Secret, candidate, out int written) && written == 32
+                    && CryptographicOperations.FixedTimeEquals(candidate, secret);
+                CryptographicOperations.ZeroMemory(candidate);
+                if (!valid) { await Reply(lastId, AutomationTransportError.AuthenticationFailed); return; }
+                if (!Protocol.ValidCapabilities(auth.Capabilities) || auth.MaxResponseBytes is < 4096 or > 16777216)
+                { await Reply(lastId, AutomationTransportError.InvalidRequest); return; }
+                if (Interlocked.CompareExchange(ref activeClient, 1, 0) != 0) { await Reply(lastId, AutomationTransportError.Busy); return; }
+                ownsClient = true; responseLimit = Math.Min(options.MaxResponseBytes, auth.MaxResponseBytes);
+                var info = new AutomationConnectionInfo(Application.InstanceId, session.SessionId, auth.Capabilities & Application.Capabilities,
+                    options.MaxRequestBytes, responseLimit, options.MaxDeadlineMilliseconds);
+                await Reply(lastId, AutomationTransportError.None, info).ConfigureAwait(false);
+                while (!disconnected.IsCancellationRequested)
+                {
+                    bytes = await Protocol.ReadFrame(pipe, options.MaxRequestBytes, disconnected.Token).ConfigureAwait(false);
+                    if (bytes is null) break;
+                    request = Protocol.DecodeRequest(bytes);
+                    if (request.Version != Protocol.Version) { await Reply(request.Id, AutomationTransportError.ProtocolMismatch); break; }
+                    if (request.Kind == RequestKind.Cancel)
+                    {
+                        if (request.Id == lastId) requestCancellation?.Cancel();
+                        continue;
+                    }
+                    if (request.Id <= lastId) { await Reply(request.Id, AutomationTransportError.InvalidRequest); break; }
+                    if (request.Kind == RequestKind.Disconnect) break;
+                    if (pending is { IsCompleted: false }) { await Reply(request.Id, AutomationTransportError.Busy); continue; }
+                    lastId = request.Id;
+                    if (request.DeadlineMilliseconds < 1 || request.DeadlineMilliseconds > options.MaxDeadlineMilliseconds)
+                    { await Reply(lastId, AutomationTransportError.InvalidRequest); continue; }
+                    requestCancellation?.Dispose();
+                    requestCancellation = CancellationTokenSource.CreateLinkedTokenSource(disconnected.Token);
+                    requestCancellation.CancelAfter(request.DeadlineMilliseconds);
+                    pending = Execute(request, info, requestCancellation.Token);
+                }
+
+                async Task Execute(Request operation, AutomationConnectionInfo connection, CancellationToken token)
+                {
+                    try { await Reply(operation.Id, AutomationTransportError.None, await Dispatch(operation, connection, token).ConfigureAwait(false)).ConfigureAwait(false); }
+                    catch (OperationCanceledException) when (token.IsCancellationRequested)
+                    {
+                        // A cancelled action response cannot certify whether canonical mutation was
+                        // already entered. Conservatively preserve ambiguity at this boundary.
+                        await Reply(operation.Id, operation.Kind == RequestKind.PerformAction ? AutomationTransportError.OutcomeUnknown
+                            : disconnected.IsCancellationRequested ? AutomationTransportError.SessionEnded : AutomationTransportError.Cancelled).ConfigureAwait(false);
+                    }
+                    catch (AutomationTransportException error) { await Reply(operation.Id, error.Error).ConfigureAwait(false); }
+                    catch (Exception) { await Reply(operation.Id, AutomationTransportError.ApplicationError).ConfigureAwait(false); }
+                }
+            }
+            catch (AutomationTransportException error) { try { await Reply(lastId, error.Error).ConfigureAwait(false); } catch (Exception) { } }
+            catch (JsonException) { try { await Reply(lastId, AutomationTransportError.InvalidRequest).ConfigureAwait(false); } catch (Exception) { } }
+            catch (Exception) { }
+            finally
+            {
+                disconnected.Cancel();
+                if (pending is not null) { try { await pending.ConfigureAwait(false); } catch (Exception) { } }
+                requestCancellation?.Dispose();
+                if (ownsClient) Interlocked.Exchange(ref activeClient, 0);
+            }
+        }
+    }
+
+    private async Task<object> Dispatch(Request request, AutomationConnectionInfo info, CancellationToken token)
+    {
+        if (session.IsStopped) throw new AutomationTransportException(AutomationTransportError.SessionEnded);
+        var required = request.Kind switch
+        {
+            RequestKind.GetRoots or RequestKind.Inspect => AutomationCapability.Inspect,
+            RequestKind.GetChildren or RequestKind.FindOne or RequestKind.FindAll => AutomationCapability.Query,
+            RequestKind.PerformAction => AutomationCapability.Actions,
+            _ => (AutomationCapability)0
+        };
+        var payload = Protocol.Read<Operation>(request.Payload);
+        if (request.Kind == RequestKind.WaitForCondition)
+            required = payload.Condition?.Query is not null ? AutomationCapability.Query : AutomationCapability.Inspect;
+        if ((info.Capabilities & required) != required) throw new AutomationTransportException(AutomationTransportError.CapabilityDenied);
+        if (request.Kind is not (RequestKind.SessionInfo or RequestKind.GetRoots or RequestKind.Checkpoint) && payload.RootId is null)
+            throw new AutomationTransportException(AutomationTransportError.InvalidRequest);
+        return request.Kind switch
+        {
+            RequestKind.SessionInfo => info,
+            RequestKind.GetRoots => await session.GetRootsAsync(token).ConfigureAwait(false),
+            RequestKind.Checkpoint => await session.CheckpointAsync(token).ConfigureAwait(false),
+            RequestKind.Inspect when payload.Handle is { } handle => await session.InspectAsync(payload.RootId!, handle, token).ConfigureAwait(false),
+            RequestKind.GetChildren when payload.Handle is { } handle => await session.GetChildrenAsync(payload.RootId!, handle, token).ConfigureAwait(false),
+            RequestKind.FindOne when payload.Query is { } query => await session.FindOneAsync(payload.RootId!, query, token).ConfigureAwait(false),
+            RequestKind.FindAll when payload.Query is { } query => await session.FindAllAsync(payload.RootId!, query, token).ConfigureAwait(false),
+            RequestKind.PerformAction when payload.Handle is { } handle && !(payload.Text is not null && payload.Number is not null)
+                => await session.PerformActionAsync(payload.RootId!, handle, payload.Action,
+                    payload.Text is not null ? AutomationActionValue.FromText(payload.Text)
+                    : payload.Number is { } number ? AutomationActionValue.FromNumber(number) : null, token).ConfigureAwait(false),
+            RequestKind.WaitForCondition when payload.Condition is { } condition
+                => await session.WaitForConditionAsync(payload.RootId!, condition, payload.WaitOptions, token).ConfigureAwait(false),
+            _ => throw new AutomationTransportException(AutomationTransportError.InvalidRequest)
+        };
+    }
+}

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
@@ -102,9 +102,9 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
                 try { listener = PipeSecurityPolicy.Create(Application.EndpointName, user, false); }
                 catch { connected.Dispose(); slots.Release(); throw; }
                 int id = Interlocked.Increment(ref nextConnection);
-                var task = Serve(connected); connections[id] = task;
-                _ = task.ContinueWith(_ => { connections.TryRemove(id, out var ignored); slots.Release(); },
-                    CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                connections[id] = completion.Task;
+                _ = ServeTracked(connected, id, completion);
             }
         }
         catch (Exception) { shutdown.Cancel(); }
@@ -114,6 +114,17 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
             await Task.WhenAll(connections.Values).ConfigureAwait(false);
             AutomationDiscovery.Remove(Application.InstanceId);
         }
+
+        async Task ServeTracked(NamedPipeServerStream connected, int id, TaskCompletionSource completion)
+        {
+            try { await Serve(connected).ConfigureAwait(false); }
+            catch (Exception) { /* Connection faults never become unobserved application exceptions. */ }
+            finally
+            {
+                // Release before removing tracking so listener disposal cannot race this semaphore.
+                slots.Release(); connections.TryRemove(id, out _); completion.TrySetResult();
+            }
+        }
     }
 
     private async Task Serve(NamedPipeServerStream pipe)
@@ -122,7 +133,7 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
         using (var disconnected = CancellationTokenSource.CreateLinkedTokenSource(shutdown.Token))
         using (var writeLock = new SemaphoreSlim(1, 1))
         {
-            bool ownsClient = false; long lastId = 0;
+            bool ownsClient = false; long lastId = 0, activeRequestId = 0;
             Task? pending = null; CancellationTokenSource? requestCancellation = null;
             int responseLimit = options.MaxResponseBytes;
             async Task Reply(long id, AutomationTransportError error, object? result = null)
@@ -168,30 +179,40 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
                     if (request.Version != Protocol.Version) { await Reply(request.Id, AutomationTransportError.ProtocolMismatch); break; }
                     if (request.Kind == RequestKind.Cancel)
                     {
-                        if (request.Id == lastId) requestCancellation?.Cancel();
+                        if (request.Id == activeRequestId) requestCancellation?.Cancel();
                         continue;
                     }
                     if (request.Id <= lastId) { await Reply(request.Id, AutomationTransportError.InvalidRequest); break; }
+                    lastId = request.Id;
                     if (request.Kind == RequestKind.Disconnect) break;
                     if (pending is { IsCompleted: false }) { await Reply(request.Id, AutomationTransportError.Busy); continue; }
-                    lastId = request.Id;
                     if (request.DeadlineMilliseconds < 1 || request.DeadlineMilliseconds > options.MaxDeadlineMilliseconds)
                     { await Reply(lastId, AutomationTransportError.InvalidRequest); continue; }
                     requestCancellation?.Dispose();
                     requestCancellation = CancellationTokenSource.CreateLinkedTokenSource(disconnected.Token);
                     requestCancellation.CancelAfter(request.DeadlineMilliseconds);
+                    activeRequestId = request.Id;
                     pending = Execute(request, info, requestCancellation.Token);
                 }
 
                 async Task Execute(Request operation, AutomationConnectionInfo connection, CancellationToken token)
                 {
-                    try { await Reply(operation.Id, AutomationTransportError.None, await Dispatch(operation, connection, token).ConfigureAwait(false)).ConfigureAwait(false); }
+                    long started = Stopwatch.GetTimestamp();
+                    bool Expired() => Stopwatch.GetElapsedTime(started).TotalMilliseconds >= operation.DeadlineMilliseconds;
+                    try
+                    {
+                        object result = await Dispatch(operation, connection, token).ConfigureAwait(false);
+                        if (result is AutomationWaitResult { Status: AutomationWaitStatus.Cancelled } && Expired())
+                            await Reply(operation.Id, AutomationTransportError.DeadlineExceeded).ConfigureAwait(false);
+                        else await Reply(operation.Id, AutomationTransportError.None, result).ConfigureAwait(false);
+                    }
                     catch (OperationCanceledException) when (token.IsCancellationRequested)
                     {
                         // A cancelled action response cannot certify whether canonical mutation was
                         // already entered. Conservatively preserve ambiguity at this boundary.
                         await Reply(operation.Id, operation.Kind == RequestKind.PerformAction ? AutomationTransportError.OutcomeUnknown
-                            : disconnected.IsCancellationRequested ? AutomationTransportError.SessionEnded : AutomationTransportError.Cancelled).ConfigureAwait(false);
+                            : disconnected.IsCancellationRequested ? AutomationTransportError.SessionEnded
+                            : Expired() ? AutomationTransportError.DeadlineExceeded : AutomationTransportError.Cancelled).ConfigureAwait(false);
                     }
                     catch (AutomationTransportException error) { await Reply(operation.Id, error.Error).ConfigureAwait(false); }
                     catch (Exception) { await Reply(operation.Id, AutomationTransportError.ApplicationError).ConfigureAwait(false); }

--- a/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
+++ b/ModernFormsNext.Automation.Windows/WindowsAutomationServer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipes;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text.Json;
@@ -17,6 +18,9 @@ namespace ModernFormsNext.Automation.Windows;
 /// </remarks>
 public sealed class WindowsAutomationServer : IAsyncDisposable
 {
+    // A weak session-keyed lease prevents duplicate controlling endpoints over the same core.
+    // The lease is released only after shutdown cleanup, so two listeners cannot overlap.
+    private static readonly ConditionalWeakTable<AutomationSession, WindowsAutomationServer> servers = new();
     private readonly AutomationSession session;
     private readonly WindowsAutomationOptions options;
     private readonly SecurityIdentifier user;
@@ -50,7 +54,7 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
     /// <param name="session">The application's existing initialized semantic session, borrowed until shutdown.</param>
     /// <param name="options">Explicit immutable application policy; null selects bounded defaults.</param>
     /// <returns>The started server, which the application must stop before its dispatcher shuts down.</returns>
-    /// <remarks>May be called on any thread after session initialization. Every call creates a distinct instance, never restarts an ended server.</remarks>
+    /// <remarks>May be called on any thread after session initialization. A session can have one server; duplicate Start returns Busy until StopAsync finishes. A later Start creates a fresh instance and credential.</remarks>
     /// <exception cref="AutomationTransportException">Secure discovery or endpoint startup failed.</exception>
     /// <example><code>
     /// using var semantic = new AutomationSession();
@@ -61,7 +65,14 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(session); options ??= new(); options.Validate();
         if (session.IsStopped) throw new AutomationTransportException(AutomationTransportError.SessionEnded);
-        try { return new(session, options); }
+        try
+        {
+            lock (servers)
+            {
+                if (servers.TryGetValue(session, out _)) throw new AutomationTransportException(AutomationTransportError.Busy);
+                var server = new WindowsAutomationServer(session, options); servers.Add(session, server); return server;
+            }
+        }
         catch (AutomationTransportException) { throw; }
         catch (Exception) { throw new AutomationTransportException(AutomationTransportError.ApplicationUnavailable); }
     }
@@ -82,6 +93,7 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
         await listenerTask.ConfigureAwait(false);
         await Task.WhenAll(connections.Values).ConfigureAwait(false);
         CryptographicOperations.ZeroMemory(secret);
+        lock (servers) servers.Remove(session);
         // Keep the cancelled CTS readable for idempotent IsStopped/StopAsync after disposal.
     }
 
@@ -190,15 +202,16 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
                     { await Reply(lastId, AutomationTransportError.InvalidRequest); continue; }
                     requestCancellation?.Dispose();
                     requestCancellation = CancellationTokenSource.CreateLinkedTokenSource(disconnected.Token);
-                    requestCancellation.CancelAfter(request.DeadlineMilliseconds);
                     activeRequestId = request.Id;
                     pending = Execute(request, info, requestCancellation.Token);
                 }
 
-                async Task Execute(Request operation, AutomationConnectionInfo connection, CancellationToken token)
+                async Task Execute(Request operation, AutomationConnectionInfo connection, CancellationToken manualCancellation)
                 {
-                    long started = Stopwatch.GetTimestamp();
-                    bool Expired() => Stopwatch.GetElapsedTime(started).TotalMilliseconds >= operation.DeadlineMilliseconds;
+                    using var requestDeadline = new CancellationTokenSource(operation.DeadlineMilliseconds);
+                    using var combined = CancellationTokenSource.CreateLinkedTokenSource(manualCancellation, requestDeadline.Token);
+                    var token = combined.Token;
+                    bool Expired() => requestDeadline.IsCancellationRequested;
                     try
                     {
                         object result = await Dispatch(operation, connection, token).ConfigureAwait(false);
@@ -218,8 +231,10 @@ public sealed class WindowsAutomationServer : IAsyncDisposable
                     catch (Exception) { await Reply(operation.Id, AutomationTransportError.ApplicationError).ConfigureAwait(false); }
                 }
             }
-            catch (AutomationTransportException error) { try { await Reply(lastId, error.Error).ConfigureAwait(false); } catch (Exception) { } }
-            catch (JsonException) { try { await Reply(lastId, AutomationTransportError.InvalidRequest).ConfigureAwait(false); } catch (Exception) { } }
+            // An invalid frame has no validated correlation ID; zero explicitly denotes an
+            // uncorrelated terminal rejection instead of misattributing it to the prior request.
+            catch (AutomationTransportException error) { try { await Reply(0, error.Error).ConfigureAwait(false); } catch (Exception) { } }
+            catch (JsonException) { try { await Reply(0, AutomationTransportError.InvalidRequest).ConfigureAwait(false); } catch (Exception) { } }
             catch (Exception) { }
             finally
             {

--- a/ModernFormsNext.Automation/AssemblyInfo.cs
+++ b/ModernFormsNext.Automation/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// The Windows adapter reconstructs detached result/snapshot DTOs using their existing internal
+// constructors. It must not access live traversal/session internals or introduce serializer APIs here.
+[assembly: InternalsVisibleTo("ModernFormsNext.Automation.Windows")]

--- a/ModernFormsNext.Automation/AutomationSession.Waits.cs
+++ b/ModernFormsNext.Automation/AutomationSession.Waits.cs
@@ -1,0 +1,198 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+using ModernFormsNext.Accessibility;
+using ModernFormsNext.WindowKit.Threading;
+
+namespace ModernFormsNext.Automation;
+
+public sealed partial class AutomationSession
+{
+    private event Action? lifetimeChanged;
+    private int activeWaits;
+
+    /// <summary>Waits for a current semantic predicate using canonical wake hints and bounded reconciliation.</summary>
+    /// <param name="rootId">The exact registration identity; an ended registration satisfies only RootEnded.</param>
+    /// <param name="condition">One handle/query predicate, or a root lifetime predicate.</param>
+    /// <param name="options">Immutable timeout/reconciliation bounds; null selects defaults.</param>
+    /// <param name="cancellationToken">Cancels queued reads and waiting; returns Cancelled after UI subscription cleanup.</param>
+    /// <returns>Detached evidence of satisfaction or an explicit unsuccessful status.</returns>
+    /// <remarks>
+    /// Safe to call from any thread; await without blocking the owning dispatcher. At most 64 waits
+    /// can observe a session concurrently. The initial read has no delay. Observation is registered
+    /// on the UI thread before a second read, so a change between the initial read and subscription
+    /// cannot be lost. Notifications only trigger fresh reads; missing notifications are reconciled.
+    /// Individual application getters cannot be preempted. Dispose the session before its dispatcher.
+    /// Redacted values cannot be tested for equality. Accepted actions do not imply completed commands.
+    /// </remarks>
+    /// <example><code>
+    /// var completed = await automation.WaitForConditionAsync(root.RootId, new()
+    /// {
+    ///     Kind = AutomationWaitKind.ValueEquals,
+    ///     Query = new() { AutomationId = "status" }, Value = "Completed"
+    /// });
+    /// </code></example>
+    public async Task<AutomationWaitResult> WaitForConditionAsync(string rootId, AutomationWaitCondition condition,
+        AutomationWaitOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        long start = Stopwatch.GetTimestamp();
+        options ??= new();
+        AutomationWaitResult End(AutomationWaitStatus status, AutomationErrorCode error = AutomationErrorCode.None,
+            AutomationNodeSnapshot? snapshot = null) => new(status, error, snapshot, Stopwatch.GetElapsedTime(start));
+        if (!Guid.TryParseExact(rootId, "N", out _) || condition is null || !Enum.IsDefined(condition.Kind)
+            || (condition.Kind == AutomationWaitKind.RootEnded ? condition.Handle is not null || condition.Query is not null
+                : (condition.Handle is null) == (condition.Query is null))
+            || condition.Value is { Length: > SemanticTraversal.MaxTextLength }
+            || (condition.Kind == AutomationWaitKind.ValueEquals && condition.Value is null)
+            || options.Timeout < TimeSpan.Zero || options.Timeout > TimeSpan.FromSeconds(60)
+            || options.ReconciliationInterval < TimeSpan.FromMilliseconds(20) || options.ReconciliationInterval > TimeSpan.FromSeconds(1))
+            return End(AutomationWaitStatus.Failed, AutomationErrorCode.InvalidArgument);
+
+        WaitObservation? observation = null;
+        using var deadline = new CancellationTokenSource();
+        // Zero timeout still admits the initial check, without scheduling any observation/timer.
+        if (options.Timeout > TimeSpan.Zero) deadline.CancelAfter(options.Timeout);
+        using var combined = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadline.Token);
+        try
+        {
+            var evaluated = await EvaluateWait(rootId, condition, combined.Token).ConfigureAwait(false);
+            if (evaluated is not null) return evaluated with { Elapsed = Stopwatch.GetElapsedTime(start) };
+            if (options.Timeout == TimeSpan.Zero) return End(AutomationWaitStatus.TimedOut);
+            observation = await OnWaitDispatcher(() =>
+            {
+                if (activeWaits >= 64) return null;
+                var value = new WaitObservation(this);
+                activeWaits++;
+                return value;
+            }).ConfigureAwait(false);
+            if (observation is null) return End(AutomationWaitStatus.Failed, AutomationErrorCode.LimitExceeded);
+            while (true)
+            {
+                combined.Token.ThrowIfCancellationRequested();
+                // Subscribe before reading again, on the same dispatcher. Rebuild only this wait's
+                // weak observation set from the existing bounded traversal, never a node index.
+                await OnWaitDispatcher(() =>
+                {
+                    observation.Refresh(rootId, condition.Handle is null && condition.Query is not null
+                        ? AutomationCapability.Query : AutomationCapability.Inspect, combined.Token);
+                    return true;
+                }).ConfigureAwait(false);
+                evaluated = await EvaluateWait(rootId, condition, combined.Token).ConfigureAwait(false);
+                if (evaluated is not null) return evaluated with { Elapsed = Stopwatch.GetElapsedTime(start) };
+                TimeSpan remaining = options.Timeout - Stopwatch.GetElapsedTime(start);
+                if (remaining <= TimeSpan.Zero) return End(AutomationWaitStatus.TimedOut);
+                await observation.WaitAsync(remaining < options.ReconciliationInterval ? remaining : options.ReconciliationInterval,
+                    combined.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (combined.IsCancellationRequested)
+        {
+            return End(cancellationToken.IsCancellationRequested ? AutomationWaitStatus.Cancelled : AutomationWaitStatus.TimedOut);
+        }
+        catch (Exception) { return End(AutomationWaitStatus.Failed, AutomationErrorCode.ApplicationError); }
+        finally
+        {
+            if (observation is not null)
+                await OnWaitDispatcher(() => { observation.Dispose(); activeWaits--; return true; }).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Queues a normal-priority dispatcher turn and completes after that turn is processed.</summary>
+    /// <param name="cancellationToken">Cancels the queued checkpoint; cancellation throws OperationCanceledException.</param>
+    /// <returns>None when processed or SessionEnded if the semantic session has ended.</returns>
+    /// <remarks>
+    /// Always queues, even on the UI thread. Await without blocking that thread. Earlier normal-priority
+    /// dispatcher work runs first; future timers, network, rendering/GPU work and arbitrary Tasks are
+    /// outside this guarantee. This is not global application idle or AsyncCommand completion.
+    /// </remarks>
+    public Task<AutomationErrorCode> CheckpointAsync(CancellationToken cancellationToken = default)
+        => dispatcher.InvokeAsync(() => stopped ? AutomationErrorCode.SessionEnded : AutomationErrorCode.None,
+            DispatcherPriority.Default, cancellationToken).GetTask();
+
+    private Task<T> OnWaitDispatcher<T>(Func<T> action)
+        => dispatcher.CheckAccess() ? Task.FromResult(dispatcher.Invoke(action))
+            : dispatcher.InvokeAsync(action).GetTask();
+
+    private async Task<AutomationWaitResult?> EvaluateWait(string rootId, AutomationWaitCondition condition, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        var rootError = await OnWaitDispatcher(() => ResolveRoot(rootId,
+            condition.Handle is null && condition.Query is not null ? AutomationCapability.Query : AutomationCapability.Inspect, out _)).ConfigureAwait(false);
+        if (condition.Kind == AutomationWaitKind.RootEnded)
+        {
+            return rootError == AutomationErrorCode.StaleNode ? new(AutomationWaitStatus.Satisfied, AutomationErrorCode.None, null, default)
+                : rootError == AutomationErrorCode.None ? null : WaitFailure(rootError);
+        }
+        if (rootError == AutomationErrorCode.StaleNode) return new(AutomationWaitStatus.RootEnded, rootError, null, default);
+        if (rootError != AutomationErrorCode.None) return WaitFailure(rootError);
+        var result = condition.Handle is { } handle
+            ? await InspectAsync(rootId, handle, token).ConfigureAwait(false)
+            : await FindOneAsync(rootId, condition.Query!, token).ConfigureAwait(false);
+        if (result.Error is AutomationErrorCode.NodeNotFound or AutomationErrorCode.NodeUnavailable)
+            return condition.Kind == AutomationWaitKind.NodeNotExposed
+                ? new(AutomationWaitStatus.Satisfied, AutomationErrorCode.None, null, default) : null;
+        if (result.Error != AutomationErrorCode.None) return WaitFailure(result.Error);
+        var node = result.Value!;
+        if (condition.Kind == AutomationWaitKind.ValueEquals && node.Redaction != AutomationRedaction.None)
+            return WaitFailure(AutomationErrorCode.CapabilityDenied);
+        bool satisfied = condition.Kind switch
+        {
+            AutomationWaitKind.NodeExists or AutomationWaitKind.Exposed => true,
+            AutomationWaitKind.Enabled => (node.States & AccessibleStates.Unavailable) == 0,
+            AutomationWaitKind.Focused => (node.States & AccessibleStates.Focused) != 0,
+            AutomationWaitKind.Selected => (node.States & AccessibleStates.Selected) != 0,
+            AutomationWaitKind.ValueEquals => string.Equals(node.Value, condition.Value, StringComparison.Ordinal),
+            AutomationWaitKind.StateContains => (node.States & condition.States) == condition.States,
+            _ => false
+        };
+        return satisfied ? new(AutomationWaitStatus.Satisfied, AutomationErrorCode.None, node, default) : null;
+    }
+
+    private static AutomationWaitResult WaitFailure(AutomationErrorCode error)
+        => new(error == AutomationErrorCode.SessionEnded ? AutomationWaitStatus.SessionEnded
+            : AutomationWaitStatus.Failed, error, null, default);
+
+    private sealed class WaitObservation : IDisposable
+    {
+        private readonly AutomationSession session;
+        private readonly List<WeakReference<AccessibleObject>> peers = [];
+        private readonly Channel<bool> changed = Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
+            { FullMode = BoundedChannelFullMode.DropWrite, SingleReader = true });
+
+        internal WaitObservation(AutomationSession session)
+        {
+            this.session = session;
+            session.lifetimeChanged += Wake;
+        }
+
+        internal void Refresh(string rootId, AutomationCapability capability, CancellationToken token)
+        {
+            ClearPeers();
+            if (session.Begin(rootId, capability, token, out _, out var traversal) != AutomationErrorCode.None) return;
+            foreach (var entry in traversal!.Entries)
+            {
+                entry.Peer.ClientNotification += OnNotification;
+                peers.Add(new(entry.Peer));
+            }
+        }
+
+        private void OnNotification(object? sender, AccessibleObjectNotificationEventArgs e) => Wake();
+        private void Wake() => changed.Writer.TryWrite(true);
+
+        internal async Task WaitAsync(TimeSpan interval, CancellationToken token)
+        {
+            using var reconcile = CancellationTokenSource.CreateLinkedTokenSource(token);
+            reconcile.CancelAfter(interval);
+            try { await changed.Reader.ReadAsync(reconcile.Token).ConfigureAwait(false); }
+            catch (OperationCanceledException) when (!token.IsCancellationRequested) { }
+        }
+
+        private void ClearPeers()
+        {
+            foreach (var weak in peers)
+                if (weak.TryGetTarget(out var peer)) peer.ClientNotification -= OnNotification;
+            peers.Clear();
+        }
+
+        public void Dispose() { ClearPeers(); session.lifetimeChanged -= Wake; changed.Writer.TryComplete(); }
+    }
+}

--- a/ModernFormsNext.Automation/AutomationSession.cs
+++ b/ModernFormsNext.Automation/AutomationSession.cs
@@ -94,6 +94,7 @@ public sealed partial class AutomationSession : IDisposable
         stopped = true;
         foreach (var root in roots) root.Detach();
         roots.Clear();
+        lifetimeChanged?.Invoke();
     }
 
     /// <summary>Marshals session cleanup to its production UI dispatcher.</summary>
@@ -110,7 +111,11 @@ public sealed partial class AutomationSession : IDisposable
     public void Dispose() => Stop();
 
     internal void VerifyAccess() => dispatcher.VerifyAccess();
-    internal void Remove(AutomationRootRegistration root) { root.Detach(); roots.Remove(root); }
+    internal void Remove(AutomationRootRegistration root)
+    {
+        root.Detach();
+        if (roots.Remove(root)) lifetimeChanged?.Invoke();
+    }
     internal bool IsLive(AutomationRootRegistration root)
     {
         if (root.IsAlive) return true;

--- a/ModernFormsNext.Automation/AutomationWaitCondition.cs
+++ b/ModernFormsNext.Automation/AutomationWaitCondition.cs
@@ -1,0 +1,76 @@
+using ModernFormsNext.Accessibility;
+
+namespace ModernFormsNext.Automation;
+
+/// <summary>Identifies a bounded predicate over current canonical semantic data.</summary>
+public enum AutomationWaitKind
+{
+    /// <summary>A unique matching node is exposed.</summary>
+    NodeExists,
+    /// <summary>The target is absent from a complete active semantic traversal.</summary>
+    NodeNotExposed,
+    /// <summary>The exposed target is not Unavailable.</summary>
+    Enabled,
+    /// <summary>The target is exposed in the active semantic projection; no occlusion guarantee is implied.</summary>
+    Exposed,
+    /// <summary>The target has the Focused state.</summary>
+    Focused,
+    /// <summary>The target has the Selected state.</summary>
+    Selected,
+    /// <summary>The unredacted semantic Value equals the supplied text ordinally.</summary>
+    ValueEquals,
+    /// <summary>The target contains every supplied state flag.</summary>
+    StateContains,
+    /// <summary>The root registration has ended, including explicit unregistration or root disposal.</summary>
+    RootEnded
+}
+
+/// <summary>Describes one live predicate without an expression language or private control access.</summary>
+/// <remarks>Supply exactly one Handle or Query except for RootEnded, which takes neither. Queries must resolve uniquely.</remarks>
+public sealed record AutomationWaitCondition
+{
+    /// <summary>Gets the predicate to evaluate.</summary>
+    public AutomationWaitKind Kind { get; init; }
+    /// <summary>Gets the optional exact session-scoped target.</summary>
+    public AutomationNodeHandle? Handle { get; init; }
+    /// <summary>Gets the optional canonical query evaluated afresh after every wakeup.</summary>
+    public AutomationQuery? Query { get; init; }
+    /// <summary>Gets the expected value for ValueEquals, at most 4096 characters. Never include secrets in diagnostics.</summary>
+    public string? Value { get; init; }
+    /// <summary>Gets all required flags for StateContains.</summary>
+    public AccessibleStates States { get; init; }
+}
+
+/// <summary>Bounds a live wait independently of semantic traversal budgets.</summary>
+public sealed record AutomationWaitOptions
+{
+    /// <summary>Gets the monotonic timeout, from zero to 60 seconds; default 10 seconds. Zero still performs an immediate check.</summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(10);
+    /// <summary>Gets the fallback interval, from 20 milliseconds to one second; default 100 milliseconds.</summary>
+    public TimeSpan ReconciliationInterval { get; init; } = TimeSpan.FromMilliseconds(100);
+}
+
+/// <summary>Explains why a live wait ended; satisfaction is distinct from an accepted action.</summary>
+public enum AutomationWaitStatus
+{
+    /// <summary>The current semantic predicate was satisfied.</summary>
+    Satisfied,
+    /// <summary>The monotonic deadline elapsed.</summary>
+    TimedOut,
+    /// <summary>The caller cancelled the wait.</summary>
+    Cancelled,
+    /// <summary>The semantic session ended.</summary>
+    SessionEnded,
+    /// <summary>The registered root ended before a node predicate was satisfied.</summary>
+    RootEnded,
+    /// <summary>A safe semantic error prevents evaluating the predicate.</summary>
+    Failed
+}
+
+/// <summary>Contains a completed wait's detached evidence and monotonic elapsed time.</summary>
+/// <param name="Status">The reason the wait ended.</param>
+/// <param name="Error">The safe semantic error, if any.</param>
+/// <param name="Snapshot">The satisfied target, or null for absence/lifetime predicates and unsuccessful waits.</param>
+/// <param name="Elapsed">Elapsed monotonic time, including queued UI work.</param>
+public sealed record AutomationWaitResult(AutomationWaitStatus Status, AutomationErrorCode Error,
+    AutomationNodeSnapshot? Snapshot, TimeSpan Elapsed);

--- a/ModernFormsNext.Automation/README.md
+++ b/ModernFormsNext.Automation/README.md
@@ -2,7 +2,9 @@
 
 Optional development-time **in-process semantic core**, issue #97 Phase 1a. It consumes the
 canonical `AccessibleObject` tree and production UI dispatcher. No Testing dependency, listener,
-IPC, discovery, authentication, MCP, screenshot, input simulation, or wait service is included.
+IPC, discovery, authentication, MCP, screenshot or input simulation is included.
+Phase 1b adds bounded semantic waits and a narrow dispatcher checkpoint to this neutral core.
+Windows IPC remains in the separately referenced Automation.Windows adapter.
 
 Create a session on the initialized application UI thread, explicitly register allowed windows or
 Skia surfaces, and await its semantic query/action methods. Dispose registrations/session before

--- a/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
+++ b/ModernFormsNext.Tests/ReleaseVersionConsistencyTests.cs
@@ -11,6 +11,7 @@ public sealed class ReleaseVersionConsistencyTests
     [
         "ModernFormsNext/ModernFormsNext.csproj",
         "ModernFormsNext.Automation/ModernFormsNext.Automation.csproj",
+        "ModernFormsNext.Automation.Windows/ModernFormsNext.Automation.Windows.csproj",
         "ModernFormsNext.CodeGeneration/ModernFormsNext.CodeGeneration.csproj",
         "ModernFormsNext.Designer/ModernFormsNext.Designer.csproj",
         "ModernFormsNext.Designing/ModernFormsNext.Designing.csproj",

--- a/ModernFormsNext.slnx
+++ b/ModernFormsNext.slnx
@@ -14,6 +14,8 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="ModernFormsNext.Automation.Tests/ModernFormsNext.Automation.Tests.csproj" />
+    <Project Path="ModernFormsNext.Automation.Windows.TestHost/ModernFormsNext.Automation.Windows.TestHost.csproj" />
+    <Project Path="ModernFormsNext.Automation.Windows.Tests/ModernFormsNext.Automation.Windows.Tests.csproj" />
     <Project Path="ModernFormsNext.CrossPlatform.Sample.Tests/ModernFormsNext.CrossPlatform.Sample.Tests.csproj" />
     <Project Path="ModernFormsNext.Designer.Tests/ModernFormsNext.Designer.Tests.csproj" />
     <Project Path="ModernFormsNext.Testing.Tests/ModernFormsNext.Testing.Tests.csproj" />
@@ -25,6 +27,7 @@
     <Project Path="ModernFormsNext.Tests/ModernFormsNext.Tests.csproj" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="ModernFormsNext.Automation.Windows/ModernFormsNext.Automation.Windows.csproj" />
     <Project Path="ModernFormsNext.Automation/ModernFormsNext.Automation.csproj" />
     <Project Path="ModernFormsNext.CodeGeneration/ModernFormsNext.CodeGeneration.csproj" />
     <Project Path="ModernFormsNext.Designer/ModernFormsNext.Designer.csproj" />

--- a/ModernFormsNext.slnx
+++ b/ModernFormsNext.slnx
@@ -27,6 +27,7 @@
     <Project Path="ModernFormsNext.Tests/ModernFormsNext.Tests.csproj" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="ModernFormsNext.Automation.Cli/ModernFormsNext.Automation.Cli.csproj" />
     <Project Path="ModernFormsNext.Automation.Windows/ModernFormsNext.Automation.Windows.csproj" />
     <Project Path="ModernFormsNext.Automation/ModernFormsNext.Automation.csproj" />
     <Project Path="ModernFormsNext.CodeGeneration/ModernFormsNext.CodeGeneration.csproj" />

--- a/docs-site/toc.yml
+++ b/docs-site/toc.yml
@@ -22,6 +22,8 @@
   href: content/docs/commands.md
 - name: In-process semantic automation
   href: content/docs/automation.md
+- name: Windows live automation bridge
+  href: content/docs/automation-live-bridge.md
 - name: Accessibility semantic model
   href: content/docs/accessibility/semantic-model.md
 - name: Android accessibility backend

--- a/docs/automation-live-bridge.md
+++ b/docs/automation-live-bridge.md
@@ -244,6 +244,19 @@ wait/request, and the server releases the controlling slot after canonical clean
 may briefly report Busy while that cleanup completes. Client disconnect completion denotes local
 stream closure, not a remote acknowledgement of UI cleanup.
 
+The caller owns each client returned by `ConnectAsync` and should use `await using` or await
+`DisposeAsync`. Disconnect/disposal is idempotent and permanent for that object: subsequent
+requests report `SessionEnded`. Reconnection requires a new `ConnectAsync` call and a new client.
+After a process restart, discover a fresh descriptor; an old descriptor cannot select the new
+instance. A server-reported `OutcomeUnknown` can leave the connection usable, whereas loss of
+the response closes the client. Neither case authorizes replay: read current application state
+or use application-specific recovery before deciding on further mutations.
+
+Ordinary requests use the negotiated `MaxDeadlineMilliseconds`; the client allows two additional
+seconds for the response. Use a cancellation token for a shorter caller deadline. Wait options
+bound the semantic predicate independently and cannot extend the transport deadline. There is
+no automatic retry of a request, including after reconnect.
+
 Server shutdown cancels listeners, connections and waits, removes discovery/auth files, and waits
 for cleanup while retaining the borrowed core session. Clients see `SessionEnded` or
 `ApplicationUnavailable` if the connection disappears; mutations retain OutcomeUnknown when

--- a/docs/automation-live-bridge.md
+++ b/docs/automation-live-bridge.md
@@ -193,6 +193,10 @@ is lost, the client reports **`OutcomeUnknown`**. It never automatically retries
 mutation. Inspect application state or seek application-specific resolution before deciding what
 to do next. Even cancellation may leave a mutation ambiguous.
 
+Numeric action input must be finite. `NaN` and infinities cannot be represented by protocol JSON;
+the client rejects them locally with `InvalidRequest` before sending an action and keeps the
+connection usable. Canonical finite range/type validation remains in the semantic core.
+
 Password/protected/sensitive values stay redacted through JSON, client DTOs and CLI output. Custom
 getter exceptions are reported as safe semantic codes. Action parameters are not echoed. For
 ordinary unmarked controls, the existing semantic value is intentionally observable; applications

--- a/docs/automation-live-bridge.md
+++ b/docs/automation-live-bridge.md
@@ -1,0 +1,300 @@
+# Windows live automation bridge
+
+Issue #97 Phase 1b adds an optional **development/testing** bridge to a running ModernFormsNext
+application. `ModernFormsNext.Automation.Windows` targets `net10.0-windows` and depends only on
+`ModernFormsNext.Automation`. It provides a Windows server, discovery and a usable public client.
+The nonpackable `ModernFormsNext.Automation.Cli` executable exercises the same client API.
+
+The [semantic core](automation.md) remains authoritative: root registrations, session/runtime
+handles, canonical `AccessibleObject` queries, `PerformAction`, capabilities, safe errors and
+privacy redaction. The adapter never traverses controls, invokes commands directly or maintains
+another live node index. Internal DTO constructors are shared narrowly with the Windows assembly
+to reconstruct detached client results; serializer attributes and Win32 APIs stay out of the core.
+
+## Explicit enablement and shutdown
+
+Referencing either package creates **no listener, descriptor, token or endpoint**. The application
+must call `Start` explicitly after initializing its production UI dispatcher. This applies equally
+to Debug and Release. There is no `Debugger.IsAttached` switch and no library `#if DEBUG` policy.
+Production apps may omit the adapter reference or simply never call `Start`.
+
+```csharp
+using ModernFormsNext.Automation;
+using ModernFormsNext.Automation.Windows;
+
+// On the initialized application UI dispatcher; form is an application-owned Form.
+var semantic = new AutomationSession();
+var registration = semantic.RegisterRoot(form);
+var server = WindowsAutomationServer.Start(semantic, new()
+{
+    ApplicationName = "Orders development instance",
+    Capabilities = AutomationCapability.Inspect
+        | AutomationCapability.Query | AutomationCapability.Actions
+});
+
+// In the application's asynchronous shutdown path, while its UI dispatcher still runs:
+await server.StopAsync();
+registration.Dispose(); // UI thread
+semantic.Dispose();     // UI thread
+```
+
+Keep the server in the application's lifetime owner. Await shutdown before allowing the main
+window/message loop to exit; do not block the UI thread with `.Wait()` or `.Result`. A closing
+handler can cancel the first close, await server cleanup, then permit and reissue close. Normal
+ModernFormsNext startup installs the dispatcher synchronization context; explicitly marshal the
+final registration/session disposal when using `ConfigureAwait(false)`.
+
+The server **borrows** the session and never stops it, unregisters roots, closes windows or disposes
+controls. `StopAsync`/`DisposeAsync` are idempotent. There is one server lease per semantic session;
+a duplicate `Start` reports `Busy` until cleanup completes. Starting again after shutdown generates
+a new endpoint, instance nonce and token. The application can independently stop the core session;
+subsequent semantic requests then report session end.
+
+## Discovery and identity
+
+`AutomationDiscovery.DiscoverAsync()` reads at most 1024 descriptors from
+`%LOCALAPPDATA%/ModernFormsNext/Automation/v1`, ordered by instance ID. An absent directory returns
+an empty list without creating it. There is no brute-force named-pipe enumeration.
+
+Each `<instance>.json` descriptor contains only public metadata:
+
+| Field | Meaning |
+| --- | --- |
+| `instanceId` | Random lowercase Guid N bridge-lifetime nonce |
+| `applicationName` | Explicit public label, 1–128 characters; not an identity |
+| `processId` | Owning process ID |
+| `processStartUtcTicks` | Process creation time as a precision-preserving decimal string |
+| `endpointName` | `mfn-automation-{pid}-{instance}` |
+| `protocolVersion` | Integer `1` |
+| `capabilities` | Server/session capability intersection |
+| `createdUtc` | Diagnostic publication time; not an elapsed deadline clock |
+
+Two applications with the same name remain distinct. Clients choose an instance or an unambiguous
+PID, never a name. Discovery and connection verify process liveness and start identity, preventing
+PID reuse from selecting a different process. Connection also checks the actual pipe server PID
+before sending the credential. Authentication checks the bridge nonce independently of PID and
+the semantic `AutomationSession.SessionId`.
+
+Discovery removes validated records whose process has exited or whose start identity differs.
+The associated secret is removed too. Malformed/unsafe records are ignored, not interpreted as
+paths to delete. Orphan secret files without a descriptor can be removed after two minutes; the
+age guard avoids deleting a server publishing its descriptor. Filename checks allow only a Guid N
+basename inside the fixed directory. Files are created exclusively and flushed; an incomplete
+record during publication is ignored until a later discovery. No file becomes a valid descriptor
+until the listener and secret exist.
+
+## Security boundary
+
+The discovery directory, descriptors, secret files and pipe use a protected DACL owned by the
+current **User SID**, granting that SID full control. Unexpected ACLs and reparse points are
+rejected. ACLs on an existing directory are validated, not silently widened or rewritten. New
+files receive their restrictive ACL during creation. Unsafe discovery produces a controlled error.
+
+The pipe is created through minimal Windows-only `CreateNamedPipeW` interop with an explicit ACL,
+overlapped I/O, initial first-instance protection and `PIPE_REJECT_REMOTE_CLIENTS`. Merely selecting
+`.NET PipeOptions.CurrentUserOnly` is insufficient for the explicit remote policy. After the first
+bounded client write, the server uses identification-level impersonation to compare the actual
+peer's User SID. The policy allows the **same user across elevation levels**; it does not treat
+elevation as a security boundary. See Microsoft's [pipe security guidance](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights)
+and [CreateNamedPipeW contract](https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createnamedpipew).
+
+Every server lifetime generates 32 bytes from `RandomNumberGenerator`. They are stored in a
+separate protected `<instance>.auth` file, not the normal descriptor. The client reads that file
+after validating the descriptor and ACL. The handshake sends the secret as Base64 and compares it
+in constant time. Secrets never enter CLI arguments, normal output, response DTOs or exception
+messages. The implementation adds no logging subsystem and clears owned byte buffers where
+practical. Stop removes credential files and clears the server's secret buffer. A stale token does
+not authenticate a new server.
+
+This is a same-user development bridge, **not a sandbox against malicious code already running
+as the same user or as an administrator**. Such code may read protected files, inspect process
+memory, manipulate the application or create its own bridge. There is no remote administration,
+TCP/WebSocket listener, Android transport or additional elevation guarantee.
+
+The automated security suite checks actual ACL contents, successful ordinary-user authentication,
+and OS access-denied results for a restricted token opening the pipe/descriptor/secret. A separate
+SMB loopback probe first connects to a permissive positive control, then verifies bridge rejection;
+if that prerequisite is unavailable it explicitly reports NOT EXECUTED. Restricted-token testing
+is distinct from another logged-on user, and SMB loopback is distinct from a second physical
+machine. Those latter scenarios require separate environment evidence.
+
+## Handshake, capabilities and wire limits
+
+Protocol 1 uses a small custom JSON envelope, not an RPC framework. Requests contain `version`,
+positive monotonic `id`, numeric `kind`, `deadlineMilliseconds` and typed `payload`. Responses
+contain `version`, `id`, controlled `error` and detached `result`. A malformed frame without a
+validated ID receives an uncorrelated terminal error with ID zero. No arbitrary application error
+text or exception object is serialized.
+
+Handshake verifies protocol, actual peer, instance nonce, credential and requested capabilities.
+Granted capabilities are the requested/server/core intersection. Canonical root policy is checked
+again by the core on every operation. Snapshot advertised actions describe canonical support;
+clients must also respect negotiated capabilities. Root descriptors retain the canonical root
+policy, which may be broader than the particular client's grant.
+
+One authenticated client owns a server at a time, including read-only clients. A second valid
+client receives `Busy`. That client may have one outstanding semantic request; `Cancel` is a
+separate control frame and does not require another slot. Public client concurrent calls report
+`Busy` instead of accumulating an unbounded queue. At most seven connections are being served,
+plus one pending listener instance. Handshakes have a five-second deadline.
+
+| Budget | Default | Allowed server configuration |
+| --- | --- | --- |
+| Request JSON bytes | 65536 | 4096–1048576 |
+| Response JSON bytes | 4194304 | 4096–16777216 |
+| String payload | 4096 UTF-16 characters | Fixed |
+| JSON depth | 32 | Fixed |
+| Maximum request deadline | 60000 ms | 1–60000 ms |
+| Outstanding semantic requests/client | 1 | Fixed |
+| Core concurrent observations/session | 64 | Fixed |
+
+Frames use a four-byte little-endian signed positive length followed by exactly that many UTF-8
+JSON bytes. Length is checked before body allocation. Partial reads, EOF, invalid lengths,
+malformed JSON, duplicate fields and oversized strings are handled explicitly. Response encoding
+uses a capped buffer, so an oversized detached result reports `PayloadTooLarge` during encoding.
+Core traversal depth/node/result budgets remain separate and authoritative. Query limits do not
+become transport frame limits.
+
+Request kinds are `Handshake`, `SessionInfo`, `GetRoots`, `Inspect`, `GetChildren`, `FindOne`,
+`FindAll`, `PerformAction`, `WaitForCondition`, `Checkpoint`, `Cancel` and `Disconnect`.
+Incompatible versions report `ProtocolMismatch`; this phase does not define a version-negotiation
+matrix. The transport-neutral payload semantics can be reused later without exposing pipe handles.
+
+## Public client and actions
+
+```csharp
+var applications = await AutomationDiscovery.DiscoverAsync(cancellationToken);
+var selected = applications.Single(app => app.InstanceId == requestedInstanceId);
+await using var client = await WindowsAutomationClient.ConnectAsync(
+    selected, cancellationToken: cancellationToken);
+var roots = await client.GetRootsAsync(cancellationToken);
+var root = roots.Value.Single(); // Require explicit selection when more than one root is present.
+var found = await client.FindOneAsync(root.RootId,
+    new AutomationQuery { AutomationId = "save" }, cancellationToken);
+if (found.Error == AutomationErrorCode.None)
+{
+    var accepted = await client.PerformActionAsync(root.RootId, found.Value!.Handle,
+        AccessibleActions.Invoke, cancellationToken: cancellationToken);
+}
+```
+
+All client methods are asynchronous and hide the pipe stream. Semantic results retain their
+existing `AutomationErrorCode`, partial-result flags, capture IDs and immutable snapshots.
+Transport failures use `AutomationTransportException.Error` with controlled messages. A detached
+handle always includes semantic session and canonical runtime ID; its operation also supplies the
+exact root registration ID. Reconnect does not invent new node identities.
+
+`PerformActionAsync` delegates exclusively to the existing core action path. `Accepted` means
+canonical acceptance, not completed business work. If an action may have executed but its response
+is lost, the client reports **`OutcomeUnknown`**. It never automatically retries Invoke or another
+mutation. Inspect application state or seek application-specific resolution before deciding what
+to do next. Even cancellation may leave a mutation ambiguous.
+
+Password/protected/sensitive values stay redacted through JSON, client DTOs and CLI output. Custom
+getter exceptions are reported as safe semantic codes. Action parameters are not echoed. For
+ordinary unmarked controls, the existing semantic value is intentionally observable; applications
+must mark confidential custom peers appropriately.
+
+## Live waits, deadlines and checkpoint
+
+Wait execution belongs to `AutomationSession`, shared by in-process and Windows clients. Conditions
+are `NodeExists`, `NodeNotExposed`, `Enabled`, `Exposed`, `Focused`, `Selected`, `ValueEquals`,
+`StateContains` and `RootEnded`. Supply an exact handle or an existing unique query; root-ended
+observes registration lifetime and takes neither. There is no expression language.
+
+The core performs an immediate read. If unsatisfied, it subscribes to bounded canonical peers on
+the UI dispatcher and rereads before awaiting a wakeup. Changes between initial query and
+subscription cannot be lost. Notifications are hints that trigger a fresh read; bounded periodic
+reconciliation handles missing notifications and newly exposed nodes. Observation references are
+weak and are removed on every terminal path.
+
+```csharp
+var completed = await client.WaitForConditionAsync(root.RootId, new()
+{
+    Kind = AutomationWaitKind.ValueEquals,
+    Query = new() { AutomationId = "status" },
+    Value = "Completed"
+}, new() { Timeout = TimeSpan.FromSeconds(10) }, cancellationToken);
+```
+
+Wait timeout defaults to ten seconds, is bounded to sixty seconds and uses monotonic elapsed
+time. Zero still checks immediately. Reconciliation defaults to 100 ms (20 ms–1 s allowed).
+Incomplete captures cannot certify absence or uniqueness; protected values cannot be probed by
+equality. The result distinguishes satisfaction, timeout, cancellation, root/session end and
+semantic failure. A transport request deadline can end a longer core wait with `DeadlineExceeded`.
+Client cancellation sends a control frame and allows a bounded two-second response/cleanup grace.
+On a lost connection the client closes the stream, and the server cancels outstanding work.
+
+Timeout and cancellation cannot preempt an application getter or action that blocks the UI thread.
+Shutdown and observation cleanup require that dispatcher to continue running. Keep custom peers
+prompt and await cleanup before closing the dispatcher.
+
+`CheckpointAsync` always queues a normal-priority dispatcher turn, after earlier work at that
+priority. It is not global application idle and says nothing about future timers, network I/O,
+GPU rendering or arbitrary Task completion. AsyncCommand completion is observed through an
+application-exposed semantic postcondition, not a global command completion bus.
+
+## Disconnect, shutdown and crash
+
+Client `DisconnectAsync`/`DisposeAsync` closes only its connection. EOF cancels the server-side
+wait/request, and the server releases the controlling slot after canonical cleanup. Reconnection
+may briefly report Busy while that cleanup completes. Client disconnect completion denotes local
+stream closure, not a remote acknowledgement of UI cleanup.
+
+Server shutdown cancels listeners, connections and waits, removes discovery/auth files, and waits
+for cleanup while retaining the borrowed core session. Clients see `SessionEnded` or
+`ApplicationUnavailable` if the connection disappears; mutations retain OutcomeUnknown when
+appropriate. A process crash similarly terminates waits, and the next discovery removes stale
+records. No mutation is replayed after reconnect.
+
+## CLI
+
+Build/run `ModernFormsNext.Automation.Cli` or invoke its generated executable. It is a nonpackable
+repository client, not a globally installed tool. The usage name `mfn-automation` below is a shell
+alias for that executable. `--json` emits machine-readable JSON; list/tree also offer readable
+text. Other successful commands emit compact JSON in either mode. Error text is always controlled.
+
+```text
+mfn-automation list --json
+mfn-automation info --instance INSTANCE --json
+mfn-automation connect --pid PID --json
+mfn-automation roots --instance INSTANCE --json
+mfn-automation tree --instance INSTANCE --root ROOT --depth 3
+mfn-automation find --instance INSTANCE --root ROOT --automation-id save --json
+mfn-automation inspect --instance INSTANCE --root ROOT --session SESSION --node NODE --json
+mfn-automation action --instance INSTANCE --root ROOT --session SESSION --node NODE --action Invoke --json
+mfn-automation action --instance INSTANCE --root ROOT --session SESSION --node NODE --action SetValue --value-stdin --json
+mfn-automation wait --instance INSTANCE --root ROOT --condition ValueEquals --automation-id status --equals Completed --timeout-ms 10000 --json
+```
+
+Pass text action values through stdin; they are bounded to 4096 characters and never echoed.
+`--number` accepts an invariant finite numeric value. Wait equality can also read stdin using
+`--value-stdin`; avoid putting confidential text in shell arguments. Root is optional only when
+the application exposes exactly one root. Handles require both `--session` and `--node`.
+Tree depth defaults to three and is limited to 0–32; core result/traversal limits still apply.
+
+Exit codes: `0` success/satisfied, `2` invalid usage or ambiguous/missing selection requirements,
+`3` semantic failure/incomplete capture/unsatisfied wait, `4` transport/discovery failure or
+ambiguous instance selection, `5` OutcomeUnknown, `130` cancellation. CLI does not guess between
+same-name applications or automatically retry actions.
+
+## Validation and deferred scope
+
+`ModernFormsNext.Automation.Windows.TestHost` is a dedicated native Windows executable with Form,
+DelegateCommand/AsyncCommand buttons, ordinary/password text boxes, checkbox, list, tree and status.
+Tests launch it as a separate process, discover/authenticate through real pipes and exercise semantic
+actions/waits without UIA, mouse/keyboard coordinates or screenshots. CLI tests launch additional
+client processes and save nonsecret smoke output under ignored `artifacts/issue-97-phase1b/cli`.
+Application-owned fixture gates complete async commands without fixed client sleeps. The no-start
+fixture retains the adapter reference and proves default-off in whichever configuration is tested.
+
+The Windows test suite covers framing, limits, negotiation, stale/PID-reuse descriptors, bad/missing/
+stale tokens, instance/version mismatch, actual ACL denial, remote-path probing, privacy, root close,
+disconnect, server stop, process kill and unknown mutation outcomes. Neutral wait tests cover the
+subscription race, reconciliation, immediate predicates and actual subscription cleanup. These are
+automated semantic/native-process checks, not manual visual or accessibility-tool validation.
+
+Issue #97 remains open. Phase 1c acceptance/integration work is separate; any broader event history,
+screenshots, diagnostics, alternate transports or application-specific policy remain deferred.
+No MCP SDK, server, tool, package or repository is added. A later optional
+`ModernFormsNext.Automation.Mcp` adapter must consume the proven client contracts separately.

--- a/docs/automation-live-bridge.md
+++ b/docs/automation-live-bridge.md
@@ -137,6 +137,9 @@ client receives `Busy`. That client may have one outstanding semantic request; `
 separate control frame and does not require another slot. Public client concurrent calls report
 `Busy` instead of accumulating an unbounded queue. At most seven connections are being served,
 plus one pending listener instance. Handshakes have a five-second deadline.
+Response writes also have a five-second I/O deadline, so a peer that stops reading cannot retain
+an unfinished writer indefinitely. After semantic work finishes, the next request may wait for
+that bounded response write to finish; it does not run concurrently with prior semantic work.
 
 | Budget | Default | Allowed server configuration |
 | --- | --- | --- |

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -8,7 +8,7 @@ Windows/Android backends or MCP. Existing application startup and accessibility 
 unchanged when this package is omitted.
 
 This is an in-process API. It opens no endpoint, enumerates no processes, and implements no
-discovery, authentication, IPC, CLI, event stream, wait service or MCP adapter. The whole #97
+discovery, authentication, IPC, CLI, event stream or MCP adapter. The whole #97
 issue remains open. A session ID identifies a semantic lifetime; it is **not an authentication
 token** or a security boundary against application code already running in the same process.
 
@@ -255,14 +255,44 @@ TreeView and custom semantic children. It verifies actual state changes, canonic
 bounded malformed peers, privacy, root/session lifetime and background dispatch with explicit
 dispatcher drains and controlled task completion.
 
-No public WaitCondition is published speculatively. Phase 1b can use existing immutable filters,
-states, capture metadata, root-scoped handles, safe errors and completeness flags. It must separately
-design condition evaluation, notification subscription/reconciliation, cancellation/deadlines and
-narrow idle checkpoints. ClientNotification is not assumed to cover all custom changes.
+### Live predicates and checkpoint (Phase 1b)
+
+`WaitForConditionAsync(rootId, condition, options, cancellationToken)` evaluates canonical state
+immediately. Supply exactly one root-scoped `Handle` or unique `Query`. Supported predicates are
+`NodeExists`, `NodeNotExposed`, `Enabled`, `Exposed`, `Focused`, `Selected`, `ValueEquals` and
+`StateContains`. `RootEnded` takes neither target and observes the registration ending (including
+explicit unregistration); it does not distinguish that from physical window closure.
+
+```csharp
+var completed = await automation.WaitForConditionAsync(root.RootId, new()
+{
+    Kind = AutomationWaitKind.ValueEquals,
+    Query = new() { AutomationId = "status" },
+    Value = "Completed"
+}, new() { Timeout = TimeSpan.FromSeconds(10) }, cancellationToken);
+if (completed.Status == AutomationWaitStatus.Satisfied)
+    Console.WriteLine(completed.Snapshot?.Value);
+```
+
+Waits subscribe to bounded canonical peers on the UI dispatcher and reread before waiting.
+Notifications are wake hints, not an authoritative event stream. Reconciliation defaults to 100 ms
+(allowed 20 ms–1 s); elapsed time/deadlines are monotonic. Timeout defaults to 10 s, is bounded to
+60 s, and zero still performs the initial check. At most 64 waits observe a session concurrently.
+All weak subscriptions and pending timers are removed on success, failure, timeout, cancellation,
+root end or session stop. Await cleanup while the dispatcher is still running.
+
+Incomplete traversals cannot prove absence or uniqueness. Redacted values cannot be tested with
+`ValueEquals`; the result is `CapabilityDenied`. `Exposed` describes the canonical projection, not
+screen occlusion. `Enabled` means exposed and lacking the canonical `Unavailable` state.
+
+`CheckpointAsync` always queues a normal-priority dispatcher turn. Previously queued normal-priority
+UI work has run when that turn completes. It makes no guarantee about future timers, network I/O,
+GPU rendering or arbitrary Tasks, and is not global idle. An AsyncCommand accepted by Invoke can
+remain pending; wait for an application-exposed postcondition such as the example above.
 
 Future named-pipe/other transport adapters call these same async methods. No Stream/Socket, JSON
 attribute, wire protocol version, auth handshake or MCP type is present in the core contract.
-Phase 1b still needs Windows IPC, discovery/authentication, live waits and a minimal client; actual
+Phase 1b adds Windows IPC, discovery/authentication and a minimal client outside this core; actual
 external-client acceptance follows separately. Events, screenshots, MCP and broader diagnostics
 remain their later scope. No #64 Phase 2 or #61/#62/#63/#72/#108/#109 work is part of this package.
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -7,6 +7,9 @@ The runtime package depends only on the platform-neutral ModernFormsNext target,
 Windows/Android backends or MCP. Existing application startup and accessibility behavior remain
 unchanged when this package is omitted.
 
+Phase 1b adds neutral live waits and a dispatcher checkpoint to this core, plus a separately
+referenced [Windows live bridge](automation-live-bridge.md) for external clients.
+
 This is an in-process API. It opens no endpoint, enumerates no processes, and implements no
 discovery, authentication, IPC, CLI, event stream or MCP adapter. The whole #97
 issue remains open. A session ID identifies a semantic lifetime; it is **not an authentication

--- a/scripts/Build-ReleaseDocumentation.ps1
+++ b/scripts/Build-ReleaseDocumentation.ps1
@@ -318,6 +318,7 @@ try {
     $apiAssemblies = @(
         [pscustomobject]@{ Id = 'ModernFormsNext'; Tfm = 'net10.0' },
         [pscustomobject]@{ Id = 'ModernFormsNext.Automation'; Tfm = 'net10.0' },
+        [pscustomobject]@{ Id = 'ModernFormsNext.Automation.Windows'; Tfm = 'net10.0-windows' },
         [pscustomobject]@{ Id = 'ModernFormsNext.CodeGeneration'; Tfm = 'net10.0' },
         [pscustomobject]@{ Id = 'ModernFormsNext.Designer'; Tfm = 'net10.0-windows' },
         [pscustomobject]@{ Id = 'ModernFormsNext.Designing'; Tfm = 'net10.0' },

--- a/scripts/Validate-ReleasePackages.ps1
+++ b/scripts/Validate-ReleasePackages.ps1
@@ -23,6 +23,7 @@ if ([string]::IsNullOrWhiteSpace($ExpectedVersion)) {
 $packageSpecs = @(
     [pscustomobject]@{ Id = "ModernFormsNext"; Frameworks = @("net10.0", "net10.0-windows"); Symbols = $true; Template = $false },
     [pscustomobject]@{ Id = "ModernFormsNext.Automation"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
+    [pscustomobject]@{ Id = "ModernFormsNext.Automation.Windows"; Frameworks = @("net10.0-windows"); Symbols = $true; Template = $false },
     [pscustomobject]@{ Id = "ModernFormsNext.CodeGeneration"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
     [pscustomobject]@{ Id = "ModernFormsNext.Designer"; Frameworks = @("net10.0-windows"); Symbols = $true; Template = $false },
     [pscustomobject]@{ Id = "ModernFormsNext.Designing"; Frameworks = @("net10.0"); Symbols = $true; Template = $false },
@@ -172,6 +173,9 @@ function Assert-PackageArchive {
             $dependencyVersion = $dependency.GetAttribute('version')
             if ($Spec.Id -ceq 'ModernFormsNext.Automation' -and $dependencyId -cne 'ModernFormsNext') {
                 throw "Automation must depend only on the neutral ModernFormsNext core; found '$dependencyId'."
+            }
+            if ($Spec.Id -ceq 'ModernFormsNext.Automation.Windows' -and $dependencyId -cne 'ModernFormsNext.Automation') {
+                throw "Automation.Windows must depend only on Automation; found '$dependencyId'."
             }
             if ($dependencyId -ceq 'Microsoft.VisualStudio.SDK' -or ($dependencyId -ceq 'MessagePack' -and $dependencyVersion -match '2\.5\.192')) {
                 throw "Package '$Path' contains forbidden dependency '$dependencyId' version '$dependencyVersion'."


### PR DESCRIPTION
## Summary

Implements #97 Phase 1b Windows live bridge over the existing semantic automation core. An explicitly enabled running application can be discovered, authenticated, queried and controlled by an external client, which then waits for a semantic postcondition and disconnects. Canonical AccessibleObject identity, permissions, privacy and PerformAction remain authoritative.

## Windows bridge

Adds the optional `ModernFormsNext.Automation.Windows` package: local Named Pipes, explicit opt-in/default-off in Debug and Release, restricted per-user discovery, PID/process-start/instance identity, separate per-lifetime authentication secret and capability negotiation. The server borrows the application's AutomationSession; stop/disposal cancels bridge work without stopping the core. One authenticated client and one outstanding semantic operation are allowed.

## Protocol

Version 1 uses bounded framed JSON: four-byte little-endian length, validated request/string/depth budgets, capped response encoding and bounded response writes. Structured transport errors remain separate from semantic results. Lost mutation responses produce `OutcomeUnknown`; no action is automatically retried. The immediate sequential-response handoff has a 250-round real-pipe regression.

## Client

`AutomationDiscovery` and `WindowsAutomationClient` provide discovery, connection, session info, roots, inspect, children, find, action, wait, checkpoint and disconnect/disposal without exposing pipe streams, wire envelopes or credential handling. A future thin MCP adapter can use these public APIs directly. Client ownership, permanent disconnect, reconnect through a new client and deadline ownership are documented.

Final review fixed a reproduced client failure: non-finite numeric input now returns `InvalidRequest` before sending and preserves the connection, instead of incorrectly reporting an unavailable application. NaN and both infinities have real-process regression coverage.

## Waits

Adds neutral `WaitForConditionAsync`: immediate evaluation, subscribe/re-read race prevention, canonical notification wake hints plus bounded reconciliation, monotonic timeout and cancellation, and cleanup on every terminal path. Ambiguous/incomplete queries cannot certify a predicate. Protected values cannot be probed for equality. `CheckpointAsync` is a dispatcher-turn barrier, not global idle or business-operation completion.

## CLI

A nonpackable scriptable CLI uses the same public client for list, connect/info, roots, tree, find, inspect, action and wait. It supports text/JSON output, stdin SetValue, bounded input and deterministic exit codes, including a distinct unknown-mutation result.

## E2E

Real process workflow: launch → discover → authenticate → roots → query → action → wait → inspect → disconnect. Tests use a dedicated native Windows host and additional CLI processes, including AsyncCommand postconditions, root close, server stop, process crash, client cleanup and unknown Invoke/SetValue outcomes. No bridge acceptance depends on UIA, mouse simulation or screenshots, and application gates avoid fixed client sleeps.

## Security

The reviewed implementation uses protected current User SID ACLs/owner checks, actual peer identity verification, explicit `PIPE_REJECT_REMOTE_CLIENTS`, descriptor/secret separation and confined stale cleanup. Regression cases reject absolute/traversal-shaped descriptor identities without deleting another live instance's files.

Actual local evidence: ACL/owner SID, OS access denied for a restricted token against pipe/descriptor/secret, and SMB loopback remote rejection after a successful positive control.

- Different logged-in user: **NOT EXECUTED**.
- Second physical machine: **NOT EXECUTED**.
- Manual visual and Android emulator/device/TalkBack checks: **NOT EXECUTED**.

This is a same-user development bridge, not a sandbox against that user or an administrator and not an elevation boundary. Managed secret string copies are not claimed to be erased.

## Scope boundary

Not implemented: MCP, Android transport, event stream, screenshots, Developer Tools integration or Phase 1c ControlGallery integration. Phase 1c still covers the small application example, representative application Focus/Select workflows and final integrated MVP acceptance. No release, tag, version bump or package publication. Local reports, evidence, helper scripts and `.codex/config.toml` are excluded from this PR.

## Validation

Validated final pre-push HEAD `6592d824f17c1d0c14f34ee6188fe983b3c62966` with SDK 10.0.401 (unchanged global.json allows latestFeature from 10.0.201).

| Suite | Debug | Release |
| --- | ---: | ---: |
| Main framework | 1149 | 1149 |
| Automation core | 140 | 140 |
| Windows bridge | 61 | 61 |
| Designer | 640 | 640 |
| Testing | 104 | 104 |
| Cross-platform sample | 16 | 16 |
| VSIX | 26 | 26 |
| Android backend | 164 | 164 |
| Windows backend | 67 | 67 |
| **Total** | **2367** | **2367** |

Zero failed/skipped tests. Subsets per configuration: waits **25**, security/protocol-policy/OS evidence **31**, framing **9**, real native-process cases **52** (including CLI **8**), canonical accessibility **32**, Windows UIA **55**, Android accessibility **84**, command regressions **408**. Subsets are included in the totals.

Restore, Debug/Release solution and explicit VSIX builds, ApiCompat (10 baseline assembly/TFM comparisons per configuration), DocFX, 32 documentation assertions, four documentation archives, 11 NuGet + 10 symbol packages and package validation, a fresh NuGet-only native consumer, and `git diff --check` all pass. The isolated consumer resolves six framework packages, with no Testing/MCP. Native HWND was independently observed on the final host. Builds/tests use `-m:1 /p:UseSharedCompilation=false`.

Builds have zero errors, with inherited **NU1902** warnings for `Microsoft.Build.Tasks.Git 10.0.301` from WindowKit's unchanged `Microsoft.SourceLink.GitHub 10.0.301` (`PrivateAssets=All`): four occurrences per solution build, two per explicit VSIX build. This existing [CVE-2026-62900 advisory](https://github.com/advisories/GHSA-23fw-v26w-5fgq) is also present with the baseline dependency reference; it is not a new bridge runtime dependency. Audit was not suppressed and no out-of-scope dependency/version update was made.

## Issue

Progresses #97 — Phase 1b only. **#97 remains OPEN.** MCP remains a separate future optional adapter.
